### PR TITLE
184 151 183 name constraint and spn

### DIFF
--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -254,14 +254,20 @@ fn test_server_rest_group_lifecycle() {
             .idm_group_add_members("demo_group", vec!["admin"])
             .unwrap();
         let members = rsclient.idm_group_get_members("demo_group").unwrap();
-        assert!(members == Some(vec!["admin".to_string()]));
+        assert!(members == Some(vec!["admin@example.com".to_string()]));
 
         // Set the list of members
         rsclient
             .idm_group_set_members("demo_group", vec!["admin", "demo_group"])
             .unwrap();
         let members = rsclient.idm_group_get_members("demo_group").unwrap();
-        assert!(members == Some(vec!["admin".to_string(), "demo_group".to_string()]));
+        assert!(
+            members
+                == Some(vec![
+                    "admin@example.com".to_string(),
+                    "demo_group@example.com".to_string()
+                ])
+        );
 
         // Remove a member from the group
         /*
@@ -290,7 +296,7 @@ fn test_server_rest_group_lifecycle() {
         // They should have members
         let members = rsclient.idm_group_get_members("idm_admins").unwrap();
         println!("{:?}", members);
-        assert!(members == Some(vec!["idm_admin".to_string()]));
+        assert!(members == Some(vec!["idm_admin@example.com".to_string()]));
     });
 }
 

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -21,7 +21,7 @@ pub enum SchemaError {
     #[error("")]
     InvalidAttribute(String),
     #[error("")]
-    InvalidAttributeSyntax,
+    InvalidAttributeSyntax(String),
     #[error("")]
     EmptyFilter,
     #[error("The schema has become internally inconsistent. You must restart and investigate.")]
@@ -241,13 +241,19 @@ pub struct Entry {
 #[serde(rename_all = "lowercase")]
 pub enum Filter {
     // This is attr - value
+    #[serde(alias = "Eq")]
     Eq(String, String),
+    #[serde(alias = "Sub")]
     Sub(String, String),
+    #[serde(alias = "Pres")]
     Pres(String),
+    #[serde(alias = "Or")]
     Or(Vec<Filter>),
+    #[serde(alias = "And")]
     And(Vec<Filter>),
+    #[serde(alias = "AndNot")]
     AndNot(Box<Filter>),
-    #[serde(rename = "self")]
+    #[serde(rename = "self", alias = "Self")]
     SelfUUID,
 }
 

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -1852,9 +1852,9 @@ mod tests {
                 "test_acp",
                 "d38640c4-0254-49f9-99b7-8ba7d0233f3d",
                 // apply to admin only
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // Allow admin to read only testperson1
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // In that read, admin may only view the "name" attribute, or query on
                 // the name attribute. Any other query (should be) rejected.
                 "name",
@@ -1928,7 +1928,7 @@ mod tests {
         let se_anon = unsafe {
             SearchEvent::new_impersonate_entry_ser(
                 JSON_ANONYMOUS_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
             )
         };
 
@@ -1937,9 +1937,9 @@ mod tests {
                 "test_acp",
                 "d38640c4-0254-49f9-99b7-8ba7d0233f3d",
                 // apply to anonymous only
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("anonymous"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("anonymous"))),
                 // Allow anonymous to read only testperson1
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // In that read, admin may only view the "name" attribute, or query on
                 // the name attribute. Any other query (should be) rejected.
                 "name",
@@ -1967,7 +1967,7 @@ mod tests {
         let mut se_anon = unsafe {
             SearchEvent::new_impersonate_entry_ser(
                 JSON_ANONYMOUS_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
             )
         };
         // the requested attrs here.
@@ -1978,9 +1978,9 @@ mod tests {
                 "test_acp",
                 "d38640c4-0254-49f9-99b7-8ba7d0233f3d",
                 // apply to anonymous only
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("anonymous"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("anonymous"))),
                 // Allow anonymous to read only testperson1
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // In that read, admin may only view the "name" attribute, or query on
                 // the name attribute. Any other query (should be) rejected.
                 "name uuid",
@@ -2024,23 +2024,23 @@ mod tests {
         let me_pres = unsafe {
             ModifyEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
-                modlist!([m_pres("name", &Value::new_iutf8s("value"))]),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
+                modlist!([m_pres("name", &Value::new_iname_s("value"))]),
             )
         };
         // Name rem
         let me_rem = unsafe {
             ModifyEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
-                modlist!([m_remove("name", &PartialValue::new_iutf8s("value"))]),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
+                modlist!([m_remove("name", &PartialValue::new_iname("value"))]),
             )
         };
         // Name purge
         let me_purge = unsafe {
             ModifyEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 modlist!([m_purge("name")]),
             )
         };
@@ -2049,7 +2049,7 @@ mod tests {
         let me_pres_class = unsafe {
             ModifyEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 modlist!([m_pres("class", &Value::new_class("account"))]),
             )
         };
@@ -2057,7 +2057,7 @@ mod tests {
         let me_rem_class = unsafe {
             ModifyEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 modlist!([m_remove("class", &PartialValue::new_class("account"))]),
             )
         };
@@ -2065,7 +2065,7 @@ mod tests {
         let me_purge_class = unsafe {
             ModifyEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 modlist!([m_purge("class")]),
             )
         };
@@ -2076,9 +2076,9 @@ mod tests {
                 "test_modify_allow",
                 "87bfe9b8-7600-431e-a492-1dde64bbc455",
                 // Apply to admin
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // To modify testperson
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // Allow pres name and class
                 "name class",
                 // Allow rem name and class
@@ -2093,9 +2093,9 @@ mod tests {
                 "test_modify_deny",
                 "87bfe9b8-7600-431e-a492-1dde64bbc456",
                 // Apply to admin
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // To modify testperson
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // Allow pres name and class
                 "member class",
                 // Allow rem name and class
@@ -2110,9 +2110,9 @@ mod tests {
                 "test_modify_no_class",
                 "87bfe9b8-7600-431e-a492-1dde64bbc457",
                 // Apply to admin
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // To modify testperson
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // Allow pres name and class
                 "name class",
                 // Allow rem name and class
@@ -2243,10 +2243,10 @@ mod tests {
                 "test_create",
                 "87bfe9b8-7600-431e-a492-1dde64bbc453",
                 // Apply to admin
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // To create matching filter testperson
                 // Can this be empty?
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // classes
                 "account",
                 // attrs
@@ -2259,9 +2259,9 @@ mod tests {
                 "test_create_2",
                 "87bfe9b8-7600-431e-a492-1dde64bbc454",
                 // Apply to admin
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // To create matching filter testperson
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
                 // classes
                 "group",
                 // attrs
@@ -2311,14 +2311,14 @@ mod tests {
         let de_admin = unsafe {
             DeleteEvent::new_impersonate_entry_ser(
                 JSON_ADMIN_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
             )
         };
 
         let de_anon = unsafe {
             DeleteEvent::new_impersonate_entry_ser(
                 JSON_ANONYMOUS_V1,
-                filter_all!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
             )
         };
 
@@ -2327,9 +2327,9 @@ mod tests {
                 "test_delete",
                 "87bfe9b8-7600-431e-a492-1dde64bbc453",
                 // Apply to admin
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("admin"))),
                 // To delete testperson
-                filter_valid!(f_eq("name", PartialValue::new_iutf8s("testperson1"))),
+                filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
             )
         };
 

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -376,7 +376,7 @@ impl Handler<InternalSearchMessage> for QueryServerReadV1 {
                 let srch = match SearchEvent::from_internal_message(&mut audit, msg, &mut qs_read) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin internal api search: {:?}", e);
                         return Err(e);
                     }
                 };
@@ -471,7 +471,7 @@ impl Handler<InternalRadiusReadMessage> for QueryServerReadV1 {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin radius read: {:?}", e);
                         return Err(e);
                     }
                 };
@@ -537,7 +537,7 @@ impl Handler<InternalRadiusTokenReadMessage> for QueryServerReadV1 {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin radius token read: {:?}", e);
                         return Err(e);
                     }
                 };
@@ -589,7 +589,7 @@ impl Handler<InternalUnixUserTokenReadMessage> for QueryServerReadV1 {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin unix token read: {:?}", e);
                         return Err(e);
                     }
                 };
@@ -642,7 +642,7 @@ impl Handler<InternalUnixGroupTokenReadMessage> for QueryServerReadV1 {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin unix group token read: {:?}", e);
                         return Err(e);
                     }
                 };
@@ -690,7 +690,7 @@ impl Handler<InternalSshKeyReadMessage> for QueryServerReadV1 {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin ssh key read: {:?}", e);
                         return Err(e);
                     }
                 };
@@ -760,7 +760,7 @@ impl Handler<InternalSshKeyTagReadMessage> for QueryServerReadV1 {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        ladmin_error!(audit, "Failed to begin search: {:?}", e);
+                        ladmin_error!(audit, "Failed to begin sshkey tag read: {:?}", e);
                         return Err(e);
                     }
                 };

--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -59,140 +59,83 @@ macro_rules! audit_log {
     })
 }
 
+macro_rules! lqueue {
+    ($au:expr, $tag:expr, $($arg:tt)*) => ({
+        /*
+        if cfg!(test) || cfg!(debug_assertions) {
+            error!($($arg)*)
+        }
+        */
+        use std::fmt;
+        use crate::audit::LogTag;
+        $au.log_event(
+            $tag,
+            fmt::format(
+                format_args!($($arg)*)
+            )
+        )
+    })
+}
+
 macro_rules! ltrace {
     ($au:expr, $($arg:tt)*) => ({
         if log_enabled!(log::Level::Debug) {
-            /*
-            if cfg!(test) || cfg!(debug_assertions) {
-                error!($($arg)*)
-            }
-            */
-            use std::fmt;
-            use crate::audit::LogTag;
-            $au.log_event(
-                LogTag::Trace,
-                fmt::format(
-                    format_args!($($arg)*)
-                )
-            )
+            lqueue!($au, LogTag::Trace, $($arg)*)
         }
     })
 }
 
 macro_rules! lfilter {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::Filter,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::Filter, $($arg)*)
     })
 }
 
 macro_rules! lfilter_warning {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::FilterWarning,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::FilterWarning, $($arg)*)
     })
 }
 
 macro_rules! lfilter_error {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::FilterError,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::FilterError, $($arg)*)
     })
 }
 
 macro_rules! ladmin_error {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::AdminError,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::AdminError, $($arg)*)
     })
 }
 
 macro_rules! ladmin_warning {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::AdminWarning,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::AdminWarning, $($arg)*)
     })
 }
 
 macro_rules! ladmin_info {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::AdminInfo,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::AdminInfo, $($arg)*)
     })
 }
 
 macro_rules! lrequest_error {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::RequestError,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::RequestError, $($arg)*)
     })
 }
 
 macro_rules! lsecurity {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::Security,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::Security, $($arg)*)
     })
 }
 
 macro_rules! lsecurity_access {
     ($au:expr, $($arg:tt)*) => ({
-        use std::fmt;
-        use crate::audit::LogTag;
-        $au.log_event(
-            LogTag::SecurityAccess,
-            fmt::format(
-                format_args!($($arg)*)
-            )
-        )
+        lqueue!($au, LogTag::SecurityAccess, $($arg)*)
     })
 }
 

--- a/kanidmd/src/lib/be/dbvalue.rs
+++ b/kanidmd/src/lib/be/dbvalue.rs
@@ -52,6 +52,7 @@ pub struct DbValueTaggedStringV1 {
 pub enum DbValueV1 {
     U8(String),
     I8(String),
+    N8(String),
     UU(Uuid),
     BO(bool),
     SY(usize),

--- a/kanidmd/src/lib/constants/entries.rs
+++ b/kanidmd/src/lib/constants/entries.rs
@@ -326,8 +326,8 @@ pub const JSON_SYSTEM_INFO_V1: &str = r#"{
     "attrs": {
         "class": ["object", "system_info", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
-        "description": ["System info and metadata object."],
-        "version": ["2"]
+        "description": ["System (local) info and metadata object."],
+        "version": ["3"]
     }
 }"#;
 

--- a/kanidmd/src/lib/constants/mod.rs
+++ b/kanidmd/src/lib/constants/mod.rs
@@ -13,7 +13,7 @@ pub use crate::constants::system_config::*;
 pub use crate::constants::uuids::*;
 
 // Increment this as we add new schema types and values!!!
-pub const SYSTEM_INDEX_VERSION: i64 = 7;
+pub const SYSTEM_INDEX_VERSION: i64 = 8;
 // On test builds, define to 60 seconds
 #[cfg(test)]
 pub const PURGE_FREQUENCY: u64 = 60;

--- a/kanidmd/src/lib/constants/schema.rs
+++ b/kanidmd/src/lib/constants/schema.rs
@@ -210,7 +210,8 @@ pub const JSON_SCHEMA_ATTR_DOMAIN_NAME: &str = r#"{
         "The domain's DNS name for webauthn and SPN generation purposes."
       ],
       "index": [
-        "EQUALITY"
+        "EQUALITY",
+        "PRESENCE"
       ],
       "unique": [
         "true"
@@ -222,7 +223,7 @@ pub const JSON_SCHEMA_ATTR_DOMAIN_NAME: &str = r#"{
         "domain_name"
       ],
       "syntax": [
-        "UTF8STRING_INSENSITIVE"
+        "UTF8STRING_INAME"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000053"

--- a/kanidmd/src/lib/constants/uuids.rs
+++ b/kanidmd/src/lib/constants/uuids.rs
@@ -104,7 +104,7 @@ pub const UUID_SCHEMA_ATTR_PASSWORD_IMPORT: &str = "00000000-0000-0000-0000-ffff
 
 // System and domain infos
 // I'd like to strongly criticise william of the past for fucking up these allocations.
-pub const _UUID_SYSTEM_INFO: &str = "00000000-0000-0000-0000-ffffff000001";
+pub const STR_UUID_SYSTEM_INFO: &str = "00000000-0000-0000-0000-ffffff000001";
 pub const UUID_DOMAIN_INFO: &str = "00000000-0000-0000-0000-ffffff000025";
 // DO NOT allocate here, allocate below.
 
@@ -151,4 +151,5 @@ lazy_static! {
     pub static ref UUID_DOES_NOT_EXIST: Uuid = Uuid::parse_str(STR_UUID_DOES_NOT_EXIST).unwrap();
     pub static ref UUID_ANONYMOUS: Uuid = Uuid::parse_str(STR_UUID_ANONYMOUS).unwrap();
     pub static ref UUID_SYSTEM_CONFIG: Uuid = Uuid::parse_str(STR_UUID_SYSTEM_CONFIG).unwrap();
+    pub static ref UUID_SYSTEM_INFO: Uuid = Uuid::parse_str(STR_UUID_SYSTEM_INFO).unwrap();
 }

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -1256,7 +1256,7 @@ fn setup_qs_idms(
     };
 
     // Create a query_server implementation
-    let query_server = QueryServer::new(be, schema);
+    let query_server = QueryServer::new(be, schema, duration_from_epoch_now());
 
     // TODO #62: Should the IDM parts be broken out to the IdmServer?
     // What's important about this initial setup here is that it also triggers
@@ -1495,7 +1495,7 @@ pub fn verify_server_core(config: Configuration) {
             return;
         }
     };
-    let server = QueryServer::new(be, schema_mem);
+    let server = QueryServer::new(be, schema_mem, duration_from_epoch_now());
 
     // Run verifications.
     let r = server.verify(&mut audit);

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -1256,7 +1256,7 @@ fn setup_qs_idms(
     };
 
     // Create a query_server implementation
-    let query_server = QueryServer::new(be, schema, duration_from_epoch_now());
+    let query_server = QueryServer::new(be, schema);
 
     // TODO #62: Should the IDM parts be broken out to the IdmServer?
     // What's important about this initial setup here is that it also triggers
@@ -1312,6 +1312,7 @@ pub fn restore_server_core(config: Configuration, dst_path: &str) {
     let schema = match Schema::new(&mut audit) {
         Ok(s) => s,
         Err(e) => {
+            audit.write_log();
             error!("Failed to setup in memory schema: {:?}", e);
             std::process::exit(1);
         }
@@ -1330,7 +1331,7 @@ pub fn restore_server_core(config: Configuration, dst_path: &str) {
         error!("Failed to restore database: {:?}", r);
         std::process::exit(1);
     }
-    info!("Restore Success!");
+    info!("Database loaded successfully");
 
     info!("Attempting to init query server ...");
 
@@ -1354,10 +1355,13 @@ pub fn restore_server_core(config: Configuration, dst_path: &str) {
     match r {
         Ok(_) => info!("Reindex Success!"),
         Err(e) => {
+            audit.write_log();
             error!("Restore failed: {:?}", e);
             std::process::exit(1);
         }
     };
+
+    info!("✅ Restore Success!");
 }
 
 pub fn reindex_server_core(config: Configuration) {
@@ -1462,6 +1466,7 @@ pub fn domain_rename_core(config: Configuration, new_domain_name: String) {
     };
 }
 
+/*
 pub fn reset_sid_core(config: Configuration) {
     let mut audit = AuditScope::new("reset_sid_core", uuid::Uuid::new_v4());
     // Setup the be
@@ -1476,6 +1481,7 @@ pub fn reset_sid_core(config: Configuration) {
     audit.write_log();
     info!("New Server ID: {:?}", nsid);
 }
+*/
 
 pub fn verify_server_core(config: Configuration) {
     let mut audit = AuditScope::new("server_verify", uuid::Uuid::new_v4());
@@ -1495,7 +1501,7 @@ pub fn verify_server_core(config: Configuration) {
             return;
         }
     };
-    let server = QueryServer::new(be, schema_mem, duration_from_epoch_now());
+    let server = QueryServer::new(be, schema_mem);
 
     // Run verifications.
     let r = server.verify(&mut audit);
@@ -1868,6 +1874,7 @@ pub fn create_server_core(config: Configuration) -> Result<ServerCtx, ()> {
     };
 
     server.expect("Failed to initialise server!").run();
+    info!("ready to rock! 🤘");
 
     Ok(ServerCtx::new(System::current(), log_tx, log_thread))
 }

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -381,7 +381,7 @@ impl Entry<EntryInit, EntryNew> {
             .map(|(k, vs)| {
                 let attr = k.to_lowercase();
                 let vv: BTreeSet<Value> = match attr.as_str() {
-                    "name" | "attributename" | "classname" | "version" | "domain" | "domain_name" => {
+                    "name" | "attributename" | "classname" | "domain" | "domain_name" => {
                         vs.into_iter().map(|v| Value::new_iutf8(v)).collect()
                     }
                     "userid" | "uidnumber" => {
@@ -451,7 +451,7 @@ impl Entry<EntryInit, EntryNew> {
                             })
                         }).collect()
                     }
-                    "gidnumber" => {
+                    "gidnumber" | "version" => {
                         vs.into_iter().map(|v| {
                             Value::new_uint32_str(v.as_str())
                             .unwrap_or_else(|| {

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -67,6 +67,7 @@ pub fn f_self<'a>() -> FC<'a> {
     FC::SelfUUID
 }
 
+#[allow(dead_code)]
 pub fn f_id(id: &str) -> FC<'static> {
     let uf = Uuid::parse_str(id)
         .ok()
@@ -75,6 +76,17 @@ pub fn f_id(id: &str) -> FC<'static> {
     let nf = FC::Eq("name", PartialValue::new_iname(id));
     let f: Vec<_> = iter::once(uf)
         .chain(iter::once(spnf))
+        .filter_map(|v| v)
+        .chain(iter::once(nf))
+        .collect();
+    FC::Or(f)
+}
+
+#[allow(dead_code)]
+pub fn f_spn_name(id: &str) -> FC<'static> {
+    let spnf = PartialValue::new_spn_s(id).map(|spn| FC::Eq("spn", spn));
+    let nf = FC::Eq("name", PartialValue::new_iname(id));
+    let f: Vec<_> = iter::once(spnf)
         .filter_map(|v| v)
         .chain(iter::once(nf))
         .collect();

--- a/kanidmd/src/lib/idm/macros.rs
+++ b/kanidmd/src/lib/idm/macros.rs
@@ -43,7 +43,7 @@ macro_rules! run_idm_test {
         let be = Backend::new(&mut audit, "", 1).expect("Failed to init be");
         let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
 
-        let test_server = QueryServer::new(be, schema_outer, duration_from_epoch_now());
+        let test_server = QueryServer::new(be, schema_outer);
         test_server
             .initialise_helper(&mut audit, duration_from_epoch_now())
             .expect("init failed");

--- a/kanidmd/src/lib/idm/macros.rs
+++ b/kanidmd/src/lib/idm/macros.rs
@@ -43,7 +43,7 @@ macro_rules! run_idm_test {
         let be = Backend::new(&mut audit, "", 1).expect("Failed to init be");
         let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
 
-        let test_server = QueryServer::new(be, schema_outer);
+        let test_server = QueryServer::new(be, schema_outer, duration_from_epoch_now());
         test_server
             .initialise_helper(&mut audit, duration_from_epoch_now())
             .expect("init failed");

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -157,7 +157,7 @@ impl<'a> IdmServerWriteTransaction<'a> {
                     // because it associates to the nonce's etc which were all cached.
 
                     let filter_entry = filter!(f_or!([
-                        f_eq("name", PartialValue::new_iutf8s(init.name.as_str())),
+                        f_eq("name", PartialValue::new_iname(init.name.as_str())),
                         // This currently says invalid syntax, which is correct, but also
                         // annoying because it would be nice to search both ...
                         // f_eq("uuid", name.as_str()),
@@ -842,7 +842,7 @@ mod tests {
         // now modify and provide a primary credential.
         let me_inv_m = unsafe {
             ModifyEvent::new_internal_invalid(
-                filter!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                filter!(f_eq("name", PartialValue::new_iname("admin"))),
                 ModifyList::new_list(vec![Modify::Present(
                     "primary_credential".to_string(),
                     v_cred,
@@ -1076,7 +1076,7 @@ mod tests {
             // Modify admin to have posixaccount
             let me_posix = unsafe {
                 ModifyEvent::new_internal_invalid(
-                    filter!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                    filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
                         Modify::Present("class".to_string(), Value::new_class("posixaccount")),
                         Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
@@ -1148,7 +1148,7 @@ mod tests {
             // make the admin a valid posix account
             let me_posix = unsafe {
                 ModifyEvent::new_internal_invalid(
-                    filter!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                    filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
                         Modify::Present("class".to_string(), Value::new_class("posixaccount")),
                         Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
@@ -1185,7 +1185,7 @@ mod tests {
             let mut idms_prox_write = idms.proxy_write(duration_from_epoch_now());
             let me_purge_up = unsafe {
                 ModifyEvent::new_internal_invalid(
-                    filter!(f_eq("name", PartialValue::new_iutf8s("admin"))),
+                    filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![Modify::Purged("unix_password".to_string())]),
                 )
             };

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -155,30 +155,17 @@ impl<'a> IdmServerWriteTransaction<'a> {
                     //
                     // Check anything needed? Get the current auth-session-id from request
                     // because it associates to the nonce's etc which were all cached.
-
-                    let filter_entry = filter!(f_or!([
-                        f_eq("name", PartialValue::new_iname(init.name.as_str())),
-                        // This currently says invalid syntax, which is correct, but also
-                        // annoying because it would be nice to search both ...
-                        // f_eq("uuid", name.as_str()),
-                    ]));
+                    let euuid = self.qs_read.name_to_uuid(au, init.name.as_str())?;
 
                     // Get the first / single entry we expect here ....
-                    let entry = match self.qs_read.internal_search(au, filter_entry) {
-                        Ok(mut entries) => {
-                            // Get only one entry out ...
-                            if entries.len() >= 2 {
-                                return Err(OperationError::InvalidDBState);
-                            }
-                            entries.pop().ok_or(OperationError::NoMatchingEntries)?
-                        }
-                        Err(e) => {
-                            // Something went wrong! Abort!
-                            return Err(e);
-                        }
-                    };
+                    let entry = self.qs_read.internal_search_uuid(au, &euuid)?;
 
-                    lsecurity!(au, "Initiating Authentication Session for ... {:?}", entry);
+                    lsecurity!(
+                        au,
+                        "Initiating Authentication Session for ... {:?}: {:?}",
+                        euuid,
+                        entry
+                    );
 
                     // Now, convert the Entry to an account - this gives us some stronger
                     // typing and functionality so we can assess what auth types can
@@ -881,6 +868,63 @@ mod tests {
         run_idm_test!(|qs: &QueryServer, idms: &IdmServer, au: &mut AuditScope| {
             init_admin_w_password(au, qs, TEST_PASSWORD).expect("Failed to setup admin account");
             let sid = init_admin_authsession_sid(idms, au);
+
+            let mut idms_write = idms.write();
+            let anon_step = AuthEvent::cred_step_password(sid, TEST_PASSWORD);
+
+            // Expect success
+            let r2 = idms_write.auth(au, &anon_step, Duration::from_secs(TEST_CURRENT_TIME));
+            debug!("r2 ==> {:?}", r2);
+
+            match r2 {
+                Ok(ar) => {
+                    let AuthResult {
+                        sessionid: _,
+                        state,
+                    } = ar;
+                    match state {
+                        AuthState::Success(_uat) => {
+                            // Check the uat.
+                        }
+                        _ => {
+                            error!("A critical error has occured! We have a non-succcess result!");
+                            panic!();
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("A critical error has occured! {:?}", e);
+                    // Should not occur!
+                    panic!();
+                }
+            };
+
+            idms_write.commit(au).expect("Must not fail");
+        })
+    }
+
+    #[test]
+    fn test_idm_simple_password_spn_auth() {
+        run_idm_test!(|qs: &QueryServer, idms: &IdmServer, au: &mut AuditScope| {
+            init_admin_w_password(au, qs, TEST_PASSWORD).expect("Failed to setup admin account");
+            let mut idms_write = idms.write();
+            let admin_init = AuthEvent::named_init("admin@example.com");
+
+            let r1 = idms_write.auth(au, &admin_init, Duration::from_secs(TEST_CURRENT_TIME));
+            let ar = r1.unwrap();
+            let AuthResult { sessionid, state } = ar;
+
+            match state {
+                AuthState::Continue(_) => {}
+                _ => {
+                    error!("Sessions was not initialised");
+                    panic!();
+                }
+            };
+
+            idms_write.commit(au).expect("Must not fail");
+
+            let sid = sessionid;
 
             let mut idms_write = idms.write();
             let anon_step = AuthEvent::cred_step_password(sid, TEST_PASSWORD);

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -1,4 +1,44 @@
 #[cfg(test)]
+macro_rules! run_test_no_init {
+    ($test_fn:expr) => {{
+        use crate::audit::AuditScope;
+        use crate::be::Backend;
+        use crate::schema::Schema;
+        use crate::server::QueryServer;
+        use crate::utils::duration_from_epoch_now;
+
+        use env_logger;
+        ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
+        let _ = env_logger::builder()
+            .format_timestamp(None)
+            .format_level(false)
+            .is_test(true)
+            .try_init();
+
+        let mut audit = AuditScope::new("run_test", uuid::Uuid::new_v4());
+
+        let be = match Backend::new(&mut audit, "", 1) {
+            Ok(be) => be,
+            Err(e) => {
+                audit.write_log();
+                error!("{:?}", e);
+                panic!()
+            }
+        };
+        let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
+        let test_server = QueryServer::new(be, schema_outer);
+
+        $test_fn(&test_server, &mut audit);
+        // Any needed teardown?
+        // Make sure there are no errors.
+        // let verifications = test_server.verify(&mut audit);
+        // ltrace!(audit, "Verification result: {:?}", verifications);
+        // assert!(verifications.len() == 0);
+        audit.write_log();
+    }};
+}
+
+#[cfg(test)]
 macro_rules! run_test {
     ($test_fn:expr) => {{
         use crate::audit::AuditScope;
@@ -26,7 +66,7 @@ macro_rules! run_test {
             }
         };
         let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
-        let test_server = QueryServer::new(be, schema_outer, duration_from_epoch_now());
+        let test_server = QueryServer::new(be, schema_outer);
 
         test_server
             .initialise_helper(&mut audit, duration_from_epoch_now())
@@ -38,6 +78,7 @@ macro_rules! run_test {
         let verifications = test_server.verify(&mut audit);
         ltrace!(audit, "Verification result: {:?}", verifications);
         assert!(verifications.len() == 0);
+        audit.write_log();
     }};
 }
 

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -130,7 +130,9 @@ macro_rules! filter {
         #[allow(unused_imports)]
         use crate::filter::FC;
         #[allow(unused_imports)]
-        use crate::filter::{f_and, f_andnot, f_eq, f_id, f_lt, f_or, f_pres, f_self, f_sub};
+        use crate::filter::{
+            f_and, f_andnot, f_eq, f_id, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub,
+        };
         Filter::new_ignore_hidden($fc)
     }};
 }

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -26,7 +26,7 @@ macro_rules! run_test {
             }
         };
         let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
-        let test_server = QueryServer::new(be, schema_outer);
+        let test_server = QueryServer::new(be, schema_outer, duration_from_epoch_now());
 
         test_server
             .initialise_helper(&mut audit, duration_from_epoch_now())

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -141,7 +141,7 @@ impl ModifyList<ModifyInvalid> {
                     let attr_norm = schema.normalise_attr_name(attr);
                     match schema_attributes.get(&attr_norm) {
                         Some(schema_a) => schema_a
-                            .validate_value(&value)
+                            .validate_value(attr_norm.as_str(), &value)
                             .map(|_| Modify::Present(attr_norm, value.clone())),
                         None => Err(SchemaError::InvalidAttribute(attr_norm)),
                     }
@@ -150,7 +150,7 @@ impl ModifyList<ModifyInvalid> {
                     let attr_norm = schema.normalise_attr_name(attr);
                     match schema_attributes.get(&attr_norm) {
                         Some(schema_a) => schema_a
-                            .validate_partialvalue(&value)
+                            .validate_partialvalue(attr_norm.as_str(), &value)
                             .map(|_| Modify::Removed(attr_norm, value.clone())),
                         None => Err(SchemaError::InvalidAttribute(attr_norm)),
                     }

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -304,11 +304,11 @@ mod tests {
             preload,
             filter!(f_or!([f_eq(
                 "name",
-                PartialValue::new_iutf8s("testgroup_b")
+                PartialValue::new_iname("testgroup_b")
             ),])),
             ModifyList::new_list(vec![
                 Modify::Purged("name".to_string()),
-                Modify::Present("name".to_string(), Value::new_iutf8s("testgroup_a"))
+                Modify::Present("name".to_string(), Value::new_iname_s("testgroup_a"))
             ]),
             None,
             |_, _| {}
@@ -350,12 +350,12 @@ mod tests {
             ))),
             preload,
             filter!(f_or!([
-                f_eq("name", PartialValue::new_iutf8s("testgroup_a")),
-                f_eq("name", PartialValue::new_iutf8s("testgroup_b")),
+                f_eq("name", PartialValue::new_iname("testgroup_a")),
+                f_eq("name", PartialValue::new_iname("testgroup_b")),
             ])),
             ModifyList::new_list(vec![
                 Modify::Purged("name".to_string()),
-                Modify::Present("name".to_string(), Value::new_iutf8s("testgroup"))
+                Modify::Present("name".to_string(), Value::new_iname_s("testgroup"))
             ]),
             None,
             |_, _| {}

--- a/kanidmd/src/lib/plugins/base.rs
+++ b/kanidmd/src/lib/plugins/base.rs
@@ -331,7 +331,7 @@ mod tests {
                 let cands = qs
                     .internal_search(
                         au,
-                        filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+                        filter!(f_eq("name", PartialValue::new_iname("testperson"))),
                     )
                     .expect("Internal search failure");
                 let ue = cands.first().expect("No cand");
@@ -426,7 +426,7 @@ mod tests {
                 let cands = qs
                     .internal_search(
                         au,
-                        filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+                        filter!(f_eq("name", PartialValue::new_iname("testperson"))),
                     )
                     .expect("Internal search failure");
                 let ue = cands.first().expect("No cand");
@@ -575,7 +575,7 @@ mod tests {
         run_modify_test!(
             Err(OperationError::SystemProtectedAttribute),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_a"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Present(
                 "uuid".to_string(),
                 Value::from("f15a7219-1d15-44e3-a7b4-bec899c07788")
@@ -606,7 +606,7 @@ mod tests {
         run_modify_test!(
             Err(OperationError::SystemProtectedAttribute),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_a"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Removed(
                 "uuid".to_string(),
                 PartialValue::new_uuids("f15a7219-1d15-44e3-a7b4-bec899c07788").unwrap()
@@ -637,7 +637,7 @@ mod tests {
         run_modify_test!(
             Err(OperationError::SystemProtectedAttribute),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_a"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Purged("uuid".to_string())]),
             None,
             |_, _| {}

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -46,7 +46,7 @@ impl Plugin for Domain {
                 ltrace!(au, "plugin_domain: Applying uuid transform");
                 // We only apply this if one isn't provided.
                 if !e.attribute_pres("domain_name") {
-                    let n = Value::new_iutf8s("example.com");
+                    let n = Value::new_iname_s("example.com");
                     e.set_avas("domain_name", vec![n]);
                     ltrace!(au, "plugin_domain: Applying domain_name transform");
                 }

--- a/kanidmd/src/lib/plugins/gidnumber.rs
+++ b/kanidmd/src/lib/plugins/gidnumber.rs
@@ -22,8 +22,8 @@ const GID_SYSTEM_NUMBER_MIN: u32 = 65536;
 const GID_SAFETY_NUMBER_MIN: u32 = 1000;
 
 lazy_static! {
-    static ref CLASS_POSIXGROUP: PartialValue = PartialValue::new_iutf8s("posixgroup");
-    static ref CLASS_POSIXACCOUNT: PartialValue = PartialValue::new_iutf8s("posixaccount");
+    static ref CLASS_POSIXGROUP: PartialValue = PartialValue::new_class("posixgroup");
+    static ref CLASS_POSIXACCOUNT: PartialValue = PartialValue::new_class("posixaccount");
 }
 
 pub struct GidNumber {}
@@ -209,7 +209,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([m_pres("class", &Value::new_class("posixgroup"))]),
             None,
             |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
@@ -242,7 +242,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([m_purge("gidnumber")]),
             None,
             |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
@@ -277,7 +277,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([
                 m_purge("gidnumber"),
                 m_pres("gidnumber", &Value::new_uint32(2000))

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -17,7 +17,7 @@ macro_rules! setup_test {
         let be = Backend::new($au, "", 1).expect("Failed to init BE");
 
         let schema_outer = Schema::new($au).expect("Failed to init schema");
-        let qs = QueryServer::new(be, schema_outer);
+        let qs = QueryServer::new(be, schema_outer, duration_from_epoch_now());
         qs.initialise_helper($au, duration_from_epoch_now())
             .expect("init failed!");
 

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -17,7 +17,7 @@ macro_rules! setup_test {
         let be = Backend::new($au, "", 1).expect("Failed to init BE");
 
         let schema_outer = Schema::new($au).expect("Failed to init schema");
-        let qs = QueryServer::new(be, schema_outer, duration_from_epoch_now());
+        let qs = QueryServer::new(be, schema_outer);
         qs.initialise_helper($au, duration_from_epoch_now())
             .expect("init failed!");
 

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -297,7 +297,7 @@ mod tests {
         run_modify_test!(
             Err(OperationError::SystemProtectedObject),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([
                 m_purge("displayname"),
                 m_pres("displayname", &Value::new_utf8s("system test")),
@@ -329,7 +329,7 @@ mod tests {
         run_modify_test!(
             Err(OperationError::SystemProtectedObject),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([m_pres("class", &Value::new_class("system")),]),
             Some(JSON_ADMIN_V1),
             |_, _| {}
@@ -358,7 +358,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("classname", PartialValue::new_iutf8s("testclass"))),
+            filter!(f_eq("classname", PartialValue::new_class("testclass"))),
             modlist!([
                 m_pres("may", &Value::new_iutf8s("name")),
                 m_pres("must", &Value::new_iutf8s("name")),
@@ -390,7 +390,7 @@ mod tests {
         run_delete_test!(
             Err(OperationError::SystemProtectedObject),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             Some(JSON_ADMIN_V1),
             |_, _| {}
         );
@@ -422,7 +422,7 @@ mod tests {
             preload,
             filter!(f_eq(
                 "name",
-                PartialValue::new_iutf8s("domain_example.net.au")
+                PartialValue::new_iname("domain_example.net.au")
             )),
             modlist!([
                 m_purge("domain_ssid"),
@@ -487,7 +487,7 @@ mod tests {
             preload,
             filter!(f_eq(
                 "name",
-                PartialValue::new_iutf8s("domain_example.net.au")
+                PartialValue::new_iname("domain_example.net.au")
             )),
             Some(JSON_ADMIN_V1),
             |_, _| {}

--- a/kanidmd/src/lib/plugins/refint.rs
+++ b/kanidmd/src/lib/plugins/refint.rs
@@ -313,7 +313,7 @@ mod tests {
                 let cands = qs
                     .internal_search(
                         au,
-                        filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+                        filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
                     )
                     .expect("Internal search failure");
                 let _ue = cands.first().expect("No cand");
@@ -351,7 +351,7 @@ mod tests {
                 let cands = qs
                     .internal_search(
                         au,
-                        filter!(f_eq("name", PartialValue::new_iutf8s("testgroup"))),
+                        filter!(f_eq("name", PartialValue::new_iname("testgroup"))),
                     )
                     .expect("Internal search failure");
                 let _ue = cands.first().expect("No cand");
@@ -392,7 +392,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Present(
                 "member".to_string(),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
@@ -424,7 +424,7 @@ mod tests {
                 "Uuid referenced not found in database".to_string()
             ))),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Present(
                 "member".to_string(),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
@@ -468,7 +468,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Purged("member".to_string())]),
             None,
             |_, _| {}
@@ -496,7 +496,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_a"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Present(
                 "member".to_string(),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
@@ -541,7 +541,7 @@ mod tests {
                 "Uuid referenced not found in database".to_string()
             ))),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Present(
                 "member".to_string(),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
@@ -587,7 +587,7 @@ mod tests {
         run_delete_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_a"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             None,
             |_au: &mut AuditScope, _qs: &mut QueryServerWriteTransaction| {}
         );
@@ -633,7 +633,7 @@ mod tests {
         run_delete_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             None,
             |_au: &mut AuditScope, _qs: &mut QueryServerWriteTransaction| {}
         );
@@ -661,7 +661,7 @@ mod tests {
         run_delete_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testgroup_b"))),
+            filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             None,
             |_au: &mut AuditScope, _qs: &mut QueryServerWriteTransaction| {}
         );

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -19,8 +19,8 @@ pub struct Spn {}
 lazy_static! {
     static ref UUID_DOMAIN_INFO_T: Uuid =
         Uuid::parse_str(UUID_DOMAIN_INFO).expect("Unable to parse constant UUID_DOMAIN_INFO");
-    static ref CLASS_GROUP: PartialValue = PartialValue::new_iutf8s("group");
-    static ref CLASS_ACCOUNT: PartialValue = PartialValue::new_iutf8s("account");
+    static ref CLASS_GROUP: PartialValue = PartialValue::new_class("group");
+    static ref CLASS_ACCOUNT: PartialValue = PartialValue::new_class("account");
     static ref PV_UUID_DOMAIN_INFO: PartialValue = PartialValue::new_uuids(UUID_DOMAIN_INFO)
         .expect("Unable to parse constant UUID_DOMAIN_INFO");
 }
@@ -327,7 +327,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([m_purge("spn")]),
             None,
             |_, _| {}
@@ -384,7 +384,7 @@ mod tests {
         run_modify_test!(
             Ok(()),
             preload,
-            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([
                 m_purge("spn"),
                 m_pres("spn", &Value::new_spn_str("invalid", "spn"))

--- a/kanidmd/src/lib/repl/cid.rs
+++ b/kanidmd/src/lib/repl/cid.rs
@@ -1,7 +1,6 @@
 use kanidm_proto::v1::OperationError;
 use std::time::Duration;
 use uuid::Uuid;
-    use std::cmp::Ordering;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Eq, PartialOrd, Ord)]
 pub struct Cid {
@@ -12,21 +11,18 @@ pub struct Cid {
 }
 
 impl Cid {
+    #[cfg(test)]
     pub(crate) fn new(d_uuid: Uuid, s_uuid: Uuid, ts: Duration) -> Self {
         Cid { d_uuid, s_uuid, ts }
     }
 
-    pub fn new_lamport(d_uuid: Uuid, s_uuid: Uuid, ts: Duration, max_cid: &Self) -> Self {
-        let c_cand = Cid { d_uuid, s_uuid, ts };
-        if c_cand.cmp(max_cid) == Ordering::Greater {
-            // It's larger, return it.
-            c_cand
+    pub fn new_lamport(d_uuid: Uuid, s_uuid: Uuid, ts: Duration, max_ts: &Duration) -> Self {
+        let ts = if ts > *max_ts {
+            ts
         } else {
-            // It's smaller, so take max_cid and increment it.
-            let mut c_cand = max_cid.clone();
-            c_cand.ts = c_cand.ts + Duration::from_nanos(1);
-            c_cand
-        }
+            *max_ts + Duration::from_nanos(1)
+        };
+        Cid { d_uuid, s_uuid, ts }
     }
 
     #[cfg(test)]
@@ -119,12 +115,12 @@ mod tests {
 
         let cid_z = unsafe { Cid::new_zero() };
 
-        let cid_a = Cid::new_lamport(d_uuid, s_uuid, ts5, &cid_z);
+        let cid_a = Cid::new_lamport(d_uuid, s_uuid, ts5.clone(), &ts5);
         assert!(cid_a.cmp(&cid_z) == Ordering::Greater);
-        let cid_b = Cid::new_lamport(d_uuid, s_uuid, ts15, &cid_a);
+        let cid_b = Cid::new_lamport(d_uuid, s_uuid, ts15.clone(), &ts10);
         assert!(cid_b.cmp(&cid_a) == Ordering::Greater);
         // Even with an older ts, we should still step forward.
-        let cid_c = Cid::new_lamport(d_uuid, s_uuid, ts10, &cid_b);
+        let cid_c = Cid::new_lamport(d_uuid, s_uuid, ts10, &ts15);
         assert!(cid_c.cmp(&cid_b) == Ordering::Greater);
     }
 }

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -1061,8 +1061,8 @@ impl<'a> SchemaWriteTransaction<'a> {
                     multivalue: false,
                     unique: false,
                     phantom: false,
-                    index: vec![IndexType::EQUALITY],
-                    syntax: SyntaxType::UTF8STRING_INSENSITIVE,
+                    index: vec![],
+                    syntax: SyntaxType::UINT32,
                 },
             );
             // Domain for sysinfo

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -3495,6 +3495,12 @@ mod tests {
     fn test_qs_upgrade_entry_attrs() {
         run_test_no_init!(|server: &QueryServer, audit: &mut AuditScope| {
             let mut server_txn = server.write(duration_from_epoch_now());
+            assert!(server_txn
+                .upgrade_reindex(audit, SYSTEM_INDEX_VERSION)
+                .is_ok());
+            assert!(server_txn.commit(audit).is_ok());
+
+            let mut server_txn = server.write(duration_from_epoch_now());
             server_txn.initialise_schema_core(audit).unwrap();
             server_txn.initialise_schema_idm(audit).unwrap();
             assert!(server_txn.commit(audit).is_ok());

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -17,6 +17,8 @@ use regex::Regex;
 lazy_static! {
     static ref SPN_RE: Regex =
         Regex::new("(?P<name>[^@]+)@(?P<realm>[^@]+)").expect("Invalid SPN regex found");
+    static ref INAME_RE: Regex =
+        Regex::new("^(_.*|.*@.*|\\d+|.*\\s.*)$").expect("Invalid Iname regex found");
 }
 
 #[allow(non_camel_case_types)]
@@ -95,6 +97,7 @@ pub enum SyntaxType {
     // We also need to "self host" a syntax type, and index type
     UTF8STRING,
     UTF8STRING_INSENSITIVE,
+    UTF8STRING_INAME,
     UUID,
     BOOLEAN,
     SYNTAX_ID,
@@ -117,6 +120,7 @@ impl TryFrom<&str> for SyntaxType {
         match n_value.as_str() {
             "UTF8STRING" => Ok(SyntaxType::UTF8STRING),
             "UTF8STRING_INSENSITIVE" => Ok(SyntaxType::UTF8STRING_INSENSITIVE),
+            "UTF8STRING_INAME" => Ok(SyntaxType::UTF8STRING_INAME),
             "UUID" => Ok(SyntaxType::UUID),
             "BOOLEAN" => Ok(SyntaxType::BOOLEAN),
             "SYNTAX_ID" => Ok(SyntaxType::SYNTAX_ID),
@@ -153,6 +157,7 @@ impl TryFrom<usize> for SyntaxType {
             11 => Ok(SyntaxType::SERVICE_PRINCIPLE_NAME),
             12 => Ok(SyntaxType::UINT32),
             13 => Ok(SyntaxType::CID),
+            14 => Ok(SyntaxType::UTF8STRING_INAME),
             _ => Err(()),
         }
     }
@@ -175,6 +180,7 @@ impl SyntaxType {
             SyntaxType::SERVICE_PRINCIPLE_NAME => 11,
             SyntaxType::UINT32 => 12,
             SyntaxType::CID => 13,
+            SyntaxType::UTF8STRING_INAME => 14,
         }
     }
 }
@@ -187,6 +193,7 @@ impl fmt::Display for SyntaxType {
             match self {
                 SyntaxType::UTF8STRING => "UTF8STRING",
                 SyntaxType::UTF8STRING_INSENSITIVE => "UTF8STRING_INSENSITIVE",
+                SyntaxType::UTF8STRING_INAME => "UTF8STRING_INAME",
                 SyntaxType::UUID => "UUID",
                 SyntaxType::BOOLEAN => "BOOLEAN",
                 SyntaxType::SYNTAX_ID => "SYNTAX_ID",
@@ -225,6 +232,7 @@ impl std::fmt::Debug for DataValue {
 pub enum PartialValue {
     Utf8(String),
     Iutf8(String),
+    Iname(String),
     Uuid(Uuid),
     Bool(bool),
     Syntax(SyntaxType),
@@ -262,6 +270,10 @@ impl PartialValue {
         PartialValue::Iutf8(s.to_lowercase())
     }
 
+    pub fn new_iname(s: &str) -> Self {
+        PartialValue::Iname(s.to_lowercase())
+    }
+
     #[inline]
     pub fn new_class(s: &str) -> Self {
         PartialValue::new_iutf8s(s)
@@ -277,6 +289,13 @@ impl PartialValue {
     pub fn is_iutf8(&self) -> bool {
         match self {
             PartialValue::Iutf8(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_iname(&self) -> bool {
+        match self {
+            PartialValue::Iname(_) => true,
             _ => false,
         }
     }
@@ -426,18 +445,16 @@ impl PartialValue {
     }
 
     pub fn new_spn_s(s: &str) -> Option<Self> {
-        SPN_RE.captures(s).map(|caps| {
-            let name = caps
-                .name("name")
-                .expect("Failed to access name group")
-                .as_str()
-                .to_string();
-            let realm = caps
-                .name("realm")
-                .expect("Failed to access realm group")
-                .as_str()
-                .to_string();
-            PartialValue::Spn(name, realm)
+        SPN_RE.captures(s).and_then(|caps| {
+            let name = match caps.name("name") {
+                Some(v) => v.as_str().to_string(),
+                None => return None,
+            };
+            let realm = match caps.name("realm") {
+                Some(v) => v.as_str().to_string(),
+                None => return None,
+            };
+            Some(PartialValue::Spn(name, realm))
         })
     }
 
@@ -486,6 +503,7 @@ impl PartialValue {
         match self {
             PartialValue::Utf8(s) => Some(s.as_str()),
             PartialValue::Iutf8(s) => Some(s.as_str()),
+            PartialValue::Iname(s) => Some(s.as_str()),
             _ => None,
         }
     }
@@ -498,6 +516,7 @@ impl PartialValue {
         match (self, s) {
             (PartialValue::Utf8(s1), PartialValue::Utf8(s2)) => s1.contains(s2),
             (PartialValue::Iutf8(s1), PartialValue::Iutf8(s2)) => s1.contains(s2),
+            (PartialValue::Iname(s1), PartialValue::Iname(s2)) => s1.contains(s2),
             _ => false,
         }
     }
@@ -512,7 +531,7 @@ impl PartialValue {
 
     pub fn get_idx_eq_key(&self) -> String {
         match &self {
-            PartialValue::Utf8(s) | PartialValue::Iutf8(s) => s.clone(),
+            PartialValue::Utf8(s) | PartialValue::Iutf8(s) | PartialValue::Iname(s) => s.clone(),
             PartialValue::Refer(u) | PartialValue::Uuid(u) => u.to_hyphenated_ref().to_string(),
             PartialValue::Bool(b) => b.to_string(),
             PartialValue::Syntax(syn) => syn.to_string(),
@@ -687,6 +706,27 @@ impl Value {
     pub fn is_insensitive_utf8(&self) -> bool {
         match self.pv {
             PartialValue::Iutf8(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn new_iname(s: String) -> Self {
+        Value {
+            pv: PartialValue::new_iname(s.as_str()),
+            data: None,
+        }
+    }
+
+    pub fn new_iname_s(s: &str) -> Self {
+        Value {
+            pv: PartialValue::new_iname(s),
+            data: None,
+        }
+    }
+
+    pub fn is_iname(&self) -> bool {
+        match self.pv {
+            PartialValue::Iname(_) => true,
             _ => false,
         }
     }
@@ -1001,6 +1041,10 @@ impl Value {
                     data: None,
                 })
             }
+            DbValueV1::N8(s) => Ok(Value {
+                pv: PartialValue::Iname(s.to_lowercase()),
+                data: None,
+            }),
             DbValueV1::UU(u) => Ok(Value {
                 pv: PartialValue::Uuid(u),
                 data: None,
@@ -1067,6 +1111,7 @@ impl Value {
         match &self.pv {
             PartialValue::Utf8(s) => DbValueV1::U8(s.clone()),
             PartialValue::Iutf8(s) => DbValueV1::I8(s.clone()),
+            PartialValue::Iname(s) => DbValueV1::N8(s.clone()),
             PartialValue::Uuid(u) => DbValueV1::UU(*u),
             PartialValue::Bool(b) => DbValueV1::BO(*b),
             PartialValue::Syntax(syn) => DbValueV1::SY(syn.to_usize()),
@@ -1129,6 +1174,7 @@ impl Value {
         match &self.pv {
             PartialValue::Utf8(s) => Some(s.as_str()),
             PartialValue::Iutf8(s) => Some(s.as_str()),
+            PartialValue::Iname(s) => Some(s.as_str()),
             _ => None,
         }
     }
@@ -1141,6 +1187,7 @@ impl Value {
         match &self.pv {
             PartialValue::Utf8(s) => Some(s),
             PartialValue::Iutf8(s) => Some(s),
+            PartialValue::Iname(s) => Some(s),
             _ => None,
         }
     }
@@ -1195,10 +1242,19 @@ impl Value {
         self.pv.clone()
     }
 
+    pub fn migrate_iutf8_iname(self) -> Option<Self> {
+        match self.pv {
+            PartialValue::Iutf8(v) => Some(Value {
+                pv: PartialValue::Iname(v),
+                data: None,
+            }),
+            _ => None,
+        }
+    }
+
     pub(crate) fn to_proto_string_clone(&self) -> String {
         match &self.pv {
-            PartialValue::Utf8(s) => s.clone(),
-            PartialValue::Iutf8(s) => s.clone(),
+            PartialValue::Utf8(s) | PartialValue::Iutf8(s) | PartialValue::Iname(s) => s.clone(),
             PartialValue::Uuid(u) => u.to_hyphenated_ref().to_string(),
             PartialValue::Bool(b) => b.to_string(),
             PartialValue::Syntax(syn) => syn.to_string(),
@@ -1246,6 +1302,14 @@ impl Value {
         // valid. IE json filter is really a filter, or cred types have supplemental
         // data.
         match &self.pv {
+            PartialValue::Iname(s) => {
+                match Uuid::parse_str(s) {
+                    // It is a uuid, disallow.
+                    Ok(_) => false,
+                    // Not a uuid, check it against the re.
+                    Err(_) => !INAME_RE.is_match(s),
+                }
+            }
             PartialValue::Cred(_) => match &self.data {
                 Some(v) => match &v {
                     DataValue::Cred(_) => true,
@@ -1275,7 +1339,9 @@ impl Value {
 
     pub fn generate_idx_eq_keys(&self) -> Vec<String> {
         match &self.pv {
-            PartialValue::Utf8(s) | PartialValue::Iutf8(s) => vec![s.clone()],
+            PartialValue::Utf8(s) | PartialValue::Iutf8(s) | PartialValue::Iname(s) => {
+                vec![s.clone()]
+            }
             PartialValue::Refer(u) | PartialValue::Uuid(u) => {
                 vec![u.to_hyphenated_ref().to_string()]
             }
@@ -1426,6 +1492,39 @@ mod tests {
     #[test]
     fn test_value_cid() {
         assert!(PartialValue::new_cid_s("_").is_none());
+    }
+
+    #[test]
+    fn test_value_iname() {
+        /*
+         * name MUST NOT:
+         * - be a pure int (confusion to gid/uid/linux)
+         * - a uuid (confuses our name mapper)
+         * - contain an @ (confuses SPN)
+         * - can not start with _ (... I forgot but it's important I swear >.>)
+         * - can not have spaces (confuses too many systems :()
+         */
+        let inv1 = Value::new_iname_s("1234");
+        let inv2 = Value::new_iname_s("bc23f637-4439-4c07-b95d-eaed0d9e4b8b");
+        let inv3 = Value::new_iname_s("hello@test.com");
+        let inv4 = Value::new_iname_s("_bad");
+        let inv5 = Value::new_iname_s("no spaces I'm sorry :(");
+
+        let val1 = Value::new_iname_s("William");
+        let val2 = Value::new_iname_s("this_is_okay");
+        let val3 = Value::new_iname_s("123_456");
+        let val4 = Value::new_iname_s("🍿");
+
+        assert!(!inv1.validate());
+        assert!(!inv2.validate());
+        assert!(!inv3.validate());
+        assert!(!inv4.validate());
+        assert!(!inv5.validate());
+
+        assert!(val1.validate());
+        assert!(val2.validate());
+        assert!(val3.validate());
+        assert!(val4.validate());
     }
 
     /*

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -36,6 +36,8 @@ impl TryFrom<&str> for IndexType {
             "EQUALITY" => Ok(IndexType::EQUALITY),
             "PRESENCE" => Ok(IndexType::PRESENCE),
             "SUBSTRING" => Ok(IndexType::SUBSTRING),
+            // UUID map?
+            // UUID rev map?
             _ => Err(()),
         }
     }

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use kanidm::config::Configuration;
 use kanidm::core::{
     backup_server_core, create_server_core, domain_rename_core, recover_account_core,
-    reindex_server_core, reset_sid_core, restore_server_core, verify_server_core,
+    reindex_server_core, restore_server_core, verify_server_core,
 };
 
 use log::{error, info};
@@ -77,8 +77,8 @@ enum Opt {
     Verify(CommonOpt),
     #[structopt(name = "recover_account")]
     RecoverAccount(RecoverAccountOpt),
-    #[structopt(name = "reset_server_id")]
-    ResetServerId(CommonOpt),
+    // #[structopt(name = "reset_server_id")]
+    // ResetServerId(CommonOpt),
     #[structopt(name = "reindex")]
     Reindex(CommonOpt),
     #[structopt(name = "domain_name_change")]
@@ -89,7 +89,7 @@ impl Opt {
     fn debug(&self) -> bool {
         match self {
             Opt::Server(sopt) => sopt.commonopts.debug,
-            Opt::Verify(sopt) | Opt::ResetServerId(sopt) | Opt::Reindex(sopt) => sopt.debug,
+            Opt::Verify(sopt) | Opt::Reindex(sopt) => sopt.debug,
             Opt::Backup(bopt) => bopt.commonopts.debug,
             Opt::Restore(ropt) => ropt.commonopts.debug,
             Opt::RecoverAccount(ropt) => ropt.commonopts.debug,
@@ -128,7 +128,6 @@ async fn main() {
             config.update_tls(&sopt.ca_path, &sopt.cert_path, &sopt.key_path);
             config.update_bind(&sopt.bind);
 
-            let _sys = actix::System::new("kanidm-server");
             let sctx = create_server_core(config);
             match sctx {
                 Ok(sctx) => {
@@ -184,12 +183,14 @@ async fn main() {
 
             recover_account_core(config, raopt.name, password);
         }
+        /*
         Opt::ResetServerId(vopt) => {
-            info!("Resetting server id. THIS MAY BREAK REPLICATION");
+            info!("Resetting server id. THIS WILL BREAK REPLICATION");
 
             config.update_db_path(&vopt.db_path);
             reset_sid_core(config);
         }
+        */
         Opt::Reindex(copt) => {
             info!("Running in reindex mode ...");
 


### PR DESCRIPTION
Fixes #184, Fixes #151 and Fixes #183 - this adds support to do on-upgrade migrations of the previous iutf8 type to iname, iname contains a better checker of the content of the name values that will become spn's, this allows auth via spn as well as just name. This really just does a lot of clean up to make spns more viable. #181 is still outstanding, but you can currently already login via spn a posixid_to_uuid supports this, it's only the resolving of unixgroup/accounts that need to have name as Option to cause a fall back to spn when in a trust.

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
