### PR TITLE
Create light images with static binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
-target
 .git
+.github
 .gitignore
+*.md
+Makefile
+target
 test.db
-

--- a/.github/workflows/kanidmd-docker_image.yml
+++ b/.github/workflows/kanidmd-docker_image.yml
@@ -1,25 +1,16 @@
-name: Docker
+name: Kanidmd release
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
     branches:
       - master
 
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 
-  # Run tests for any PRs.
   pull_request:
 
-env:
-  IMAGE_NAME: kanidm/server
-  DOCKERFILE_DIR: kanidmd
-
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
 
@@ -27,18 +18,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            docker build . --file $DOCKERFILE_DIR/Dockerfile
-          fi
+        run: make test/kanidmd
 
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
     needs: test
 
     runs-on: ubuntu-latest
@@ -48,16 +30,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file $DOCKERFILE_DIR/Dockerfile --tag image
+        run: make build/kanidm
 
       - name: Log into registry
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
       - name: Push image
         run: |
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_NAME | tr '[A-Z]' '[a-z]')
-
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
@@ -67,9 +46,5 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag image $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          VERSION=$VERSION make push/kanidmd
 

--- a/.github/workflows/radius-docker_image.yml
+++ b/.github/workflows/radius-docker_image.yml
@@ -1,25 +1,16 @@
-name: Docker
+name: Radius docker image
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
     branches:
       - master
 
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 
-  # Run tests for any PRs.
   pull_request:
 
-env:
-  IMAGE_NAME: kanidm/radius
-  DOCKERFILE_DIR: kanidm_rlm_python
-
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
 
@@ -27,18 +18,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            cd $DOCKERFILE_DIR && docker build . --file Dockerfile
-          fi
+        run: make build/radiusd
 
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
     needs: test
 
     runs-on: ubuntu-latest
@@ -48,16 +30,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: cd $DOCKERFILE_DIR && docker build . --file Dockerfile --tag image
+        run: make build/radiusd
 
       - name: Log into registry
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
       - name: Push image
         run: |
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_NAME | tr '[A-Z]' '[a-z]')
-
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
@@ -67,9 +46,5 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag image $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          VERSION=$VERSION make push/radiusd
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl-src"
+version = "111.9.0+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1775,7 @@ dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-src 111.9.0+1.1.1g (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3186,6 +3195,7 @@ dependencies = [
 "checksum oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
 "checksum openssl 0.10.29 (registry+https://github.com/rust-lang/crates.io-index)" = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-src 111.9.0+1.1.1g (registry+https://github.com/rust-lang/crates.io-index)" = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
 "checksum openssl-sys 0.9.55 (registry+https://github.com/rust-lang/crates.io-index)" = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,52 @@
+.PHONY: help build/kanidmd build/radiusd test/kanidmd push/kanidmd push/radiusd vendor-prep doc install-tools prep
 
-docker-kanidmd:
-	docker build -f kanidmd/Dockerfile -t kanidm/server:latest .
+IMAGE_BASE ?= kanidm
+IMAGE_VERSION ?= latest
 
-docker-radiusd:
-	docker build -f kanidm_rlm_python/Dockerfile -t kanidm/radius:latest kanidm_rlm_python
+.DEFAULT: help
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##/\n\t/'
+
+build/kanidmd:	## build kanidmd images
+build/kanidmd:
+	@docker build -f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:$(IMAGE_VERSION) .
+	@docker build -f kanidmd/Dockerfile \
+		--target alpine \
+		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION)-alpine \
+		.
+
+build/radiusd:	## build radiusd image
+build/radiusd:
+	@docker build -f kanidm_rlm_python/Dockerfile -t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) \
+		kanidm_rlm_python
+
+test/kanidmd:	## test kanidmd
+test/kanidmd:
+	@docker build -f kanidmd/Dockerfile \
+		--target builder \
+		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION)-builder \
+		.
+	@docker run --rm $(IMAGE_BASE)/server:$(IMAGE_VERSION)-builder cargo test
+
+push/kanidmd:	## push kanidmd images
+push/kanidmd:
+	@docker push $(IMAGE_BASE)/server:$(IMAGE_VERSION)
+	@docker push $(IMAGE_BASE)/server:$(IMAGE_VERSION)-alpine
+
+push/radiusd:	## push radiusd image
+push/radiusd:
+	@docker push $(IMAGE_BASE)/radius:$(IMAGE_VERSION)
 
 vendor-prep:
 	cargo vendor
 	tar -czf vendor.tar.gz vendor
 
-doc-local:
+doc: ## build doc local
+doc:
 	cargo doc --document-private-items
 
-install-tools-local:
+install-tools: ## install tools in local environment
+install-tools:
 	cd kanidm_tools && cargo install --path . --force
 
 prep:

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -74,7 +74,7 @@ zxcvbn = "2.0"
 base64 = "0.12"
 
 [features]
-default = [ "libsqlite3-sys/bundled" ]
+default = [ "libsqlite3-sys/bundled", "openssl/vendored" ]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -1,38 +1,32 @@
-FROM opensuse/tumbleweed:latest AS ref_repo
-RUN zypper mr -d repo-non-oss && \
-    zypper mr -d repo-oss && \
-    zypper mr -d repo-update && \
-    zypper ar https://download.opensuse.org/update/tumbleweed/ repo-update-https && \
-    zypper ar https://download.opensuse.org/tumbleweed/repo/oss/ repo-oss-https && \
-    zypper ar https://download.opensuse.org/tumbleweed/repo/non-oss/ repo-non-oss-https && \
-    zypper ref
+ARG BASE_IMAGE=ekidd/rust-musl-builder:1.43.0
+FROM ${BASE_IMAGE} AS builder
+LABEL mantainer william@blackhats.net.au
 
-# // setup the builder pkgs
-FROM ref_repo AS build_base
-RUN zypper install -y cargo rust gcc libopenssl-devel pam-devel
-
-# // setup the runner pkgs
-FROM ref_repo AS run_base
-RUN zypper install -y openssl timezone pam
-
-# // build artifacts
-FROM build_base AS builder
-
-COPY . /home/kanidm/
-WORKDIR /home/kanidm/
+ADD --chown=rust:rust . ./
+WORKDIR kanidmd
 RUN cargo build --release
 
-# == end builder setup, we now have static artifacts.
-FROM run_base
-MAINTAINER william@blackhats.net.au
+
+FROM alpine:3.11 AS alpine
+LABEL mantainer william@blackhats.net.au
+
+RUN apk --no-cache add ca-certificates
+COPY --from=builder \
+    /home/rust/src/target/x86_64-unknown-linux-musl/release/kanidmd \
+    /sbin/
 EXPOSE 8443
-
-WORKDIR /
-COPY --from=builder /home/kanidm/target/release/kanidmd /sbin/
-
 VOLUME /data
+CMD ["/sbin/kanidmd", "server", "-D", "/data/kanidm.db",  "-C", "/data/ca.pem", \
+     "-c", "/data/cert.pem", "-k", "/data/key.pem", "--bindaddr", "0.0.0.0:8443"]
 
+FROM scratch
+LABEL mantainer william@blackhats.net.au
 
-ENV RUST_BACKTRACE 1
-CMD ["/sbin/kanidmd", "server", "-D", "/data/kanidm.db",  "-C", "/data/ca.pem", "-c", "/data/cert.pem", "-k", "/data/key.pem", "--bindaddr", "0.0.0.0:8443"]
+COPY --from=builder \
+    /home/rust/src/target/x86_64-unknown-linux-musl/release/kanidmd \
+    /sbin/
+EXPOSE 8443
+VOLUME /data
+CMD ["/sbin/kanidmd", "server", "-D", "/data/kanidm.db",  "-C", "/data/ca.pem", \
+     "-c", "/data/cert.pem", "-k", "/data/key.pem", "--bindaddr", "0.0.0.0:8443"]
 


### PR DESCRIPTION
- Change base builder image to `ekidd/rust-musl-builder` for create static
binaries.
- Add two flavours: alpine and stand alone binary.
- Add makefile commands for build, test and push kanidmd images and
  refactor previous code.
- Add missing things to `.dockerignore`.
- Refactor CI to use Makefile.

Implements # .

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [ ] design document included (if relevant)

This is a propose to create safest and lightest images.
We could include a SUSE flavour too if you need. I think that alpine and scratch are enough but I understand your situation.