### PR TITLE
Fix sqlite fails in CI tests and fmt error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,13 +12,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: stable
           override: true
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
+          components: rustfmt
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
@@ -31,7 +29,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install -y \
-          libsqlite3-dev \
           libpam0g-dev \
           libssl1.0-dev
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "idlset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "kanidm_proto 0.1.2",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1406,6 +1407,7 @@ dependencies = [
  "kanidm_client 0.1.2",
  "kanidm_proto 0.1.2",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_sqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1460,6 +1462,7 @@ name = "libsqlite3-sys"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/kanidm_unix_int/Cargo.toml
+++ b/kanidm_unix_int/Cargo.toml
@@ -58,11 +58,15 @@ serde_derive = "1.0"
 serde_cbor = "0.11"
 structopt = { version = "0.3", default-features = false }
 
+libsqlite3-sys = { version = "0.17" }
 rusqlite = { version = "0.21" }
 r2d2 = "0.8"
 r2d2_sqlite = "0.14"
 
 reqwest = { version = "0.10" }
+
+[features]
+default = [ "libsqlite3-sys/bundled" ]
 
 [dev-dependencies]
 kanidm = { path = "../kanidmd", version = "0.1" }

--- a/kanidm_unix_int/src/daemon.rs
+++ b/kanidm_unix_int/src/daemon.rs
@@ -241,13 +241,11 @@ async fn main() {
             match socket_res {
                 Ok(socket) => {
                     let cachelayer_ref = cachelayer.clone();
-                    tokio::spawn(
-                        async move {
-                            if let Err(e) = handle_client(socket, cachelayer_ref.clone()).await {
-                                error!("an error occured; error = {:?}", e);
-                            }
-                        },
-                    );
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_client(socket, cachelayer_ref.clone()).await {
+                            error!("an error occured; error = {:?}", e);
+                        }
+                    });
                 }
                 Err(err) => {
                     error!("Accept error -> {:?}", err);

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -51,6 +51,7 @@ serde_cbor = "0.11"
 serde_json = "1.0"
 serde_derive = "1.0"
 
+libsqlite3-sys = { version = "0.17" }
 rusqlite = { version = "0.21", features = ["backup"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.14"
@@ -71,6 +72,9 @@ idlset = { version = "0.1" , features = ["use_smallvec"] }
 
 zxcvbn = "2.0"
 base64 = "0.12"
+
+[features]
+default = [ "libsqlite3-sys/bundled" ]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -9,11 +9,11 @@ RUN zypper mr -d repo-non-oss && \
 
 # // setup the builder pkgs
 FROM ref_repo AS build_base
-RUN zypper install -y cargo rust gcc sqlite3-devel libopenssl-devel pam-devel
+RUN zypper install -y cargo rust gcc libopenssl-devel pam-devel
 
 # // setup the runner pkgs
 FROM ref_repo AS run_base
-RUN zypper install -y sqlite3 openssl timezone pam
+RUN zypper install -y openssl timezone pam
 
 # // build artifacts
 FROM build_base AS builder


### PR DESCRIPTION
Add `libsqlite3-sys` crate to avoid sqlite3 missmatching version.

From [https://lib.rs/crates/libsqlite3-sys](https://lib.rs/crates/libsqlite3-sys)
> If you use the bundled feature, libsqlite3-sys will use the cc crate to compile SQLite from source and link against that. This source is embedded in the libsqlite3-sys crate and is currently SQLite 3.30.1 (as of rusqlite 0.21.0 / libsqlite3-sys 0.17.0). This is probably the simplest solution to any build problems.

Remove sqlite OS packages dependencies for build.

Also, we fix a format error to allow CI tests to pass again.

- [X] cargo fmt has been run
- [X] cargo test has been run and passes
- [ ] design document included (if relevant)
