### PR TITLE
Feature/entry extend apply modlist tests

### DIFF
--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1998,17 +1998,10 @@ mod tests {
 
         // Assert present for multivalue
         let present_multivalue_mods = unsafe {
-            ModifyList::new_valid_list(
-                vec![Modify::Present(
-                     String::from("class"),
-                     Value::new_iutf8s("test"),
-                    ),
-                    Modify::Present(
-                        String::from("class"),
-                        Value::new_iutf8s("multi_test"),
-                    ),
-                ]
-            )
+            ModifyList::new_valid_list(vec![
+                Modify::Present(String::from("class"), Value::new_iutf8s("test")),
+                Modify::Present(String::from("class"), Value::new_iutf8s("multi_test")),
+            ])
         };
 
         e.apply_modlist(&present_multivalue_mods);
@@ -2017,17 +2010,15 @@ mod tests {
         assert!(e.attribute_equality("class", &PartialValue::new_iutf8s("multi_test")));
 
         // Assert purge on single/multi/empty value
-        let purge_single_mods = unsafe {
-            ModifyList::new_valid_list(vec![Modify::Purged(String::from("attr"))])
-        };
+        let purge_single_mods =
+            unsafe { ModifyList::new_valid_list(vec![Modify::Purged(String::from("attr"))]) };
 
         e.apply_modlist(&purge_single_mods);
 
         assert!(!e.attribute_pres("attr"));
 
-        let purge_multi_mods = unsafe {
-            ModifyList::new_valid_list(vec![Modify::Purged(String::from("class"))])
-        };
+        let purge_multi_mods =
+            unsafe { ModifyList::new_valid_list(vec![Modify::Purged(String::from("class"))]) };
 
         e.apply_modlist(&purge_multi_mods);
 
@@ -2055,7 +2046,6 @@ mod tests {
         e.apply_modlist(&remove_empty_mods);
 
         assert!(e.attrs.get("attr").unwrap().is_empty());
-
     }
 
     #[test]

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -154,9 +154,9 @@ impl<'a> Iterator for EntryAvasMut<'a> {
     }
 }
 
-// Entry should have a lifecycle of types. THis is Raw (modifiable) and Entry (verified).
+// Entry should have a lifecycle of types. This is Raw (modifiable) and Entry (verified).
 // This way, we can move between them, but only certain actions are possible on either
-// This means modifications happen on Raw, but to move to Entry, you schema normalise.
+// This means modifications happen on Raw, but to move to Entry, you schema normalize.
 // Vice versa, you can for free, move to Raw, but you lose the validation.
 
 // Because this is type system it's "free" in the end, and means we force validation
@@ -240,7 +240,7 @@ fn compare_attrs(
 /// An entry that has had access controls applied moves from `EntryValid` to `EntryReduced`,
 /// to show that the avas have reduced to the valid read set of the current [`event`] user.
 ///
-/// The second type of `STATE` reperesents the database commit state and internal db ID's. A
+/// The second type of `STATE` represents the database commit state and internal db ID's. A
 /// new entry that has never been committed is `EntryNew`, but an entry that has been retrieved
 /// from the database is `EntryCommitted`. This affects the operations you can apply IE modify
 /// or delete.
@@ -375,7 +375,7 @@ impl Entry<EntryInit, EntryNew> {
                         vs.into_iter().map(|v| Value::new_class(v.as_str())).collect()
                     }
                     "acp_create_attr" | "acp_search_attr" | "acp_modify_removedattr" | "acp_modify_presentattr" |
-                    "systemmay" | "may" | "systemmust" | "must" 
+                    "systemmay" | "may" | "systemmust" | "must"
                     => {
                         vs.into_iter().map(|v| Value::new_attr(v.as_str())).collect()
                     }

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -156,7 +156,7 @@ impl<'a> Iterator for EntryAvasMut<'a> {
 
 // Entry should have a lifecycle of types. This is Raw (modifiable) and Entry (verified).
 // This way, we can move between them, but only certain actions are possible on either
-// This means modifications happen on Raw, but to move to Entry, you schema normalize.
+// This means modifications happen on Raw, but to move to Entry, you schema normalise.
 // Vice versa, you can for free, move to Raw, but you lose the validation.
 
 // Because this is type system it's "free" in the end, and means we force validation


### PR DESCRIPTION
I was trying to implement #108 but after review all entries code I realized that I isn't related with it.

## Implements
Add entry test cases for `apply_modlist`:
    - present multivalue
    - purge single/multi/empty value
    - remove exists and doesn't exist value

## Format and tests
- [x] cargo fmt has been run
- [x] cargo test has been run and passes
