### PR TITLE
216 - add initial /status endpoint

### DIFF
--- a/kanidm_unix_int/src/daemon.rs
+++ b/kanidm_unix_int/src/daemon.rs
@@ -241,11 +241,13 @@ async fn main() {
             match socket_res {
                 Ok(socket) => {
                     let cachelayer_ref = cachelayer.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = handle_client(socket, cachelayer_ref.clone()).await {
-                            error!("an error occured; error = {:?}", e);
-                        }
-                    });
+                    tokio::spawn(
+                        async move {
+                            if let Err(e) = handle_client(socket, cachelayer_ref.clone()).await {
+                                error!("an error occured; error = {:?}", e);
+                            }
+                        },
+                    );
                 }
                 Err(err) => {
                     error!("Accept error -> {:?}", err);

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -35,6 +35,7 @@ mod idm;
 mod repl;
 mod schema;
 mod server;
+mod status;
 
 pub mod config;
 pub mod core;

--- a/kanidmd/src/lib/status.rs
+++ b/kanidmd/src/lib/status.rs
@@ -1,0 +1,35 @@
+use crate::async_log::{EventLog, LogEvent};
+use actix::prelude::*;
+
+pub struct StatusActor {
+    log_addr: actix::Addr<EventLog>,
+}
+
+impl StatusActor {
+    pub fn start(log_addr: actix::Addr<EventLog>) -> actix::Addr<StatusActor> {
+        SyncArbiter::start(1, move || StatusActor {
+            log_addr: log_addr.clone(),
+        })
+    }
+}
+
+impl Actor for StatusActor {
+    type Context = SyncContext<Self>;
+}
+
+pub struct StatusRequestEvent {}
+
+impl Message for StatusRequestEvent {
+    type Result = bool;
+}
+
+impl Handler<StatusRequestEvent> for StatusActor {
+    type Result = bool;
+
+    fn handle(&mut self, _event: StatusRequestEvent, _ctx: &mut SyncContext<Self>) -> Self::Result {
+        self.log_addr.do_send(LogEvent {
+            msg: "status request event: ok".to_string(),
+        });
+        true
+    }
+}


### PR DESCRIPTION
This is a stub implementation of 216, adding a `/status` endpoint. Importantly this actually contacts a status thread, which means that the main thread pools aren't affected by this. The idea of the thread pool is that later we can have this thread aggregate statistics and information from the other operation threads that can be displayed in the status.

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
