### PR TITLE
260 entry ava interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli",
 ]
@@ -652,8 +652,6 @@ dependencies = [
 [[package]]
 name = "concread"
 version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a22319b5f3043efd199c030cef117a4de34a4350ba687010b1c1ac2b649201"
 dependencies = [
  "crossbeam",
  "crossbeam-epoch",
@@ -2107,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026c63fe245362be0322bfec5a9656d458d13f9cfb1785d1b38458b9968e8080"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -2117,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9281a268ec213237dcd2aa3c3d0f46681b04ced37c1616fd36567a9e6954b0"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
 ]
@@ -2614,9 +2612,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "6135c78461981c79497158ef777264c51d9d0f4f3fc3a4d22b915900e42dac6a"
 dependencies = [
  "serde_derive",
 ]
@@ -2633,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "93c5eaa17d0954cb481cdcfffe9d84fcfa7a1a9f2349271e678677be4c26ae31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2837,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "a994520748611c17d163e81b6c4a4b13d11b7f63884362ab2efac3aa9cf16d00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,9 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.1.16"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e391cd28b9a522a8a3a4566fcd6d031847d82e436196c1120017e3b1112872fa"
 dependencies = [
  "crossbeam",
  "crossbeam-epoch",

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -35,6 +35,7 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     config.secure_cookies = false;
     config.integration_test_config = Some(int_config);
     config.log_level = Some(LogLevel::Quiet as u32);
+    // config.log_level = Some(LogLevel::FullTrace as u32);
     thread::spawn(move || {
         // Spawn a thread for the test runner, this should have a unique
         // port....

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -60,8 +60,8 @@ r2d2_sqlite = "0.14"
 structopt = { version = "0.3", default-features = false }
 time = "0.1"
 
-concread = "0.1"
-# concread = { path = "../../concread" }
+# concread = "0.1"
+concread = { path = "../../concread" }
 crossbeam = "0.7"
 
 openssl = "0.10"

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -60,8 +60,8 @@ r2d2_sqlite = "0.14"
 structopt = { version = "0.3", default-features = false }
 time = "0.1"
 
-# concread = "0.1"
-concread = { path = "../../concread" }
+concread = "0.1"
+# concread = { path = "../../concread" }
 crossbeam = "0.7"
 
 openssl = "0.10"

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -19,10 +19,10 @@
 use concread::cowcell::*;
 use kanidm_proto::v1::Filter as ProtoFilter;
 use kanidm_proto::v1::OperationError;
-use std::collections::BTreeSet;
 use std::collections::BTreeMap;
-use uuid::Uuid;
+use std::collections::BTreeSet;
 use std::ops::DerefMut;
+use uuid::Uuid;
 
 use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInit, EntryNew, EntryReduced, EntrySealed};

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -739,9 +739,10 @@ impl Handler<InternalSshKeyReadMessage> for QueryServerReadV1 {
                         let r = entries
                             .pop()
                             // get the first entry
-                            .map(|e| {
+                            .and_then(|e| {
                                 // From the entry, turn it into the value
-                                e.get_ava_ssh_pubkeys("ssh_publickey")
+                                e.get_ava_iter_sshpubkeys("ssh_publickey")
+                                    .map(|i| i.map(|s| s.to_string()).collect())
                             })
                             .unwrap_or_else(|| {
                                 // No matching entry? Return none.
@@ -815,6 +816,7 @@ impl Handler<InternalSshKeyTagReadMessage> for QueryServerReadV1 {
                                     vs.get(&pv)
                                         // Now turn that value to a pub key.
                                         .and_then(|v| v.get_sshkey())
+                                        .map(|s| s.to_string())
                                 })
                             })
                             .unwrap_or_else(|| {

--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -657,7 +657,7 @@ impl Handler<InternalCredentialSetMessage> for QueryServerWriteV1 {
                     SetCredentialRequest::GeneratePassword => {
                         let gpe = GeneratePasswordEvent::from_parts(
                             &mut audit,
-                            &mut idms_prox_write.qs_write,
+                            &idms_prox_write.qs_write,
                             msg.uat,
                             target_uuid,
                             msg.appid,

--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -357,7 +357,7 @@ impl QueryServerWriteV1 {
         proto_ml: ProtoModifyList,
         filter: Filter<FilterInvalid>,
     ) -> Result<(), OperationError> {
-        let mut qs_write = self.qs.write(duration_from_epoch_now());
+        let qs_write = self.qs.write(duration_from_epoch_now());
 
         let target_uuid = qs_write
             .name_to_uuid(audit, uuid_or_name.as_str())
@@ -367,8 +367,7 @@ impl QueryServerWriteV1 {
             })?;
 
         let mdf =
-            match ModifyEvent::from_parts(audit, uat, target_uuid, proto_ml, filter, &mut qs_write)
-            {
+            match ModifyEvent::from_parts(audit, uat, target_uuid, proto_ml, filter, &qs_write) {
                 Ok(m) => m,
                 Err(e) => {
                     ladmin_error!(audit, "Failed to begin modify: {:?}", e);
@@ -391,7 +390,7 @@ impl QueryServerWriteV1 {
         ml: ModifyList<ModifyInvalid>,
         filter: Filter<FilterInvalid>,
     ) -> Result<(), OperationError> {
-        let mut qs_write = self.qs.write(duration_from_epoch_now());
+        let qs_write = self.qs.write(duration_from_epoch_now());
 
         let target_uuid = qs_write
             .name_to_uuid(audit, uuid_or_name.as_str())
@@ -406,7 +405,7 @@ impl QueryServerWriteV1 {
             target_uuid,
             ml,
             filter,
-            &mut qs_write,
+            &qs_write,
         ) {
             Ok(m) => m,
             Err(e) => {
@@ -432,9 +431,9 @@ impl Handler<CreateMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<CreateMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
-                let crt = match CreateEvent::from_message(&mut audit, msg, &mut qs_write) {
+                let crt = match CreateEvent::from_message(&mut audit, msg, &qs_write) {
                     Ok(c) => c,
                     Err(e) => {
                         ladmin_warning!(audit, "Failed to begin create: {:?}", e);
@@ -467,8 +466,8 @@ impl Handler<ModifyMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<ModifyMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
-                let mdf = match ModifyEvent::from_message(&mut audit, msg, &mut qs_write) {
+                let qs_write = self.qs.write(duration_from_epoch_now());
+                let mdf = match ModifyEvent::from_message(&mut audit, msg, &qs_write) {
                     Ok(m) => m,
                     Err(e) => {
                         ladmin_error!(audit, "Failed to begin modify: {:?}", e);
@@ -500,9 +499,9 @@ impl Handler<DeleteMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<DeleteMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
-                let del = match DeleteEvent::from_message(&mut audit, msg, &mut qs_write) {
+                let del = match DeleteEvent::from_message(&mut audit, msg, &qs_write) {
                     Ok(d) => d,
                     Err(e) => {
                         ladmin_error!(audit, "Failed to begin delete: {:?}", e);
@@ -534,16 +533,16 @@ impl Handler<InternalDeleteMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<InternalDeleteMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
-                let del =
-                    match DeleteEvent::from_parts(&mut audit, msg.uat, msg.filter, &mut qs_write) {
-                        Ok(d) => d,
-                        Err(e) => {
-                            ladmin_error!(audit, "Failed to begin delete: {:?}", e);
-                            return Err(e);
-                        }
-                    };
+                let del = match DeleteEvent::from_parts(&mut audit, msg.uat, msg.filter, &qs_write)
+                {
+                    Ok(d) => d,
+                    Err(e) => {
+                        ladmin_error!(audit, "Failed to begin delete: {:?}", e);
+                        return Err(e);
+                    }
+                };
 
                 ltrace!(audit, "Begin delete event {:?}", del);
 
@@ -569,13 +568,10 @@ impl Handler<ReviveRecycledMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<ReviveRecycledMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
                 let rev = match ReviveRecycledEvent::from_parts(
-                    &mut audit,
-                    msg.uat,
-                    msg.filter,
-                    &mut qs_write,
+                    &mut audit, msg.uat, msg.filter, &qs_write,
                 ) {
                     Ok(r) => r,
                     Err(e) => {
@@ -639,7 +635,7 @@ impl Handler<InternalCredentialSetMessage> for QueryServerWriteV1 {
                     SetCredentialRequest::Password(cleartext) => {
                         let pce = PasswordChangeEvent::from_parts(
                             &mut audit,
-                            &mut idms_prox_write.qs_write,
+                            &idms_prox_write.qs_write,
                             msg.uat,
                             target_uuid,
                             cleartext,
@@ -682,7 +678,7 @@ impl Handler<InternalCredentialSetMessage> for QueryServerWriteV1 {
                     SetCredentialRequest::TOTPGenerate(label) => {
                         let gte = GenerateTOTPEvent::from_parts(
                             &mut audit,
-                            &mut idms_prox_write.qs_write,
+                            &idms_prox_write.qs_write,
                             msg.uat,
                             target_uuid,
                             label,
@@ -702,7 +698,7 @@ impl Handler<InternalCredentialSetMessage> for QueryServerWriteV1 {
                     SetCredentialRequest::TOTPVerify(uuid, chal) => {
                         let vte = VerifyTOTPEvent::from_parts(
                             &mut audit,
-                            &mut idms_prox_write.qs_write,
+                            &idms_prox_write.qs_write,
                             msg.uat,
                             target_uuid,
                             uuid,
@@ -746,7 +742,7 @@ impl Handler<IdmAccountSetPasswordMessage> for QueryServerWriteV1 {
 
                 let pce = PasswordChangeEvent::from_idm_account_set_password(
                     &mut audit,
-                    &mut idms_prox_write.qs_write,
+                    &idms_prox_write.qs_write,
                     msg,
                 )
                 .map_err(|e| {
@@ -796,7 +792,7 @@ impl Handler<InternalRegenerateRadiusMessage> for QueryServerWriteV1 {
 
                 let rrse = RegenerateRadiusSecretEvent::from_parts(
                     &mut audit,
-                    &mut idms_prox_write.qs_write,
+                    &idms_prox_write.qs_write,
                     msg.uat,
                     target_uuid,
                 )
@@ -831,7 +827,7 @@ impl Handler<PurgeAttributeMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<PurgeAttributeMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
                 let target_uuid = qs_write
                     .name_to_uuid(&mut audit, msg.uuid_or_name.as_str())
@@ -846,7 +842,7 @@ impl Handler<PurgeAttributeMessage> for QueryServerWriteV1 {
                     target_uuid,
                     msg.attr,
                     msg.filter,
-                    &mut qs_write,
+                    &qs_write,
                 ) {
                     Ok(m) => m,
                     Err(e) => {
@@ -879,7 +875,7 @@ impl Handler<RemoveAttributeValueMessage> for QueryServerWriteV1 {
             &mut audit,
             "actors::v1_write::handle<RemoveAttributeValueMessage>",
             || {
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
                 let target_uuid = qs_write
                     .name_to_uuid(&mut audit, msg.uuid_or_name.as_str())
@@ -897,7 +893,7 @@ impl Handler<RemoveAttributeValueMessage> for QueryServerWriteV1 {
                     target_uuid,
                     proto_ml,
                     msg.filter,
-                    &mut qs_write,
+                    &qs_write,
                 ) {
                     Ok(m) => m,
                     Err(e) => {
@@ -1186,7 +1182,7 @@ impl Handler<IdmAccountUnixSetCredMessage> for QueryServerWriteV1 {
 
                 let upce = UnixPasswordChangeEvent::from_parts(
                     &mut audit,
-                    &mut idms_prox_write.qs_write,
+                    &idms_prox_write.qs_write,
                     msg.uat,
                     target_uuid,
                     msg.cred,
@@ -1221,7 +1217,7 @@ impl Handler<PurgeTombstoneEvent> for QueryServerWriteV1 {
             "actors::v1_write::handle<PurgeTombstoneEvent>",
             || {
                 ltrace!(audit, "Begin purge tombstone event {:?}", msg);
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
                 let res = qs_write
                     .purge_tombstones(&mut audit)
@@ -1247,7 +1243,7 @@ impl Handler<PurgeRecycledEvent> for QueryServerWriteV1 {
             "actors::v1_write::handle<PurgeRecycledEvent>",
             || {
                 ltrace!(audit, "Begin purge recycled event {:?}", msg);
-                let mut qs_write = self.qs.write(duration_from_epoch_now());
+                let qs_write = self.qs.write(duration_from_epoch_now());
 
                 let res = qs_write
                     .purge_recycled(&mut audit)

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::fs;
 
 use crate::value::IndexType;
+use std::cell::UnsafeCell;
 use std::collections::HashSet as Set;
 use std::sync::Arc;
 
@@ -69,12 +70,12 @@ pub struct Backend {
 }
 
 pub struct BackendReadTransaction<'a> {
-    idlayer: IdlArcSqliteReadTransaction<'a>,
+    idlayer: UnsafeCell<IdlArcSqliteReadTransaction<'a>>,
     idxmeta: CowCellReadTxn<Set<IdxKey>>,
 }
 
 pub struct BackendWriteTransaction<'a> {
-    idlayer: IdlArcSqliteWriteTransaction<'a>,
+    idlayer: UnsafeCell<IdlArcSqliteWriteTransaction<'a>>,
     idxmeta: CowCellReadTxn<Set<IdxKey>>,
     idxmeta_wr: CowCellWriteTxn<'a, Set<IdxKey>>,
 }
@@ -93,14 +94,14 @@ impl IdRawEntry {
 
 pub trait BackendTransaction {
     type IdlLayerType: IdlArcSqliteTransaction;
-    fn get_idlayer(&mut self) -> &mut Self::IdlLayerType;
+    fn get_idlayer(&self) -> &mut Self::IdlLayerType;
 
     fn get_idxmeta_ref(&self) -> &Set<IdxKey>;
 
     /// Recursively apply a filter, transforming into IDL's on the way. This builds a query
     /// execution log, so that it can be examined how an operation proceeded.
     fn filter2idl(
-        &mut self,
+        &self,
         au: &mut AuditScope,
         filt: &FilterResolved,
         thres: usize,
@@ -428,7 +429,7 @@ pub trait BackendTransaction {
 
     // Take filter, and AuditScope ref?
     fn search(
-        &mut self,
+        &self,
         au: &mut AuditScope,
         filt: &Filter<FilterValidResolved>,
     ) -> Result<Vec<Entry<EntrySealed, EntryCommitted>>, OperationError> {
@@ -510,7 +511,7 @@ pub trait BackendTransaction {
     /// load any candidates if they match. This is heavily used in uuid
     /// refint and attr uniqueness.
     fn exists(
-        &mut self,
+        &self,
         au: &mut AuditScope,
         filt: &Filter<FilterValidResolved>,
     ) -> Result<bool, OperationError> {
@@ -565,12 +566,12 @@ pub trait BackendTransaction {
         }) // end audit segment
     }
 
-    fn verify(&mut self) -> Vec<Result<(), ConsistencyError>> {
+    fn verify(&self) -> Vec<Result<(), ConsistencyError>> {
         // Vec::new()
         self.get_idlayer().verify()
     }
 
-    fn backup(&mut self, audit: &mut AuditScope, dst_path: &str) -> Result<(), OperationError> {
+    fn backup(&self, audit: &mut AuditScope, dst_path: &str) -> Result<(), OperationError> {
         // load all entries into RAM, may need to change this later
         // if the size of the database compared to RAM is an issue
         let idl = IDL::ALLIDS;
@@ -600,7 +601,7 @@ pub trait BackendTransaction {
     }
 
     fn name2uuid(
-        &mut self,
+        &self,
         audit: &mut AuditScope,
         name: &str,
     ) -> Result<Option<Uuid>, OperationError> {
@@ -608,7 +609,7 @@ pub trait BackendTransaction {
     }
 
     fn uuid2spn(
-        &mut self,
+        &self,
         audit: &mut AuditScope,
         uuid: &Uuid,
     ) -> Result<Option<Value>, OperationError> {
@@ -616,7 +617,7 @@ pub trait BackendTransaction {
     }
 
     fn uuid2rdn(
-        &mut self,
+        &self,
         audit: &mut AuditScope,
         uuid: &Uuid,
     ) -> Result<Option<String>, OperationError> {
@@ -627,8 +628,19 @@ pub trait BackendTransaction {
 impl<'a> BackendTransaction for BackendReadTransaction<'a> {
     type IdlLayerType = IdlArcSqliteReadTransaction<'a>;
 
-    fn get_idlayer(&mut self) -> &mut IdlArcSqliteReadTransaction<'a> {
-        &mut self.idlayer
+    fn get_idlayer(&self) -> &mut IdlArcSqliteReadTransaction<'a> {
+        // OKAY here be the cursed bullshit. We know that in our application
+        // that during a transaction, that we are the only holder of the
+        // idlayer, so we KNOW it can be mut, and we know every thing it
+        // returns is a copy anyway. But if we permeate that mut up, it prevents
+        // reference holding of read-only structures in loops, which was forcing
+        // a lot of clones.
+        //
+        // Instead we make everything immutable, and use interior mutability
+        // to the idlayer here since we know and can assert it is correct
+        // that during this inner mutable phase, that nothing will be
+        // conflicting during this cache operation.
+        unsafe { &mut (*self.idlayer.get()) }
     }
 
     fn get_idxmeta_ref(&self) -> &Set<IdxKey> {
@@ -639,8 +651,8 @@ impl<'a> BackendTransaction for BackendReadTransaction<'a> {
 impl<'a> BackendTransaction for BackendWriteTransaction<'a> {
     type IdlLayerType = IdlArcSqliteWriteTransaction<'a>;
 
-    fn get_idlayer(&mut self) -> &mut IdlArcSqliteWriteTransaction<'a> {
-        &mut self.idlayer
+    fn get_idlayer(&self) -> &mut IdlArcSqliteWriteTransaction<'a> {
+        unsafe { &mut (*self.idlayer.get()) }
     }
 
     fn get_idxmeta_ref(&self) -> &Set<IdxKey> {
@@ -650,7 +662,7 @@ impl<'a> BackendTransaction for BackendWriteTransaction<'a> {
 
 impl<'a> BackendWriteTransaction<'a> {
     pub fn create(
-        &mut self,
+        &self,
         au: &mut AuditScope,
         entries: Vec<Entry<EntrySealed, EntryNew>>,
     ) -> Result<Vec<Entry<EntrySealed, EntryCommitted>>, OperationError> {
@@ -663,9 +675,10 @@ impl<'a> BackendWriteTransaction<'a> {
                 return Err(OperationError::EmptyRequest);
             }
 
+            let idlayer = self.get_idlayer();
             // Now, assign id's to all the new entries.
 
-            let mut id_max = self.idlayer.get_id2entry_max_id().and_then(|id_max| {
+            let mut id_max = idlayer.get_id2entry_max_id().and_then(|id_max| {
                 u64::try_from(id_max).map_err(|_| OperationError::InvalidEntryID)
             })?;
             let c_entries: Vec<_> = entries
@@ -676,9 +689,9 @@ impl<'a> BackendWriteTransaction<'a> {
                 })
                 .collect();
 
-            self.idlayer.write_identries(au, c_entries.iter())?;
+            idlayer.write_identries(au, c_entries.iter())?;
 
-            self.idlayer.set_id2entry_max_id(id_max);
+            idlayer.set_id2entry_max_id(id_max);
 
             // Now update the indexes as required.
             for e in c_entries.iter() {
@@ -690,7 +703,7 @@ impl<'a> BackendWriteTransaction<'a> {
     }
 
     pub fn modify(
-        &mut self,
+        &self,
         au: &mut AuditScope,
         pre_entries: &[Entry<EntrySealed, EntryCommitted>],
         post_entries: &[Entry<EntrySealed, EntryCommitted>],
@@ -738,7 +751,8 @@ impl<'a> BackendWriteTransaction<'a> {
             */
 
             // Now, given the list of id's, update them
-            self.idlayer.write_identries(au, post_entries.iter())?;
+            self.get_idlayer()
+                .write_identries(au, post_entries.iter())?;
 
             // Finally, we now reindex all the changed entries. We do this by iterating and zipping
             // over the set, because we know the list is in the same order.
@@ -750,7 +764,7 @@ impl<'a> BackendWriteTransaction<'a> {
     }
 
     pub fn delete(
-        &mut self,
+        &self,
         au: &mut AuditScope,
         entries: &[Entry<EntrySealed, EntryCommitted>],
     ) -> Result<(), OperationError> {
@@ -767,7 +781,7 @@ impl<'a> BackendWriteTransaction<'a> {
             let id_list = entries.iter().map(|e| e.get_id());
 
             // Now, given the list of id's, delete them.
-            self.idlayer.delete_identry(au, id_list)?;
+            self.get_idlayer().delete_identry(au, id_list)?;
 
             // Finally, purge the indexes from the entries we removed.
             entries
@@ -791,7 +805,7 @@ impl<'a> BackendWriteTransaction<'a> {
     // TODO: Can this be improved?
     #[allow(clippy::cognitive_complexity)]
     fn entry_index(
-        &mut self,
+        &self,
         audit: &mut AuditScope,
         pre: Option<&Entry<EntrySealed, EntryCommitted>>,
         post: Option<&Entry<EntrySealed, EntryCommitted>>,
@@ -825,6 +839,8 @@ impl<'a> BackendWriteTransaction<'a> {
         // and can trigger correct actions.
         //
 
+        let idlayer = self.get_idlayer();
+
         let mask_pre = pre.and_then(|e| e.mask_recycled_ts());
         let mask_pre = if !uuid_same {
             // Okay, so if the uuids are different this is probably from
@@ -848,19 +864,19 @@ impl<'a> BackendWriteTransaction<'a> {
 
             // Write the changes out to the backend
             if let Some(rem) = n2u_rem {
-                self.idlayer.write_name2uuid_rem(audit, rem)?
+                idlayer.write_name2uuid_rem(audit, rem)?
             }
 
             match u2s_act {
                 None => {}
-                Some(Ok(k)) => self.idlayer.write_uuid2spn(audit, uuid, Some(k))?,
-                Some(Err(_)) => self.idlayer.write_uuid2spn(audit, uuid, None)?,
+                Some(Ok(k)) => idlayer.write_uuid2spn(audit, uuid, Some(k))?,
+                Some(Err(_)) => idlayer.write_uuid2spn(audit, uuid, None)?,
             }
 
             match u2r_act {
                 None => {}
-                Some(Ok(k)) => self.idlayer.write_uuid2rdn(audit, uuid, Some(k))?,
-                Some(Err(_)) => self.idlayer.write_uuid2rdn(audit, uuid, None)?,
+                Some(Ok(k)) => idlayer.write_uuid2rdn(audit, uuid, Some(k))?,
+                Some(Err(_)) => idlayer.write_uuid2rdn(audit, uuid, None)?,
             }
             // Return none, mask_pre is now completed.
             None
@@ -882,22 +898,22 @@ impl<'a> BackendWriteTransaction<'a> {
 
         // Write the changes out to the backend
         if let Some(add) = n2u_add {
-            self.idlayer.write_name2uuid_add(audit, e_uuid, add)?
+            idlayer.write_name2uuid_add(audit, e_uuid, add)?
         }
         if let Some(rem) = n2u_rem {
-            self.idlayer.write_name2uuid_rem(audit, rem)?
+            idlayer.write_name2uuid_rem(audit, rem)?
         }
 
         match u2s_act {
             None => {}
-            Some(Ok(k)) => self.idlayer.write_uuid2spn(audit, e_uuid, Some(k))?,
-            Some(Err(_)) => self.idlayer.write_uuid2spn(audit, e_uuid, None)?,
+            Some(Ok(k)) => idlayer.write_uuid2spn(audit, e_uuid, Some(k))?,
+            Some(Err(_)) => idlayer.write_uuid2spn(audit, e_uuid, None)?,
         }
 
         match u2r_act {
             None => {}
-            Some(Ok(k)) => self.idlayer.write_uuid2rdn(audit, e_uuid, Some(k))?,
-            Some(Err(_)) => self.idlayer.write_uuid2rdn(audit, e_uuid, None)?,
+            Some(Ok(k)) => idlayer.write_uuid2rdn(audit, e_uuid, Some(k))?,
+            Some(Err(_)) => idlayer.write_uuid2rdn(audit, e_uuid, None)?,
         }
 
         // Extremely Cursed - Okay, we know that self.idxmeta will NOT be changed
@@ -915,10 +931,10 @@ impl<'a> BackendWriteTransaction<'a> {
                 match act {
                     Ok((attr, itype, idx_key)) => {
                         ltrace!(audit, "Adding {:?} idx -> {:?}: {:?}", itype, attr, idx_key);
-                        match self.idlayer.get_idl(audit, attr, itype, idx_key)? {
+                        match idlayer.get_idl(audit, attr, itype, idx_key)? {
                             Some(mut idl) => {
                                 idl.insert_id(e_id);
-                                self.idlayer.write_idl(audit, attr, itype, idx_key, &idl)
+                                idlayer.write_idl(audit, attr, itype, idx_key, &idl)
                             }
                             None => {
                                 ladmin_error!(
@@ -932,10 +948,10 @@ impl<'a> BackendWriteTransaction<'a> {
                     }
                     Err((attr, itype, idx_key)) => {
                         ltrace!(audit, "Removing {:?} idx -> {:?}: {:?}", itype, attr, idx_key);
-                        match self.idlayer.get_idl(audit, attr, itype, idx_key)? {
+                        match idlayer.get_idl(audit, attr, itype, idx_key)? {
                             Some(mut idl) => {
                                 idl.remove_id(e_id);
-                                self.idlayer.write_idl(audit, attr, itype, idx_key, &idl)
+                                idlayer.write_idl(audit, attr, itype, idx_key, &idl)
                             }
                             None => {
                                 ladmin_error!(
@@ -954,10 +970,10 @@ impl<'a> BackendWriteTransaction<'a> {
 
     #[allow(dead_code)]
     fn missing_idxs(
-        &mut self,
+        &self,
         audit: &mut AuditScope,
     ) -> Result<Vec<(String, IndexType)>, OperationError> {
-        let idx_table_list = self.idlayer.list_idxs(audit)?;
+        let idx_table_list = self.get_idlayer().list_idxs(audit)?;
 
         // Turn the vec to a real set
         let idx_table_set: Set<_> = idx_table_list.into_iter().collect();
@@ -981,26 +997,23 @@ impl<'a> BackendWriteTransaction<'a> {
     }
 
     fn create_idxs(&self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        let idlayer = self.get_idlayer();
         // Create name2uuid and uuid2name
         ltrace!(audit, "Creating index -> name2uuid");
-        self.idlayer.create_name2uuid(audit)?;
+        idlayer.create_name2uuid(audit)?;
 
         ltrace!(audit, "Creating index -> uuid2spn");
-        self.idlayer.create_uuid2spn(audit)?;
+        idlayer.create_uuid2spn(audit)?;
 
         ltrace!(audit, "Creating index -> uuid2rdn");
-        self.idlayer.create_uuid2rdn(audit)?;
+        idlayer.create_uuid2rdn(audit)?;
 
         self.idxmeta
             .iter()
-            .try_for_each(|ikey| self.idlayer.create_idx(audit, &ikey.attr, &ikey.itype))
+            .try_for_each(|ikey| idlayer.create_idx(audit, &ikey.attr, &ikey.itype))
     }
 
-    pub fn upgrade_reindex(
-        &mut self,
-        audit: &mut AuditScope,
-        v: i64,
-    ) -> Result<(), OperationError> {
+    pub fn upgrade_reindex(&self, audit: &mut AuditScope, v: i64) -> Result<(), OperationError> {
         let dbv = self.get_db_index_version();
         ladmin_info!(audit, "upgrade_reindex -> dbv: {} v: {}", dbv, v);
         if dbv < v {
@@ -1016,9 +1029,10 @@ impl<'a> BackendWriteTransaction<'a> {
         }
     }
 
-    pub fn reindex(&mut self, audit: &mut AuditScope) -> Result<(), OperationError> {
+    pub fn reindex(&self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        let idlayer = self.get_idlayer();
         // Purge the idxs
-        unsafe { self.idlayer.purge_idxs(audit)? };
+        unsafe { idlayer.purge_idxs(audit)? };
 
         // Using the index metadata on the txn, create all our idx tables
         self.create_idxs(audit)?;
@@ -1027,7 +1041,7 @@ impl<'a> BackendWriteTransaction<'a> {
         // Future idea: Do this in batches of X amount to limit memory
         // consumption.
         let idl = IDL::ALLIDS;
-        let entries = self.idlayer.get_identry(audit, &idl).map_err(|e| {
+        let entries = idlayer.get_identry(audit, &idl).map_err(|e| {
             ladmin_error!(audit, "get_identry failure {:?}", e);
             e
         })?;
@@ -1054,26 +1068,23 @@ impl<'a> BackendWriteTransaction<'a> {
     }
 
     #[cfg(test)]
-    pub fn purge_idxs(&mut self, audit: &mut AuditScope) -> Result<(), OperationError> {
-        unsafe { self.idlayer.purge_idxs(audit) }
+    pub fn purge_idxs(&self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        unsafe { self.get_idlayer().purge_idxs(audit) }
     }
 
     #[cfg(test)]
     pub fn load_test_idl(
-        &mut self,
+        &self,
         audit: &mut AuditScope,
         attr: &String,
         itype: &IndexType,
         idx_key: &String,
     ) -> Result<Option<IDLBitRange>, OperationError> {
-        self.idlayer.get_idl(audit, attr, itype, idx_key)
+        self.get_idlayer().get_idl(audit, attr, itype, idx_key)
     }
 
-    pub fn restore(
-        &mut self,
-        audit: &mut AuditScope,
-        src_path: &str,
-    ) -> Result<(), OperationError> {
+    pub fn restore(&self, audit: &mut AuditScope, src_path: &str) -> Result<(), OperationError> {
+        let idlayer = self.get_idlayer();
         // load all entries into RAM, may need to change this later
         // if the size of the database compared to RAM is an issue
         let serialized_string = fs::read_to_string(src_path).map_err(|e| {
@@ -1081,7 +1092,7 @@ impl<'a> BackendWriteTransaction<'a> {
             OperationError::FsError
         })?;
 
-        unsafe { self.idlayer.purge_id2entry(audit) }.map_err(|e| {
+        unsafe { idlayer.purge_id2entry(audit) }.map_err(|e| {
             ladmin_error!(audit, "purge_id2entry failed {:?}", e);
             e
         })?;
@@ -1134,8 +1145,7 @@ impl<'a> BackendWriteTransaction<'a> {
             })
             .collect();
 
-        self.idlayer
-            .write_identries_raw(audit, identries?.into_iter())?;
+        idlayer.write_identries_raw(audit, identries?.into_iter())?;
 
         // for debug
         /*
@@ -1165,6 +1175,9 @@ impl<'a> BackendWriteTransaction<'a> {
             idxmeta_wr,
         } = self;
 
+        // Unwrap the Cell we have finished with it.
+        let idlayer = idlayer.into_inner();
+
         idlayer.commit(audit).and_then(|r| {
             idxmeta_wr.commit();
             Ok(r)
@@ -1174,11 +1187,11 @@ impl<'a> BackendWriteTransaction<'a> {
     fn reset_db_s_uuid(&self) -> Result<Uuid, OperationError> {
         // The value is missing. Generate a new one and store it.
         let nsid = Uuid::new_v4();
-        self.idlayer.write_db_s_uuid(nsid)?;
+        self.get_idlayer().write_db_s_uuid(nsid)?;
         Ok(nsid)
     }
 
-    pub fn get_db_s_uuid(&mut self) -> Uuid {
+    pub fn get_db_s_uuid(&self) -> Uuid {
         match self
             .get_idlayer()
             .get_db_s_uuid()
@@ -1191,11 +1204,11 @@ impl<'a> BackendWriteTransaction<'a> {
 
     fn reset_db_d_uuid(&self) -> Result<Uuid, OperationError> {
         let nsid = Uuid::new_v4();
-        self.idlayer.write_db_d_uuid(nsid)?;
+        self.get_idlayer().write_db_d_uuid(nsid)?;
         Ok(nsid)
     }
 
-    pub fn get_db_d_uuid(&mut self) -> Uuid {
+    pub fn get_db_d_uuid(&self) -> Uuid {
         match self
             .get_idlayer()
             .get_db_d_uuid()
@@ -1206,11 +1219,11 @@ impl<'a> BackendWriteTransaction<'a> {
         }
     }
 
-    pub fn set_db_ts_max(&mut self, ts: &Duration) -> Result<(), OperationError> {
+    pub fn set_db_ts_max(&self, ts: &Duration) -> Result<(), OperationError> {
         self.get_idlayer().set_db_ts_max(ts)
     }
 
-    pub fn get_db_ts_max(&mut self, ts: &Duration) -> Result<Duration, OperationError> {
+    pub fn get_db_ts_max(&self, ts: &Duration) -> Result<Duration, OperationError> {
         // if none, return ts. If found, return it.
         match self.get_idlayer().get_db_ts_max()? {
             Some(dts) => Ok(dts),
@@ -1218,11 +1231,11 @@ impl<'a> BackendWriteTransaction<'a> {
         }
     }
 
-    fn get_db_index_version(&mut self) -> i64 {
+    fn get_db_index_version(&self) -> i64 {
         self.get_idlayer().get_db_index_version()
     }
 
-    fn set_db_index_version(&mut self, v: i64) -> Result<(), OperationError> {
+    fn set_db_index_version(&self, v: i64) -> Result<(), OperationError> {
         self.get_idlayer().set_db_index_version(v)
     }
 }
@@ -1262,14 +1275,14 @@ impl Backend {
 
     pub fn read(&self) -> BackendReadTransaction {
         BackendReadTransaction {
-            idlayer: self.idlayer.read(),
+            idlayer: UnsafeCell::new(self.idlayer.read()),
             idxmeta: self.idxmeta.read(),
         }
     }
 
     pub fn write(&self) -> BackendWriteTransaction {
         BackendWriteTransaction {
-            idlayer: self.idlayer.write(),
+            idlayer: UnsafeCell::new(self.idlayer.write()),
             idxmeta: self.idxmeta.read(),
             idxmeta_wr: self.idxmeta.write(),
         }

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -94,6 +94,8 @@ impl IdRawEntry {
 
 pub trait BackendTransaction {
     type IdlLayerType: IdlArcSqliteTransaction;
+
+    #[allow(clippy::mut_from_ref)]
     fn get_idlayer(&self) -> &mut Self::IdlLayerType;
 
     fn get_idxmeta_ref(&self) -> &Set<IdxKey>;
@@ -628,6 +630,7 @@ pub trait BackendTransaction {
 impl<'a> BackendTransaction for BackendReadTransaction<'a> {
     type IdlLayerType = IdlArcSqliteReadTransaction<'a>;
 
+    #[allow(clippy::mut_from_ref)]
     fn get_idlayer(&self) -> &mut IdlArcSqliteReadTransaction<'a> {
         // OKAY here be the cursed bullshit. We know that in our application
         // that during a transaction, that we are the only holder of the
@@ -651,6 +654,7 @@ impl<'a> BackendTransaction for BackendReadTransaction<'a> {
 impl<'a> BackendTransaction for BackendWriteTransaction<'a> {
     type IdlLayerType = IdlArcSqliteWriteTransaction<'a>;
 
+    #[allow(clippy::mut_from_ref)]
     fn get_idlayer(&self) -> &mut IdlArcSqliteWriteTransaction<'a> {
         unsafe { &mut (*self.idlayer.get()) }
     }
@@ -1178,9 +1182,9 @@ impl<'a> BackendWriteTransaction<'a> {
         // Unwrap the Cell we have finished with it.
         let idlayer = idlayer.into_inner();
 
-        idlayer.commit(audit).and_then(|r| {
+        idlayer.commit(audit).and_then(|()| {
             idxmeta_wr.commit();
-            Ok(r)
+            Ok(())
         })
     }
 

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -1323,7 +1323,7 @@ pub fn backup_server_core(config: Configuration, dst_path: &str) {
         }
     };
 
-    let mut be_ro_txn = be.read();
+    let be_ro_txn = be.read();
     let r = be_ro_txn.backup(&mut audit, dst_path);
     audit.write_log();
     match r {
@@ -1357,7 +1357,7 @@ pub fn restore_server_core(config: Configuration, dst_path: &str) {
         }
     };
 
-    let mut be_wr_txn = be.write();
+    let be_wr_txn = be.write();
     let r = be_wr_txn
         .restore(&mut audit, dst_path)
         .and_then(|_| be_wr_txn.commit(&mut audit));
@@ -1383,7 +1383,7 @@ pub fn restore_server_core(config: Configuration, dst_path: &str) {
 
     info!("Start reindex phase ...");
 
-    let mut qs_write = qs.write(duration_from_epoch_now());
+    let qs_write = qs.write(duration_from_epoch_now());
     let r = qs_write
         .reindex(&mut audit)
         .and_then(|_| qs_write.commit(&mut audit));
@@ -1421,7 +1421,7 @@ pub fn reindex_server_core(config: Configuration) {
     };
 
     // Reindex only the core schema attributes to bootstrap the process.
-    let mut be_wr_txn = be.write();
+    let be_wr_txn = be.write();
     let r = be_wr_txn
         .reindex(&mut audit)
         .and_then(|_| be_wr_txn.commit(&mut audit));
@@ -1454,7 +1454,7 @@ pub fn reindex_server_core(config: Configuration) {
 
     eprintln!("Start Index Phase 2 ...");
 
-    let mut qs_write = qs.write(duration_from_epoch_now());
+    let qs_write = qs.write(duration_from_epoch_now());
     let r = qs_write
         .reindex(&mut audit)
         .and_then(|_| qs_write.commit(&mut audit));
@@ -1499,7 +1499,7 @@ pub fn domain_rename_core(config: Configuration, new_domain_name: String) {
         }
     };
 
-    let mut qs_write = qs.write(duration_from_epoch_now());
+    let qs_write = qs.write(duration_from_epoch_now());
     let r = qs_write
         .domain_rename(&mut audit, new_domain_name.as_str())
         .and_then(|_| qs_write.commit(&mut audit));

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -47,9 +47,10 @@ use crate::be::IdxKey;
 
 use ldap3_server::simple::{LdapPartialAttribute, LdapSearchResultEntry};
 use std::collections::BTreeSet as Set;
+use std::collections::BTreeSet;
 // BTreeMap could be faster, but it's small datasets?
-use std::collections::HashMap as Map;
-// use std::collections::BTreeMap as Map;
+// use std::collections::HashMap as Map;
+use std::collections::BTreeMap as Map;
 use std::collections::HashSet;
 use uuid::Uuid;
 
@@ -1299,7 +1300,7 @@ impl Entry<EntrySealed, EntryCommitted> {
 
     pub fn reduce_attributes(
         self,
-        allowed_attrs: Set<&str>,
+        allowed_attrs: BTreeSet<&str>,
     ) -> Entry<EntryReduced, EntryCommitted> {
         // Remove all attrs from our tree that are NOT in the allowed set.
 

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -26,7 +26,6 @@
 //! [`filter`]: ../filter/index.html
 //! [`schema`]: ../schema/index.html
 
-// use serde_json::{Error, Value};
 use crate::audit::AuditScope;
 use crate::credential::Credential;
 use crate::filter::{Filter, FilterInvalid, FilterResolved, FilterValidResolved};
@@ -48,9 +47,9 @@ use crate::be::IdxKey;
 
 use ldap3_server::simple::{LdapPartialAttribute, LdapSearchResultEntry};
 use std::collections::BTreeSet as Set;
-// For now, BTreeMap here is slighttly faster.
-// use std::collections::HashMap as Map;
-use std::collections::BTreeMap as Map;
+// BTreeMap could be faster, but it's small datasets?
+use std::collections::HashMap as Map;
+// use std::collections::BTreeMap as Map;
 use std::collections::HashSet;
 use uuid::Uuid;
 
@@ -153,14 +152,6 @@ pub struct EntryReduced {
 
 fn compare_attrs(left: &Map<String, Set<Value>>, right: &Map<String, Set<Value>>) -> bool {
     // We can't shortcut based on len because cid mod may not be present.
-    /*
-    // If BTreeMap ...
-    left.iter()
-        // Always exclude last modified cid.
-        .filter(|(k, _v)| k != &"last_modified_cid")
-        // .zip(right.iter().filter(|(k, _v)| k != &"last_modified_cid"))
-        // .all(|((ka, va), (kb, vb))| ka == kb && va == vb)
-    */
     // Build the set of all keys between both.
     let allkeys: Set<&str> = left
         .keys()

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -35,7 +35,7 @@ pub struct SearchResult {
 impl SearchResult {
     pub fn new(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         entries: Vec<Entry<EntryReduced, EntryCommitted>>,
     ) -> Result<Self, OperationError> {
         let entries: Result<_, _> = entries
@@ -121,7 +121,7 @@ impl std::fmt::Display for Event {
 impl Event {
     pub fn from_ro_request(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         user_uuid: &Uuid,
     ) -> Result<Self, OperationError> {
         qs.internal_search_uuid(audit, &user_uuid)
@@ -136,7 +136,7 @@ impl Event {
 
     pub fn from_ro_uat(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         uat: Option<UserAuthToken>,
     ) -> Result<Self, OperationError> {
         ltrace!(audit, "from_ro_uat -> {:?}", uat);
@@ -160,7 +160,7 @@ impl Event {
 
     pub fn from_rw_uat(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
     ) -> Result<Self, OperationError> {
         ltrace!(audit, "from_rw_uat -> {:?}", uat);
@@ -184,7 +184,7 @@ impl Event {
 
     pub fn from_rw_request(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         user_uuid: &str,
     ) -> Result<Self, OperationError> {
         // Do we need to check or load the entry from the user_uuid?
@@ -261,7 +261,7 @@ impl SearchEvent {
     pub fn from_message(
         audit: &mut AuditScope,
         msg: SearchMessage,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         match Filter::from_ro(audit, &msg.req.filter, qs) {
             Ok(f) => Ok(SearchEvent {
@@ -287,7 +287,7 @@ impl SearchEvent {
     pub fn from_internal_message(
         audit: &mut AuditScope,
         msg: InternalSearchMessage,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         let r_attrs: Option<BTreeSet<String>> = msg.attrs.map(|vs| {
             vs.into_iter()
@@ -326,7 +326,7 @@ impl SearchEvent {
     pub fn from_internal_recycle_message(
         audit: &mut AuditScope,
         msg: InternalSearchRecycledMessage,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         let r_attrs: Option<BTreeSet<String>> = msg.attrs.map(|vs| {
             vs.into_iter()
@@ -360,7 +360,7 @@ impl SearchEvent {
     pub fn from_whoami_request(
         audit: &mut AuditScope,
         uat: Option<UserAuthToken>,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         Ok(SearchEvent {
             event: Event::from_ro_uat(audit, qs, uat)?,
@@ -378,7 +378,7 @@ impl SearchEvent {
         audit: &mut AuditScope,
         uat: Option<UserAuthToken>,
         target_uuid: Uuid,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         Ok(SearchEvent {
             event: Event::from_ro_uat(audit, qs, uat)?,
@@ -459,7 +459,7 @@ impl SearchEvent {
 
     pub(crate) fn new_ext_impersonate_uuid(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         euuid: &Uuid,
         filter: Filter<FilterInvalid>,
         attrs: Option<BTreeSet<String>>,
@@ -515,7 +515,7 @@ impl CreateEvent {
     pub fn from_message(
         audit: &mut AuditScope,
         msg: CreateMessage,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         let rentries: Result<Vec<_>, _> = msg
             .req
@@ -597,7 +597,7 @@ impl DeleteEvent {
     pub fn from_message(
         audit: &mut AuditScope,
         msg: DeleteMessage,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         match Filter::from_rw(audit, &msg.req.filter, qs) {
             Ok(f) => Ok(DeleteEvent {
@@ -619,7 +619,7 @@ impl DeleteEvent {
         audit: &mut AuditScope,
         uat: Option<UserAuthToken>,
         filter: Filter<FilterInvalid>,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         Ok(DeleteEvent {
             event: Event::from_rw_uat(audit, qs, uat)?,
@@ -687,7 +687,7 @@ impl ModifyEvent {
     pub fn from_message(
         audit: &mut AuditScope,
         msg: ModifyMessage,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         match Filter::from_rw(audit, &msg.req.filter, qs) {
             Ok(f) => match ModifyList::from(audit, &msg.req.modlist, qs) {
@@ -718,7 +718,7 @@ impl ModifyEvent {
         target_uuid: Uuid,
         proto_ml: ProtoModifyList,
         filter: Filter<FilterInvalid>,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         let f_uuid = filter_all!(f_eq("uuid", PartialValue::new_uuid(target_uuid)));
         // Add any supplemental conditions we have.
@@ -749,7 +749,7 @@ impl ModifyEvent {
         target_uuid: Uuid,
         ml: ModifyList<ModifyInvalid>,
         filter: Filter<FilterInvalid>,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         let f_uuid = filter_all!(f_eq("uuid", PartialValue::new_uuid(target_uuid)));
         // Add any supplemental conditions we have.
@@ -777,7 +777,7 @@ impl ModifyEvent {
         target_uuid: Uuid,
         attr: String,
         filter: Filter<FilterInvalid>,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         let ml = ModifyList::new_purge(attr.as_str());
         let f_uuid = filter_all!(f_eq("uuid", PartialValue::new_uuid(target_uuid)));
@@ -1011,7 +1011,7 @@ pub struct WhoamiResult {
 impl WhoamiResult {
     pub fn new(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         e: Entry<EntryReduced, EntryCommitted>,
         uat: UserAuthToken,
     ) -> Result<Self, OperationError> {
@@ -1087,7 +1087,7 @@ impl ReviveRecycledEvent {
         audit: &mut AuditScope,
         uat: Option<UserAuthToken>,
         filter: Filter<FilterInvalid>,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         Ok(ReviveRecycledEvent {
             event: Event::from_rw_uat(audit, qs, uat)?,

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -9,6 +9,7 @@
 //! [`Entry`]: ../entry/struct.Entry.html
 
 use crate::audit::AuditScope;
+use crate::be::IdxKey;
 use crate::event::{Event, EventOrigin};
 use crate::ldap::ldap_attr_filter_map;
 use crate::schema::SchemaTransaction;
@@ -21,6 +22,7 @@ use kanidm_proto::v1::{OperationError, SchemaError};
 use ldap3_server::simple::LdapFilter;
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::iter;
 
 use uuid::Uuid;
@@ -259,7 +261,7 @@ impl Filter<FilterValid> {
     pub fn resolve(
         &self,
         ev: &Event,
-        idxmeta: Option<&BTreeSet<(String, IndexType)>>,
+        idxmeta: Option<&HashSet<IdxKey>>,
     ) -> Result<Filter<FilterValidResolved>, OperationError> {
         // Given a filter, resolve Not and SelfUUID to real terms.
         Ok(Filter {
@@ -267,8 +269,11 @@ impl Filter<FilterValid> {
                 inner: match idxmeta {
                     Some(idx) => {
                         // Convert it to a reference set.
-                        let idx_ref: BTreeSet<(&String, &IndexType)> =
-                            idx.iter().map(|(attr, itype)| (attr, itype)).collect();
+
+                        // TODO #259: Fix this to use borrows
+                        let idx_ref: HashSet<(&String, &IndexType)> =
+                            idx.iter().map(|ikey| (&ikey.attr, &ikey.itype)).collect();
+
                         FilterResolved::resolve_idx(self.state.inner.clone(), ev, &idx_ref)
                     }
                     None => FilterResolved::resolve_no_idx(self.state.inner.clone(), ev),
@@ -822,7 +827,7 @@ impl Ord for FilterResolved {
 
 impl FilterResolved {
     #[cfg(test)]
-    unsafe fn from_invalid(fc: FilterComp, idxmeta: &BTreeSet<(&String, &IndexType)>) -> Self {
+    unsafe fn from_invalid(fc: FilterComp, idxmeta: &HashSet<(&String, &IndexType)>) -> Self {
         match fc {
             FilterComp::Eq(a, v) => {
                 let idx = idxmeta.contains(&(&a, &IndexType::EQUALITY));
@@ -872,7 +877,7 @@ impl FilterResolved {
     fn resolve_idx(
         fc: FilterComp,
         ev: &Event,
-        idxmeta: &BTreeSet<(&String, &IndexType)>,
+        idxmeta: &HashSet<(&String, &IndexType)>,
     ) -> Option<Self> {
         match fc {
             FilterComp::Eq(a, v) => {

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -424,7 +424,7 @@ impl Filter<FilterInvalid> {
     pub fn from_ro(
         audit: &mut AuditScope,
         f: &ProtoFilter,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         lperf_trace_segment!(audit, "filter::from_ro", || {
             Ok(Filter {
@@ -438,7 +438,7 @@ impl Filter<FilterInvalid> {
     pub fn from_rw(
         audit: &mut AuditScope,
         f: &ProtoFilter,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         lperf_trace_segment!(audit, "filter::from_rw", || {
             Ok(Filter {
@@ -452,7 +452,7 @@ impl Filter<FilterInvalid> {
     pub fn from_ldap_ro(
         audit: &mut AuditScope,
         f: &LdapFilter,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         lperf_trace_segment!(audit, "filter::from_ldap_ro", || {
             Ok(Filter {
@@ -631,7 +631,7 @@ impl FilterComp {
     fn from_ro(
         audit: &mut AuditScope,
         f: &ProtoFilter,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         Ok(match f {
             ProtoFilter::Eq(a, v) => {
@@ -666,7 +666,7 @@ impl FilterComp {
     fn from_rw(
         audit: &mut AuditScope,
         f: &ProtoFilter,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         Ok(match f {
             ProtoFilter::Eq(a, v) => {
@@ -701,7 +701,7 @@ impl FilterComp {
     fn from_ldap_ro(
         audit: &mut AuditScope,
         f: &LdapFilter,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         Ok(match f {
             LdapFilter::And(l) => FilterComp::And(

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -29,16 +29,19 @@ macro_rules! try_from_entry {
         }
 
         // Now extract our needed attributes
-        let name =
-            $value
-                .get_ava_single_string("name")
-                .ok_or(OperationError::InvalidAccountState(
-                    "Missing attribute: name".to_string(),
-                ))?;
+        let name = $value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or(OperationError::InvalidAccountState(
+                "Missing attribute: name".to_string(),
+            ))?;
 
-        let displayname = $value.get_ava_single_string("displayname").ok_or(
-            OperationError::InvalidAccountState("Missing attribute: displayname".to_string()),
-        )?;
+        let displayname = $value
+            .get_ava_single_str("displayname")
+            .map(|s| s.to_string())
+            .ok_or(OperationError::InvalidAccountState(
+                "Missing attribute: displayname".to_string(),
+            ))?;
 
         let primary = $value
             .get_ava_single_credential("primary_credential")

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -27,7 +27,7 @@ impl PasswordChangeEvent {
 
     pub fn from_idm_account_set_password(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         msg: IdmAccountSetPasswordMessage,
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, msg.uat)?;
@@ -43,7 +43,7 @@ impl PasswordChangeEvent {
 
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
         cleartext: String,
@@ -79,7 +79,7 @@ impl UnixPasswordChangeEvent {
 
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
         cleartext: String,
@@ -104,7 +104,7 @@ pub struct GeneratePasswordEvent {
 impl GeneratePasswordEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
         appid: Option<String>,
@@ -128,7 +128,7 @@ pub struct RegenerateRadiusSecretEvent {
 impl RegenerateRadiusSecretEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
     ) -> Result<Self, OperationError> {
@@ -154,7 +154,7 @@ pub struct RadiusAuthTokenEvent {
 impl RadiusAuthTokenEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
     ) -> Result<Self, OperationError> {
@@ -180,7 +180,7 @@ pub struct UnixUserTokenEvent {
 impl UnixUserTokenEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
     ) -> Result<Self, OperationError> {
@@ -206,7 +206,7 @@ pub struct UnixGroupTokenEvent {
 impl UnixGroupTokenEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
     ) -> Result<Self, OperationError> {
@@ -242,7 +242,7 @@ impl UnixUserAuthEvent {
 
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
         cleartext: String,
@@ -267,7 +267,7 @@ pub struct GenerateTOTPEvent {
 impl GenerateTOTPEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
         label: String,
@@ -304,7 +304,7 @@ pub struct VerifyTOTPEvent {
 impl VerifyTOTPEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         uat: Option<UserAuthToken>,
         target: Uuid,
         session: Uuid,

--- a/kanidmd/src/lib/idm/group.rs
+++ b/kanidmd/src/lib/idm/group.rs
@@ -22,20 +22,23 @@ pub struct Group {
 
 macro_rules! try_from_account_e {
     ($au:expr, $value:expr, $qs:expr) => {{
-        let name = $value.get_ava_single_string("name").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: name".to_string())
-        })?;
+        let name = $value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: name".to_string())
+            })?;
 
         let uuid = *$value.get_uuid();
 
         let upg = Group { name, uuid };
 
-        let mut groups: Vec<Group> = match $value.get_ava_reference_uuid("memberof") {
-            Some(l) => {
+        let mut groups: Vec<Group> = match $value.get_ava_as_refuuid("memberof") {
+            Some(riter) => {
                 // given a list of uuid, make a filter: even if this is empty, the be will
                 // just give and empty result set.
                 let f = filter!(f_or(
-                    l.into_iter()
+                    riter
                         .map(|u| f_eq("uuid", PartialValue::new_uuidr(u)))
                         .collect()
                 ));
@@ -96,9 +99,12 @@ impl Group {
         }
 
         // Now extract our needed attributes
-        let name = value.get_ava_single_string("name").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: name".to_string())
-        })?;
+        let name = value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: name".to_string())
+            })?;
 
         let uuid = *value.get_uuid();
 

--- a/kanidmd/src/lib/idm/radius.rs
+++ b/kanidmd/src/lib/idm/radius.rs
@@ -40,15 +40,21 @@ impl RadiusAccount {
             })?
             .to_string();
 
-        let name = value.get_ava_single_string("name").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: name".to_string())
-        })?;
+        let name = value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: name".to_string())
+            })?;
 
         let uuid = *value.get_uuid();
 
-        let displayname = value.get_ava_single_string("displayname").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
-        })?;
+        let displayname = value
+            .get_ava_single_str("displayname")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
+            })?;
 
         let groups = Group::try_from_account_entry_red_ro(au, &value, qs)?;
 

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -915,7 +915,7 @@ mod tests {
     ) -> Result<(), OperationError> {
         let cred = Credential::new_password_only(pw);
         let v_cred = Value::new_credential("primary", cred);
-        let mut qs_write = qs.write(duration_from_epoch_now());
+        let qs_write = qs.write(duration_from_epoch_now());
 
         // now modify and provide a primary credential.
         let me_inv_m = unsafe {
@@ -1207,7 +1207,7 @@ mod tests {
     #[test]
     fn test_idm_unixusertoken() {
         run_idm_test!(|_qs: &QueryServer, idms: &IdmServer, au: &mut AuditScope| {
-            let mut idms_prox_write = idms.proxy_write(duration_from_epoch_now());
+            let idms_prox_write = idms.proxy_write(duration_from_epoch_now());
             // Modify admin to have posixaccount
             let me_posix = unsafe {
                 ModifyEvent::new_internal_invalid(
@@ -1317,7 +1317,7 @@ mod tests {
             assert!(idms_write.commit(au).is_ok());
 
             // Check deleting the password
-            let mut idms_prox_write = idms.proxy_write(duration_from_epoch_now());
+            let idms_prox_write = idms.proxy_write(duration_from_epoch_now());
             let me_purge_up = unsafe {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),

--- a/kanidmd/src/lib/idm/unix.rs
+++ b/kanidmd/src/lib/idm/unix.rs
@@ -48,9 +48,12 @@ macro_rules! try_from_entry {
             ));
         }
 
-        let name = $value.get_ava_single_string("name").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: name".to_string())
-        })?;
+        let name = $value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: name".to_string())
+            })?;
 
         let spn = $value
             .get_ava_single("spn")
@@ -61,17 +64,25 @@ macro_rules! try_from_entry {
 
         let uuid = *$value.get_uuid();
 
-        let displayname = $value.get_ava_single_string("displayname").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
-        })?;
+        let displayname = $value
+            .get_ava_single_str("displayname")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
+            })?;
 
         let gidnumber = $value.get_ava_single_uint32("gidnumber").ok_or_else(|| {
             OperationError::InvalidAccountState("Missing attribute: gidnumber".to_string())
         })?;
 
-        let shell = $value.get_ava_single_string("loginshell");
+        let shell = $value
+            .get_ava_single_str("loginshell")
+            .map(|s| s.to_string());
 
-        let sshkeys = $value.get_ava_ssh_pubkeys("ssh_publickey");
+        let sshkeys = $value
+            .get_ava_iter_sshpubkeys("ssh_publickey")
+            .map(|i| i.map(|s| s.to_string()).collect())
+            .unwrap_or_else(|| Vec::new());
 
         let cred = $value
             .get_ava_single_credential("unix_password")
@@ -206,9 +217,12 @@ macro_rules! try_from_group_e {
             ));
         }
 
-        let name = $value.get_ava_single_string("name").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: name".to_string())
-        })?;
+        let name = $value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: name".to_string())
+            })?;
 
         let spn = $value
             .get_ava_single("spn")
@@ -249,9 +263,12 @@ macro_rules! try_from_account_group_e {
             ));
         }
 
-        let name = $value.get_ava_single_string("name").ok_or_else(|| {
-            OperationError::InvalidAccountState("Missing attribute: name".to_string())
-        })?;
+        let name = $value
+            .get_ava_single_str("name")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OperationError::InvalidAccountState("Missing attribute: name".to_string())
+            })?;
 
         let spn = $value
             .get_ava_single("spn")
@@ -274,13 +291,13 @@ macro_rules! try_from_account_group_e {
             uuid,
         };
 
-        match $value.get_ava_reference_uuid("memberof") {
-            Some(l) => {
+        match $value.get_ava_as_refuuid("memberof") {
+            Some(riter) => {
                 let f = filter!(f_and!([
                     f_eq("class", PartialValue::new_class("posixgroup")),
                     f_eq("class", PartialValue::new_class("group")),
                     f_or(
-                        l.into_iter()
+                        riter
                             .map(|u| f_eq("uuid", PartialValue::new_uuidr(u)))
                             .collect()
                     )

--- a/kanidmd/src/lib/idm/unix.rs
+++ b/kanidmd/src/lib/idm/unix.rs
@@ -82,7 +82,7 @@ macro_rules! try_from_entry {
         let sshkeys = $value
             .get_ava_iter_sshpubkeys("ssh_publickey")
             .map(|i| i.map(|s| s.to_string()).collect())
-            .unwrap_or_else(|| Vec::new());
+            .unwrap_or_else(Vec::new);
 
         let cred = $value
             .get_ava_single_credential("unix_password")

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -43,7 +43,7 @@ pub struct LdapServer {
 
 impl LdapServer {
     pub fn new(au: &mut AuditScope, idms: &IdmServer) -> Result<Self, OperationError> {
-        let mut idms_prox_read = idms.proxy_read();
+        let idms_prox_read = idms.proxy_read();
         // This is the rootdse path.
         // get the domain_info item
         let domain_entry = idms_prox_read
@@ -51,7 +51,8 @@ impl LdapServer {
             .internal_search_uuid(au, &UUID_DOMAIN_INFO)?;
 
         let domain_name = domain_entry
-            .get_ava_single_string("domain_name")
+            .get_ava_single_str("domain_name")
+            .map(|s| s.to_string())
             .ok_or(OperationError::InvalidEntryState)?;
 
         let basedn = ldap_domain_to_dc(domain_name.as_str());

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -205,7 +205,7 @@ impl LdapServer {
 
             lperf_segment!(au, "ldap::do_search<core>", || {
                 // Now start the txn - we need it for resolving filter components.
-                let mut idm_read = idms.proxy_read();
+                let idm_read = idms.proxy_read();
 
                 // join the filter, with ext_filter
                 let lfilter = match ext_filter {
@@ -238,7 +238,7 @@ impl LdapServer {
 
                 // Kanidm Filter from LdapFilter
                 let filter =
-                    Filter::from_ldap_ro(au, &lfilter, &mut idm_read.qs_read).map_err(|e| {
+                    Filter::from_ldap_ro(au, &lfilter, &idm_read.qs_read).map_err(|e| {
                         lrequest_error!(au, "invalid ldap filter {:?}", e);
                         e
                     })?;
@@ -249,7 +249,7 @@ impl LdapServer {
                 let se = lperf_trace_segment!(au, "ldap::do_search<core><prepare_se>", || {
                     SearchEvent::new_ext_impersonate_uuid(
                         au,
-                        &mut idm_read.qs_read,
+                        &idm_read.qs_read,
                         &uat.effective_uuid,
                         filter,
                         attrs,
@@ -267,7 +267,7 @@ impl LdapServer {
                         let lres: Result<Vec<_>, _> = res
                             .into_iter()
                             .map(|e| {
-                                e.to_ldap(au, &mut idm_read.qs_read, self.basedn.as_str())
+                                e.to_ldap(au, &idm_read.qs_read, self.basedn.as_str())
                                     // if okay, wrap in a ldap msg.
                                     .map(|r| sr.gen_result_entry(r))
                             })

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -17,7 +17,12 @@ macro_rules! run_test_no_init {
 
         let mut audit = AuditScope::new("run_test", uuid::Uuid::new_v4(), None);
 
-        let be = match Backend::new(&mut audit, "", 1) {
+        let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
+        let idxmeta = {
+            let schema_txn = schema_outer.write();
+            schema_txn.reload_idxmeta()
+        };
+        let be = match Backend::new(&mut audit, "", 1, idxmeta) {
             Ok(be) => be,
             Err(e) => {
                 audit.write_log();
@@ -25,7 +30,6 @@ macro_rules! run_test_no_init {
                 panic!()
             }
         };
-        let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
         let test_server = QueryServer::new(be, schema_outer);
 
         $test_fn(&test_server, &mut audit);
@@ -57,7 +61,12 @@ macro_rules! run_test {
 
         let mut audit = AuditScope::new("run_test", uuid::Uuid::new_v4(), None);
 
-        let be = match Backend::new(&mut audit, "", 1) {
+        let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
+        let idxmeta = {
+            let schema_txn = schema_outer.write();
+            schema_txn.reload_idxmeta()
+        };
+        let be = match Backend::new(&mut audit, "", 1, idxmeta) {
             Ok(be) => be,
             Err(e) => {
                 audit.write_log();
@@ -65,7 +74,6 @@ macro_rules! run_test {
                 panic!()
             }
         };
-        let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
         let test_server = QueryServer::new(be, schema_outer);
 
         test_server
@@ -124,8 +132,12 @@ macro_rules! run_idm_test {
 
         let mut audit = AuditScope::new("run_test", uuid::Uuid::new_v4(), None);
 
-        let be = Backend::new(&mut audit, "", 1).expect("Failed to init be");
         let schema_outer = Schema::new(&mut audit).expect("Failed to init schema");
+        let idxmeta = {
+            let schema_txn = schema_outer.write();
+            schema_txn.reload_idxmeta()
+        };
+        let be = Backend::new(&mut audit, "", 1, idxmeta).expect("Failed to init be");
 
         let test_server = QueryServer::new(be, schema_outer);
         test_server

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -47,7 +47,7 @@ impl Modify {
     pub fn from(
         audit: &mut AuditScope,
         m: &ProtoModify,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         Ok(match m {
             ProtoModify::Present(a, v) => Modify::Present(a.clone(), qs.clone_value(audit, a, v)?),
@@ -109,7 +109,7 @@ impl ModifyList<ModifyInvalid> {
     pub fn from(
         audit: &mut AuditScope,
         ml: &ProtoModifyList,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         // For each ProtoModify, do a from.
         let inner: Result<Vec<_>, _> = ml

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -38,7 +38,7 @@ fn get_cand_attr_set<VALID, STATE>(
         let mut values: Vec<PartialValue> = match e.get_ava(attr) {
             Some(vs) => {
                 // We have values, map them.
-                vs.into_iter().map(|v| v.to_partialvalue()).collect()
+                vs.map(|v| v.to_partialvalue()).collect()
             }
             None => {
                 // No values, so empty set.

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -72,7 +72,7 @@ fn get_cand_attr_set<VALID, STATE>(
 
 fn enforce_unique<STATE>(
     au: &mut AuditScope,
-    qs: &mut QueryServerWriteTransaction,
+    qs: &QueryServerWriteTransaction,
     cand: &[Entry<EntryInvalid, STATE>],
     attr: &str,
 ) -> Result<(), OperationError> {
@@ -132,7 +132,7 @@ impl Plugin for AttrUnique {
 
     fn pre_create_transform(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -151,7 +151,7 @@ impl Plugin for AttrUnique {
 
     fn pre_modify(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
@@ -170,7 +170,7 @@ impl Plugin for AttrUnique {
 
     fn verify(
         au: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Vec<Result<(), ConsistencyError>> {
         // Only check live entries, not recycled.
         let filt_in = filter!(f_pres("class"));

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -28,7 +28,7 @@ impl Plugin for Domain {
 
     fn pre_create_transform(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_domain_generate_uuid() {
         run_test!(|server: &QueryServer, au: &mut AuditScope| {
-            let mut server_txn = server.write(duration_from_epoch_now());
+            let server_txn = server.write(duration_from_epoch_now());
             let e_dom = server_txn
                 .internal_search_uuid(au, &UUID_DOMAIN_INFO)
                 .expect("must not fail");

--- a/kanidmd/src/lib/plugins/gidnumber.rs
+++ b/kanidmd/src/lib/plugins/gidnumber.rs
@@ -79,7 +79,7 @@ impl Plugin for GidNumber {
 
     fn pre_create_transform(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -92,7 +92,7 @@ impl Plugin for GidNumber {
 
     fn pre_modify(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
@@ -115,7 +115,7 @@ mod tests {
 
     fn check_gid(
         au: &mut AuditScope,
-        qs_write: &mut QueryServerWriteTransaction,
+        qs_write: &QueryServerWriteTransaction,
         uuid: &str,
         gid: u32,
     ) {
@@ -148,7 +148,7 @@ mod tests {
             preload,
             create,
             None,
-            |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
+            |au, qs_write: &QueryServerWriteTransaction| check_gid(
                 au,
                 qs_write,
                 "83a0927f-3de1-45ec-bea0-2f7b997ef244",
@@ -181,7 +181,7 @@ mod tests {
             preload,
             create,
             None,
-            |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
+            |au, qs_write: &QueryServerWriteTransaction| check_gid(
                 au,
                 qs_write,
                 "83a0927f-3de1-45ec-bea0-2f7b997ef244",
@@ -213,7 +213,7 @@ mod tests {
             filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([m_pres("class", &Value::new_class("posixgroup"))]),
             None,
-            |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
+            |au, qs_write: &QueryServerWriteTransaction| check_gid(
                 au,
                 qs_write,
                 "83a0927f-3de1-45ec-bea0-2f7b997ef244",
@@ -246,7 +246,7 @@ mod tests {
             filter!(f_eq("name", PartialValue::new_iname("testperson"))),
             modlist!([m_purge("gidnumber")]),
             None,
-            |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
+            |au, qs_write: &QueryServerWriteTransaction| check_gid(
                 au,
                 qs_write,
                 "83a0927f-3de1-45ec-bea0-2f7b997ef244",
@@ -282,7 +282,7 @@ mod tests {
                 m_pres("gidnumber", &Value::new_uint32(2000))
             ]),
             None,
-            |au, qs_write: &mut QueryServerWriteTransaction| check_gid(
+            |au, qs_write: &QueryServerWriteTransaction| check_gid(
                 au,
                 qs_write,
                 "83a0927f-3de1-45ec-bea0-2f7b997ef244",

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -14,9 +14,13 @@ macro_rules! setup_test {
             .try_init();
 
         // Create an in memory BE
-        let be = Backend::new($au, "", 1).expect("Failed to init BE");
-
         let schema_outer = Schema::new($au).expect("Failed to init schema");
+        let idxmeta = {
+            let schema_txn = schema_outer.write();
+            schema_txn.reload_idxmeta()
+        };
+        let be = Backend::new($au, "", 1, idxmeta).expect("Failed to init BE");
+
         let qs = QueryServer::new(be, schema_outer);
         qs.initialise_helper($au, duration_from_epoch_now())
             .expect("init failed!");

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -26,7 +26,7 @@ macro_rules! setup_test {
             .expect("init failed!");
 
         if !$preload_entries.is_empty() {
-            let mut qs_write = qs.write(duration_from_epoch_now());
+            let qs_write = qs.write(duration_from_epoch_now());
             qs_write
                 .internal_create($au, $preload_entries)
                 .expect("Failed to preload entries");
@@ -66,11 +66,11 @@ macro_rules! run_create_test {
             };
 
             {
-                let mut qs_write = qs.write(duration_from_epoch_now());
+                let qs_write = qs.write(duration_from_epoch_now());
                 let r = qs_write.create(&mut au, &ce);
                 debug!("test result: {:?}", r);
                 assert!(r == $expect);
-                $check(&mut au, &mut qs_write);
+                $check(&mut au, &qs_write);
                 match r {
                     Ok(_) => {
                         qs_write.commit(&mut au).expect("commit failure!");
@@ -121,7 +121,7 @@ macro_rules! run_modify_test {
             };
 
             {
-                let mut qs_write = qs.write(duration_from_epoch_now());
+                let qs_write = qs.write(duration_from_epoch_now());
                 let r = lperf_segment!(
                     &mut au,
                     "plugins::macros::run_modify_test -> main_test",
@@ -130,7 +130,7 @@ macro_rules! run_modify_test {
                 lperf_segment!(
                     &mut au,
                     "plugins::macros::run_modify_test -> post_test check",
-                    || { $check(&mut au, &mut qs_write) }
+                    || { $check(&mut au, &qs_write) }
                 );
                 debug!("test result: {:?}", r);
                 assert!(r == $expect);
@@ -183,10 +183,10 @@ macro_rules! run_delete_test {
             };
 
             {
-                let mut qs_write = qs.write(duration_from_epoch_now());
+                let qs_write = qs.write(duration_from_epoch_now());
                 let r = qs_write.delete(&mut au, &de);
                 debug!("test result: {:?}", r);
-                $check(&mut au, &mut qs_write);
+                $check(&mut au, &qs_write);
                 assert!(r == $expect);
                 match r {
                     Ok(_) => {

--- a/kanidmd/src/lib/plugins/memberof.rs
+++ b/kanidmd/src/lib/plugins/memberof.rs
@@ -37,16 +37,17 @@ where
     STATE: std::fmt::Debug,
 {
     // From the list of groups which were changed in this operation:
-    let changed_groups: Vec<_> = changed
+    // let changed_groups: Vec<_> = changed
+    let mut affected_uuids: Vec<&Uuid> = changed
         .into_iter()
         .filter(|e| e.attribute_value_pres("class", &CLASS_GROUP))
-        .collect();
-
-    ltrace!(au, "groups reporting change: {:?}", changed_groups);
-
-    // Now, build a map of all UUID's that will require updates as a result of this change
-    let mut affected_uuids: Vec<&Uuid> = changed_groups
-        .iter()
+        /*
+            .collect();
+        ltrace!(au, "groups reporting change: {:?}", changed_groups);
+        // Now, build a map of all UUID's that will require updates as a result of this change
+        let mut affected_uuids: Vec<&Uuid> = changed_groups
+            .iter()
+            */
         .filter_map(|e| {
             // Only groups with member get collected up here.
             e.get_ava("member")
@@ -369,7 +370,6 @@ impl Plugin for MemberOf {
                     continue;
                 }
             }
-
             // Could check all dmos in mos?
 
             /* To check nested! */

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -24,7 +24,7 @@ trait Plugin {
 
     fn pre_create_transform(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         _cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -38,7 +38,7 @@ trait Plugin {
 
     fn pre_create(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // List of what we will commit that is valid?
         _cand: &[Entry<EntrySealed, EntryNew>],
         _ce: &CreateEvent,
@@ -49,7 +49,7 @@ trait Plugin {
 
     fn post_create(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // List of what we commited that was valid?
         _cand: &[Entry<EntrySealed, EntryCommitted>],
         _ce: &CreateEvent,
@@ -64,7 +64,7 @@ trait Plugin {
 
     fn pre_modify(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         _cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
@@ -74,7 +74,7 @@ trait Plugin {
 
     fn post_modify(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // List of what we modified that was valid?
         _pre_cand: &[Entry<EntrySealed, EntryCommitted>],
         _cand: &[Entry<EntrySealed, EntryCommitted>],
@@ -90,7 +90,7 @@ trait Plugin {
 
     fn pre_delete(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         _cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         _de: &DeleteEvent,
     ) -> Result<(), OperationError> {
@@ -100,7 +100,7 @@ trait Plugin {
 
     fn post_delete(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // List of what we delete that was valid?
         _cand: &[Entry<EntrySealed, EntryCommitted>],
         _ce: &DeleteEvent,
@@ -115,7 +115,7 @@ trait Plugin {
 
     fn verify(
         au: &mut AuditScope,
-        _qs: &mut QueryServerReadTransaction,
+        _qs: &QueryServerReadTransaction,
     ) -> Vec<Result<(), ConsistencyError>> {
         ladmin_error!(au, "plugin {} has an unimplemented verify!", Self::id());
         vec![Err(ConsistencyError::Unknown)]
@@ -257,7 +257,7 @@ macro_rules! run_verify_plugin {
 impl Plugins {
     pub fn run_pre_create_transform(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -286,7 +286,7 @@ impl Plugins {
 
     pub fn run_pre_create(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &[Entry<EntrySealed, EntryNew>],
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -301,7 +301,7 @@ impl Plugins {
 
     pub fn run_post_create(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &[Entry<EntrySealed, EntryCommitted>],
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -323,7 +323,7 @@ impl Plugins {
 
     pub fn run_pre_modify(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         me: &ModifyEvent,
     ) -> Result<(), OperationError> {
@@ -342,7 +342,7 @@ impl Plugins {
 
     pub fn run_post_modify(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         pre_cand: &[Entry<EntrySealed, EntryCommitted>],
         cand: &[Entry<EntrySealed, EntryCommitted>],
         me: &ModifyEvent,
@@ -368,7 +368,7 @@ impl Plugins {
 
     pub fn run_pre_delete(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         de: &DeleteEvent,
     ) -> Result<(), OperationError> {
@@ -383,7 +383,7 @@ impl Plugins {
 
     pub fn run_post_delete(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &[Entry<EntrySealed, EntryCommitted>],
         de: &DeleteEvent,
     ) -> Result<(), OperationError> {
@@ -405,7 +405,7 @@ impl Plugins {
 
     pub fn run_verify(
         au: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Vec<Result<(), ConsistencyError>> {
         lperf_segment!(au, "plugins::run_verify", || {
             let mut results = Vec::new();

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -18,7 +18,7 @@ impl Plugin for PasswordImport {
 
     fn pre_create_transform(
         _au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -67,7 +67,7 @@ impl Plugin for PasswordImport {
 
     fn pre_modify(
         _au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
@@ -254,7 +254,7 @@ mod tests {
                 Value::from(IMPORT_HASH)
             )]),
             None,
-            |au: &mut AuditScope, qs: &mut QueryServerWriteTransaction| {
+            |au: &mut AuditScope, qs: &QueryServerWriteTransaction| {
                 let e = qs
                     .internal_search_uuid(
                         au,

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -50,7 +50,7 @@ impl Plugin for Protected {
 
     fn pre_create(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // List of what we will commit that is valid?
         cand: &[Entry<EntrySealed, EntryNew>],
         ce: &CreateEvent,
@@ -83,7 +83,7 @@ impl Plugin for Protected {
 
     fn pre_modify(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // Should these be EntrySealed?
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         me: &ModifyEvent,
@@ -174,7 +174,7 @@ impl Plugin for Protected {
 
     fn pre_delete(
         au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
+        _qs: &QueryServerWriteTransaction,
         // Should these be EntrySealed
         cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         de: &DeleteEvent,

--- a/kanidmd/src/lib/plugins/refint.rs
+++ b/kanidmd/src/lib/plugins/refint.rs
@@ -30,7 +30,7 @@ pub struct ReferentialIntegrity;
 impl ReferentialIntegrity {
     fn check_uuid_exists(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         rtype: &str,
         uuid_value: &Value,
     ) -> Result<(), OperationError> {
@@ -83,7 +83,7 @@ impl Plugin for ReferentialIntegrity {
     // be in cand AND db" to simply "is it in the DB?".
     fn post_create(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &[Entry<EntrySealed, EntryCommitted>],
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
@@ -108,7 +108,7 @@ impl Plugin for ReferentialIntegrity {
 
     fn post_modify(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         _pre_cand: &[Entry<EntrySealed, EntryCommitted>],
         _cand: &[Entry<EntrySealed, EntryCommitted>],
         me: &ModifyEvent,
@@ -131,7 +131,7 @@ impl Plugin for ReferentialIntegrity {
 
     fn post_delete(
         au: &mut AuditScope,
-        qs: &mut QueryServerWriteTransaction,
+        qs: &QueryServerWriteTransaction,
         cand: &[Entry<EntrySealed, EntryCommitted>],
         _ce: &DeleteEvent,
     ) -> Result<(), OperationError> {
@@ -184,7 +184,7 @@ impl Plugin for ReferentialIntegrity {
 
     fn verify(
         au: &mut AuditScope,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Vec<Result<(), ConsistencyError>> {
         // Get all entries as cand
         //      build a cand-uuid set
@@ -301,7 +301,7 @@ mod tests {
             preload,
             create,
             None,
-            |au: &mut AuditScope, qs: &mut QueryServerWriteTransaction| {
+            |au: &mut AuditScope, qs: &QueryServerWriteTransaction| {
                 let cands = qs
                     .internal_search(
                         au,
@@ -337,7 +337,7 @@ mod tests {
             preload,
             create,
             None,
-            |au: &mut AuditScope, qs: &mut QueryServerWriteTransaction| {
+            |au: &mut AuditScope, qs: &QueryServerWriteTransaction| {
                 let cands = qs
                     .internal_search(
                         au,
@@ -559,7 +559,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             None,
-            |_au: &mut AuditScope, _qs: &mut QueryServerWriteTransaction| {}
+            |_au: &mut AuditScope, _qs: &QueryServerWriteTransaction| {}
         );
     }
 
@@ -601,7 +601,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             None,
-            |_au: &mut AuditScope, _qs: &mut QueryServerWriteTransaction| {}
+            |_au: &mut AuditScope, _qs: &QueryServerWriteTransaction| {}
         );
     }
 
@@ -627,7 +627,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             None,
-            |_au: &mut AuditScope, _qs: &mut QueryServerWriteTransaction| {}
+            |_au: &mut AuditScope, _qs: &QueryServerWriteTransaction| {}
         );
     }
 }

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -25,11 +25,12 @@ use kanidm_proto::v1::{ConsistencyError, OperationError, SchemaError};
 
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
-use std::collections::HashMap as Map;
+// use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use uuid::Uuid;
 
-use concread::collections::bptree::*;
+use concread::cowcell::*;
 
 // representations of schema that confines object types, classes
 // and attributes. This ties in deeply with "Entry".
@@ -54,22 +55,36 @@ lazy_static! {
 /// [`Attributes`]: struct.SchemaAttribute.html
 /// [`Classes`]: struct.SchemaClass.html
 pub struct Schema {
-    classes: BptreeMap<String, SchemaClass>,
-    attributes: BptreeMap<String, SchemaAttribute>,
+    // classes: BptreeMap<String, SchemaClass>,
+    // attributes: BptreeMap<String, SchemaAttribute>,
+    classes: CowCell<HashMap<String, SchemaClass>>,
+    attributes: CowCell<HashMap<String, SchemaAttribute>>,
+    unique_cache: CowCell<Vec<String>>,
+    ref_cache: CowCell<HashMap<String, SchemaAttribute>>,
 }
 
 /// A writable transaction of the working schema set. You should not change this directly,
 /// the writability is for the server internally to allow reloading of the schema. Changes
 /// you make will be lost when the server re-reads the schema from disk.
 pub struct SchemaWriteTransaction<'a> {
-    classes: BptreeMapWriteTxn<'a, String, SchemaClass>,
-    attributes: BptreeMapWriteTxn<'a, String, SchemaAttribute>,
+    // classes: BptreeMapWriteTxn<'a, String, SchemaClass>,
+    // attributes: BptreeMapWriteTxn<'a, String, SchemaAttribute>,
+    classes: CowCellWriteTxn<'a, HashMap<String, SchemaClass>>,
+    attributes: CowCellWriteTxn<'a, HashMap<String, SchemaAttribute>>,
+
+    unique_cache: CowCellWriteTxn<'a, Vec<String>>,
+    ref_cache: CowCellWriteTxn<'a, HashMap<String, SchemaAttribute>>,
 }
 
 /// A readonly transaction of the working schema set.
 pub struct SchemaReadTransaction {
-    classes: BptreeMapReadTxn<String, SchemaClass>,
-    attributes: BptreeMapReadTxn<String, SchemaAttribute>,
+    // classes: BptreeMapReadTxn<String, SchemaClass>,
+    // attributes: BptreeMapReadTxn<String, SchemaAttribute>,
+    classes: CowCellReadTxn<HashMap<String, SchemaClass>>,
+    attributes: CowCellReadTxn<HashMap<String, SchemaAttribute>>,
+
+    unique_cache: CowCellReadTxn<Vec<String>>,
+    ref_cache: CowCellReadTxn<HashMap<String, SchemaAttribute>>,
 }
 
 /// An item reperesenting an attribute and the rules that enforce it. These rules enforce if an
@@ -114,16 +129,20 @@ impl SchemaAttribute {
 
         // name
         let name = value
-            .get_ava_single_string("attributename")
+            .get_ava_single_str("attributename")
+            .map(|s| s.to_string())
             .ok_or_else(|| {
                 ladmin_error!(audit, "missing attributename");
                 OperationError::InvalidSchemaState("missing attributename".to_string())
             })?;
         // description
-        let description = value.get_ava_single_string("description").ok_or_else(|| {
-            ladmin_error!(audit, "missing description");
-            OperationError::InvalidSchemaState("missing description".to_string())
-        })?;
+        let description = value
+            .get_ava_single_str("description")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                ladmin_error!(audit, "missing description");
+                OperationError::InvalidSchemaState("missing description".to_string())
+            })?;
 
         // multivalue
         let multivalue = value.get_ava_single_bool("multivalue").ok_or_else(|| {
@@ -415,33 +434,39 @@ impl SchemaClass {
         let uuid = *value.get_uuid();
 
         // name
-        let name = value.get_ava_single_string("classname").ok_or_else(|| {
-            ladmin_error!(audit, "missing classname");
-            OperationError::InvalidSchemaState("missing classname".to_string())
-        })?;
+        let name = value
+            .get_ava_single_str("classname")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                ladmin_error!(audit, "missing classname");
+                OperationError::InvalidSchemaState("missing classname".to_string())
+            })?;
         // description
-        let description = value.get_ava_single_string("description").ok_or_else(|| {
-            ladmin_error!(audit, "missing description");
-            OperationError::InvalidSchemaState("missing description".to_string())
-        })?;
+        let description = value
+            .get_ava_single_str("description")
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                ladmin_error!(audit, "missing description");
+                OperationError::InvalidSchemaState("missing description".to_string())
+            })?;
 
         // These are all "optional" lists of strings.
-        let systemmay = value.get_ava_opt_string("systemmay").ok_or_else(|| {
-            ladmin_error!(audit, "missing or invalid systemmay");
-            OperationError::InvalidSchemaState("Missing or invalid systemmay".to_string())
-        })?;
-        let systemmust = value.get_ava_opt_string("systemmust").ok_or_else(|| {
-            ladmin_error!(audit, "missing or invalid systemmust");
-            OperationError::InvalidSchemaState("Missing or invalid systemmust".to_string())
-        })?;
-        let may = value.get_ava_opt_string("may").ok_or_else(|| {
-            ladmin_error!(audit, "missing or invalid may");
-            OperationError::InvalidSchemaState("Missing or invalid may".to_string())
-        })?;
-        let must = value.get_ava_opt_string("must").ok_or_else(|| {
-            ladmin_error!(audit, "missing or invalid must");
-            OperationError::InvalidSchemaState("Missing or invalid must".to_string())
-        })?;
+        let systemmay = value
+            .get_ava_as_str("systemmay")
+            .map(|i| i.map(|s| s.to_string()).collect())
+            .unwrap_or_else(|| Vec::new());
+        let systemmust = value
+            .get_ava_as_str("systemmust")
+            .map(|i| i.map(|s| s.to_string()).collect())
+            .unwrap_or_else(|| Vec::new());
+        let may = value
+            .get_ava_as_str("may")
+            .map(|i| i.map(|s| s.to_string()).collect())
+            .unwrap_or_else(|| Vec::new());
+        let must = value
+            .get_ava_as_str("must")
+            .map(|i| i.map(|s| s.to_string()).collect())
+            .unwrap_or_else(|| Vec::new());
 
         Ok(SchemaClass {
             name,
@@ -456,8 +481,14 @@ impl SchemaClass {
 }
 
 pub trait SchemaTransaction {
-    fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass>;
-    fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute>;
+    // fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass>;
+    // fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute>;
+
+    fn get_classes(&self) -> &HashMap<String, SchemaClass>;
+    fn get_attributes(&self) -> &HashMap<String, SchemaAttribute>;
+
+    fn get_attributes_unique(&self) -> &Vec<String>;
+    fn get_reference_types(&self) -> &HashMap<String, SchemaAttribute>;
 
     fn validate(&self, _audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
         let mut res = Vec::new();
@@ -521,29 +552,6 @@ pub trait SchemaTransaction {
             None
         }
     }
-
-    fn get_attributes_unique(&self) -> Vec<String> {
-        // This could be improved by caching this set on schema reload!
-        self.get_attributes()
-            .iter()
-            .filter_map(|(k, v)| if v.unique { Some(k.clone()) } else { None })
-            .collect()
-    }
-
-    // Probably need something like get_classes or similar
-    // so that externals can call and use this data.
-
-    fn get_reference_types(&self) -> Map<String, SchemaAttribute> {
-        let snapshot = self.get_attributes();
-        snapshot
-            .iter()
-            .filter(|(_, sa)| match &sa.syntax {
-                SyntaxType::REFERENCE_UUID => true,
-                _ => false,
-            })
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
-    }
 }
 
 impl<'a> SchemaWriteTransaction<'a> {
@@ -556,8 +564,12 @@ impl<'a> SchemaWriteTransaction<'a> {
         let SchemaWriteTransaction {
             classes,
             attributes,
+            unique_cache,
+            ref_cache,
         } = self;
 
+        unique_cache.commit();
+        ref_cache.commit();
         classes.commit();
         attributes.commit();
         Ok(())
@@ -569,10 +581,21 @@ impl<'a> SchemaWriteTransaction<'a> {
     ) -> Result<(), OperationError> {
         // purge all old attributes.
         self.attributes.clear();
+
+        self.unique_cache.clear();
+        self.ref_cache.clear();
         // Update with new ones.
         // Do we need to check for dups?
         // No, they'll over-write each other ... but we do need name uniqueness.
         attributetypes.into_iter().for_each(|a| {
+            // Update the unique and ref caches.
+            if a.syntax == SyntaxType::REFERENCE_UUID {
+                self.ref_cache.insert(a.name.clone(), a.clone());
+            }
+            if a.unique {
+                self.unique_cache.push(a.name.clone());
+            }
+            // Finally insert.
             self.attributes.insert(a.name.clone(), a);
         });
 
@@ -1397,6 +1420,23 @@ impl<'a> SchemaWriteTransaction<'a> {
 }
 
 impl<'a> SchemaTransaction for SchemaWriteTransaction<'a> {
+    fn get_attributes_unique(&self) -> &Vec<String> {
+        &(*self.unique_cache)
+    }
+
+    fn get_reference_types(&self) -> &HashMap<String, SchemaAttribute> {
+        &(*self.ref_cache)
+    }
+
+    fn get_classes(&self) -> &HashMap<String, SchemaClass> {
+        &(*self.classes)
+    }
+
+    fn get_attributes(&self) -> &HashMap<String, SchemaAttribute> {
+        &(*self.attributes)
+    }
+
+    /*
     fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass> {
         self.classes.to_snapshot()
     }
@@ -1404,9 +1444,27 @@ impl<'a> SchemaTransaction for SchemaWriteTransaction<'a> {
     fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute> {
         self.attributes.to_snapshot()
     }
+    */
 }
 
 impl SchemaTransaction for SchemaReadTransaction {
+    fn get_attributes_unique(&self) -> &Vec<String> {
+        &(*self.unique_cache)
+    }
+
+    fn get_reference_types(&self) -> &HashMap<String, SchemaAttribute> {
+        &(*self.ref_cache)
+    }
+
+    fn get_classes(&self) -> &HashMap<String, SchemaClass> {
+        &(*self.classes)
+    }
+
+    fn get_attributes(&self) -> &HashMap<String, SchemaAttribute> {
+        &(*self.attributes)
+    }
+
+    /*
     fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass> {
         self.classes.to_snapshot()
     }
@@ -1414,13 +1472,18 @@ impl SchemaTransaction for SchemaReadTransaction {
     fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute> {
         self.attributes.to_snapshot()
     }
+    */
 }
 
 impl Schema {
     pub fn new(audit: &mut AuditScope) -> Result<Self, OperationError> {
         let s = Schema {
-            classes: BptreeMap::new(),
-            attributes: BptreeMap::new(),
+            // classes: BptreeMap::new(),
+            // attributes: BptreeMap::new(),
+            classes: CowCell::new(HashMap::new()),
+            attributes: CowCell::new(HashMap::new()),
+            unique_cache: CowCell::new(Vec::new()),
+            ref_cache: CowCell::new(HashMap::new()),
         };
         let mut sw = s.write();
         let r1 = sw.generate_in_memory(audit);
@@ -1435,6 +1498,8 @@ impl Schema {
         SchemaReadTransaction {
             classes: self.classes.read(),
             attributes: self.attributes.read(),
+            unique_cache: self.unique_cache.read(),
+            ref_cache: self.ref_cache.read(),
         }
     }
 
@@ -1442,6 +1507,8 @@ impl Schema {
         SchemaWriteTransaction {
             classes: self.classes.write(),
             attributes: self.attributes.write(),
+            unique_cache: self.unique_cache.write(),
+            ref_cache: self.ref_cache.write(),
         }
     }
 }

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -447,19 +447,19 @@ impl SchemaClass {
         let systemmay = value
             .get_ava_as_str("systemmay")
             .map(|i| i.map(|s| s.to_string()).collect())
-            .unwrap_or_else(|| Vec::new());
+            .unwrap_or_else(Vec::new);
         let systemmust = value
             .get_ava_as_str("systemmust")
             .map(|i| i.map(|s| s.to_string()).collect())
-            .unwrap_or_else(|| Vec::new());
+            .unwrap_or_else(Vec::new);
         let may = value
             .get_ava_as_str("may")
             .map(|i| i.map(|s| s.to_string()).collect())
-            .unwrap_or_else(|| Vec::new());
+            .unwrap_or_else(Vec::new);
         let must = value
             .get_ava_as_str("must")
             .map(|i| i.map(|s| s.to_string()).collect())
-            .unwrap_or_else(|| Vec::new());
+            .unwrap_or_else(Vec::new);
 
         Ok(SchemaClass {
             name,

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -25,7 +25,6 @@ use kanidm_proto::v1::{ConsistencyError, OperationError, SchemaError};
 
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
-// use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use uuid::Uuid;
@@ -55,8 +54,6 @@ lazy_static! {
 /// [`Attributes`]: struct.SchemaAttribute.html
 /// [`Classes`]: struct.SchemaClass.html
 pub struct Schema {
-    // classes: BptreeMap<String, SchemaClass>,
-    // attributes: BptreeMap<String, SchemaAttribute>,
     classes: CowCell<HashMap<String, SchemaClass>>,
     attributes: CowCell<HashMap<String, SchemaAttribute>>,
     unique_cache: CowCell<Vec<String>>,
@@ -67,8 +64,6 @@ pub struct Schema {
 /// the writability is for the server internally to allow reloading of the schema. Changes
 /// you make will be lost when the server re-reads the schema from disk.
 pub struct SchemaWriteTransaction<'a> {
-    // classes: BptreeMapWriteTxn<'a, String, SchemaClass>,
-    // attributes: BptreeMapWriteTxn<'a, String, SchemaAttribute>,
     classes: CowCellWriteTxn<'a, HashMap<String, SchemaClass>>,
     attributes: CowCellWriteTxn<'a, HashMap<String, SchemaAttribute>>,
 
@@ -78,8 +73,6 @@ pub struct SchemaWriteTransaction<'a> {
 
 /// A readonly transaction of the working schema set.
 pub struct SchemaReadTransaction {
-    // classes: BptreeMapReadTxn<String, SchemaClass>,
-    // attributes: BptreeMapReadTxn<String, SchemaAttribute>,
     classes: CowCellReadTxn<HashMap<String, SchemaClass>>,
     attributes: CowCellReadTxn<HashMap<String, SchemaAttribute>>,
 
@@ -481,9 +474,6 @@ impl SchemaClass {
 }
 
 pub trait SchemaTransaction {
-    // fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass>;
-    // fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute>;
-
     fn get_classes(&self) -> &HashMap<String, SchemaClass>;
     fn get_attributes(&self) -> &HashMap<String, SchemaAttribute>;
 
@@ -1435,16 +1425,6 @@ impl<'a> SchemaTransaction for SchemaWriteTransaction<'a> {
     fn get_attributes(&self) -> &HashMap<String, SchemaAttribute> {
         &(*self.attributes)
     }
-
-    /*
-    fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass> {
-        self.classes.to_snapshot()
-    }
-
-    fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute> {
-        self.attributes.to_snapshot()
-    }
-    */
 }
 
 impl SchemaTransaction for SchemaReadTransaction {
@@ -1463,23 +1443,11 @@ impl SchemaTransaction for SchemaReadTransaction {
     fn get_attributes(&self) -> &HashMap<String, SchemaAttribute> {
         &(*self.attributes)
     }
-
-    /*
-    fn get_classes(&self) -> BptreeMapReadSnapshot<String, SchemaClass> {
-        self.classes.to_snapshot()
-    }
-
-    fn get_attributes(&self) -> BptreeMapReadSnapshot<String, SchemaAttribute> {
-        self.attributes.to_snapshot()
-    }
-    */
 }
 
 impl Schema {
     pub fn new(audit: &mut AuditScope) -> Result<Self, OperationError> {
         let s = Schema {
-            // classes: BptreeMap::new(),
-            // attributes: BptreeMap::new(),
             classes: CowCell::new(HashMap::new()),
             attributes: CowCell::new(HashMap::new()),
             unique_cache: CowCell::new(Vec::new()),


### PR DESCRIPTION
Fixes #260 fixes #257 fixes #157. This is really a set of cleanups around the code base to minimise clones, choose better datastructures for specific tasks, improve the ability to pass references in certain calls and more. Generally this just makes everything a bit smoother, and really has big gains on the write path (it's about 20% faster now). 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
