### PR TITLE
Add DBVersioning for entries

### DIFF
--- a/designs/auth.rst
+++ b/designs/auth.rst
@@ -296,3 +296,34 @@ system yet), method two probably is the best, but you need token constraint
 to make sure you can't replay to another host.
 
 
+
+Brain Dump Internal Details
+===========================
+
+Credentials should be a real struct on entry, that is serialised to str to dbentry. This allows repl
+to still work, but then we can actually keep detailed structures for types in the DB instead. When
+we send to proto entry, we could probably keep it as a real struct on protoentry, but then we could
+eliminate all private types from transmission.
+
+
+When we login, we need to know what groups/roles are relevant to that authentication. To achieve this
+we can have each group contain a policy of auth types (the credentials above all provide an auth
+type). The login then has a known auth type of "how" they logged in, so when we go to generate
+the users "token" for that session, we can correlate these, and only attach groups that satisfy
+the authentication type requirements.
+
+IE the session associates the method you used to login to your token and a cookie.
+
+If you require extra groups, then we should support a token refresh that given the prior auth +
+extra factors, we can then re-issue the token to support the extra groups as presented. We may
+also want some auth types to NOT allow refresh.
+
+We may want groups to support expiry where they are not valid past some time stamp. This may
+required tagging or other details.
+
+
+How do we ensure integrity of the token? Do we have to? Is the clients job to trust the token given
+the TLS tunnel?
+
+
+

--- a/src/lib/be/dbentry.rs
+++ b/src/lib/be/dbentry.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DbEntryV1 {
+    pub attrs: BTreeMap<String, Vec<String>>,
+}
+
+// REMEMBER: If you add a new version here, you MUST
+// update entry.rs into_dbentry to export to the latest
+// type always!!
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DbEntryVers {
+    V1(DbEntryV1),
+}
+
+// This is actually what we store into the DB.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DbEntry {
+    pub ent: DbEntryVers,
+}

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -23,6 +23,7 @@ pub enum OperationError {
     Plugin,
     FilterGeneration,
     InvalidDBState,
+    InvalidEntryID,
     InvalidRequestState,
     InvalidState,
     InvalidEntryState,
@@ -38,8 +39,8 @@ pub enum ConsistencyError {
     // Class, Attribute
     SchemaClassMissingAttribute(String, String),
     QueryServerSearchFailure,
-    EntryUuidCorrupt(i64),
+    EntryUuidCorrupt(u64),
     UuidIndexCorrupt(String),
     UuidNotUnique(String),
-    RefintNotUpheld(i64),
+    RefintNotUpheld(u64),
 }

--- a/src/lib/event.rs
+++ b/src/lib/event.rs
@@ -156,7 +156,7 @@ impl CreateEvent {
         let rentries: Result<Vec<_>, _> = request
             .entries
             .iter()
-            .map(|e| Entry::from(audit, e, qs))
+            .map(|e| Entry::from_proto_entry(audit, e, qs))
             .collect();
         match rentries {
             Ok(entries) => Ok(CreateEvent {

--- a/src/lib/plugins/refint.rs
+++ b/src/lib/plugins/refint.rs
@@ -53,7 +53,6 @@ impl Plugin for ReferentialIntegrity {
         "referential_integrity"
     }
 
-
     // Why are these checks all in post?
     //
     // There is a situation to account for which is that a create or mod

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -4,9 +4,7 @@
 use std::sync::Arc;
 
 use crate::audit::AuditScope;
-use crate::be::{
-    Backend, BackendError, BackendReadTransaction, BackendTransaction, BackendWriteTransaction,
-};
+use crate::be::{Backend, BackendReadTransaction, BackendTransaction, BackendWriteTransaction};
 
 use crate::constants::{JSON_ANONYMOUS_V1, JSON_SYSTEM_INFO_V1};
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntryValid};
@@ -106,7 +104,6 @@ pub trait QueryServerReadTransaction {
         // How to get schema?
         let vf = match ee.filter.validate(self.get_schema()) {
             Ok(f) => f,
-            // TODO: Do something with this error
             Err(e) => return Err(OperationError::SchemaViolation(e)),
         };
 
@@ -649,15 +646,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
         let mut audit_be = AuditScope::new("backend_modify");
 
-        let res = self
-            .be_txn
-            // Change this to an update, not delete.
-            .modify(&mut audit_be, &del_cand)
-            .map(|_| ())
-            .map_err(|e| match e {
-                BackendError::EmptyRequest => OperationError::EmptyRequest,
-                BackendError::EntryMissingId => OperationError::InvalidRequestState,
-            });
+        let res = self.be_txn.modify(&mut audit_be, &del_cand);
         au.append_scope(audit_be);
 
         if res.is_err() {
@@ -700,12 +689,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         let res = self
             .be_txn
             // Change this to an update, not delete.
-            .delete(&mut audit_be, &ts)
-            .map(|_| ())
-            .map_err(|e| match e {
-                BackendError::EmptyRequest => OperationError::EmptyRequest,
-                BackendError::EntryMissingId => OperationError::InvalidRequestState,
-            });
+            .delete(&mut audit_be, &ts);
         au.append_scope(audit_be);
 
         if res.is_err() {
@@ -735,14 +719,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         // Backend Modify
         let mut audit_be = AuditScope::new("backend_modify");
 
-        let res = self
-            .be_txn
-            .modify(&mut audit_be, &tombstone_cand)
-            .map(|_| ())
-            .map_err(|e| match e {
-                BackendError::EmptyRequest => OperationError::EmptyRequest,
-                BackendError::EntryMissingId => OperationError::InvalidRequestState,
-            });
+        let res = self.be_txn.modify(&mut audit_be, &tombstone_cand);
         au.append_scope(audit_be);
 
         if res.is_err() {
@@ -871,14 +848,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         // Backend Modify
         let mut audit_be = AuditScope::new("backend_modify");
 
-        let res = self
-            .be_txn
-            .modify(&mut audit_be, &norm_cand)
-            .map(|_| ())
-            .map_err(|e| match e {
-                BackendError::EmptyRequest => OperationError::EmptyRequest,
-                BackendError::EntryMissingId => OperationError::InvalidRequestState,
-            });
+        let res = self.be_txn.modify(&mut audit_be, &norm_cand);
         au.append_scope(audit_be);
 
         if res.is_err() {


### PR DESCRIPTION
Implements #35.

This separates the "Entry" as a higher level server concept, from the Backend's concept of an Entry. The primary reason for this is to allow datastructure versioning of the content stored in the DB backend. IE if we plan to add attribute value tags, we'll need to change from a map of attr: value, to attr: (tag, value). This would require changes to the data already existing in the db. By versioning the content in DBEntry we can then perform migrations and checks, as well as supply defaults, restore from old backups and more.

Additionally, this also means that higher level concepts, and complex structures can be added to "Entry" that compile to Attr-value sets. This will allow us to have structured data in the Entry like embedded json/cbor - provided of course they can all serialise down to avas.

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
