### PR TITLE
Add concurrent structures

### DIFF
--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/lib/lib.rs"
 name = "kanidmd"
 path = "src/server/main.rs"
 
+# [[bench]]
+# name = "kanidm_benchmark"
+# harness = false
+
 
 [dependencies]
 kanidm_proto = { path = "../kanidm_proto", version = "0.1" }
@@ -63,4 +67,7 @@ num_cpus = "1.10"
 
 idlset = "0.1"
 zxcvbn = "2.0"
+
+[dev-dependencies]
+criterion = "0.3"
 

--- a/kanidmd/benches/kanidm_benchmark.rs
+++ b/kanidmd/benches/kanidm_benchmark.rs
@@ -1,0 +1,28 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[macro_use]
+use kanidm;
+use kanidm::constants::UUID_ADMIN;
+
+pub fn criterion_benchmark_search_1(c: &mut Criterion) {
+    // Setup
+    //
+    run_test!(|server: &QueryServer, audit: &mut AuditScope| {
+        let filt = filter!(f_eq("name", PartialValue::new_iutf8s("testperson")));
+        let admin = server_txn
+            .internal_search_uuid(audit, &UUID_ADMIN)
+            .expect("failed");
+
+        let se1 = unsafe { SearchEvent::new_impersonate_entry(admin.clone(), filt.clone()) };
+
+        c.bench_function("search 2000", |b| {
+            b.iter(|| {
+                let r1 = server_txn.search(audit, &se1).expect("search failure");
+                assert!(r1.is_empty());
+            })
+        });
+    })
+}
+
+criterion_group!(benches, criterion_benchmark_search_1);
+criterion_main!(benches);

--- a/kanidmd/src/lib/core.rs
+++ b/kanidmd/src/lib/core.rs
@@ -1202,7 +1202,7 @@ pub fn restore_server_core(config: Configuration, dst_path: &str) {
     };
 
     // Limit the scope of the schema txn.
-    let idxmeta = { schema.write().get_idxmeta() };
+    let idxmeta = { schema.write().get_idxmeta_set() };
 
     let mut be_wr_txn = be.write(idxmeta);
     let r = be_wr_txn
@@ -1266,7 +1266,7 @@ pub fn reindex_server_core(config: Configuration) {
 
     info!("Start Index Phase 1 ...");
     // Limit the scope of the schema txn.
-    let idxmeta = { schema.write().get_idxmeta() };
+    let idxmeta = { schema.write().get_idxmeta_set() };
 
     // Reindex only the core schema attributes to bootstrap the process.
     let be_wr_txn = be.write(idxmeta);

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -300,9 +300,13 @@ impl Plugins {
         cand: &[Entry<EntryValid, EntryNew>],
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
-        audit_segment!(au, || {
-            run_pre_create_plugin!(au, qs, cand, ce, protected::Protected)
-        })
+        audit_segment!(au, || run_pre_create_plugin!(
+            au,
+            qs,
+            cand,
+            ce,
+            protected::Protected
+        ))
     }
 
     pub fn run_post_create(
@@ -311,10 +315,20 @@ impl Plugins {
         cand: &[Entry<EntryValid, EntryCommitted>],
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
-        audit_segment!(au, || {
-            run_post_create_plugin!(au, qs, cand, ce, refint::ReferentialIntegrity)
-                .and_then(|_| run_post_create_plugin!(au, qs, cand, ce, memberof::MemberOf))
-        })
+        audit_segment!(au, || run_post_create_plugin!(
+            au,
+            qs,
+            cand,
+            ce,
+            refint::ReferentialIntegrity
+        )
+        .and_then(|_| run_post_create_plugin!(
+            au,
+            qs,
+            cand,
+            ce,
+            memberof::MemberOf
+        )))
     }
 
     pub fn run_pre_modify(
@@ -340,13 +354,23 @@ impl Plugins {
         cand: &[Entry<EntryValid, EntryCommitted>],
         me: &ModifyEvent,
     ) -> Result<(), OperationError> {
-        audit_segment!(au, || {
-            run_post_modify_plugin!(au, qs, pre_cand, cand, me, refint::ReferentialIntegrity)
-                .and_then(|_| {
-                    run_post_modify_plugin!(au, qs, pre_cand, cand, me, memberof::MemberOf)
-                })
-                .and_then(|_| run_post_modify_plugin!(au, qs, pre_cand, cand, me, spn::Spn))
-        })
+        audit_segment!(au, || run_post_modify_plugin!(
+            au,
+            qs,
+            pre_cand,
+            cand,
+            me,
+            refint::ReferentialIntegrity
+        )
+        .and_then(|_| run_post_modify_plugin!(au, qs, pre_cand, cand, me, memberof::MemberOf))
+        .and_then(|_| run_post_modify_plugin!(
+            au,
+            qs,
+            pre_cand,
+            cand,
+            me,
+            spn::Spn
+        )))
     }
 
     pub fn run_pre_delete(
@@ -355,9 +379,13 @@ impl Plugins {
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         de: &DeleteEvent,
     ) -> Result<(), OperationError> {
-        audit_segment!(au, || {
-            run_pre_delete_plugin!(au, qs, cand, de, protected::Protected)
-        })
+        audit_segment!(au, || run_pre_delete_plugin!(
+            au,
+            qs,
+            cand,
+            de,
+            protected::Protected
+        ))
     }
 
     pub fn run_post_delete(
@@ -366,10 +394,20 @@ impl Plugins {
         cand: &[Entry<EntryValid, EntryCommitted>],
         de: &DeleteEvent,
     ) -> Result<(), OperationError> {
-        audit_segment!(au, || {
-            run_post_delete_plugin!(au, qs, cand, de, refint::ReferentialIntegrity)
-                .and_then(|_| run_post_delete_plugin!(au, qs, cand, de, memberof::MemberOf))
-        })
+        audit_segment!(au, || run_post_delete_plugin!(
+            au,
+            qs,
+            cand,
+            de,
+            refint::ReferentialIntegrity
+        )
+        .and_then(|_| run_post_delete_plugin!(
+            au,
+            qs,
+            cand,
+            de,
+            memberof::MemberOf
+        )))
     }
 
     pub fn run_verify(

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -95,7 +95,7 @@ pub trait QueryServerTransaction {
         // NOTE: Filters are validated in event conversion.
 
         let schema = self.get_schema();
-        let idxmeta = schema.get_idxmeta();
+        let idxmeta = schema.get_idxmeta_set();
         // Now resolve all references and indexes.
         let vfr = try_audit!(au, se.filter.resolve(&se.event, Some(&idxmeta)));
 
@@ -132,7 +132,7 @@ pub trait QueryServerTransaction {
         let mut audit_be = AuditScope::new("backend_exists");
 
         let schema = self.get_schema();
-        let idxmeta = schema.get_idxmeta();
+        let idxmeta = schema.get_idxmeta_set();
         let vfr = try_audit!(au, ee.filter.resolve(&ee.event, Some(&idxmeta)));
 
         let res = self
@@ -715,7 +715,7 @@ impl QueryServer {
     pub fn write(&self) -> QueryServerWriteTransaction {
         // Feed the current schema index metadata to the be write transaction.
         let schema_write = self.schema.write();
-        let idxmeta = schema_write.get_idxmeta();
+        let idxmeta = schema_write.get_idxmeta_set();
 
         QueryServerWriteTransaction {
             // I think this is *not* needed, because commit is mut self which should


### PR DESCRIPTION
Implements #10, improve concurrent datastructures.

This replaces the cowcell from concread with bptreemap from concread, which should yield better performance on high throughput situations, especially with schema and acp updates. This is because we no longer copy the full sets on the start of a txn, as the bptree map is able to delay copying *until* we actually commit to a write. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
