### PR TITLE
99 logging rewrite

### DIFF
--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -1,21 +1,20 @@
 use actix::prelude::*;
 use std::fmt;
+// use std::ptr;
 use std::time::Duration;
 use std::time::SystemTime;
 
 use chrono::offset::Utc;
 use chrono::DateTime;
+use uuid::Uuid;
 
 #[macro_export]
 macro_rules! audit_log {
     ($audit:expr, $($arg:tt)*) => ({
         use std::fmt;
         if cfg!(test) || cfg!(debug_assertions) {
-            // debug!("DEBUG AUDIT ({}:{} {})-> ", file!(), line!(), $audit.id());
-            // debug!($($arg)*)
-            // debug!("DEBUG AUDIT ({}:{} {})-> ", file!(), line!(), $audit.id());
-            // debug!("line: {}", line!());
             debug!($($arg)*)
+            // } else {
         }
         $audit.log_event(
             fmt::format(
@@ -35,20 +34,27 @@ macro_rules! audit_log {
  * })
  */
 
-macro_rules! audit_segment {
-    ($au:expr, $fun:expr) => {{
+macro_rules! lperf_segment {
+    ($au:expr, $id:expr, $fun:expr) => {{
         use std::time::Instant;
 
-        let start = Instant::now();
         // start timer.
-        // run fun with our derived audit event.
+        let start = Instant::now();
+
+        // Create a new perf event - this sets
+        // us as the current active, and the parent
+        // correctly.
+        let pe = unsafe { $au.new_perfevent($id) };
+
+        // fun run time
         let r = $fun();
         // end timer, and diff
         let end = Instant::now();
         let diff = end.duration_since(start);
 
-        audit_log!($au, "duration -> {:?}", diff);
-        $au.set_duration(diff);
+        // Now we are done, we put our parent back as
+        // the active.
+        unsafe { $au.end_perfevent(pe, diff) };
 
         // Return the result. Hope this works!
         r
@@ -85,30 +91,35 @@ macro_rules! try_audit {
     };
 }
 
-#[derive(Serialize, Deserialize)]
-enum AuditEvent {
-    Log(AuditLog),
-    Scope(AuditScope),
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 struct AuditLog {
     time: String,
-    name: String,
+    data: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PerfEvent {
+    id: String,
+    duration: Option<Duration>,
+    contains: Vec<PerfEvent>,
+    #[serde(skip_serializing)]
+    parent: Option<&'static mut PerfEvent>,
 }
 
 // This structure tracks and event lifecycle, and is eventually
 // sent to the logging system where it's structured and written
 // out to the current logging BE.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 pub struct AuditScope {
     // vec of start/end points of various parts of the event?
     // We probably need some functions for this. Is there a way in rust
     // to automatically annotate line numbers of code?
-    time: String,
-    name: String,
-    duration: Option<Duration>,
-    events: Vec<AuditEvent>,
+    uuid: Uuid,
+    events: Vec<AuditLog>,
+    perf: Vec<PerfEvent>,
+    // active perf event
+    #[serde(skip_serializing)]
+    active_perf: Option<&'static mut PerfEvent>,
 }
 
 // Allow us to be sent to the log subsystem
@@ -131,34 +142,80 @@ impl AuditScope {
         let datetime: DateTime<Utc> = t_now.into();
 
         AuditScope {
-            time: datetime.to_rfc3339(),
-            name: String::from(name),
-            duration: None,
-            events: Vec::new(),
+            uuid: Uuid::new_v4(),
+            events: vec![AuditLog {
+                time: datetime.to_rfc3339(),
+                data: format!("start {}", name),
+            }],
+            perf: vec![],
+            active_perf: None,
         }
     }
 
-    pub fn id(&self) -> &str {
-        self.name.as_str()
-    }
-
-    pub fn set_duration(&mut self, diff: Duration) {
-        self.duration = Some(diff);
-    }
-
-    // Given a new audit event, append it in.
-    pub fn append_scope(&mut self, scope: AuditScope) {
-        self.events.push(AuditEvent::Scope(scope))
+    pub fn get_uuid(&self) -> &Uuid {
+        &self.uuid
     }
 
     pub fn log_event(&mut self, data: String) {
         let t_now = SystemTime::now();
         let datetime: DateTime<Utc> = t_now.into();
 
-        self.events.push(AuditEvent::Log(AuditLog {
+        self.events.push(AuditLog {
             time: datetime.to_rfc3339(),
-            name: data,
-        }))
+            data: data,
+        })
+    }
+
+    pub(crate) unsafe fn new_perfevent(&mut self, id: &str) -> &'static mut PerfEvent {
+        // Does an active event currently exist?
+        if self.active_perf.is_none() {
+            // No, we are a new event.
+            self.perf.push(PerfEvent {
+                id: id.to_string(),
+                duration: None,
+                contains: vec![],
+                parent: None,
+            });
+            // Get a put ptr, we are now the active.
+            let xref = self.perf.last_mut().expect("perf alloc failure?") as *mut PerfEvent;
+            let mref = &mut (*xref);
+            self.active_perf = Some(mref);
+            // return the mut ptr.
+            &mut (*xref)
+        } else {
+            // Yes, there is an active event.
+            // get the currennt active ptr
+            let xref = if let Some(ref mut iparent) = self.active_perf {
+                iparent.contains.push(PerfEvent {
+                    id: id.to_string(),
+                    duration: None,
+                    contains: vec![],
+                    parent: None,
+                });
+                iparent.contains.last_mut().expect("perf alloc failure?") as *mut PerfEvent
+            } else {
+                panic!("Invalid parent state");
+            };
+            // Alloc in the vec, set parnt to active, then get a mut pointer
+            // to ourself, then set ourself as the active.
+            (*xref).parent = Some(&mut (*xref));
+            std::mem::swap(&mut (*xref).parent, &mut self.active_perf);
+            // return the mut ptr.
+            &mut (*xref)
+        }
+    }
+
+    pub(crate) unsafe fn end_perfevent(&mut self, pe: &'static mut PerfEvent, diff: Duration) {
+        // assert that we are the current active, else we have active children
+        // that are unclosed!
+        // ???
+
+        // We are done, put the duration into the pe.
+        pe.duration = Some(diff);
+        // put parent back as the active.
+        std::mem::swap(&mut pe.parent, &mut self.active_perf);
+        // And none the PE
+        pe.parent = None;
     }
 }
 

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -310,7 +310,9 @@ pub trait BackendTransaction {
 
             // Using the indexes, resolve the IDL here, or ALLIDS.
             // Also get if the filter was 100% resolved or not.
-            let idl = self.filter2idl(au, filt.to_inner(), FILTER_TEST_THRESHOLD)?;
+            let idl = lperf_segment!(au, "be::search -> filter2idl", || {
+                self.filter2idl(au, filt.to_inner(), FILTER_TEST_THRESHOLD)
+            })?;
 
             let entries = try_audit!(au, self.get_idlayer().get_identry(au, &idl));
             // Do other things
@@ -365,7 +367,9 @@ pub trait BackendTransaction {
 
             // Using the indexes, resolve the IDL here, or ALLIDS.
             // Also get if the filter was 100% resolved or not.
-            let idl = self.filter2idl(au, filt.to_inner(), FILTER_TEST_THRESHOLD)?;
+            let idl = lperf_segment!(au, "be::exists -> filter2idl", || {
+                self.filter2idl(au, filt.to_inner(), FILTER_TEST_THRESHOLD)
+            })?;
 
             // Now, check the idl -- if it's fully resolved, we can skip this because the query
             // was fully indexed.
@@ -490,56 +494,58 @@ impl<'a> BackendWriteTransaction<'a> {
         pre_entries: &[Entry<EntrySealed, EntryCommitted>],
         post_entries: &[Entry<EntrySealed, EntryCommitted>],
     ) -> Result<(), OperationError> {
-        if post_entries.is_empty() || pre_entries.is_empty() {
-            audit_log!(
-                au,
-                "No entries provided to BE to modify, invalid server call!"
-            );
-            return Err(OperationError::EmptyRequest);
-        }
+        lperf_segment!(au, "be::modify", || {
+            if post_entries.is_empty() || pre_entries.is_empty() {
+                audit_log!(
+                    au,
+                    "No entries provided to BE to modify, invalid server call!"
+                );
+                return Err(OperationError::EmptyRequest);
+            }
 
-        assert!(post_entries.len() == pre_entries.len());
+            assert!(post_entries.len() == pre_entries.len());
 
-        /*
-        // Assert the Id's exist on the entry, and serialise them.
-        // Now, that means the ID must be > 0!!!
-        let ser_entries: Result<Vec<IdEntry>, _> = post_entries
-            .iter()
-            .map(|e| {
-                let id = i64::try_from(e.get_id())
-                    .map_err(|_| OperationError::InvalidEntryID)
-                    .and_then(|id| {
-                        if id == 0 {
-                            Err(OperationError::InvalidEntryID)
-                        } else {
-                            Ok(id)
-                        }
-                    })?;
+            /*
+            // Assert the Id's exist on the entry, and serialise them.
+            // Now, that means the ID must be > 0!!!
+            let ser_entries: Result<Vec<IdEntry>, _> = post_entries
+                .iter()
+                .map(|e| {
+                    let id = i64::try_from(e.get_id())
+                        .map_err(|_| OperationError::InvalidEntryID)
+                        .and_then(|id| {
+                            if id == 0 {
+                                Err(OperationError::InvalidEntryID)
+                            } else {
+                                Ok(id)
+                            }
+                        })?;
 
-                Ok(IdEntry { id, data: e.clone() })
-            })
-            .collect();
+                    Ok(IdEntry { id, data: e.clone() })
+                })
+                .collect();
 
-        let ser_entries = try_audit!(au, ser_entries);
+            let ser_entries = try_audit!(au, ser_entries);
 
-        // Simple: If the list of id's is not the same as the input list, we are missing id's
-        //
-        // The entry state checks prevent this from really ever being triggered, but we
-        // still prefer paranoia :)
-        if post_entries.len() != ser_entries.len() {
-            return Err(OperationError::InvalidEntryState);
-        }
-        */
+            // Simple: If the list of id's is not the same as the input list, we are missing id's
+            //
+            // The entry state checks prevent this from really ever being triggered, but we
+            // still prefer paranoia :)
+            if post_entries.len() != ser_entries.len() {
+                return Err(OperationError::InvalidEntryState);
+            }
+            */
 
-        // Now, given the list of id's, update them
-        self.idlayer.write_identries(au, post_entries.iter())?;
+            // Now, given the list of id's, update them
+            self.idlayer.write_identries(au, post_entries.iter())?;
 
-        // Finally, we now reindex all the changed entries. We do this by iterating and zipping
-        // over the set, because we know the list is in the same order.
-        pre_entries
-            .iter()
-            .zip(post_entries.iter())
-            .try_for_each(|(pre, post)| self.entry_index(au, Some(pre), Some(post)))
+            // Finally, we now reindex all the changed entries. We do this by iterating and zipping
+            // over the set, because we know the list is in the same order.
+            pre_entries
+                .iter()
+                .zip(post_entries.iter())
+                .try_for_each(|(pre, post)| self.entry_index(au, Some(pre), Some(post)))
+        })
     }
 
     pub fn delete(

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -303,7 +303,7 @@ pub trait BackendTransaction {
         //
         // Unlike DS, even if we don't get the index back, we can just pass
         // to the in-memory filter test and be done.
-        audit_segment!(au, || {
+        lperf_segment!(au, "be::search", || {
             // Do a final optimise of the filter
             let filt = filt.optimise();
             audit_log!(au, "filter optimised to --> {:?}", filt);
@@ -358,7 +358,7 @@ pub trait BackendTransaction {
         au: &mut AuditScope,
         filt: &Filter<FilterValidResolved>,
     ) -> Result<bool, OperationError> {
-        audit_segment!(au, || {
+        lperf_segment!(au, "be::exists", || {
             // Do a final optimise of the filter
             let filt = filt.optimise();
             audit_log!(au, "filter optimised to --> {:?}", filt);
@@ -451,9 +451,7 @@ impl<'a> BackendWriteTransaction<'a> {
         au: &mut AuditScope,
         entries: Vec<Entry<EntrySealed, EntryNew>>,
     ) -> Result<Vec<Entry<EntrySealed, EntryCommitted>>, OperationError> {
-        // figured we would want a audit_segment to wrap internal_create so when doing profiling we can
-        // tell which function is calling it. either this one or restore.
-        audit_segment!(au, || {
+        lperf_segment!(au, "be::create", || {
             if entries.is_empty() {
                 audit_log!(
                     au,
@@ -549,8 +547,7 @@ impl<'a> BackendWriteTransaction<'a> {
         au: &mut AuditScope,
         entries: &[Entry<EntrySealed, EntryCommitted>],
     ) -> Result<(), OperationError> {
-        // Perform a search for the entries --> This is a problem for the caller
-        audit_segment!(au, || {
+        lperf_segment!(au, "be::delete", || {
             if entries.is_empty() {
                 audit_log!(
                     au,
@@ -894,7 +891,7 @@ impl<'a> BackendWriteTransaction<'a> {
 impl Backend {
     pub fn new(audit: &mut AuditScope, path: &str, pool_size: u32) -> Result<Self, OperationError> {
         // this has a ::memory() type, but will path == "" work?
-        audit_segment!(audit, || {
+        lperf_segment!(audit, "be::new", || {
             let be = Backend {
                 idlayer: Arc::new(IdlArcSqlite::new(audit, path, pool_size)?),
             };

--- a/kanidmd/src/lib/plugins/base.rs
+++ b/kanidmd/src/lib/plugins/base.rs
@@ -176,9 +176,7 @@ impl Plugin for Base {
         // internal exists is actually a wrapper around a search for uuid internally
         //
         // But does it add value? How many people will try to custom define/add uuid?
-        let mut au_qs = AuditScope::new("qs_exist");
-        let r = qs.internal_exists(&mut au_qs, filt_in);
-        au.append_scope(au_qs);
+        let r = qs.internal_exists(au, filt_in);
 
         match r {
             Ok(b) => {

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -114,8 +114,16 @@ macro_rules! run_modify_test {
 
             {
                 let mut qs_write = qs.write(duration_from_epoch_now());
-                let r = qs_write.modify(&mut au, &me);
-                $check(&mut au, &mut qs_write);
+                let r = lperf_segment!(
+                    &mut au,
+                    "plugins::macros::run_modify_test -> main_test",
+                    || { qs_write.modify(&mut au, &me) }
+                );
+                lperf_segment!(
+                    &mut au,
+                    "plugins::macros::run_modify_test -> post_test check",
+                    || { $check(&mut au, &mut qs_write) }
+                );
                 debug!("{:?}", r);
                 assert!(r == $expect);
                 match r {

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -47,7 +47,7 @@ macro_rules! run_create_test {
         use crate::utils::duration_from_epoch_now;
 
         let mut au = AuditScope::new("run_create_test");
-        audit_segment!(au, || {
+        lperf_segment!(&mut au, "plugins::macros::run_create_test", || {
             let qs = setup_test!(&mut au, $preload_entries);
 
             let ce = match $internal {
@@ -57,29 +57,26 @@ macro_rules! run_create_test {
                 },
             };
 
-            let mut au_test = AuditScope::new("create_test");
             {
                 let mut qs_write = qs.write(duration_from_epoch_now());
-                let r = qs_write.create(&mut au_test, &ce);
+                let r = qs_write.create(&mut au, &ce);
                 debug!("r: {:?}", r);
                 assert!(r == $expect);
-                $check(&mut au_test, &mut qs_write);
+                $check(&mut au, &mut qs_write);
                 match r {
                     Ok(_) => {
-                        qs_write.commit(&mut au_test).expect("commit failure!");
+                        qs_write.commit(&mut au).expect("commit failure!");
                     }
                     Err(e) => {
-                        audit_log!(&mut au_test, "Rolling back => {:?}", e);
+                        audit_log!(&mut au, "Rolling back => {:?}", e);
                     }
                 }
             }
             // Make sure there are no errors.
             debug!("starting verification");
-            let ver = qs.verify(&mut au_test);
+            let ver = qs.verify(&mut au);
             debug!("verification -> {:?}", ver);
             assert!(ver.len() == 0);
-
-            au.append_scope(au_test);
         });
         // Dump the raw audit log.
         println!("{}", au);
@@ -105,7 +102,7 @@ macro_rules! run_modify_test {
         use crate::utils::duration_from_epoch_now;
 
         let mut au = AuditScope::new("run_modify_test");
-        audit_segment!(au, || {
+        lperf_segment!(&mut au, "plugins::macros::run_modify_test", || {
             let qs = setup_test!(&mut au, $preload_entries);
 
             let me = match $internal {
@@ -115,29 +112,26 @@ macro_rules! run_modify_test {
                 },
             };
 
-            let mut au_test = AuditScope::new("modify_test");
             {
                 let mut qs_write = qs.write(duration_from_epoch_now());
-                let r = qs_write.modify(&mut au_test, &me);
-                $check(&mut au_test, &mut qs_write);
+                let r = qs_write.modify(&mut au, &me);
+                $check(&mut au, &mut qs_write);
                 debug!("{:?}", r);
                 assert!(r == $expect);
                 match r {
                     Ok(_) => {
-                        qs_write.commit(&mut au_test).expect("commit failure!");
+                        qs_write.commit(&mut au).expect("commit failure!");
                     }
                     Err(e) => {
-                        audit_log!(&mut au_test, "Rolling back => {:?}", e);
+                        audit_log!(&mut au, "Rolling back => {:?}", e);
                     }
                 }
             }
             // Make sure there are no errors.
             debug!("starting verification");
-            let ver = qs.verify(&mut au_test);
+            let ver = qs.verify(&mut au);
             debug!("verification -> {:?}", ver);
             assert!(ver.len() == 0);
-
-            au.append_scope(au_test);
         });
         // Dump the raw audit log.
         println!("{}", au);
@@ -162,7 +156,7 @@ macro_rules! run_delete_test {
         use crate::utils::duration_from_epoch_now;
 
         let mut au = AuditScope::new("run_delete_test");
-        audit_segment!(au, || {
+        lperf_segment!(&mut au, "plugins::macros::run_delete_test", || {
             let qs = setup_test!(&mut au, $preload_entries);
 
             let de = match $internal {
@@ -172,28 +166,25 @@ macro_rules! run_delete_test {
                 None => unsafe { DeleteEvent::new_internal_invalid($delete_filter.clone()) },
             };
 
-            let mut au_test = AuditScope::new("delete_test");
             {
                 let mut qs_write = qs.write(duration_from_epoch_now());
-                let r = qs_write.delete(&mut au_test, &de);
-                $check(&mut au_test, &mut qs_write);
+                let r = qs_write.delete(&mut au, &de);
+                $check(&mut au, &mut qs_write);
                 assert!(r == $expect);
                 match r {
                     Ok(_) => {
-                        qs_write.commit(&mut au_test).expect("commit failure!");
+                        qs_write.commit(&mut au).expect("commit failure!");
                     }
                     Err(e) => {
-                        audit_log!(&mut au_test, "Rolling back => {:?}", e);
+                        audit_log!(&mut au, "Rolling back => {:?}", e);
                     }
                 }
             }
             // Make sure there are no errors.
             debug!("starting verification");
-            let ver = qs.verify(&mut au_test);
+            let ver = qs.verify(&mut au);
             debug!("verification -> {:?}", ver);
             assert!(ver.len() == 0);
-
-            au.append_scope(au_test);
         });
         // Dump the raw audit log.
         println!("{}", au);

--- a/kanidmd/src/lib/plugins/refint.rs
+++ b/kanidmd/src/lib/plugins/refint.rs
@@ -43,11 +43,9 @@ impl ReferentialIntegrity {
                     "uuid could not become reference value".to_string()
                 ))
         );
-        let mut au_qs = AuditScope::new("qs_exist");
         // NOTE: This only checks LIVE entries (not using filter_all)
         let filt_in = filter!(f_eq("uuid", PartialValue::new_uuid(*uuid)));
-        let r = qs.internal_exists(&mut au_qs, filt_in);
-        au.append_scope(au_qs);
+        let r = qs.internal_exists(au, filt_in);
 
         let b = try_audit!(au, r);
         // Is the reference in the result set?

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -616,8 +616,7 @@ impl<'a> SchemaWriteTransaction<'a> {
     }
 
     pub fn generate_in_memory(&mut self, audit: &mut AuditScope) -> Result<(), OperationError> {
-        let mut au = AuditScope::new("generate_in_memory");
-        let r = audit_segment!(au, || {
+        let r = lperf_segment!(audit, "schema::generate_in_memory", || {
             //
             self.classes.clear();
             self.attributes.clear();
@@ -1340,8 +1339,8 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
 
-            let r = self.validate(&mut au);
-            audit_log!(au, "{:?}", r);
+            let r = self.validate(audit);
+            audit_log!(audit, "{:?}", r);
             if r.is_empty() {
                 self.reload_idxmeta();
                 Ok(())
@@ -1349,8 +1348,6 @@ impl<'a> SchemaWriteTransaction<'a> {
                 Err(OperationError::ConsistencyError(r))
             }
         });
-
-        audit.append_scope(au);
         r
     }
 }


### PR DESCRIPTION
Partial Implement of 99 logging rewrite. This improves the format of the "audit" log, and adds better performance diagnostics, sorted by "most expensive", and visualised as a nested tree. This should make logging faster, easier to read, and easier to analyse performance hotspots. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
