### PR TITLE
Improve server hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "kanidm_proto",
  "lazy_static",
  "ldap3_server",
+ "libc",
  "libsqlite3-sys",
  "log",
  "num_cpus",
@@ -1587,6 +1588,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-util 0.2.0",
  "toml",
+ "users",
  "uuid",
  "zxcvbn",
 ]
@@ -1666,6 +1668,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.3.1",
  "toml",
+ "users",
 ]
 
 [[package]]
@@ -3299,6 +3302,16 @@ dependencies = [
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "users"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 
 [profile.release]
 debug = true
-lto = true
+# Have to disable to allow aarch64 to build
+# lto = true
 
 [workspace]
 members = [

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ help:
 
 buildx/kanidmd: ## build multiarch images
 buildx/kanidmd:
-	@docker buildx build --progress plain --platform linux/arm64 -f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:$(IMAGE_VERSION) .
+	@docker buildx build --push --platform linux/amd64,linux/arm64 -f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:$(IMAGE_VERSION) .
+	@docker buildx imagetools inspect $(IMAGE_BASE)/server:$(IMAGE_VERSION)
 
 build/kanidmd:	## build kanidmd images
 build/kanidmd:

--- a/kanidm_book/src/SUMMARY.md
+++ b/kanidm_book/src/SUMMARY.md
@@ -12,6 +12,7 @@
 - [Password Quality and Badlisting](./password_quality.md)
 - [Recycle Bin](./recycle_bin.md)
 - [Legacy Applications -- LDAP](./ldap.md)
+- [Security Hardening](./security_hardening.md)
 -----------
 [Why TLS?](./why_tls.md)
 

--- a/kanidm_book/src/security_hardening.md
+++ b/kanidm_book/src/security_hardening.md
@@ -1,0 +1,117 @@
+# Security Hardening
+
+Kanidm ships with a secure-by-default configuration, however that is only as strong
+as the platform that Kanidm operates in. This could be your container environment
+or your Unix-like system.
+
+This chapter will detail a number of warnings and security practices you should
+follow to ensure that Kanidm operates in a secure environment.
+
+The main server is a high-value target for a potential attack, as Kanidm serves as
+the authority on identity and authorisation in a network. Compromise of the Kanidm
+server is equivalent to a full-network take over, AKA "game over".
+
+The unixd resolver is also a high value target as it can be accessed to allow unauthorised
+access to a server, to intercept communications to the server, or more. This also must be protected
+carfully.
+
+For this reason the kanidm's components must be protected carefully. Kanidm avoids many classic
+attacks by being developed in a memory safe language, but risks still exist.
+
+At startup Kanidm will warn you if the environment it is running in is suspicious or
+has risks. For example:
+
+    kanidmd server -c /tmp/server.toml
+    WARNING: permissions on /tmp/server.toml may not be secure. Should be readonly to running uid. This could be a security risk ...
+    WARNING: /tmp/server.toml has 'everyone' permission bits in the mode. This could be a security risk ...
+    WARNING: /tmp/server.toml owned by the current uid, which may allow file permission changes. This could be a security risk ...
+    WARNING: permissions on ../insecure/ca.pem may not be secure. Should be readonly to running uid. This could be a security risk ...
+    WARNING: permissions on ../insecure/cert.pem may not be secure. Should be readonly to running uid. This could be a security risk ...
+    WARNING: permissions on ../insecure/key.pem may not be secure. Should be readonly to running uid. This could be a security risk ...
+    WARNING: ../insecure/key.pem has 'everyone' permission bits in the mode. This could be a security risk ...
+    WARNING: DB folder /tmp has 'everyone' permission bits in the mode. This could be a security risk ...
+
+Each warning highlights an issue that may exist in your environment. It is not possible for us to
+prescribe an exact configuration that may secure your system. This is why we only present
+possible risks.
+
+### Should be readonly to running uid
+
+Files such as configurations should be readonly to this UID/GID. This is so that if an attacker is
+able to gain code execution, they are unable to modify the configuration to write or over-write
+files in other locations, or to tamper with the systems configuration.
+
+This can be prevented by changing the files ownership to another user, or removing "write" bits
+from the group.
+
+### 'everyone' permission bits in the mode
+
+This means that given a permission mask, "everyone" or all users of the system can read, write or
+execute the content of this file. This may mean that if an account on the system is compromised the
+attacker can read Kanidm content and may be able to further attack the system as a result.
+
+This can be prevented by removed everyone execute bits from parent directories containing the
+configuration, and removing everyone bits from the files in question.
+
+### owned by the current uid, which may allow file permission changes
+
+File permissions in unix systems are a discrestionary access control system, which means the
+named uid owner is able to further modify the access of a file regardless of the current
+settings. For example:
+
+    [william@amethyst 12:25] /tmp > touch test
+    [william@amethyst 12:25] /tmp > ls -al test
+    -rw-r--r--  1 william  wheel  0 29 Jul 12:25 test
+    [william@amethyst 12:25] /tmp > chmod 400 test
+    [william@amethyst 12:25] /tmp > ls -al test
+    -r--------  1 william  wheel  0 29 Jul 12:25 test
+    [william@amethyst 12:25] /tmp > chmod 644 test
+    [william@amethyst 12:26] /tmp > ls -al test
+    -rw-r--r--  1 william  wheel  0 29 Jul 12:25 test
+
+Notice that even though the file was set to "read only" to william, and no permission to any
+other users, that as "william" I can change the bits to add write permissions back or permissions
+for other users.
+
+This can be prevent by making the file owner a different UID to the running process for kanidm.
+
+### A secure example
+
+Between these three issues it can be hard to see a possible strategy to secure files, however
+one way exists - group read permissions. The most effective method to secure resources for kanidm
+is to set configurations to:
+
+    [william@amethyst 12:26] /etc/kanidm > ls -al server.toml
+    -r--r-----   1 root           kanidm      212 28 Jul 16:53 server.toml
+
+The kanidm server should be run as "kanidm:kanidm" with the appropriate user and user private
+group created on your system. This applies to unixd configuration as well.
+
+For the database your data folder should be:
+
+    [root@amethyst 12:38] /data/kanidm > ls -al .
+    total 1064
+    drwxrwx---   3 root     kanidm      96 29 Jul 12:38 .
+    -rw-r-----   1 kanidm   kanidm  544768 29 Jul 12:38 kanidm.db
+
+IE this means 770 root:kanidm. This allows kanidm to create new files in the folder, but prevents
+kanidm being able to change the permissions of the folder. Because the folder does not have
+everyone mode bits, the content of the database is secure because users can now cd/read
+from the directory.
+
+Configurations for clients such as /etc/kanidm/config should be secured with the permissions
+as:
+
+    [william@amethyst 12:26] /etc/kanidm > ls -al config
+    -r--r--r--    1 root  wheel    38 10 Jul 10:10 config
+
+This file should be everyone-readable which is why the bits are defined as such.
+
+> NOTE: Why do you use 440 or 444 modes?
+>
+> A bug exists in the implementation of readonly() in rust that checks this as "does a write
+> bit exist for any user" vs "can the current uid write the file?". This distinction is subtle
+> but it affects the check. We don't believe this is a significant issue though because
+> setting these to 440 and 444 helps to prevent accidental changes by an administrator anyway
+
+

--- a/kanidm_client/Cargo.toml
+++ b/kanidm_client/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 toml = "0.5"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+# users = "0.10"
 
 [dev-dependencies]
 tokio = "0.2"

--- a/kanidm_unix_int/Cargo.toml
+++ b/kanidm_unix_int/Cargo.toml
@@ -65,6 +65,8 @@ r2d2_sqlite = "0.16"
 
 reqwest = { version = "0.10" }
 
+users = "0.10"
+
 [features]
 default = [ "libsqlite3-sys/bundled" ]
 

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -83,6 +83,9 @@ futures-util = "0.3"
 tokio-util = { version = "0.2", features = ["codec"] }
 tokio-openssl = "0.4"
 
+libc = "0.2"
+users = "0.10"
+
 [features]
 default = [ "libsqlite3-sys/bundled", "openssl/vendored" ]
 

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -2,39 +2,29 @@ ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS builder
 LABEL mantainer william@blackhats.net.au
 
-RUN zypper mr -d repo-non-oss && \
-    zypper mr -d repo-oss && \
-    zypper mr -d repo-update && \
-    zypper ar https://download.opensuse.org/update/tumbleweed/ repo-update-https && \
-    zypper ar https://download.opensuse.org/tumbleweed/repo/oss/ repo-oss-https && \
-    zypper ar https://download.opensuse.org/tumbleweed/repo/non-oss/ repo-non-oss-https && \
-    zypper ref && \
+RUN zypper ref && \
     zypper install -y \
         cargo \
         rust \
         gcc \
-        automake \
-        autoconf \
-        make \
-        libopenssl-devel \
-        pam-devel && \
+        clang lld \
+        make automake autoconf \
+        libopenssl-devel pam-devel && \
     zypper clean -a
+
 
 COPY . /usr/src/kanidm
 WORKDIR /usr/src/kanidm/kanidmd
 
-RUN RUSTC_BOOTSTRAP=1 cargo build --features=concread/simd_support --release
+RUN ln -s -f /usr/bin/clang /usr/bin/cc && \
+    ln -s -f /usr/bin/ld.lld /usr/bin/ld
+
+RUN CC=/usr/bin/clang RUSTC_BOOTSTRAP=1 cargo build --features=concread/simd_support --release
 
 FROM ${BASE_IMAGE}
 LABEL mantainer william@blackhats.net.au
 
-RUN zypper mr -d repo-non-oss && \
-    zypper mr -d repo-oss && \
-    zypper mr -d repo-update && \
-    zypper ar https://download.opensuse.org/update/tumbleweed/ repo-update-https && \
-    zypper ar https://download.opensuse.org/tumbleweed/repo/oss/ repo-oss-https && \
-    zypper ar https://download.opensuse.org/tumbleweed/repo/non-oss/ repo-non-oss-https && \
-    zypper ref && \
+RUN zypper ref && \
     zypper install -y \
         timezone \
         pam && \

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -715,6 +715,7 @@ pub trait AccessControlsTransaction {
         })
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn modify_allow_operation(
         &self,
         audit: &mut AuditScope,
@@ -913,6 +914,7 @@ pub trait AccessControlsTransaction {
         })
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn create_allow_operation(
         &self,
         audit: &mut AuditScope,

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -1,6 +1,7 @@
 mod ctx;
 mod ldaps;
 // use actix_files as fs;
+use libc::umask;
 use actix::prelude::*;
 use actix_session::{CookieSession, Session};
 use actix_web::web::{self, Data, HttpResponse, Json, Path};
@@ -1626,9 +1627,11 @@ pub async fn create_server_core(config: Configuration) -> Result<ServerCtx, ()> 
     }
 
     info!("Starting kanidm with configuration: {}", config);
+    // Setup umask, so that every we touch or create is secure.
+    let _ = unsafe { umask(0o0027) };
+
     // The log server is started on it's own thread, and is contacted
     // asynchronously.
-
     let (log_tx, log_rx) = unbounded();
     let log_thread = thread::spawn(move || async_log::run(log_rx));
 

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -7,7 +7,6 @@ use uuid::Uuid;
 
 use kanidm_proto::v1::{OperationError, UserAuthToken};
 
-#[derive(Debug)]
 pub struct PasswordChangeEvent {
     pub event: Event,
     pub target: Uuid,
@@ -60,7 +59,6 @@ impl PasswordChangeEvent {
     }
 }
 
-#[derive(Debug)]
 pub struct UnixPasswordChangeEvent {
     pub event: Event,
     pub target: Uuid,
@@ -223,11 +221,19 @@ impl UnixGroupTokenEvent {
     }
 }
 
-#[derive(Debug)]
 pub struct UnixUserAuthEvent {
     pub event: Event,
     pub target: Uuid,
     pub cleartext: String,
+}
+
+impl std::fmt::Debug for UnixUserAuthEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("UnixUserAuthEvent")
+            .field("event", &self.event)
+            .field("target", &self.target)
+            .finish()
+    }
 }
 
 impl UnixUserAuthEvent {
@@ -333,7 +339,6 @@ impl VerifyTOTPEvent {
     }
 }
 
-#[derive(Debug)]
 pub struct LdapAuthEvent {
     // pub event: Event,
     pub target: Uuid,

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -977,6 +977,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         })
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub fn delete(&self, au: &mut AuditScope, de: &DeleteEvent) -> Result<(), OperationError> {
         lperf_segment!(au, "server::delete", || {
             // Do you have access to view all the set members? Reduce based on your
@@ -1279,6 +1280,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         })
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub fn modify(&self, au: &mut AuditScope, me: &ModifyEvent) -> Result<(), OperationError> {
         lperf_segment!(au, "server::modify", || {
             // Get the candidates.


### PR DESCRIPTION
This adds a number of warnings to the server to help administrators make better informed decisions about the security of their environment, and adds a chapter to the book on how to help administrators make these decisions.

Fixes #293 
Fixes #292 
Fixes #291 
Fixes #276 
Fixes #275 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
