### PR TITLE
Move a bit the code to 2018 edition. Fix most of the clippy errors.

### DIFF
--- a/kanidm_client/Cargo.toml
+++ b/kanidm_client/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 description = "Kanidm Client Library"
 documentation = "https://docs.rs/kanidm_client/latest/kanidm_client/"
 homepage = "https://github.com/Firstyear/kanidm/"
-repostiory = "https://github.com/Firstyear/kanidm/"
+repository = "https://github.com/Firstyear/kanidm/"
 
 [dependencies]
 log = "0.4"

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -1,34 +1,16 @@
 #![deny(warnings)]
 
-#[macro_use]
-extern crate log;
-
-extern crate actix;
-use actix::prelude::*;
-
-extern crate kanidm;
-extern crate kanidm_client;
-extern crate kanidm_proto;
-extern crate serde_json;
-
-use kanidm_client::{KanidmClient, KanidmClientBuilder};
-
-use kanidm::config::{Configuration, IntegrationTestConfig};
-use kanidm::core::create_server_core;
-use kanidm_proto::v1::{Entry, Filter, Modify, ModifyList};
-
-extern crate reqwest;
-
-extern crate futures;
-// use futures::future;
-// use futures::future::Future;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::thread;
 
-extern crate env_logger;
-extern crate tokio;
+use kanidm::config::{Configuration, IntegrationTestConfig};
+use kanidm::core::create_server_core;
+use kanidm_client::{KanidmClient, KanidmClientBuilder};
+use kanidm_proto::v1::{Entry, Filter, Modify, ModifyList};
+
+use actix::prelude::*;
+use log::debug;
 
 static PORT_ALLOC: AtomicUsize = AtomicUsize::new(8080);
 static ADMIN_TEST_PASSWORD: &'static str = "integration test admin password";

--- a/kanidm_proto/Cargo.toml
+++ b/kanidm_proto/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 description = "Kanidm Protocol Bindings for serde"
 documentation = "https://docs.rs/kanidm_proto/latest/kanidm_proto/"
 homepage = "https://github.com/Firstyear/kanidm/"
-repostiory = "https://github.com/Firstyear/kanidm/"
+repository = "https://github.com/Firstyear/kanidm/"
 
 [dependencies]
 serde = "1.0"

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -214,7 +214,7 @@ pub struct ModifyList {
 
 impl ModifyList {
     pub fn new_list(mods: Vec<Modify>) -> Self {
-        ModifyList { mods: mods }
+        ModifyList { mods }
     }
 }
 
@@ -234,7 +234,7 @@ pub struct SearchRequest {
 
 impl SearchRequest {
     pub fn new(filter: Filter) -> Self {
-        SearchRequest { filter: filter }
+        SearchRequest { filter }
     }
 }
 
@@ -245,7 +245,7 @@ pub struct SearchResponse {
 
 impl SearchResponse {
     pub fn new(entries: Vec<Entry>) -> Self {
-        SearchResponse { entries: entries }
+        SearchResponse { entries }
     }
 }
 
@@ -256,7 +256,7 @@ pub struct CreateRequest {
 
 impl CreateRequest {
     pub fn new(entries: Vec<Entry>) -> Self {
-        CreateRequest { entries: entries }
+        CreateRequest { entries }
     }
 }
 
@@ -267,7 +267,7 @@ pub struct DeleteRequest {
 
 impl DeleteRequest {
     pub fn new(filter: Filter) -> Self {
-        DeleteRequest { filter: filter }
+        DeleteRequest { filter }
     }
 }
 
@@ -280,10 +280,7 @@ pub struct ModifyRequest {
 
 impl ModifyRequest {
     pub fn new(filter: Filter, modlist: ModifyList) -> Self {
-        ModifyRequest {
-            filter: filter,
-            modlist: modlist,
-        }
+        ModifyRequest { filter, modlist }
     }
 }
 
@@ -371,7 +368,7 @@ pub struct SearchRecycledRequest {
 
 impl SearchRecycledRequest {
     pub fn new(filter: Filter) -> Self {
-        SearchRecycledRequest { filter: filter }
+        SearchRecycledRequest { filter }
     }
 }
 
@@ -383,17 +380,17 @@ pub struct ReviveRecycledRequest {
 
 impl ReviveRecycledRequest {
     pub fn new(filter: Filter) -> Self {
-        ReviveRecycledRequest { filter: filter }
+        ReviveRecycledRequest { filter }
     }
 }
 
 // This doesn't need seralise because it's only accessed via a "get".
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct WhoamiRequest {}
 
 impl WhoamiRequest {
     pub fn new() -> Self {
-        WhoamiRequest {}
+        Default::default()
     }
 }
 
@@ -406,10 +403,7 @@ pub struct WhoamiResponse {
 
 impl WhoamiResponse {
     pub fn new(e: Entry, uat: UserAuthToken) -> Self {
-        WhoamiResponse {
-            youare: e,
-            uat: uat,
-        }
+        WhoamiResponse { youare: e, uat }
     }
 }
 

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 description = "Kanidm Client Tools"
 documentation = "https://docs.rs/kanidm_tools/latest/kanidm_tools/"
 homepage = "https://github.com/Firstyear/kanidm/"
-repostiory = "https://github.com/Firstyear/kanidm/"
+repository = "https://github.com/Firstyear/kanidm/"
 
 [[bin]]
 name = "kanidm"

--- a/kanidm_tools/src/badlist_preprocess.rs
+++ b/kanidm_tools/src/badlist_preprocess.rs
@@ -1,21 +1,16 @@
-extern crate structopt;
-
-// use shellexpand;
-use rayon::prelude::*;
-use serde_json;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use structopt::StructOpt;
-use zxcvbn;
 
 use kanidm_proto::v1::Modify;
 
-extern crate env_logger;
-#[macro_use]
-extern crate log;
+use log::{debug, error, info};
+use rayon::prelude::*;
+use serde_json;
+use structopt::StructOpt;
+use zxcvbn;
 
 #[derive(Debug, StructOpt)]
 struct ClientOpt {

--- a/kanidm_tools/src/badlist_preprocess.rs
+++ b/kanidm_tools/src/badlist_preprocess.rs
@@ -92,7 +92,7 @@ fn main() {
             }
         })
         .filter(|v| {
-            if v.len() == 0 {
+            if v.is_empty() {
                 return false;
             }
             if v.len() < 10 {

--- a/kanidm_tools/src/main.rs
+++ b/kanidm_tools/src/main.rs
@@ -1,20 +1,17 @@
-extern crate structopt;
-use kanidm_client::{KanidmClient, KanidmClientBuilder};
-use kanidm_proto::v1::{Entry, Filter, Modify, ModifyList};
-use serde::de::DeserializeOwned;
-use std::path::PathBuf;
-use structopt::StructOpt;
-
-use shellexpand;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
+use std::path::PathBuf;
 
-extern crate env_logger;
-#[macro_use]
-extern crate log;
+use kanidm_client::{KanidmClient, KanidmClientBuilder};
+use kanidm_proto::v1::{Entry, Filter, Modify, ModifyList};
+
+use log::debug;
+use serde::de::DeserializeOwned;
+use shellexpand;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct CommonOpt {

--- a/kanidm_tools/src/main.rs
+++ b/kanidm_tools/src/main.rs
@@ -544,13 +544,10 @@ fn main() {
             GroupOpt::ListMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
                 let members = client.idm_group_get_members(gcopt.name.as_str()).unwrap();
-                match members {
-                    Some(groups) => {
-                        for m in groups {
-                            println!("{:?}", m);
-                        }
+                if let Some(groups) = members {
+                    for m in groups {
+                        println!("{:?}", m);
                     }
-                    None => {}
                 }
             }
             GroupOpt::AddMembers(gcopt) => {

--- a/kanidm_tools/src/ssh_authorizedkeys.rs
+++ b/kanidm_tools/src/ssh_authorizedkeys.rs
@@ -1,12 +1,10 @@
-extern crate structopt;
-use kanidm_client::KanidmClientBuilder;
-use shellexpand;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-extern crate env_logger;
-#[macro_use]
-extern crate log;
+use kanidm_client::KanidmClientBuilder;
+
+use log::debug;
+use shellexpand;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct ClientOpt {

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -10,7 +10,7 @@ license = "MPL-2.0"
 description = "Kanidm Server Library and Binary"
 documentation = "https://docs.rs/kanidm/latest/kanidm/"
 homepage = "https://github.com/Firstyear/kanidm/"
-repostiory = "https://github.com/Firstyear/kanidm/"
+repository = "https://github.com/Firstyear/kanidm/"
 
 [lib]
 name = "kanidm"

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -34,7 +34,7 @@ pub struct WhoamiMessage {
 
 impl WhoamiMessage {
     pub fn new(uat: Option<UserAuthToken>) -> Self {
-        WhoamiMessage { uat: uat }
+        WhoamiMessage { uat }
     }
 }
 
@@ -50,10 +50,7 @@ pub struct AuthMessage {
 
 impl AuthMessage {
     pub fn new(req: AuthRequest, sessionid: Option<Uuid>) -> Self {
-        AuthMessage {
-            sessionid: sessionid,
-            req: req,
-        }
+        AuthMessage { sessionid, req }
     }
 }
 
@@ -68,7 +65,7 @@ pub struct SearchMessage {
 
 impl SearchMessage {
     pub fn new(uat: Option<UserAuthToken>, req: SearchRequest) -> Self {
-        SearchMessage { uat: uat, req: req }
+        SearchMessage { uat, req }
     }
 }
 
@@ -142,11 +139,7 @@ impl Actor for QueryServerReadV1 {
 impl QueryServerReadV1 {
     pub fn new(log: actix::Addr<EventLog>, qs: QueryServer, idms: Arc<IdmServer>) -> Self {
         log_event!(log, "Starting query server v1 worker ...");
-        QueryServerReadV1 {
-            log: log,
-            qs: qs,
-            idms: idms,
-        }
+        QueryServerReadV1 { log, qs, idms }
     }
 
     pub fn start(
@@ -320,7 +313,7 @@ impl Handler<InternalSearchMessage> for QueryServerReadV1 {
 
             match qs_read.search_ext(&mut audit, &srch) {
                 Ok(entries) => SearchResult::new(&mut audit, &qs_read, entries)
-                    .map(|ok_sr| ok_sr.to_proto_array()),
+                    .map(|ok_sr| ok_sr.into_proto_array()),
                 Err(e) => Err(e),
             }
         });

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -15,7 +15,7 @@ pub struct TlsConfiguration {
     pub key: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Configuration {
     pub address: String,
     pub threads: usize,
@@ -52,11 +52,11 @@ impl Configuration {
             address: String::from("127.0.0.1:8080"),
             threads: num_cpus::get(),
             db_path: String::from(""),
-            maximum_request: 262144, // 256k
+            maximum_request: 262_144, // 256k
             // log type
             // log path
             // TODO #63: default true in prd
-            secure_cookies: if cfg!(test) { false } else { true },
+            secure_cookies: !cfg!(test),
             tls_config: None,
             cookie_key: [0; 32],
             integration_test_config: None,
@@ -79,7 +79,7 @@ impl Configuration {
     pub fn update_bind(&mut self, b: &Option<String>) {
         self.address = b
             .as_ref()
-            .map(|s| s.clone())
+            .cloned()
             .unwrap_or_else(|| String::from("127.0.0.1:8080"));
     }
 

--- a/kanidmd/src/lib/constants/mod.rs
+++ b/kanidmd/src/lib/constants/mod.rs
@@ -17,158 +17,135 @@ pub static AUTH_SESSION_TIMEOUT: u64 = 300;
 pub static PW_MIN_LENGTH: usize = 10;
 
 // Built in group and account ranges.
-pub static STR_UUID_ADMIN: &'static str = "00000000-0000-0000-0000-000000000000";
-pub static _UUID_IDM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000001";
-pub static _UUID_IDM_PEOPLE_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000002";
-pub static _UUID_IDM_PEOPLE_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000003";
-pub static _UUID_IDM_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000004";
-pub static _UUID_IDM_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000005";
-pub static _UUID_IDM_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000006";
-pub static _UUID_IDM_RADIUS_SERVERS: &'static str = "00000000-0000-0000-0000-000000000007";
-pub static _UUID_IDM_HP_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000008";
-pub static _UUID_IDM_HP_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000009";
-pub static _UUID_IDM_SCHEMA_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000010";
-pub static _UUID_IDM_ACP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000011";
-pub static _UUID_IDM_HP_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000012";
-pub static _UUID_IDM_PEOPLE_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000013";
-pub static _UUID_IDM_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000014";
-pub static _UUID_IDM_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000015";
-pub static _UUID_IDM_HP_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000016";
-pub static _UUID_IDM_HP_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000017";
-pub static _UUID_IDM_ADMIN_V1: &'static str = "00000000-0000-0000-0000-000000000018";
-pub static _UUID_SYSTEM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000019";
+pub static STR_UUID_ADMIN: &str = "00000000-0000-0000-0000-000000000000";
+pub static _UUID_IDM_ADMINS: &str = "00000000-0000-0000-0000-000000000001";
+pub static _UUID_IDM_PEOPLE_READ_PRIV: &str = "00000000-0000-0000-0000-000000000002";
+pub static _UUID_IDM_PEOPLE_WRITE_PRIV: &str = "00000000-0000-0000-0000-000000000003";
+pub static _UUID_IDM_GROUP_WRITE_PRIV: &str = "00000000-0000-0000-0000-000000000004";
+pub static _UUID_IDM_ACCOUNT_READ_PRIV: &str = "00000000-0000-0000-0000-000000000005";
+pub static _UUID_IDM_ACCOUNT_WRITE_PRIV: &str = "00000000-0000-0000-0000-000000000006";
+pub static _UUID_IDM_RADIUS_SERVERS: &str = "00000000-0000-0000-0000-000000000007";
+pub static _UUID_IDM_HP_ACCOUNT_READ_PRIV: &str = "00000000-0000-0000-0000-000000000008";
+pub static _UUID_IDM_HP_ACCOUNT_WRITE_PRIV: &str = "00000000-0000-0000-0000-000000000009";
+pub static _UUID_IDM_SCHEMA_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000010";
+pub static _UUID_IDM_ACP_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000011";
+pub static _UUID_IDM_HP_GROUP_WRITE_PRIV: &str = "00000000-0000-0000-0000-000000000012";
+pub static _UUID_IDM_PEOPLE_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000013";
+pub static _UUID_IDM_ACCOUNT_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000014";
+pub static _UUID_IDM_GROUP_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000015";
+pub static _UUID_IDM_HP_ACCOUNT_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000016";
+pub static _UUID_IDM_HP_GROUP_MANAGE_PRIV: &str = "00000000-0000-0000-0000-000000000017";
+pub static _UUID_IDM_ADMIN_V1: &str = "00000000-0000-0000-0000-000000000018";
+pub static _UUID_SYSTEM_ADMINS: &str = "00000000-0000-0000-0000-000000000019";
 // TODO
-pub static UUID_DOMAIN_ADMINS: &'static str = "00000000-0000-0000-0000-000000000020";
+pub static UUID_DOMAIN_ADMINS: &str = "00000000-0000-0000-0000-000000000020";
 //
-pub static _UUID_IDM_HIGH_PRIVILEGE: &'static str = "00000000-0000-0000-0000-000000001000";
+pub static _UUID_IDM_HIGH_PRIVILEGE: &str = "00000000-0000-0000-0000-000000001000";
 
 // Builtin schema
-pub static UUID_SCHEMA_ATTR_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000000";
-pub static UUID_SCHEMA_ATTR_UUID: &'static str = "00000000-0000-0000-0000-ffff00000001";
-pub static UUID_SCHEMA_ATTR_NAME: &'static str = "00000000-0000-0000-0000-ffff00000002";
-pub static UUID_SCHEMA_ATTR_SPN: &'static str = "00000000-0000-0000-0000-ffff00000003";
-pub static UUID_SCHEMA_ATTR_DESCRIPTION: &'static str = "00000000-0000-0000-0000-ffff00000004";
-pub static UUID_SCHEMA_ATTR_MULTIVALUE: &'static str = "00000000-0000-0000-0000-ffff00000005";
-pub static UUID_SCHEMA_ATTR_UNIQUE: &'static str = "00000000-0000-0000-0000-ffff00000047";
-pub static UUID_SCHEMA_ATTR_INDEX: &'static str = "00000000-0000-0000-0000-ffff00000006";
-pub static UUID_SCHEMA_ATTR_SYNTAX: &'static str = "00000000-0000-0000-0000-ffff00000007";
-pub static UUID_SCHEMA_ATTR_SYSTEMMAY: &'static str = "00000000-0000-0000-0000-ffff00000008";
-pub static UUID_SCHEMA_ATTR_MAY: &'static str = "00000000-0000-0000-0000-ffff00000009";
-pub static UUID_SCHEMA_ATTR_SYSTEMMUST: &'static str = "00000000-0000-0000-0000-ffff00000010";
-pub static UUID_SCHEMA_ATTR_MUST: &'static str = "00000000-0000-0000-0000-ffff00000011";
-pub static UUID_SCHEMA_ATTR_MEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000012";
-pub static UUID_SCHEMA_ATTR_MEMBER: &'static str = "00000000-0000-0000-0000-ffff00000013";
-pub static UUID_SCHEMA_ATTR_DIRECTMEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000014";
-pub static UUID_SCHEMA_ATTR_VERSION: &'static str = "00000000-0000-0000-0000-ffff00000015";
-pub static UUID_SCHEMA_ATTR_DOMAIN: &'static str = "00000000-0000-0000-0000-ffff00000016";
-pub static UUID_SCHEMA_ATTR_ACP_ENABLE: &'static str = "00000000-0000-0000-0000-ffff00000017";
-pub static UUID_SCHEMA_ATTR_ACP_RECEIVER: &'static str = "00000000-0000-0000-0000-ffff00000018";
-pub static UUID_SCHEMA_ATTR_ACP_TARGETSCOPE: &'static str = "00000000-0000-0000-0000-ffff00000019";
-pub static UUID_SCHEMA_ATTR_ACP_SEARCH_ATTR: &'static str = "00000000-0000-0000-0000-ffff00000020";
-pub static UUID_SCHEMA_ATTR_ACP_CREATE_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000021";
-pub static UUID_SCHEMA_ATTR_ACP_CREATE_ATTR: &'static str = "00000000-0000-0000-0000-ffff00000022";
-pub static UUID_SCHEMA_ATTR_ACP_MODIFY_REMOVEDATTR: &'static str =
-    "00000000-0000-0000-0000-ffff00000023";
-pub static UUID_SCHEMA_ATTR_ACP_MODIFY_PRESENTATTR: &'static str =
-    "00000000-0000-0000-0000-ffff00000024";
-pub static UUID_SCHEMA_ATTR_ACP_MODIFY_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000025";
-pub static UUID_SCHEMA_CLASS_ATTRIBUTETYPE: &'static str = "00000000-0000-0000-0000-ffff00000026";
-pub static UUID_SCHEMA_CLASS_CLASSTYPE: &'static str = "00000000-0000-0000-0000-ffff00000027";
-pub static UUID_SCHEMA_CLASS_OBJECT: &'static str = "00000000-0000-0000-0000-ffff00000028";
-pub static UUID_SCHEMA_CLASS_EXTENSIBLEOBJECT: &'static str =
-    "00000000-0000-0000-0000-ffff00000029";
-pub static UUID_SCHEMA_CLASS_MEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000030";
-pub static UUID_SCHEMA_CLASS_RECYCLED: &'static str = "00000000-0000-0000-0000-ffff00000031";
-pub static UUID_SCHEMA_CLASS_TOMBSTONE: &'static str = "00000000-0000-0000-0000-ffff00000032";
-pub static UUID_SCHEMA_CLASS_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffff00000033";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_PROFILE: &'static str =
-    "00000000-0000-0000-0000-ffff00000034";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_SEARCH: &'static str =
-    "00000000-0000-0000-0000-ffff00000035";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_DELETE: &'static str =
-    "00000000-0000-0000-0000-ffff00000036";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_MODIFY: &'static str =
-    "00000000-0000-0000-0000-ffff00000037";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_CREATE: &'static str =
-    "00000000-0000-0000-0000-ffff00000038";
-pub static UUID_SCHEMA_CLASS_SYSTEM: &'static str = "00000000-0000-0000-0000-ffff00000039";
-pub static UUID_SCHEMA_ATTR_DISPLAYNAME: &'static str = "00000000-0000-0000-0000-ffff00000040";
-pub static UUID_SCHEMA_ATTR_MAIL: &'static str = "00000000-0000-0000-0000-ffff00000041";
-pub static UUID_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = "00000000-0000-0000-0000-ffff00000042";
-pub static UUID_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str =
-    "00000000-0000-0000-0000-ffff00000043";
-pub static UUID_SCHEMA_CLASS_PERSON: &'static str = "00000000-0000-0000-0000-ffff00000044";
-pub static UUID_SCHEMA_CLASS_GROUP: &'static str = "00000000-0000-0000-0000-ffff00000045";
-pub static UUID_SCHEMA_CLASS_ACCOUNT: &'static str = "00000000-0000-0000-0000-ffff00000046";
+pub static UUID_SCHEMA_ATTR_CLASS: &str = "00000000-0000-0000-0000-ffff00000000";
+pub static UUID_SCHEMA_ATTR_UUID: &str = "00000000-0000-0000-0000-ffff00000001";
+pub static UUID_SCHEMA_ATTR_NAME: &str = "00000000-0000-0000-0000-ffff00000002";
+pub static UUID_SCHEMA_ATTR_SPN: &str = "00000000-0000-0000-0000-ffff00000003";
+pub static UUID_SCHEMA_ATTR_DESCRIPTION: &str = "00000000-0000-0000-0000-ffff00000004";
+pub static UUID_SCHEMA_ATTR_MULTIVALUE: &str = "00000000-0000-0000-0000-ffff00000005";
+pub static UUID_SCHEMA_ATTR_UNIQUE: &str = "00000000-0000-0000-0000-ffff00000047";
+pub static UUID_SCHEMA_ATTR_INDEX: &str = "00000000-0000-0000-0000-ffff00000006";
+pub static UUID_SCHEMA_ATTR_SYNTAX: &str = "00000000-0000-0000-0000-ffff00000007";
+pub static UUID_SCHEMA_ATTR_SYSTEMMAY: &str = "00000000-0000-0000-0000-ffff00000008";
+pub static UUID_SCHEMA_ATTR_MAY: &str = "00000000-0000-0000-0000-ffff00000009";
+pub static UUID_SCHEMA_ATTR_SYSTEMMUST: &str = "00000000-0000-0000-0000-ffff00000010";
+pub static UUID_SCHEMA_ATTR_MUST: &str = "00000000-0000-0000-0000-ffff00000011";
+pub static UUID_SCHEMA_ATTR_MEMBEROF: &str = "00000000-0000-0000-0000-ffff00000012";
+pub static UUID_SCHEMA_ATTR_MEMBER: &str = "00000000-0000-0000-0000-ffff00000013";
+pub static UUID_SCHEMA_ATTR_DIRECTMEMBEROF: &str = "00000000-0000-0000-0000-ffff00000014";
+pub static UUID_SCHEMA_ATTR_VERSION: &str = "00000000-0000-0000-0000-ffff00000015";
+pub static UUID_SCHEMA_ATTR_DOMAIN: &str = "00000000-0000-0000-0000-ffff00000016";
+pub static UUID_SCHEMA_ATTR_ACP_ENABLE: &str = "00000000-0000-0000-0000-ffff00000017";
+pub static UUID_SCHEMA_ATTR_ACP_RECEIVER: &str = "00000000-0000-0000-0000-ffff00000018";
+pub static UUID_SCHEMA_ATTR_ACP_TARGETSCOPE: &str = "00000000-0000-0000-0000-ffff00000019";
+pub static UUID_SCHEMA_ATTR_ACP_SEARCH_ATTR: &str = "00000000-0000-0000-0000-ffff00000020";
+pub static UUID_SCHEMA_ATTR_ACP_CREATE_CLASS: &str = "00000000-0000-0000-0000-ffff00000021";
+pub static UUID_SCHEMA_ATTR_ACP_CREATE_ATTR: &str = "00000000-0000-0000-0000-ffff00000022";
+pub static UUID_SCHEMA_ATTR_ACP_MODIFY_REMOVEDATTR: &str = "00000000-0000-0000-0000-ffff00000023";
+pub static UUID_SCHEMA_ATTR_ACP_MODIFY_PRESENTATTR: &str = "00000000-0000-0000-0000-ffff00000024";
+pub static UUID_SCHEMA_ATTR_ACP_MODIFY_CLASS: &str = "00000000-0000-0000-0000-ffff00000025";
+pub static UUID_SCHEMA_CLASS_ATTRIBUTETYPE: &str = "00000000-0000-0000-0000-ffff00000026";
+pub static UUID_SCHEMA_CLASS_CLASSTYPE: &str = "00000000-0000-0000-0000-ffff00000027";
+pub static UUID_SCHEMA_CLASS_OBJECT: &str = "00000000-0000-0000-0000-ffff00000028";
+pub static UUID_SCHEMA_CLASS_EXTENSIBLEOBJECT: &str = "00000000-0000-0000-0000-ffff00000029";
+pub static UUID_SCHEMA_CLASS_MEMBEROF: &str = "00000000-0000-0000-0000-ffff00000030";
+pub static UUID_SCHEMA_CLASS_RECYCLED: &str = "00000000-0000-0000-0000-ffff00000031";
+pub static UUID_SCHEMA_CLASS_TOMBSTONE: &str = "00000000-0000-0000-0000-ffff00000032";
+pub static UUID_SCHEMA_CLASS_SYSTEM_INFO: &str = "00000000-0000-0000-0000-ffff00000033";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_PROFILE: &str = "00000000-0000-0000-0000-ffff00000034";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_SEARCH: &str = "00000000-0000-0000-0000-ffff00000035";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_DELETE: &str = "00000000-0000-0000-0000-ffff00000036";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_MODIFY: &str = "00000000-0000-0000-0000-ffff00000037";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_CREATE: &str = "00000000-0000-0000-0000-ffff00000038";
+pub static UUID_SCHEMA_CLASS_SYSTEM: &str = "00000000-0000-0000-0000-ffff00000039";
+pub static UUID_SCHEMA_ATTR_DISPLAYNAME: &str = "00000000-0000-0000-0000-ffff00000040";
+pub static UUID_SCHEMA_ATTR_MAIL: &str = "00000000-0000-0000-0000-ffff00000041";
+pub static UUID_SCHEMA_ATTR_SSH_PUBLICKEY: &str = "00000000-0000-0000-0000-ffff00000042";
+pub static UUID_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &str = "00000000-0000-0000-0000-ffff00000043";
+pub static UUID_SCHEMA_CLASS_PERSON: &str = "00000000-0000-0000-0000-ffff00000044";
+pub static UUID_SCHEMA_CLASS_GROUP: &str = "00000000-0000-0000-0000-ffff00000045";
+pub static UUID_SCHEMA_CLASS_ACCOUNT: &str = "00000000-0000-0000-0000-ffff00000046";
 // GAP - 47
-pub static UUID_SCHEMA_ATTR_ATTRIBUTENAME: &'static str = "00000000-0000-0000-0000-ffff00000048";
-pub static UUID_SCHEMA_ATTR_CLASSNAME: &'static str = "00000000-0000-0000-0000-ffff00000049";
-pub static UUID_SCHEMA_ATTR_LEGALNAME: &'static str = "00000000-0000-0000-0000-ffff00000050";
-pub static UUID_SCHEMA_ATTR_RADIUS_SECRET: &'static str = "00000000-0000-0000-0000-ffff00000051";
-pub static UUID_SCHEMA_CLASS_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffff00000052";
-pub static UUID_SCHEMA_ATTR_DOMAIN_NAME: &'static str = "00000000-0000-0000-0000-ffff00000053";
-pub static UUID_SCHEMA_ATTR_DOMAIN_UUID: &'static str = "00000000-0000-0000-0000-ffff00000054";
-pub static UUID_SCHEMA_ATTR_DOMAIN_SSID: &'static str = "00000000-0000-0000-0000-ffff00000055";
+pub static UUID_SCHEMA_ATTR_ATTRIBUTENAME: &str = "00000000-0000-0000-0000-ffff00000048";
+pub static UUID_SCHEMA_ATTR_CLASSNAME: &str = "00000000-0000-0000-0000-ffff00000049";
+pub static UUID_SCHEMA_ATTR_LEGALNAME: &str = "00000000-0000-0000-0000-ffff00000050";
+pub static UUID_SCHEMA_ATTR_RADIUS_SECRET: &str = "00000000-0000-0000-0000-ffff00000051";
+pub static UUID_SCHEMA_CLASS_DOMAIN_INFO: &str = "00000000-0000-0000-0000-ffff00000052";
+pub static UUID_SCHEMA_ATTR_DOMAIN_NAME: &str = "00000000-0000-0000-0000-ffff00000053";
+pub static UUID_SCHEMA_ATTR_DOMAIN_UUID: &str = "00000000-0000-0000-0000-ffff00000054";
+pub static UUID_SCHEMA_ATTR_DOMAIN_SSID: &str = "00000000-0000-0000-0000-ffff00000055";
 
-pub static UUID_SCHEMA_ATTR_GIDNUMBER: &'static str = "00000000-0000-0000-0000-ffff00000056";
-pub static UUID_SCHEMA_CLASS_POSIXACCOUNT: &'static str = "00000000-0000-0000-0000-ffff00000057";
-pub static UUID_SCHEMA_CLASS_POSIXGROUP: &'static str = "00000000-0000-0000-0000-ffff00000058";
-pub static UUID_SCHEMA_ATTR_BADLIST_PASSWORD: &'static str = "00000000-0000-0000-0000-ffff00000059";
-pub static UUID_SCHEMA_CLASS_SYSTEM_CONFIG: &'static str = "00000000-0000-0000-0000-ffff00000060";
+pub static UUID_SCHEMA_ATTR_GIDNUMBER: &str = "00000000-0000-0000-0000-ffff00000056";
+pub static UUID_SCHEMA_CLASS_POSIXACCOUNT: &str = "00000000-0000-0000-0000-ffff00000057";
+pub static UUID_SCHEMA_CLASS_POSIXGROUP: &str = "00000000-0000-0000-0000-ffff00000058";
+pub static UUID_SCHEMA_ATTR_BADLIST_PASSWORD: &str = "00000000-0000-0000-0000-ffff00000059";
+pub static UUID_SCHEMA_CLASS_SYSTEM_CONFIG: &str = "00000000-0000-0000-0000-ffff00000060";
 
 // System and domain infos
 // I'd like to strongly criticise william of the past for fucking up these allocations.
-pub static _UUID_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffffff000001";
-pub static UUID_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffffff000025";
+pub static _UUID_SYSTEM_INFO: &str = "00000000-0000-0000-0000-ffffff000001";
+pub static UUID_DOMAIN_INFO: &str = "00000000-0000-0000-0000-ffffff000025";
 // DO NOT allocate here, allocate below.
 
 // Access controls
 // skip 00 / 01 - see system info
-pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000002";
-pub static _UUID_IDM_ADMINS_ACP_REVIVE_V1: &'static str = "00000000-0000-0000-0000-ffffff000003";
-pub static _UUID_IDM_SELF_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000004";
-pub static _UUID_IDM_ALL_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000006";
-pub static _UUID_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000007";
-pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000008";
-pub static _UUID_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000009";
-pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000010";
-pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000011";
-pub static _UUID_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000012";
-pub static _UUID_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000013";
-pub static _UUID_IDM_ACP_RADIUS_SERVERS_V1: &'static str = "00000000-0000-0000-0000-ffffff000014";
-pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000015";
-pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000016";
-pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000017";
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000018";
-pub static _UUID_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str =
+pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &str = "00000000-0000-0000-0000-ffffff000002";
+pub static _UUID_IDM_ADMINS_ACP_REVIVE_V1: &str = "00000000-0000-0000-0000-ffffff000003";
+pub static _UUID_IDM_SELF_ACP_READ_V1: &str = "00000000-0000-0000-0000-ffffff000004";
+pub static _UUID_IDM_ALL_ACP_READ_V1: &str = "00000000-0000-0000-0000-ffffff000006";
+pub static _UUID_IDM_ACP_PEOPLE_READ_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000007";
+pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000008";
+pub static _UUID_IDM_ACP_GROUP_WRITE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000009";
+pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000010";
+pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000011";
+pub static _UUID_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000012";
+pub static _UUID_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000013";
+pub static _UUID_IDM_ACP_RADIUS_SERVERS_V1: &str = "00000000-0000-0000-0000-ffffff000014";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000015";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000016";
+pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000017";
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000018";
+pub static _UUID_IDM_ACP_ACP_MANAGE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000019";
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &str =
     "00000000-0000-0000-0000-ffffff000020";
-pub static _UUID_IDM_SELF_ACP_WRITE_V1: &'static str = "00000000-0000-0000-0000-ffffff000021";
-pub static _UUID_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000022";
-pub static _UUID_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000023";
-pub static _UUID_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000024";
+pub static _UUID_IDM_SELF_ACP_WRITE_V1: &str = "00000000-0000-0000-0000-ffffff000021";
+pub static _UUID_IDM_ACP_GROUP_MANAGE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000022";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000023";
+pub static _UUID_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000024";
 // Skip 25 - see domain info.
-pub static UUID_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000026";
-pub static STR_UUID_SYSTEM_CONFIG: &'static str = "00000000-0000-0000-0000-ffffff000027";
-pub static UUID_IDM_ACP_SYSTEM_CONFIG_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000028";
+pub static UUID_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000026";
+pub static STR_UUID_SYSTEM_CONFIG: &str = "00000000-0000-0000-0000-ffffff000027";
+pub static UUID_IDM_ACP_SYSTEM_CONFIG_PRIV_V1: &str = "00000000-0000-0000-0000-ffffff000028";
 
 // End of system ranges
-pub static STR_UUID_DOES_NOT_EXIST: &'static str = "00000000-0000-0000-0000-fffffffffffe";
-pub static STR_UUID_ANONYMOUS: &'static str = "00000000-0000-0000-0000-ffffffffffff";
+pub static STR_UUID_DOES_NOT_EXIST: &str = "00000000-0000-0000-0000-fffffffffffe";
+pub static STR_UUID_ANONYMOUS: &str = "00000000-0000-0000-0000-ffffffffffff";
 
 lazy_static! {
     pub static ref UUID_ADMIN: Uuid = Uuid::parse_str(STR_UUID_ADMIN).unwrap();
@@ -177,7 +154,7 @@ lazy_static! {
     pub static ref UUID_SYSTEM_CONFIG: Uuid = Uuid::parse_str(STR_UUID_SYSTEM_CONFIG).unwrap();
 }
 
-pub static JSON_ADMIN_V1: &'static str = r#"{
+pub static JSON_ADMIN_V1: &str = r#"{
     "valid": {
         "uuid": "00000000-0000-0000-0000-000000000000"
     },
@@ -191,7 +168,7 @@ pub static JSON_ADMIN_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_ADMIN_V1: &'static str = r#"{
+pub static JSON_IDM_ADMIN_V1: &str = r#"{
     "valid": {
         "uuid": "00000000-0000-0000-0000-000000000018"
     },
@@ -205,7 +182,7 @@ pub static JSON_IDM_ADMIN_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_ADMINS_V1: &'static str = r#"{
+pub static JSON_IDM_ADMINS_V1: &str = r#"{
     "valid": {
         "uuid": "00000000-0000-0000-0000-000000000001"
     },
@@ -219,7 +196,7 @@ pub static JSON_IDM_ADMINS_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_SYSTEM_ADMINS_V1: &'static str = r#"{
+pub static JSON_SYSTEM_ADMINS_V1: &str = r#"{
     "valid": {
         "uuid": "00000000-0000-0000-0000-000000000019"
     },
@@ -235,7 +212,7 @@ pub static JSON_SYSTEM_ADMINS_V1: &'static str = r#"{
 
 // groups
 // * People read managers
-pub static JSON_IDM_PEOPLE_READ_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_PEOPLE_READ_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_people_read_priv"],
@@ -245,7 +222,7 @@ pub static JSON_IDM_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * People write managers
-pub static JSON_IDM_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_PEOPLE_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_people_manage_priv"],
@@ -256,7 +233,7 @@ pub static JSON_IDM_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static JSON_IDM_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_PEOPLE_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_people_write_priv"],
@@ -267,7 +244,7 @@ pub static JSON_IDM_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 // * group write manager (no read, everyone has read via the anon, etc)
 // IDM_GROUP_CREATE_PRIV
-pub static JSON_IDM_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_GROUP_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_group_manage_priv"],
@@ -279,7 +256,7 @@ pub static JSON_IDM_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static JSON_IDM_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_GROUP_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_group_write_priv"],
@@ -291,7 +268,7 @@ pub static JSON_IDM_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * account read manager
-pub static JSON_IDM_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACCOUNT_READ_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_account_read_priv"],
@@ -303,7 +280,7 @@ pub static JSON_IDM_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * account write manager
-pub static JSON_IDM_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_account_manage_priv"],
@@ -314,7 +291,7 @@ pub static JSON_IDM_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static JSON_IDM_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACCOUNT_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_account_write_priv"],
@@ -324,7 +301,7 @@ pub static JSON_IDM_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * RADIUS servers
-pub static JSON_IDM_RADIUS_SERVERS_V1: &'static str = r#"{
+pub static JSON_IDM_RADIUS_SERVERS_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_radius_servers"],
@@ -333,7 +310,7 @@ pub static JSON_IDM_RADIUS_SERVERS_V1: &'static str = r#"{
     }
 }"#;
 // * high priv account read manager
-pub static JSON_IDM_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_HP_ACCOUNT_READ_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_hp_account_read_priv"],
@@ -345,7 +322,7 @@ pub static JSON_IDM_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * high priv account write manager
-pub static JSON_IDM_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_HP_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_hp_account_manage_priv"],
@@ -356,7 +333,7 @@ pub static JSON_IDM_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_hp_account_write_priv"],
@@ -368,7 +345,7 @@ pub static JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * Schema write manager
-pub static JSON_IDM_SCHEMA_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_SCHEMA_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_schema_manage_priv"],
@@ -380,7 +357,7 @@ pub static JSON_IDM_SCHEMA_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * ACP read/write manager
-pub static JSON_IDM_ACP_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_acp_manage_priv"],
@@ -390,7 +367,7 @@ pub static JSON_IDM_ACP_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_HP_GROUP_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_hp_group_manage_priv"],
@@ -399,7 +376,7 @@ pub static JSON_IDM_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
         "member": ["00000000-0000-0000-0000-000000000019"]
     }
 }"#;
-pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_hp_group_write_priv"],
@@ -410,7 +387,7 @@ pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static JSON_DOMAIN_ADMINS: &'static str = r#"{
+pub static JSON_DOMAIN_ADMINS: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["domain_admins"],
@@ -423,7 +400,7 @@ pub static JSON_DOMAIN_ADMINS: &'static str = r#"{
 }"#;
 
 // This must be the last group to init to include the UUID of the other high priv groups.
-pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
+pub static JSON_IDM_HIGH_PRIVILEGE_V1: &str = r#"{
     "attrs": {
         "class": ["group", "object"],
         "name": ["idm_high_privilege"],
@@ -454,7 +431,7 @@ pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
+pub static JSON_SYSTEM_INFO_V1: &str = r#"{
     "attrs": {
         "class": ["object", "system_info", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
@@ -463,7 +440,7 @@ pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_DOMAIN_INFO_V1: &'static str = r#"{
+pub static JSON_DOMAIN_INFO_V1: &str = r#"{
     "attrs": {
         "class": ["object", "domain_info", "system"],
         "name": ["domain_local"],
@@ -474,8 +451,8 @@ pub static JSON_DOMAIN_INFO_V1: &'static str = r#"{
 
 /*
 // Template acp
-pub static _UUID_IDM_ACP_XX_V1: &'static str = "00000000-0000-0000-0000-ffffff0000XX";
-pub static JSON_IDM_ACP_XX_V1: &'static str = r#"{
+pub static _UUID_IDM_ACP_XX_V1: &str = "00000000-0000-0000-0000-ffffff0000XX";
+pub static JSON_IDM_ACP_XX_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -516,7 +493,7 @@ pub static JSON_IDM_ACP_XX_V1: &'static str = r#"{
 }"#;
 */
 
-pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = r#"{
+pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
         "name": ["idm_admins_acp_recycle_search"],
@@ -532,7 +509,7 @@ pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &'static str = r#"{
+pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_modify"],
         "name": ["idm_admins_acp_revive"],
@@ -549,7 +526,7 @@ pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
+pub static JSON_IDM_SELF_ACP_READ_V1: &str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
         "name": ["idm_self_acp_read"],
@@ -575,7 +552,7 @@ pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_SELF_ACP_WRITE_V1: &'static str = r#"{
+pub static JSON_IDM_SELF_ACP_WRITE_V1: &str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_modify"],
         "name": ["idm_self_acp_write"],
@@ -596,7 +573,7 @@ pub static JSON_IDM_SELF_ACP_WRITE_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
+pub static JSON_IDM_ALL_ACP_READ_V1: &str = r#"{
     "state": null,
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
@@ -624,7 +601,7 @@ pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
 }"#;
 
 // 7 people read acp JSON_IDM_PEOPLE_READ_PRIV_V1
-pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -646,7 +623,7 @@ pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 8 people write acp JSON_IDM_PEOPLE_WRITE_PRIV_V1
-pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -671,7 +648,7 @@ pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 9 group write acp JSON_IDM_GROUP_WRITE_PRIV_V1
-pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -700,7 +677,7 @@ pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 10 account read acp JSON_IDM_ACCOUNT_READ_PRIV_V1
-pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -722,7 +699,7 @@ pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 11 account write acp JSON_IDM_ACCOUNT_WRITE_PRIV_V1
-pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -747,7 +724,7 @@ pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 12 service account create acp (only admins?)  JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1
-pub static JSON_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -779,7 +756,7 @@ pub static JSON_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 13 user (person) account create acp  JSON_IDM_PERSON_ACCOUNT_CREATE_PRIV_V1
-pub static JSON_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -814,7 +791,7 @@ pub static JSON_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
 // 14 radius read acp JSON_IDM_RADIUS_SERVERS_V1
 // The targetscope of this could change later to a "radius access" group or similar so we can add/remove
 //  users from having radius access easier.
-pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -836,7 +813,7 @@ pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
     }
 }"#;
 // 15 high priv account read JSON_IDM_HP_ACCOUNT_READ_PRIV_V1
-pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -858,7 +835,7 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 16 high priv account write JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1
-pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -884,7 +861,7 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 17 high priv group write --> JSON_IDM_HP_GROUP_WRITE_PRIV_V1 (12)
-pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -914,7 +891,7 @@ pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 18 schema write JSON_IDM_SCHEMA_WRITE_PRIV_V1
-pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -974,7 +951,7 @@ pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 19 acp read/write
-pub static JSON_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_ACP_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1066,7 +1043,7 @@ pub static JSON_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1124,7 +1101,7 @@ pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
 // 21 - anonymous / everyone schema read.
 
 // 22 - group create right
-pub static JSON_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_GROUP_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1155,7 +1132,7 @@ pub static JSON_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 23 - HP account manage
-pub static JSON_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1187,7 +1164,7 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 24 - hp group manage
-pub static JSON_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1217,7 +1194,7 @@ pub static JSON_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 28 - domain admins acp
-pub static JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1251,7 +1228,7 @@ pub static JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 28 - system config
-pub static JSON_IDM_ACP_SYSTEM_CONFIG_PRIV_V1: &'static str = r#"{
+pub static JSON_IDM_ACP_SYSTEM_CONFIG_PRIV_V1: &str = r#"{
     "attrs": {
         "class": [
             "object",
@@ -1281,7 +1258,7 @@ pub static JSON_IDM_ACP_SYSTEM_CONFIG_PRIV_V1: &'static str = r#"{
 }"#;
 
 // Anonymous should be the last opbject in the range here.
-pub static JSON_ANONYMOUS_V1: &'static str = r#"{
+pub static JSON_ANONYMOUS_V1: &str = r#"{
     "attrs": {
         "class": ["account", "object"],
         "name": ["anonymous"],
@@ -1295,7 +1272,7 @@ pub static JSON_ANONYMOUS_V1: &'static str = r#"{
 // Schema uuids start at 00000000-0000-0000-0000-ffff00000000
 
 // system supplementary
-pub static JSON_SCHEMA_ATTR_DISPLAYNAME: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_DISPLAYNAME: &str = r#"{
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000040"
     },
@@ -1329,7 +1306,7 @@ pub static JSON_SCHEMA_ATTR_DISPLAYNAME: &'static str = r#"{
       ]
     }
 }"#;
-pub static JSON_SCHEMA_ATTR_MAIL: &'static str = r#"
+pub static JSON_SCHEMA_ATTR_MAIL: &str = r#"
   {
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000041"
@@ -1365,7 +1342,7 @@ pub static JSON_SCHEMA_ATTR_MAIL: &'static str = r#"
     }
   }
 "#;
-pub static JSON_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = r#"
+pub static JSON_SCHEMA_ATTR_SSH_PUBLICKEY: &str = r#"
   {
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000042"
@@ -1399,7 +1376,7 @@ pub static JSON_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = r#"
     }
   }
 "#;
-pub static JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str = r#"
+pub static JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &str = r#"
   {
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000043"
@@ -1433,7 +1410,7 @@ pub static JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str = r#"
     }
   }
 "#;
-pub static JSON_SCHEMA_ATTR_LEGALNAME: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_LEGALNAME: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1463,7 +1440,7 @@ pub static JSON_SCHEMA_ATTR_LEGALNAME: &'static str = r#"{
       ]
     }
 }"#;
-pub static JSON_SCHEMA_ATTR_RADIUS_SECRET: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_RADIUS_SECRET: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1492,7 +1469,7 @@ pub static JSON_SCHEMA_ATTR_RADIUS_SECRET: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_SCHEMA_ATTR_DOMAIN_NAME: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_DOMAIN_NAME: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1522,7 +1499,7 @@ pub static JSON_SCHEMA_ATTR_DOMAIN_NAME: &'static str = r#"{
       ]
     }
 }"#;
-pub static JSON_SCHEMA_ATTR_DOMAIN_UUID: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_DOMAIN_UUID: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1552,7 +1529,7 @@ pub static JSON_SCHEMA_ATTR_DOMAIN_UUID: &'static str = r#"{
       ]
     }
 }"#;
-pub static JSON_SCHEMA_ATTR_DOMAIN_SSID: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_DOMAIN_SSID: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1581,7 +1558,7 @@ pub static JSON_SCHEMA_ATTR_DOMAIN_SSID: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_SCHEMA_ATTR_GIDNUMBER: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_GIDNUMBER: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1610,7 +1587,7 @@ pub static JSON_SCHEMA_ATTR_GIDNUMBER: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_SCHEMA_ATTR_BADLIST_PASSWORD: &'static str = r#"{
+pub static JSON_SCHEMA_ATTR_BADLIST_PASSWORD: &str = r#"{
     "attrs": {
       "class": [
         "object",
@@ -1639,7 +1616,7 @@ pub static JSON_SCHEMA_ATTR_BADLIST_PASSWORD: &'static str = r#"{
     }
 }"#;
 
-pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_PERSON: &str = r#"
   {
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000044"
@@ -1672,7 +1649,7 @@ pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
   }
 "#;
 
-pub static JSON_SCHEMA_CLASS_GROUP: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_GROUP: &str = r#"
   {
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000045"
@@ -1703,7 +1680,7 @@ pub static JSON_SCHEMA_CLASS_GROUP: &'static str = r#"
     }
   }
 "#;
-pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_ACCOUNT: &str = r#"
   {
     "attrs": {
       "class": [
@@ -1739,7 +1716,7 @@ pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
 //  domain_name <- should be the dns name?
 //  domain_ssid <- for radius
 //
-pub static JSON_SCHEMA_CLASS_DOMAIN_INFO: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_DOMAIN_INFO: &str = r#"
   {
     "attrs": {
       "class": [
@@ -1768,7 +1745,7 @@ pub static JSON_SCHEMA_CLASS_DOMAIN_INFO: &'static str = r#"
   }
 "#;
 
-pub static JSON_SCHEMA_CLASS_POSIXGROUP: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_POSIXGROUP: &str = r#"
   {
     "attrs": {
       "class": [
@@ -1792,7 +1769,7 @@ pub static JSON_SCHEMA_CLASS_POSIXGROUP: &'static str = r#"
   }
 "#;
 
-pub static JSON_SCHEMA_CLASS_POSIXACCOUNT: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_POSIXACCOUNT: &str = r#"
   {
     "attrs": {
       "class": [
@@ -1816,7 +1793,7 @@ pub static JSON_SCHEMA_CLASS_POSIXACCOUNT: &'static str = r#"
   }
 "#;
 
-pub static JSON_SCHEMA_CLASS_SYSTEM_CONFIG: &'static str = r#"
+pub static JSON_SCHEMA_CLASS_SYSTEM_CONFIG: &str = r#"
   {
     "attrs": {
       "class": [
@@ -1846,7 +1823,7 @@ pub static JSON_SCHEMA_CLASS_SYSTEM_CONFIG: &'static str = r#"
 
 // ============ TEST DATA ============
 #[cfg(test)]
-pub static JSON_TESTPERSON1: &'static str = r#"{
+pub static JSON_TESTPERSON1: &str = r#"{
     "valid": null,
     "state": null,
     "attrs": {
@@ -1857,7 +1834,7 @@ pub static JSON_TESTPERSON1: &'static str = r#"{
 }"#;
 
 #[cfg(test)]
-pub static JSON_TESTPERSON2: &'static str = r#"{
+pub static JSON_TESTPERSON2: &str = r#"{
     "valid": null,
     "state": null,
     "attrs": {

--- a/kanidmd/src/lib/constants/system_config.rs
+++ b/kanidmd/src/lib/constants/system_config.rs
@@ -1,5 +1,5 @@
 // This is seperated because the password badlist section may become very long
-pub static JSON_SYSTEM_CONFIG_V1: &'static str = r####"{
+pub static JSON_SYSTEM_CONFIG_V1: &str = r####"{
     "attrs": {
         "class": ["object", "system_config", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000027"],

--- a/kanidmd/src/lib/core.rs
+++ b/kanidmd/src/lib/core.rs
@@ -199,11 +199,7 @@ fn json_rest_event_get(
 
     // TODO: I think we'll need to change this to take an internal filter
     // type that we send to the qs.
-    let obj = InternalSearchMessage {
-        uat: uat,
-        filter: filter,
-        attrs: attrs,
-    };
+    let obj = InternalSearchMessage { uat, filter, attrs };
 
     let res = state.qe_r.send(obj).from_err().and_then(|res| match res {
         Ok(event_result) => Ok(HttpResponse::Ok().json(event_result)),
@@ -224,11 +220,7 @@ fn json_rest_event_get_id(
 
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(path.as_str())));
 
-    let obj = InternalSearchMessage {
-        uat: uat,
-        filter: filter,
-        attrs: attrs,
-    };
+    let obj = InternalSearchMessage { uat, filter, attrs };
 
     let res = state.qe_r.send(obj).from_err().and_then(|res| match res {
         Ok(mut event_result) => {
@@ -251,10 +243,7 @@ fn json_rest_event_delete_id(
 
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(path.as_str())));
 
-    let obj = InternalDeleteMessage {
-        uat: uat,
-        filter: filter,
-    };
+    let obj = InternalDeleteMessage { uat, filter };
 
     let res = state.qe_w.send(obj).from_err().and_then(|res| match res {
         Ok(_) => {
@@ -279,8 +268,8 @@ fn json_rest_event_get_id_attr(
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(id.as_str())));
 
     let obj = InternalSearchMessage {
-        uat: uat,
-        filter: filter,
+        uat,
+        filter,
         attrs: Some(vec![attr.clone()]),
     };
 
@@ -379,11 +368,11 @@ fn json_rest_event_post_id_attr(
                 match r_obj {
                     Ok(obj) => {
                         let m_obj = AppendAttributeMessage {
-                            uat: uat,
+                            uat,
                             uuid_or_name: id,
-                            attr: attr,
+                            attr,
                             values: obj,
-                            filter: filter,
+                            filter,
                         };
                         // Add a msg here
                         let res = state.qe_w.send(m_obj).from_err().and_then(|res| match res {
@@ -429,11 +418,11 @@ fn json_rest_event_put_id_attr(
                 match r_obj {
                     Ok(obj) => {
                         let m_obj = SetAttributeMessage {
-                            uat: uat,
+                            uat,
                             uuid_or_name: id,
-                            attr: attr,
+                            attr,
                             values: obj,
-                            filter: filter,
+                            filter,
                         };
                         let res = state.qe_w.send(m_obj).from_err().and_then(|res| match res {
                             Ok(_) => Ok(HttpResponse::Ok().json(())),
@@ -463,17 +452,14 @@ fn json_rest_event_delete_id_attr(
     // TODO: Attempt to get an option Vec<String> here?
 
     let obj = PurgeAttributeMessage {
-        uat: uat,
+        uat,
         uuid_or_name: id,
-        attr: attr,
-        filter: filter,
+        attr,
+        filter,
     };
 
     let res = state.qe_w.send(obj).from_err().and_then(|res| match res {
-        Ok(event_result) => {
-            // Only send back the first result, or None
-            Ok(HttpResponse::Ok().json(event_result))
-        }
+        Ok(()) => Ok(HttpResponse::Ok().json(())),
         Err(e) => Ok(operation_error_to_response(e)),
     });
 
@@ -576,8 +562,8 @@ fn schema_attributetype_get_id(
     ]));
 
     let obj = InternalSearchMessage {
-        uat: uat,
-        filter: filter,
+        uat,
+        filter,
         attrs: None,
     };
 
@@ -611,8 +597,8 @@ fn schema_classtype_get_id(
     ]));
 
     let obj = InternalSearchMessage {
-        uat: uat,
-        filter: filter,
+        uat,
+        filter,
         attrs: None,
     };
 
@@ -714,7 +700,7 @@ fn account_get_id_ssh_pubkeys(
     let id = path.into_inner();
 
     let obj = InternalSshKeyReadMessage {
-        uat: uat,
+        uat,
         uuid_or_name: id,
     };
 
@@ -753,10 +739,10 @@ fn account_post_id_ssh_pubkey(
                 match r_obj {
                     Ok((tag, key)) => {
                         let m_obj = InternalSshKeyCreateMessage {
-                            uat: uat,
+                            uat,
                             uuid_or_name: id,
-                            tag: tag,
-                            key: key,
+                            tag,
+                            key,
                             filter: filter_all!(f_eq("class", PartialValue::new_class("account"))),
                         };
                         // Add a msg here
@@ -787,9 +773,9 @@ fn account_get_id_ssh_pubkey_tag(
     let (id, tag) = path.into_inner();
 
     let obj = InternalSshKeyTagReadMessage {
-        uat: uat,
+        uat,
         uuid_or_name: id,
-        tag: tag,
+        tag,
     };
 
     let res = state.qe_r.send(obj).from_err().and_then(|res| match res {
@@ -814,7 +800,7 @@ fn account_delete_id_ssh_pubkey_tag(
     let (id, tag) = path.into_inner();
 
     let obj = RemoveAttributeValueMessage {
-        uat: uat,
+        uat,
         uuid_or_name: id,
         attr: "ssh_publickey".to_string(),
         value: tag,
@@ -822,7 +808,7 @@ fn account_delete_id_ssh_pubkey_tag(
     };
 
     let res = state.qe_w.send(obj).from_err().and_then(|res| match res {
-        Ok(event_result) => Ok(HttpResponse::Ok().json(event_result)),
+        Ok(()) => Ok(HttpResponse::Ok().json(())),
         Err(e) => Ok(operation_error_to_response(e)),
     });
 
@@ -837,7 +823,7 @@ fn account_get_id_radius(
     let id = path.into_inner();
 
     let obj = InternalRadiusReadMessage {
-        uat: uat,
+        uat,
         uuid_or_name: id,
     };
 
@@ -888,7 +874,7 @@ fn account_get_id_radius_token(
     let id = path.into_inner();
 
     let obj = InternalRadiusTokenReadMessage {
-        uat: uat,
+        uat,
         uuid_or_name: id,
     };
 
@@ -1401,7 +1387,7 @@ pub fn verify_server_core(config: Configuration) {
 
     debug!("{}", audit);
 
-    if r.len() == 0 {
+    if r.is_empty() {
         info!("Verification passed!");
         std::process::exit(0);
     } else {
@@ -1547,8 +1533,7 @@ pub fn create_server_core(config: Configuration) {
         config.threads,
     );
     // Start the write thread
-    let server_write_addr =
-        QueryServerWriteV1::start(log_addr.clone(), qs.clone(), idms_arc.clone());
+    let server_write_addr = QueryServerWriteV1::start(log_addr, qs, idms_arc);
 
     // Setup timed events associated to the write thread
     let _int_addr = IntervalActor::new(server_write_addr.clone()).start();
@@ -1557,14 +1542,14 @@ pub fn create_server_core(config: Configuration) {
     let max_size = config.maximum_request;
     let secure_cookies = config.secure_cookies;
     // domain will come from the qs now!
-    let cookie_key: [u8; 32] = config.cookie_key.clone();
+    let cookie_key: [u8; 32] = config.cookie_key;
 
     // start the web server
     let aws_builder = actix_web::server::new(move || {
         App::with_state(AppState {
             qe_r: server_read_addr.clone(),
             qe_w: server_write_addr.clone(),
-            max_size: max_size,
+            max_size,
         })
         // Connect all our end points here.
         .middleware(middleware::Logger::default())

--- a/kanidmd/src/lib/credential.rs
+++ b/kanidmd/src/lib/credential.rs
@@ -139,8 +139,8 @@ impl TryFrom<DbCredV1> for Credential {
 
         Ok(Credential {
             password: v_password,
-            claims: claims,
-            uuid: uuid,
+            claims,
+            uuid,
         })
     }
 }
@@ -158,7 +158,7 @@ impl Credential {
         Credential {
             password: Some(Password::new(cleartext)),
             claims: self.claims.clone(),
-            uuid: self.uuid.clone(),
+            uuid: self.uuid,
         }
     }
 
@@ -181,7 +181,7 @@ impl Credential {
                 None => None,
             },
             claims: self.claims.clone(),
-            uuid: self.uuid.clone(),
+            uuid: self.uuid,
         }
     }
 

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -130,8 +130,8 @@ impl Account {
             displayname: self.name.clone(),
             uuid: self.uuid.to_hyphenated_ref().to_string(),
             application: None,
-            groups: self.groups.iter().map(|g| g.into_proto()).collect(),
-            claims: claims.iter().map(|c| c.into_proto()).collect(),
+            groups: self.groups.iter().map(|g| g.to_proto()).collect(),
+            claims: claims.iter().map(|c| c.to_proto()).collect(),
         })
     }
 

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -49,7 +49,7 @@ impl TryFrom<&Credential> for CredHandler {
 }
 
 impl CredHandler {
-    pub fn validate(&mut self, creds: &Vec<AuthCredential>) -> CredState {
+    pub fn validate(&mut self, creds: &[AuthCredential]) -> CredState {
         match self {
             CredHandler::Denied => {
                 // Sad trombone.
@@ -184,10 +184,10 @@ impl AuthSession {
         let finished: bool = handler.is_denied();
 
         AuthSession {
-            account: account,
-            handler: handler,
-            appid: appid,
-            finished: finished,
+            account,
+            handler,
+            appid,
+            finished,
         }
     }
 
@@ -195,7 +195,7 @@ impl AuthSession {
     pub fn validate_creds(
         &mut self,
         au: &mut AuditScope,
-        creds: &Vec<AuthCredential>,
+        creds: &[AuthCredential],
     ) -> Result<AuthState, OperationError> {
         if self.finished {
             return Err(OperationError::InvalidAuthState(

--- a/kanidmd/src/lib/idm/claim.rs
+++ b/kanidmd/src/lib/idm/claim.rs
@@ -14,7 +14,7 @@ impl Claim {
     }
     */
 
-    pub fn into_proto(&self) -> ProtoClaim {
+    pub fn to_proto(&self) -> ProtoClaim {
         unimplemented!();
     }
 }

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -19,7 +19,7 @@ impl PasswordChangeEvent {
     pub fn new_internal(target: &Uuid, cleartext: &str, appid: Option<&str>) -> Self {
         PasswordChangeEvent {
             event: Event::from_internal(),
-            target: target.clone(),
+            target: *target,
             cleartext: cleartext.to_string(),
             appid: appid.map(|v| v.to_string()),
         }
@@ -31,7 +31,7 @@ impl PasswordChangeEvent {
         msg: IdmAccountSetPasswordMessage,
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, msg.uat)?;
-        let u = e.get_uuid().ok_or(OperationError::InvalidState)?.clone();
+        let u = *e.get_uuid().ok_or(OperationError::InvalidState)?;
 
         Ok(PasswordChangeEvent {
             event: e,
@@ -53,9 +53,9 @@ impl PasswordChangeEvent {
 
         Ok(PasswordChangeEvent {
             event: e,
-            target: target,
-            cleartext: cleartext,
-            appid: appid,
+            target,
+            cleartext,
+            appid,
         })
     }
 }
@@ -79,8 +79,8 @@ impl GeneratePasswordEvent {
 
         Ok(GeneratePasswordEvent {
             event: e,
-            target: target,
-            appid: appid,
+            target,
+            appid,
         })
     }
 }
@@ -100,20 +100,14 @@ impl RegenerateRadiusSecretEvent {
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, uat)?;
 
-        Ok(RegenerateRadiusSecretEvent {
-            event: e,
-            target: target,
-        })
+        Ok(RegenerateRadiusSecretEvent { event: e, target })
     }
 
     #[cfg(test)]
     pub fn new_internal(target: Uuid) -> Self {
         let e = Event::from_internal();
 
-        RegenerateRadiusSecretEvent {
-            event: e,
-            target: target,
-        }
+        RegenerateRadiusSecretEvent { event: e, target }
     }
 }
 
@@ -132,19 +126,13 @@ impl RadiusAuthTokenEvent {
     ) -> Result<Self, OperationError> {
         let e = Event::from_ro_uat(audit, qs, uat)?;
 
-        Ok(RadiusAuthTokenEvent {
-            event: e,
-            target: target,
-        })
+        Ok(RadiusAuthTokenEvent { event: e, target })
     }
 
     #[cfg(test)]
     pub fn new_internal(target: Uuid) -> Self {
         let e = Event::from_internal();
 
-        RadiusAuthTokenEvent {
-            event: e,
-            target: target,
-        }
+        RadiusAuthTokenEvent { event: e, target }
     }
 }

--- a/kanidmd/src/lib/idm/group.rs
+++ b/kanidmd/src/lib/idm/group.rs
@@ -37,7 +37,7 @@ macro_rules! try_from_account_e {
                 })?;
                 // Now convert the group entries to groups.
                 let groups: Result<Vec<_>, _> =
-                    ges.into_iter().map(|e| Group::try_from_entry(e)).collect();
+                    ges.into_iter().map(Group::try_from_entry).collect();
                 groups.map_err(|e| {
                     // log
                     e
@@ -87,22 +87,16 @@ impl Group {
         }
 
         // Now extract our needed attributes
-        let name =
-            value
-                .get_ava_single_string("name")
-                .ok_or(OperationError::InvalidAccountState(
-                    "Missing attribute: name".to_string(),
-                ))?;
+        let name = value.get_ava_single_string("name").ok_or_else(|| {
+            OperationError::InvalidAccountState("Missing attribute: name".to_string())
+        })?;
 
-        let uuid = value.get_uuid().clone();
+        let uuid = *value.get_uuid();
 
-        Ok(Group {
-            name: name,
-            uuid: uuid,
-        })
+        Ok(Group { name, uuid })
     }
 
-    pub fn into_proto(&self) -> ProtoGroup {
+    pub fn to_proto(&self) -> ProtoGroup {
         ProtoGroup {
             name: self.name.clone(),
             uuid: self.uuid.to_hyphenated_ref().to_string(),

--- a/kanidmd/src/lib/idm/macros.rs
+++ b/kanidmd/src/lib/idm/macros.rs
@@ -13,7 +13,7 @@ macro_rules! entry_str_to_account {
             .expect("Failed to munge spn from name!");
         e.set_avas("spn", vec![spn]);
 
-        let e = unsafe { e.to_valid_new().to_valid_committed() };
+        let e = unsafe { e.into_valid_new().into_valid_committed() };
 
         Account::try_from_entry_no_groups(e).expect("Account conversion failure")
     }};

--- a/kanidmd/src/lib/idm/radius.rs
+++ b/kanidmd/src/lib/idm/radius.rs
@@ -35,32 +35,29 @@ impl RadiusAccount {
 
         let radius_secret = value
             .get_ava_single_radiuscred("radius_secret")
-            .ok_or(OperationError::InvalidAccountState(
-                "Missing attribute: radius_secret".to_string(),
-            ))?
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: radius_secret".to_string())
+            })?
             .to_string();
 
-        let name =
-            value
-                .get_ava_single_string("name")
-                .ok_or(OperationError::InvalidAccountState(
-                    "Missing attribute: name".to_string(),
-                ))?;
+        let name = value.get_ava_single_string("name").ok_or_else(|| {
+            OperationError::InvalidAccountState("Missing attribute: name".to_string())
+        })?;
 
-        let uuid = value.get_uuid().clone();
+        let uuid = *value.get_uuid();
 
-        let displayname = value.get_ava_single_string("displayname").ok_or(
-            OperationError::InvalidAccountState("Missing attribute: displayname".to_string()),
-        )?;
+        let displayname = value.get_ava_single_string("displayname").ok_or_else(|| {
+            OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
+        })?;
 
         let groups = Group::try_from_account_entry_red_ro(au, &value, qs)?;
 
         Ok(RadiusAccount {
-            name: name,
-            uuid: uuid,
-            displayname: displayname,
-            groups: groups,
-            radius_secret: radius_secret,
+            name,
+            uuid,
+            displayname,
+            groups,
+            radius_secret,
         })
     }
 
@@ -72,7 +69,7 @@ impl RadiusAccount {
             displayname: self.displayname.clone(),
             uuid: self.uuid.to_hyphenated_ref().to_string(),
             secret: self.radius_secret.clone(),
-            groups: self.groups.iter().map(|g| g.into_proto()).collect(),
+            groups: self.groups.iter().map(|g| g.to_proto()).collect(),
         })
     }
 }

--- a/kanidmd/src/lib/interval.rs
+++ b/kanidmd/src/lib/interval.rs
@@ -12,7 +12,7 @@ pub struct IntervalActor {
 
 impl IntervalActor {
     pub fn new(server: actix::Addr<QueryServerWriteV1>) -> Self {
-        IntervalActor { server: server }
+        IntervalActor { server }
     }
 
     // Define new events here

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -9,7 +9,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 
-// This has to be before be so the import order works
+// This has to be before 'be' so the import order works
 #[macro_use]
 mod macros;
 mod crypto;

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -131,7 +131,7 @@ macro_rules! filter_valid {
         use crate::filter::{Filter, FilterInvalid};
         let f: Filter<FilterInvalid> = Filter::new($fc);
         // Create a resolved filter, via the most unsafe means possible!
-        f.to_valid()
+        f.into_valid()
     }};
 }
 
@@ -147,7 +147,7 @@ macro_rules! filter_resolved {
         use crate::filter::{Filter, FilterInvalid};
         let f: Filter<FilterInvalid> = Filter::new($fc);
         // Create a resolved filter, via the most unsafe means possible!
-        f.to_valid_resolved()
+        f.into_valid_resolved()
     }};
 }
 

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -56,7 +56,7 @@ impl Modify {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ModifyList<VALID> {
     valid: VALID,
     // The order of this list matters. Each change must be done in order.
@@ -83,7 +83,7 @@ impl ModifyList<ModifyInvalid> {
     pub fn new_list(mods: Vec<Modify>) -> Self {
         ModifyList {
             valid: ModifyInvalid,
-            mods: mods,
+            mods,
         }
     }
 
@@ -135,7 +135,7 @@ impl ModifyList<ModifyInvalid> {
         */
 
         let res: Result<Vec<Modify>, _> = (&self.mods)
-            .into_iter()
+            .iter()
             .map(|m| match m {
                 Modify::Present(attr, value) => {
                     let attr_norm = schema.normalise_attr_name(attr);
@@ -178,7 +178,7 @@ impl ModifyList<ModifyInvalid> {
     }
 
     #[cfg(test)]
-    pub unsafe fn to_valid(self) -> ModifyList<ModifyValid> {
+    pub unsafe fn into_valid(self) -> ModifyList<ModifyValid> {
         ModifyList {
             valid: ModifyValid,
             mods: self.mods,
@@ -191,7 +191,7 @@ impl ModifyList<ModifyValid> {
     pub unsafe fn new_valid_list(mods: Vec<Modify>) -> Self {
         ModifyList {
             valid: ModifyValid,
-            mods: mods,
+            mods,
         }
     }
 

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -21,7 +21,7 @@ pub struct AttrUnique;
 
 fn get_cand_attr_set<VALID, STATE>(
     au: &mut AuditScope,
-    cand: &Vec<Entry<VALID, STATE>>,
+    cand: &[Entry<VALID, STATE>],
     attr: &str,
 ) -> Result<BTreeMap<PartialValue, PartialValue>, OperationError> {
     let mut cand_attr: BTreeMap<PartialValue, PartialValue> = BTreeMap::new();
@@ -73,7 +73,7 @@ fn get_cand_attr_set<VALID, STATE>(
 fn enforce_unique<STATE>(
     au: &mut AuditScope,
     qs: &mut QueryServerWriteTransaction,
-    cand: &Vec<Entry<EntryInvalid, STATE>>,
+    cand: &[Entry<EntryInvalid, STATE>],
     attr: &str,
 ) -> Result<(), OperationError> {
     debug!("{:?}", attr);
@@ -85,7 +85,7 @@ fn enforce_unique<STATE>(
     debug!("{:?}", cand_attr);
 
     // No candidates to check!
-    if cand_attr.len() == 0 {
+    if cand_attr.is_empty() {
         return Ok(());
     }
 
@@ -110,7 +110,7 @@ fn enforce_unique<STATE>(
     let conflict_cand = try_audit!(au, qs.internal_search(au, filt_in));
 
     // If all okay, okay!
-    if conflict_cand.len() > 0 {
+    if !conflict_cand.is_empty() {
         return Err(OperationError::Plugin(PluginError::AttrUnique(
             "duplicate value detected".to_string(),
         )));

--- a/kanidmd/src/lib/plugins/memberof.rs
+++ b/kanidmd/src/lib/plugins/memberof.rs
@@ -111,7 +111,7 @@ fn apply_memberof(
             .iter()
             .map(|g| {
                 // These are turned into reference values.
-                Value::new_refer(g.get_uuid().clone())
+                Value::new_refer(*g.get_uuid())
             })
             .collect();
 
@@ -124,15 +124,12 @@ fn apply_memberof(
             .iter()
             .map(|g| {
                 // TODO #61: This could be more effecient
-                let mut v = vec![Value::new_refer(g.get_uuid().clone())];
-                match g.get_ava("memberof") {
-                    Some(mos) => {
-                        for mo in mos {
-                            // This is cloning the existing reference values
-                            v.push(mo.clone())
-                        }
+                let mut v = vec![Value::new_refer(*g.get_uuid())];
+                if let Some(mos) = g.get_ava("memberof") {
+                    for mo in mos {
+                        // This is cloning the existing reference values
+                        v.push(mo.clone())
                     }
-                    None => {}
                 }
                 v
             })
@@ -178,7 +175,7 @@ fn apply_memberof(
             au,
             qs.internal_modify(
                 au,
-                filter!(f_eq("uuid", PartialValue::new_uuid(a_uuid.clone()))),
+                filter!(f_eq("uuid", PartialValue::new_uuid(*a_uuid))),
                 modlist,
             )
         );
@@ -198,7 +195,7 @@ impl Plugin for MemberOf {
     fn post_create(
         au: &mut AuditScope,
         qs: &mut QueryServerWriteTransaction,
-        cand: &Vec<Entry<EntryValid, EntryCommitted>>,
+        cand: &[Entry<EntryValid, EntryCommitted>],
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
         //
@@ -211,8 +208,8 @@ impl Plugin for MemberOf {
     fn post_modify(
         au: &mut AuditScope,
         qs: &mut QueryServerWriteTransaction,
-        pre_cand: &Vec<Entry<EntryValid, EntryCommitted>>,
-        cand: &Vec<Entry<EntryValid, EntryCommitted>>,
+        pre_cand: &[Entry<EntryValid, EntryCommitted>],
+        cand: &[Entry<EntryValid, EntryCommitted>],
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
         // The condition here is critical - ONLY trigger on entries where changes occur!
@@ -281,7 +278,7 @@ impl Plugin for MemberOf {
     fn post_delete(
         au: &mut AuditScope,
         qs: &mut QueryServerWriteTransaction,
-        cand: &Vec<Entry<EntryValid, EntryCommitted>>,
+        cand: &[Entry<EntryValid, EntryCommitted>],
         _ce: &DeleteEvent,
     ) -> Result<(), OperationError> {
         //
@@ -314,7 +311,7 @@ impl Plugin for MemberOf {
             // searcch direct memberships of live groups.
             let filt_in = filter!(f_and!([
                 f_eq("class", PartialValue::new_class("group")),
-                f_eq("member", PartialValue::new_refer(e.get_uuid().clone()))
+                f_eq("member", PartialValue::new_refer(*e.get_uuid()))
             ]));
 
             let direct_memberof = match qs

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -52,7 +52,7 @@ impl Plugin for Protected {
         au: &mut AuditScope,
         _qs: &mut QueryServerWriteTransaction,
         // List of what we will commit that is valid?
-        cand: &Vec<Entry<EntryValid, EntryNew>>,
+        cand: &[Entry<EntryValid, EntryNew>],
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
         if ce.event.is_internal() {
@@ -149,7 +149,7 @@ impl Plugin for Protected {
 
         audit_log!(au, "class: system -> {}", system_pres);
         // No system types being altered, return.
-        if system_pres == false {
+        if !system_pres {
             return Ok(());
         }
 

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -152,8 +152,8 @@ impl Plugin for Spn {
         au: &mut AuditScope,
         qs: &mut QueryServerWriteTransaction,
         // List of what we modified that was valid?
-        pre_cand: &Vec<Entry<EntryValid, EntryCommitted>>,
-        cand: &Vec<Entry<EntryValid, EntryCommitted>>,
+        pre_cand: &[Entry<EntryValid, EntryCommitted>],
+        cand: &[Entry<EntryValid, EntryCommitted>],
         _ce: &ModifyEvent,
     ) -> Result<(), OperationError> {
         // On modify, if changing domain_name on UUID_DOMAIN_INFO
@@ -166,15 +166,12 @@ impl Plugin for Spn {
                 .fold(None, |acc, (post, pre)| {
                     if acc.is_some() {
                         acc
+                    } else if post.attribute_value_pres("uuid", &PV_UUID_DOMAIN_INFO)
+                        && post.get_ava_single("domain_name") != pre.get_ava_single("domain_name")
+                    {
+                        post.get_ava_single("domain_name")
                     } else {
-                        if post.attribute_value_pres("uuid", &PV_UUID_DOMAIN_INFO)
-                            && post.get_ava_single("domain_name")
-                                != pre.get_ava_single("domain_name")
-                        {
-                            post.get_ava_single("domain_name")
-                        } else {
-                            acc
-                        }
+                        acc
                     }
                 });
 

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -53,41 +53,35 @@ impl SchemaAttribute {
         }
 
         // uuid
-        let uuid = value.get_uuid().clone();
+        let uuid = *value.get_uuid();
 
         // name
-        let name =
-            try_audit!(
-                audit,
-                value.get_ava_single_string("attributename").ok_or(
-                    OperationError::InvalidSchemaState("missing attributename".to_string())
-                )
-            );
+        let name = try_audit!(
+            audit,
+            value.get_ava_single_string("attributename").ok_or_else(|| {
+                OperationError::InvalidSchemaState("missing attributename".to_string())
+            })
+        );
         // description
-        let description =
-            try_audit!(
-                audit,
-                value.get_ava_single_string("description").ok_or(
-                    OperationError::InvalidSchemaState("missing description".to_string())
-                )
-            );
+        let description = try_audit!(
+            audit,
+            value.get_ava_single_string("description").ok_or_else(|| {
+                OperationError::InvalidSchemaState("missing description".to_string())
+            })
+        );
 
         // multivalue
         let multivalue = try_audit!(
             audit,
-            value
-                .get_ava_single_bool("multivalue")
-                .ok_or(OperationError::InvalidSchemaState(
-                    "missing multivalue".to_string()
-                ))
+            value.get_ava_single_bool("multivalue").ok_or_else(|| {
+                OperationError::InvalidSchemaState("missing multivalue".to_string())
+            })
         );
         let unique = try_audit!(
             audit,
             value
                 .get_ava_single_bool("unique")
-                .ok_or(OperationError::InvalidSchemaState(
-                    "missing unique".to_string()
-                ))
+                .ok_or_else(|| OperationError::InvalidSchemaState("missing unique".to_string()))
         );
         // index vec
         // even if empty, it SHOULD be present ... (is that value to put an empty set?)
@@ -96,10 +90,7 @@ impl SchemaAttribute {
             audit,
             value
                 .get_ava_opt_index("index")
-                .and_then(|vv: Vec<&IndexType>| Ok(vv
-                    .into_iter()
-                    .map(|v: &IndexType| v.clone())
-                    .collect()))
+                .and_then(|vv: Vec<&IndexType>| Ok(vv.into_iter().cloned().collect()))
                 .map_err(|_| OperationError::InvalidSchemaState("Invalid index".to_string()))
         );
         // syntax type
@@ -107,20 +98,18 @@ impl SchemaAttribute {
             audit,
             value
                 .get_ava_single_syntax("syntax")
-                .and_then(|s: &SyntaxType| Some(s.clone()))
-                .ok_or(OperationError::InvalidSchemaState(
-                    "missing syntax".to_string()
-                ))
+                .cloned()
+                .ok_or_else(|| OperationError::InvalidSchemaState("missing syntax".to_string()))
         );
 
         Ok(SchemaAttribute {
-            name: name,
-            uuid: uuid,
-            description: description,
-            multivalue: multivalue,
-            unique: unique,
-            index: index,
-            syntax: syntax,
+            name,
+            uuid,
+            description,
+            multivalue,
+            unique,
+            index,
+            syntax,
         })
     }
 
@@ -290,7 +279,7 @@ impl SchemaAttribute {
     pub fn validate_ava(&self, ava: &BTreeSet<Value>) -> Result<(), SchemaError> {
         debug!("Checking for valid {:?} -> {:?}", self.name, ava);
         // Check multivalue
-        if self.multivalue == false && ava.len() > 1 {
+        if !self.multivalue && ava.len() > 1 {
             debug!("Ava len > 1 on single value attribute!");
             return Err(SchemaError::InvalidAttributeSyntax);
         };
@@ -425,58 +414,45 @@ impl SchemaClass {
         }
 
         // uuid
-        let uuid = value.get_uuid().clone();
+        let uuid = *value.get_uuid();
 
         // name
         let name = try_audit!(
             audit,
             value
                 .get_ava_single_string("classname")
-                .ok_or(OperationError::InvalidSchemaState(
-                    "missing classname".to_string()
-                ))
+                .ok_or_else(|| OperationError::InvalidSchemaState("missing classname".to_string()))
         );
         // description
-        let description =
-            try_audit!(
-                audit,
-                value.get_ava_single_string("description").ok_or(
-                    OperationError::InvalidSchemaState("missing description".to_string())
-                )
-            );
+        let description = try_audit!(
+            audit,
+            value.get_ava_single_string("description").ok_or_else(|| {
+                OperationError::InvalidSchemaState("missing description".to_string())
+            })
+        );
 
         // These are all "optional" lists of strings.
-        let systemmay =
-            value
-                .get_ava_opt_string("systemmay")
-                .ok_or(OperationError::InvalidSchemaState(
-                    "Missing or invalid systemmay".to_string(),
-                ))?;
-        let systemmust =
-            value
-                .get_ava_opt_string("systemmust")
-                .ok_or(OperationError::InvalidSchemaState(
-                    "Missing or invalid systemmust".to_string(),
-                ))?;
-        let may = value
-            .get_ava_opt_string("may")
-            .ok_or(OperationError::InvalidSchemaState(
-                "Missing or invalid may".to_string(),
-            ))?;
-        let must = value
-            .get_ava_opt_string("must")
-            .ok_or(OperationError::InvalidSchemaState(
-                "Missing or invalid must".to_string(),
-            ))?;
+        let systemmay = value.get_ava_opt_string("systemmay").ok_or_else(|| {
+            OperationError::InvalidSchemaState("Missing or invalid systemmay".to_string())
+        })?;
+        let systemmust = value.get_ava_opt_string("systemmust").ok_or_else(|| {
+            OperationError::InvalidSchemaState("Missing or invalid systemmust".to_string())
+        })?;
+        let may = value.get_ava_opt_string("may").ok_or_else(|| {
+            OperationError::InvalidSchemaState("Missing or invalid may".to_string())
+        })?;
+        let must = value.get_ava_opt_string("must").ok_or_else(|| {
+            OperationError::InvalidSchemaState("Missing or invalid must".to_string())
+        })?;
 
         Ok(SchemaClass {
-            name: name,
-            uuid: uuid,
-            description: description,
-            systemmay: systemmay,
-            systemmust: systemmust,
-            may: may,
-            must: must,
+            name,
+            uuid,
+            description,
+            systemmay,
+            systemmust,
+            may,
+            must,
         })
     }
 }
@@ -1188,7 +1164,7 @@ impl SchemaInner {
             );
 
             let r = s.validate(&mut au);
-            if r.len() == 0 {
+            if r.is_empty() {
                 s.reload_idxmeta();
                 Ok(s)
             } else {
@@ -1289,7 +1265,7 @@ impl SchemaInner {
             Some(a_schema) => Ok(a_schema.multivalue),
             None => {
                 debug!("Attribute does not exist?!");
-                return Err(SchemaError::InvalidAttribute);
+                Err(SchemaError::InvalidAttribute)
             }
         }
     }
@@ -1352,12 +1328,12 @@ impl<'a> SchemaWriteTransaction<'a> {
             .inner
             .attributes
             .values()
-            .map(|a| Entry::<EntryValid, EntryNew>::from(a))
+            .map(Entry::<EntryValid, EntryNew>::from)
             .chain(
                 self.inner
                     .classes
                     .values()
-                    .map(|c| Entry::<EntryValid, EntryNew>::from(c)),
+                    .map(Entry::<EntryValid, EntryNew>::from),
             )
             .collect();
         r
@@ -1431,7 +1407,7 @@ mod tests {
             $type:ty
         ) => {{
             let e1: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str($e);
-            let ev1 = unsafe { e1.to_valid_committed() };
+            let ev1 = unsafe { e1.into_valid_committed() };
 
             let r1 = <$type>::try_from($audit, &ev1);
             assert!(r1.is_ok());
@@ -1445,7 +1421,7 @@ mod tests {
             $type:ty
         ) => {{
             let e1: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str($e);
-            let ev1 = unsafe { e1.to_valid_committed() };
+            let ev1 = unsafe { e1.into_valid_committed() };
 
             let r1 = <$type>::try_from($audit, &ev1);
             assert!(r1.is_err());
@@ -1985,7 +1961,7 @@ mod tests {
             }
         }"#,
             )
-            .to_valid_new()
+            .into_valid_new()
         };
 
         let e_valid = e_test.validate(&schema).expect("validation failure");

--- a/kanidmd/src/lib/utils.rs
+++ b/kanidmd/src/lib/utils.rs
@@ -14,16 +14,16 @@ pub fn uuid_to_gid_u32(u: &Uuid) -> u32 {
     u32::from_be_bytes(x)
 }
 
-fn uuid_from_u64_u32(a: u64, b: u32, sid: &SID) -> Uuid {
+fn uuid_from_u64_u32(a: u64, b: u32, sid: SID) -> Uuid {
     let mut v: Vec<u8> = Vec::with_capacity(16);
     v.extend_from_slice(&a.to_be_bytes());
     v.extend_from_slice(&b.to_be_bytes());
-    v.extend_from_slice(sid);
+    v.extend_from_slice(&sid);
 
     Builder::from_slice(v.as_slice()).unwrap().build()
 }
 
-pub fn uuid_from_duration(d: Duration, sid: &SID) -> Uuid {
+pub fn uuid_from_duration(d: Duration, sid: SID) -> Uuid {
     uuid_from_u64_u32(d.as_secs(), d.subsec_nanos(), sid)
 }
 
@@ -44,7 +44,7 @@ pub fn readable_password_from_random() -> String {
 }
 
 #[allow(dead_code)]
-pub fn uuid_from_now(sid: &SID) -> Uuid {
+pub fn uuid_from_now(sid: SID) -> Uuid {
     let d = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
@@ -59,13 +59,13 @@ mod tests {
 
     #[test]
     fn test_utils_uuid_from_duration() {
-        let u1 = uuid_from_duration(Duration::from_secs(1), &[0xff; 4]);
+        let u1 = uuid_from_duration(Duration::from_secs(1), [0xff; 4]);
         assert_eq!(
             "00000000-0000-0001-0000-0000ffffffff",
             u1.to_hyphenated().to_string()
         );
 
-        let u2 = uuid_from_duration(Duration::from_secs(1000), &[0xff; 4]);
+        let u2 = uuid_from_duration(Duration::from_secs(1000), [0xff; 4]);
         assert_eq!(
             "00000000-0000-03e8-0000-0000ffffffff",
             u2.to_hyphenated().to_string()

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -1,13 +1,6 @@
 #![deny(warnings)]
 
-extern crate actix;
-extern crate env_logger;
-extern crate rpassword;
-
-extern crate kanidm;
-extern crate structopt;
-#[macro_use]
-extern crate log;
+use std::path::PathBuf;
 
 use kanidm::config::Configuration;
 use kanidm::core::{
@@ -15,7 +8,7 @@ use kanidm::core::{
     reindex_server_core, reset_sid_core, restore_server_core, verify_server_core,
 };
 
-use std::path::PathBuf;
+use log::{error, info};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
I would like to move the codebase into the 2018 edition.

This PR is:

* Dropping some of the `extern crate`
* Fixing some typos in Cargo.toml
* Fixing most of the clippy errors / warnings

Note that there are still two clippy errors related with complexity. I am not confident to address them with my current rust knowledge, but I will try in a future PR (if you do not fix them before).

- [X] cargo fmt has been run
- [X] cargo test has been run and passes
- [ ] design document included (if relevant)
