### PR TITLE
Add upg to radius

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -566,9 +566,7 @@ impl KanidmClient {
         id: &str,
         gidnumber: Option<u32>,
     ) -> Result<(), ClientError> {
-        let gx = GroupUnixExtend {
-            gidnumber,
-        };
+        let gx = GroupUnixExtend { gidnumber };
         self.perform_post_request(format!("/v1/group/{}/_unix", id).as_str(), gx)
     }
 

--- a/kanidmd/src/lib/idm/group.rs
+++ b/kanidmd/src/lib/idm/group.rs
@@ -22,7 +22,15 @@ pub struct Group {
 
 macro_rules! try_from_account_e {
     ($au:expr, $value:expr, $qs:expr) => {{
-        let groups: Vec<Group> = match $value.get_ava_reference_uuid("memberof") {
+        let name = $value.get_ava_single_string("name").ok_or_else(|| {
+            OperationError::InvalidAccountState("Missing attribute: name".to_string())
+        })?;
+
+        let uuid = *$value.get_uuid();
+
+        let upg = Group { name, uuid };
+
+        let mut groups: Vec<Group> = match $value.get_ava_reference_uuid("memberof") {
             Some(l) => {
                 // given a list of uuid, make a filter: even if this is empty, the be will
                 // just give and empty result set.
@@ -48,6 +56,7 @@ macro_rules! try_from_account_e {
                 vec![]
             }
         };
+        groups.push(upg);
         Ok(groups)
     }};
 }


### PR DESCRIPTION
This fixes an issue where UPG's were not synthesised into radius tokens, preventing some configuration situations from working. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
