### PR TITLE
Implement backup, restore and server modes, with configuration args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ name = "rsidm"
 path = "src/lib/lib.rs"
 
 [[bin]]
-name = "rsidm_core"
+name = "rsidmd"
 path = "src/server/main.rs"
 
 [[bin]]
-name = "rsidm_whoami"
-path = "src/clients/whoami.rs"
+name = "kanidm"
+path = "src/clients/main.rs"
 
 
 [dependencies]
@@ -43,12 +43,15 @@ tokio = "0.1"
 futures = "0.1"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 serde = "1.0"
+serde_cbor = "0.10"
 serde_json = "1.0"
 serde_derive = "1.0"
 
 rusqlite = { version = "0.15", features = ["backup"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.7"
+
+structopt = { version = "0.2", default-features = false }
 
 concread = "0.1"
 

--- a/src/clients/main.rs
+++ b/src/clients/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello kanidm");
+}

--- a/src/lib/async_log.rs
+++ b/src/lib/async_log.rs
@@ -1,0 +1,81 @@
+use actix::prelude::*;
+
+use crate::audit::AuditScope;
+
+// Helper for internal logging.
+// Should only be used at startup/shutdown
+#[macro_export]
+macro_rules! log_event {
+    ($log_addr:expr, $($arg:tt)*) => ({
+        use crate::async_log::LogEvent;
+        use std::fmt;
+        $log_addr.do_send(
+            LogEvent {
+                msg: fmt::format(
+                    format_args!($($arg)*)
+                )
+            }
+        )
+    })
+}
+
+// We need to pass in config for this later
+// Or we need to pass in the settings for it IE level and dest?
+// Is there an efficent way to set a log level filter in the macros
+// so that we don't msg unless it's the correct level?
+// Do we need config in the log macro?
+
+pub fn start() -> actix::Addr<EventLog> {
+    SyncArbiter::start(1, move || EventLog {})
+}
+
+pub struct EventLog {}
+
+impl Actor for EventLog {
+    type Context = SyncContext<Self>;
+
+    /*
+    fn started(&mut self, ctx: &mut Self::Context) {
+        ctx.set_mailbox_capacity(1 << 31);
+    }
+    */
+}
+
+// What messages can we be sent. Basically this is all the possible
+// inputs we *could* recieve.
+
+// Add a macro for easy msg write
+
+pub struct LogEvent {
+    pub msg: String,
+}
+
+impl Message for LogEvent {
+    type Result = ();
+}
+
+impl Handler<LogEvent> for EventLog {
+    type Result = ();
+
+    fn handle(&mut self, event: LogEvent, _: &mut SyncContext<Self>) -> Self::Result {
+        info!("logevent: {}", event.msg);
+    }
+}
+
+impl Handler<AuditScope> for EventLog {
+    type Result = ();
+
+    fn handle(&mut self, event: AuditScope, _: &mut SyncContext<Self>) -> Self::Result {
+        info!("audit: {}", event);
+    }
+}
+
+/*
+impl Handler<Event> for EventLog {
+    type Result = ();
+
+    fn handle(&mut self, event: Event, _: &mut SyncContext<Self>) -> Self::Result {
+        println!("EVENT: {:?}", event)
+    }
+}
+*/

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Configuration {
     pub address: String,
@@ -21,6 +23,16 @@ impl Configuration {
             // log path
             // TODO: default true in prd
             secure_cookies: false,
+        }
+    }
+
+    pub fn update_db_path(&mut self, p: &PathBuf) {
+        match p.to_str() {
+            Some(p) => self.db_path = p.to_string(),
+            None => {
+                error!("Invalid DB path supplied");
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -34,6 +34,7 @@ pub enum OperationError {
     SQLiteError, //(RusqliteError)
     FsError,
     SerdeJsonError,
+    SerdeCborError,
     AccessDenied,
     NotAuthenticated,
     InvalidAuthState(&'static str),

--- a/src/lib/idm/claim.rs
+++ b/src/lib/idm/claim.rs
@@ -1,0 +1,18 @@
+use crate::proto::v1::Claim as ProtoClaim;
+
+#[derive(Debug)]
+pub struct Claim {
+    // For now, empty. Later we'll flesh this out to uuid + name?
+}
+
+impl Claim {
+    pub fn new() -> Self {
+        Claim {
+            // Fill this in!
+        }
+    }
+
+    pub fn into_proto(&self) -> ProtoClaim {
+        unimplemented!();
+    }
+}

--- a/src/lib/idm/group.rs
+++ b/src/lib/idm/group.rs
@@ -1,0 +1,17 @@
+use crate::proto::v1::Group as ProtoGroup;
+
+#[derive(Debug, Clone)]
+pub struct Group {
+    // name
+// uuid
+}
+
+impl Group {
+    pub fn new() -> Self {
+        Group {}
+    }
+
+    pub fn into_proto(&self) -> ProtoGroup {
+        unimplemented!();
+    }
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate log;
 extern crate serde;
+extern crate serde_cbor;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib/proto/v1/actors.rs
+++ b/src/lib/proto/v1/actors.rs
@@ -53,7 +53,7 @@ impl QueryServerV1 {
     // threads for write vs read
     pub fn start(
         log: actix::Addr<EventLog>,
-        path: &str,
+        be: Backend,
         threads: usize,
     ) -> Result<actix::Addr<QueryServerV1>, OperationError> {
         let mut audit = AuditScope::new("server_start");
@@ -67,14 +67,6 @@ impl QueryServerV1 {
                 Ok(s) => s,
                 Err(e) => return Err(e),
             };
-
-            // Create a new backend audit scope
-            let mut audit_be = AuditScope::new("backend_new");
-            let be = match Backend::new(&mut audit_be, path) {
-                Ok(be) => be,
-                Err(e) => return Err(e),
-            };
-            audit.append_scope(audit_be);
 
             {
                 let be_txn = be.write();

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -2,21 +2,100 @@ extern crate actix;
 extern crate env_logger;
 
 extern crate rsidm;
+extern crate structopt;
+#[macro_use]
+extern crate log;
 
 use rsidm::config::Configuration;
-use rsidm::core::create_server_core;
+use rsidm::core::{backup_server_core, create_server_core, restore_server_core};
+
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct ServerOpt {
+    #[structopt(short = "d", long = "debug")]
+    debug: bool,
+    #[structopt(parse(from_os_str), short = "D", long = "db_path")]
+    db_path: PathBuf,
+}
+
+#[derive(Debug, StructOpt)]
+struct BackupOpt {
+    #[structopt(parse(from_os_str))]
+    path: PathBuf,
+    #[structopt(flatten)]
+    serveropts: ServerOpt,
+}
+
+#[derive(Debug, StructOpt)]
+struct RestoreOpt {
+    #[structopt(parse(from_os_str))]
+    path: PathBuf,
+    #[structopt(flatten)]
+    serveropts: ServerOpt,
+}
+
+#[derive(Debug, StructOpt)]
+enum Opt {
+    #[structopt(name = "server")]
+    Server(ServerOpt),
+    #[structopt(name = "backup")]
+    Backup(BackupOpt),
+    #[structopt(name = "restore")]
+    Restore(RestoreOpt),
+}
 
 fn main() {
+    // Read cli args, determine if we should backup/restore
+    let opt = Opt::from_args();
+
     // Read our config (if any)
-    let config = Configuration::new();
+    let mut config = Configuration::new();
+    // Apply any cli overrides?
 
     // Configure the server logger. This could be adjusted based on what config
     // says.
     ::std::env::set_var("RUST_LOG", "actix_web=info,rsidm=info");
     env_logger::init();
 
-    let sys = actix::System::new("rsidm-server");
+    match opt {
+        Opt::Server(sopt) => {
+            info!("Running in server mode ...");
 
-    create_server_core(config);
-    let _ = sys.run();
+            config.update_db_path(&sopt.db_path);
+
+            let sys = actix::System::new("rsidm-server");
+            create_server_core(config);
+            let _ = sys.run();
+        }
+        Opt::Backup(bopt) => {
+            info!("Running in backup mode ...");
+
+            config.update_db_path(&bopt.serveropts.db_path);
+
+            let p = match bopt.path.to_str() {
+                Some(p) => p,
+                None => {
+                    error!("Invalid backup path");
+                    std::process::exit(1);
+                }
+            };
+            backup_server_core(config, p);
+        }
+        Opt::Restore(ropt) => {
+            info!("Running in restore mode ...");
+
+            config.update_db_path(&ropt.serveropts.db_path);
+
+            let p = match ropt.path.to_str() {
+                Some(p) => p,
+                None => {
+                    error!("Invalid restore path");
+                    std::process::exit(1);
+                }
+            };
+            restore_server_core(config, p);
+        }
+    }
 }


### PR DESCRIPTION
Implements #11 . This allows backup and restore of the server from the main server binary. Due to the
design of sqlite, backups can be taken while the server is running. Scheduled backups are not yet implemented as part of this feature, due to needing to be able to roll-out old backups. 

- [ x ] cargo fmt has been run
- [x  ] cargo test has been run and passes
- [ - ] design document included (if relevant)
