### PR TITLE
Cleanup and improve client error handling

### DIFF
--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -23,7 +23,7 @@ impl KanidmAsyncClient {
         // format doesn't work in async ?!
         // let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).unwrap();
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
 
         let response = self
             .client
@@ -34,21 +34,28 @@ impl KanidmAsyncClient {
             .await
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().await.ok())),
+            unexpect => {
+                return Err(ClientError::Http(
+                    unexpect,
+                    response.json().await.ok(),
+                    opid,
+                ))
+            }
         }
 
-        // TODO #253: What about errors
-        let r: T = response.json().await.unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .await
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     async fn perform_put_request<R: Serialize, T: DeserializeOwned>(
@@ -61,7 +68,7 @@ impl KanidmAsyncClient {
         // format doesn't work in async ?!
         // let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).unwrap();
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
 
         let response = self
             .client
@@ -72,21 +79,29 @@ impl KanidmAsyncClient {
             .await
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().await.ok())),
+            unexpect => {
+                return Err(ClientError::Http(
+                    unexpect,
+                    response.json().await.ok(),
+                    opid,
+                ))
+            }
         }
 
-        // TODO #253: What about errors
-        let r: T = response.json().await.unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .await
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     async fn perform_get_request<T: DeserializeOwned>(&self, dest: &str) -> Result<T, ClientError> {
@@ -100,21 +115,29 @@ impl KanidmAsyncClient {
             .await
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().await.ok())),
+            unexpect => {
+                return Err(ClientError::Http(
+                    unexpect,
+                    response.json().await.ok(),
+                    opid,
+                ))
+            }
         }
 
-        // TODO #253: What about errors
-        let r: T = response.json().await.unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .await
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     async fn perform_delete_request(&self, dest: &str) -> Result<bool, ClientError> {
@@ -126,20 +149,28 @@ impl KanidmAsyncClient {
             .await
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().await.ok())),
+            unexpect => {
+                return Err(ClientError::Http(
+                    unexpect,
+                    response.json().await.ok(),
+                    opid,
+                ))
+            }
         }
 
-        let r: bool = response.json().await.unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .await
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     pub async fn auth_step_init(&self, ident: &str) -> Result<AuthState, ClientError> {
@@ -205,17 +236,37 @@ impl KanidmAsyncClient {
         let whoami_dest = [self.addr.as_str(), "/v1/self"].concat();
         // format!("{}/v1/self", self.addr);
         debug!("{:?}", whoami_dest);
-        let response = self.client.get(whoami_dest.as_str()).send().await.unwrap();
+        let response = self
+            .client
+            .get(whoami_dest.as_str())
+            .send()
+            .await
+            .map_err(ClientError::Transport)?;
+
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             // Continue to process.
             reqwest::StatusCode::OK => {}
             reqwest::StatusCode::UNAUTHORIZED => return Ok(None),
-            unexpect => return Err(ClientError::Http(unexpect, response.json().await.ok())),
+            unexpect => {
+                return Err(ClientError::Http(
+                    unexpect,
+                    response.json().await.ok(),
+                    opid,
+                ))
+            }
         }
 
-        let r: WhoamiResponse =
-            serde_json::from_str(response.text().await.unwrap().as_str()).unwrap();
+        let r: WhoamiResponse = response
+            .json()
+            .await
+            .map_err(|e| ClientError::JSONDecode(e, opid))?;
 
         Ok(Some((r.youare, r.uat)))
     }

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -1,5 +1,12 @@
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
 extern crate log;
@@ -8,6 +15,7 @@ use reqwest::header::CONTENT_TYPE;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_derive::Deserialize;
+use serde_json::error::Error as SerdeJsonError;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Read;
@@ -33,12 +41,13 @@ pub const KOPID: &str = "X-KANIDM-OPID";
 #[derive(Debug)]
 pub enum ClientError {
     Unauthorized,
-    Http(reqwest::StatusCode, Option<OperationError>),
+    Http(reqwest::StatusCode, Option<OperationError>, String),
     Transport(reqwest::Error),
     AuthenticationFailed,
-    JsonParse,
     EmptyResponse,
     TOTPVerifyFailed(Uuid, TOTPSecret),
+    JSONDecode(reqwest::Error, String),
+    JSONEncode(SerdeJsonError),
 }
 
 #[derive(Debug, Deserialize)]
@@ -293,7 +302,7 @@ impl KanidmClient {
     ) -> Result<T, ClientError> {
         let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).unwrap();
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
 
         let response = self
             .client
@@ -303,21 +312,21 @@ impl KanidmClient {
             .send()
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().ok())),
+            unexpect => return Err(ClientError::Http(unexpect, response.json().ok(), opid)),
         }
 
-        // TODO #253: What about errors
-        let r: T = response.json().unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     fn perform_put_request<R: Serialize, T: DeserializeOwned>(
@@ -327,7 +336,7 @@ impl KanidmClient {
     ) -> Result<T, ClientError> {
         let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).unwrap();
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
 
         let response = self
             .client
@@ -337,21 +346,21 @@ impl KanidmClient {
             .send()
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().ok())),
+            unexpect => return Err(ClientError::Http(unexpect, response.json().ok(), opid)),
         }
 
-        // TODO #253: What about errors
-        let r: T = response.json().unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     fn perform_get_request<T: DeserializeOwned>(&self, dest: &str) -> Result<T, ClientError> {
@@ -362,21 +371,21 @@ impl KanidmClient {
             .send()
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().ok())),
+            unexpect => return Err(ClientError::Http(unexpect, response.json().ok(), opid)),
         }
 
-        // TODO #253: What about errors
-        let r: T = response.json().unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     fn perform_delete_request(&self, dest: &str) -> Result<bool, ClientError> {
@@ -387,36 +396,50 @@ impl KanidmClient {
             .send()
             .map_err(ClientError::Transport)?;
 
-        let opid = response.headers().get(KOPID);
-        debug!(
-            "opid -> {:?}",
-            opid.expect("Missing opid? Refusing to proceed ...")
-        );
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             reqwest::StatusCode::OK => {}
-            unexpect => return Err(ClientError::Http(unexpect, response.json().ok())),
+            unexpect => return Err(ClientError::Http(unexpect, response.json().ok(), opid)),
         }
 
-        let r: bool = response.json().unwrap();
-
-        Ok(r)
+        response
+            .json()
+            .map_err(|e| ClientError::JSONDecode(e, opid))
     }
 
     // whoami
     // Can't use generic get due to possible un-auth case.
     pub fn whoami(&self) -> Result<Option<(Entry, UserAuthToken)>, ClientError> {
         let whoami_dest = format!("{}/v1/self", self.addr);
-        let response = self.client.get(whoami_dest.as_str()).send().unwrap();
+        let response = self
+            .client
+            .get(whoami_dest.as_str())
+            .send()
+            .map_err(ClientError::Transport)?;
+
+        let opid = response
+            .headers()
+            .get(KOPID)
+            .and_then(|hv| hv.to_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "missing_kopid".to_string());
+        debug!("opid -> {:?}", opid);
 
         match response.status() {
             // Continue to process.
             reqwest::StatusCode::OK => {}
             reqwest::StatusCode::UNAUTHORIZED => return Ok(None),
-            unexpect => return Err(ClientError::Http(unexpect, response.json().ok())),
+            unexpect => return Err(ClientError::Http(unexpect, response.json().ok(), opid)),
         }
 
-        let r: WhoamiResponse = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+        let r: WhoamiResponse = response
+            .json()
+            .map_err(|e| ClientError::JSONDecode(e, opid))?;
 
         Ok(Some((r.youare, r.uat)))
     }
@@ -560,12 +583,12 @@ impl KanidmClient {
         self.perform_get_request(format!("/v1/group/{}/_attr/member", id).as_str())
     }
 
-    pub fn idm_group_set_members(&self, id: &str, members: Vec<&str>) -> Result<bool, ClientError> {
+    pub fn idm_group_set_members(&self, id: &str, members: &[&str]) -> Result<bool, ClientError> {
         let m: Vec<_> = members.iter().map(|v| (*v).to_string()).collect();
         self.perform_put_request(format!("/v1/group/{}/_attr/member", id).as_str(), m)
     }
 
-    pub fn idm_group_add_members(&self, id: &str, members: Vec<&str>) -> Result<bool, ClientError> {
+    pub fn idm_group_add_members(&self, id: &str, members: &[&str]) -> Result<bool, ClientError> {
         let m: Vec<_> = members.iter().map(|v| (*v).to_string()).collect();
         self.perform_post_request(format!("/v1/group/{}/_attr/member", id).as_str(), m)
     }
@@ -833,7 +856,12 @@ impl KanidmClient {
     // pub fn idm_domain_get_attr
     pub fn idm_domain_get_ssid(&self, id: &str) -> Result<String, ClientError> {
         self.perform_get_request(format!("/v1/domain/{}/_attr/domain_ssid", id).as_str())
-            .and_then(|mut r: Vec<String>| Ok(r.pop().unwrap()))
+            .and_then(|mut r: Vec<String>|
+                // Get the first result
+                r.pop()
+                .ok_or(
+                    ClientError::EmptyResponse
+                ))
     }
 
     // pub fn idm_domain_put_attr

--- a/kanidm_client/tests/default_entries.rs
+++ b/kanidm_client/tests/default_entries.rs
@@ -63,9 +63,7 @@ fn create_user(rsclient: &KanidmClient, id: &str, group_name: &str) -> () {
         None => rsclient.idm_group_create(&group_name).unwrap(),
     };
 
-    rsclient
-        .idm_group_add_members(&group_name, vec![id])
-        .unwrap();
+    rsclient.idm_group_add_members(&group_name, &[id]).unwrap();
 }
 
 fn is_attr_writable(rsclient: &KanidmClient, id: &str, attr: &str) -> Option<bool> {
@@ -115,7 +113,7 @@ fn is_attr_writable(rsclient: &KanidmClient, id: &str, attr: &str) -> Option<boo
 fn add_all_attrs(mut rsclient: &mut KanidmClient, id: &str, group_name: &str) {
     // Extend with posix attrs to test read attr: gidnumber and loginshell
     rsclient
-        .idm_group_add_members("idm_admins", vec!["admin"])
+        .idm_group_add_members("idm_admins", &["admin"])
         .unwrap();
     rsclient
         .idm_account_unix_extend(id, None, Some(&"/bin/bash"))
@@ -157,10 +155,10 @@ fn create_user_with_all_attrs(
 
 fn login_account(rsclient: &mut KanidmClient, id: &str) -> () {
     rsclient
-        .idm_group_add_members("idm_people_account_password_import_priv", vec!["admin"])
+        .idm_group_add_members("idm_people_account_password_import_priv", &["admin"])
         .unwrap();
     rsclient
-        .idm_group_add_members("idm_people_extend_priv", vec!["admin"])
+        .idm_group_add_members("idm_people_extend_priv", &["admin"])
         .unwrap();
 
     rsclient
@@ -215,7 +213,7 @@ fn test_modify_group(rsclient: &KanidmClient, group_names: &[&str], is_modificab
         ["description", "name"].iter().for_each(|attr| {
             assert!(is_attr_writable(&rsclient, group, attr).unwrap() == is_modificable)
         });
-        assert!(rsclient.idm_group_add_members(group, vec!["test"]).is_ok() == is_modificable);
+        assert!(rsclient.idm_group_add_members(group, &["test"]).is_ok() == is_modificable);
     });
 }
 
@@ -326,7 +324,7 @@ fn test_default_entries_rbac_group_managers() {
 
         rsclient.idm_group_create("test_group").unwrap();
         rsclient
-            .idm_group_add_members("test_group", vec!["test"])
+            .idm_group_add_members("test_group", &["test"])
             .unwrap();
         assert!(is_attr_writable(&rsclient, "test_group", "description").unwrap());
     });
@@ -588,7 +586,7 @@ fn test_default_entries_rbac_anonymous_entry() {
             .unwrap();
         create_user_with_all_attrs(&mut rsclient, "test", Some("test_group"));
         rsclient
-            .idm_group_add_members("test_group", vec!["anonymous"])
+            .idm_group_add_members("test_group", &["anonymous"])
             .unwrap();
         add_all_attrs(&mut rsclient, "anonymous", "test_group");
 

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -251,14 +251,14 @@ fn test_server_rest_group_lifecycle() {
 
         // Add a member.
         rsclient
-            .idm_group_add_members("demo_group", vec!["admin"])
+            .idm_group_add_members("demo_group", &["admin"])
             .unwrap();
         let members = rsclient.idm_group_get_members("demo_group").unwrap();
         assert!(members == Some(vec!["admin@example.com".to_string()]));
 
         // Set the list of members
         rsclient
-            .idm_group_set_members("demo_group", vec!["admin", "demo_group"])
+            .idm_group_set_members("demo_group", &["admin", "demo_group"])
             .unwrap();
         let members = rsclient.idm_group_get_members("demo_group").unwrap();
         assert!(
@@ -395,7 +395,7 @@ fn test_server_rest_account_lifecycle() {
         // To enable the admin to actually make some of these changes, we have
         // to make them a people admin. NOT recommended in production!
         rsclient
-            .idm_group_add_members("idm_account_write_priv", vec!["admin"])
+            .idm_group_add_members("idm_account_write_priv", &["admin"])
             .unwrap();
 
         // Create a new account
@@ -499,7 +499,7 @@ fn test_server_rest_posix_lifecycle() {
         assert!(res.is_ok());
         // Not recommended in production!
         rsclient
-            .idm_group_add_members("idm_admins", vec!["admin"])
+            .idm_group_add_members("idm_admins", &["admin"])
             .unwrap();
 
         // Create a new account
@@ -517,7 +517,7 @@ fn test_server_rest_posix_lifecycle() {
         // Extend the group with posix attrs
         rsclient.idm_group_create("posix_group").unwrap();
         rsclient
-            .idm_group_add_members("posix_group", vec!["posix_account"])
+            .idm_group_add_members("posix_group", &["posix_account"])
             .unwrap();
         rsclient.idm_group_unix_extend("posix_group", None).unwrap();
 
@@ -576,7 +576,7 @@ fn test_server_rest_posix_auth_lifecycle() {
 
         // Not recommended in production!
         rsclient
-            .idm_group_add_members("idm_admins", vec!["admin"])
+            .idm_group_add_members("idm_admins", &["admin"])
             .unwrap();
 
         // Setup a unix user
@@ -634,7 +634,7 @@ fn test_server_rest_recycle_lifecycle() {
 
         // Not recommended in production!
         rsclient
-            .idm_group_add_members("idm_admins", vec!["admin"])
+            .idm_group_add_members("idm_admins", &["admin"])
             .unwrap();
 
         // Setup a unix user
@@ -674,10 +674,10 @@ fn test_server_rest_account_import_password() {
         // To enable the admin to actually make some of these changes, we have
         // to make them a password import admin. NOT recommended in production!
         rsclient
-            .idm_group_add_members("idm_people_account_password_import_priv", vec!["admin"])
+            .idm_group_add_members("idm_people_account_password_import_priv", &["admin"])
             .unwrap();
         rsclient
-            .idm_group_add_members("idm_people_extend_priv", vec!["admin"])
+            .idm_group_add_members("idm_people_extend_priv", &["admin"])
             .unwrap();
 
         // Create a new account
@@ -718,7 +718,7 @@ fn test_server_rest_totp_auth_lifecycle() {
 
         // Not recommended in production!
         rsclient
-            .idm_group_add_members("idm_admins", vec!["admin"])
+            .idm_group_add_members("idm_admins", &["admin"])
             .unwrap();
 
         // Create a new account

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -171,70 +171,82 @@ impl AccountOpt {
                         }
                     };
 
-                    client
-                        .idm_account_primary_credential_set_password(
-                            acsopt.aopts.account_id.as_str(),
-                            password.as_str(),
-                        )
-                        .unwrap();
+                    if let Err(e) = client.idm_account_primary_credential_set_password(
+                        acsopt.aopts.account_id.as_str(),
+                        password.as_str(),
+                    ) {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
                 AccountCredential::GeneratePassword(acsopt) => {
                     let client = acsopt.copt.to_client();
 
-                    let npw = client
-                        .idm_account_primary_credential_set_generated(
-                            acsopt.aopts.account_id.as_str(),
-                        )
-                        .unwrap();
-                    println!(
-                        "Generated password for {}: {}",
-                        acsopt.aopts.account_id, npw
-                    );
+                    match client.idm_account_primary_credential_set_generated(
+                        acsopt.aopts.account_id.as_str(),
+                    ) {
+                        Ok(npw) => {
+                            println!(
+                                "Generated password for {}: {}",
+                                acsopt.aopts.account_id, npw
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("Error -> {:?}", e);
+                        }
+                    }
                 }
             }, // end AccountOpt::Credential
             AccountOpt::Radius(aropt) => match aropt {
                 AccountRadius::Show(aopt) => {
                     let client = aopt.copt.to_client();
 
-                    let rcred = client
-                        .idm_account_radius_credential_get(aopt.aopts.account_id.as_str())
-                        .unwrap();
+                    let rcred =
+                        client.idm_account_radius_credential_get(aopt.aopts.account_id.as_str());
 
                     match rcred {
-                        Some(s) => println!("Radius secret: {}", s),
-                        None => println!("NO Radius secret"),
+                        Ok(Some(s)) => println!("Radius secret: {}", s),
+                        Ok(None) => println!("NO Radius secret"),
+                        Err(e) => {
+                            eprintln!("Error -> {:?}", e);
+                        }
                     }
                 }
                 AccountRadius::Generate(aopt) => {
                     let client = aopt.copt.to_client();
-                    client
+                    if let Err(e) = client
                         .idm_account_radius_credential_regenerate(aopt.aopts.account_id.as_str())
-                        .unwrap();
+                    {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
                 AccountRadius::Delete(aopt) => {
                     let client = aopt.copt.to_client();
-                    client
-                        .idm_account_radius_credential_delete(aopt.aopts.account_id.as_str())
-                        .unwrap();
+                    if let Err(e) =
+                        client.idm_account_radius_credential_delete(aopt.aopts.account_id.as_str())
+                    {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             }, // end AccountOpt::Radius
             AccountOpt::Posix(apopt) => match apopt {
                 AccountPosix::Show(aopt) => {
                     let client = aopt.copt.to_client();
-                    let token = client
-                        .idm_account_unix_token_get(aopt.aopts.account_id.as_str())
-                        .unwrap();
-                    println!("{}", token);
+                    match client.idm_account_unix_token_get(aopt.aopts.account_id.as_str()) {
+                        Ok(token) => println!("{}", token),
+                        Err(e) => {
+                            eprintln!("Error -> {:?}", e);
+                        }
+                    }
                 }
                 AccountPosix::Set(aopt) => {
                     let client = aopt.copt.to_client();
-                    client
-                        .idm_account_unix_extend(
-                            aopt.aopts.account_id.as_str(),
-                            aopt.gidnumber,
-                            aopt.shell.as_deref(),
-                        )
-                        .unwrap();
+                    if let Err(e) = client.idm_account_unix_extend(
+                        aopt.aopts.account_id.as_str(),
+                        aopt.gidnumber,
+                        aopt.shell.as_deref(),
+                    ) {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
                 AccountPosix::SetPassword(aopt) => {
                     let client = aopt.copt.to_client();
@@ -246,77 +258,74 @@ impl AccountOpt {
                         }
                     };
 
-                    client
-                        .idm_account_unix_cred_put(
-                            aopt.aopts.account_id.as_str(),
-                            password.as_str(),
-                        )
-                        .unwrap();
+                    if let Err(e) = client.idm_account_unix_cred_put(
+                        aopt.aopts.account_id.as_str(),
+                        password.as_str(),
+                    ) {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             }, // end AccountOpt::Posix
             AccountOpt::Ssh(asopt) => match asopt {
                 AccountSsh::List(aopt) => {
                     let client = aopt.copt.to_client();
 
-                    let pkeys = client
-                        .idm_account_get_ssh_pubkeys(aopt.aopts.account_id.as_str())
-                        .unwrap();
-
-                    for pkey in pkeys {
-                        println!("{}", pkey)
+                    match client.idm_account_get_ssh_pubkeys(aopt.aopts.account_id.as_str()) {
+                        Ok(pkeys) => pkeys.iter().for_each(|pkey| println!("{}", pkey)),
+                        Err(e) => {
+                            eprintln!("Error -> {:?}", e);
+                        }
                     }
                 }
                 AccountSsh::Add(aopt) => {
                     let client = aopt.copt.to_client();
-                    client
-                        .idm_account_post_ssh_pubkey(
-                            aopt.aopts.account_id.as_str(),
-                            aopt.tag.as_str(),
-                            aopt.pubkey.as_str(),
-                        )
-                        .unwrap();
+                    if let Err(e) = client.idm_account_post_ssh_pubkey(
+                        aopt.aopts.account_id.as_str(),
+                        aopt.tag.as_str(),
+                        aopt.pubkey.as_str(),
+                    ) {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
                 AccountSsh::Delete(aopt) => {
                     let client = aopt.copt.to_client();
-                    client
-                        .idm_account_delete_ssh_pubkey(
-                            aopt.aopts.account_id.as_str(),
-                            aopt.tag.as_str(),
-                        )
-                        .unwrap();
+                    if let Err(e) = client.idm_account_delete_ssh_pubkey(
+                        aopt.aopts.account_id.as_str(),
+                        aopt.tag.as_str(),
+                    ) {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             }, // end AccountOpt::Ssh
             AccountOpt::List(copt) => {
                 let client = copt.to_client();
-                let r = client.idm_account_list().unwrap();
-                for e in r {
-                    println!("{}", e);
+                match client.idm_account_list() {
+                    Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
+                    Err(e) => eprintln!("Error -> {:?}", e),
                 }
             }
             AccountOpt::Get(aopt) => {
                 let client = aopt.copt.to_client();
-                let e = client
-                    .idm_account_get(aopt.aopts.account_id.as_str())
-                    .unwrap();
-                match e {
-                    Some(e) => println!("{}", e),
-                    None => println!("No matching entries"),
+                match client.idm_account_get(aopt.aopts.account_id.as_str()) {
+                    Ok(Some(e)) => println!("{}", e),
+                    Ok(None) => println!("No matching entries"),
+                    Err(e) => eprintln!("Error -> {:?}", e),
                 }
             }
             AccountOpt::Delete(aopt) => {
                 let client = aopt.copt.to_client();
-                client
-                    .idm_account_delete(aopt.aopts.account_id.as_str())
-                    .unwrap();
+                if let Err(e) = client.idm_account_delete(aopt.aopts.account_id.as_str()) {
+                    eprintln!("Error -> {:?}", e)
+                }
             }
             AccountOpt::Create(acopt) => {
                 let client = acopt.copt.to_client();
-                client
-                    .idm_account_create(
-                        acopt.aopts.account_id.as_str(),
-                        acopt.display_name.as_str(),
-                    )
-                    .unwrap();
+                if let Err(e) = client.idm_account_create(
+                    acopt.aopts.account_id.as_str(),
+                    acopt.display_name.as_str(),
+                ) {
+                    eprintln!("Error -> {:?}", e)
+                }
             }
         }
     }

--- a/kanidm_tools/src/cli/group.rs
+++ b/kanidm_tools/src/cli/group.rs
@@ -70,29 +70,38 @@ impl GroupOpt {
         match self {
             GroupOpt::List(copt) => {
                 let client = copt.to_client();
-                let r = client.idm_group_list().unwrap();
-                for e in r {
-                    println!("{}", e);
+                match client.idm_group_list() {
+                    Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
+                    Err(e) => {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             }
             GroupOpt::Create(gcopt) => {
                 let client = gcopt.copt.to_client();
-                client.idm_group_create(gcopt.name.as_str()).unwrap();
+                if let Err(e) = client.idm_group_create(gcopt.name.as_str()) {
+                    eprintln!("Error -> {:?}", e);
+                }
             }
             GroupOpt::Delete(gcopt) => {
                 let client = gcopt.copt.to_client();
-                client.idm_group_delete(gcopt.name.as_str()).unwrap();
+                if let Err(e) = client.idm_group_delete(gcopt.name.as_str()) {
+                    eprintln!("Error -> {:?}", e);
+                }
             }
             GroupOpt::PurgeMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
-                client.idm_group_purge_members(gcopt.name.as_str()).unwrap();
+                if let Err(e) = client.idm_group_purge_members(gcopt.name.as_str()) {
+                    eprintln!("Error -> {:?}", e);
+                }
             }
             GroupOpt::ListMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
-                let members = client.idm_group_get_members(gcopt.name.as_str()).unwrap();
-                if let Some(groups) = members {
-                    for m in groups {
-                        println!("{:?}", m);
+                match client.idm_group_get_members(gcopt.name.as_str()) {
+                    Ok(Some(groups)) => groups.iter().for_each(|m| println!("{:?}", m)),
+                    Ok(None) => {}
+                    Err(e) => {
+                        eprintln!("Error -> {:?}", e);
                     }
                 }
             }
@@ -100,31 +109,33 @@ impl GroupOpt {
                 let client = gcopt.copt.to_client();
                 let new_members: Vec<&str> = gcopt.members.iter().map(|s| s.as_str()).collect();
 
-                client
-                    .idm_group_add_members(gcopt.name.as_str(), new_members)
-                    .unwrap();
+                if let Err(e) = client.idm_group_add_members(gcopt.name.as_str(), &new_members) {
+                    eprintln!("Error -> {:?}", e);
+                }
             }
             GroupOpt::SetMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
                 let new_members: Vec<&str> = gcopt.members.iter().map(|s| s.as_str()).collect();
 
-                client
-                    .idm_group_set_members(gcopt.name.as_str(), new_members)
-                    .unwrap();
+                if let Err(e) = client.idm_group_set_members(gcopt.name.as_str(), &new_members) {
+                    eprintln!("Error -> {:?}", e);
+                }
             }
             GroupOpt::Posix(gpopt) => match gpopt {
                 GroupPosix::Show(gcopt) => {
                     let client = gcopt.copt.to_client();
-                    let token = client
-                        .idm_group_unix_token_get(gcopt.name.as_str())
-                        .unwrap();
-                    println!("{}", token);
+                    match client.idm_group_unix_token_get(gcopt.name.as_str()) {
+                        Ok(token) => println!("{}", token),
+                        Err(e) => eprintln!("Error -> {:?}", e),
+                    }
                 }
                 GroupPosix::Set(gcopt) => {
                     let client = gcopt.copt.to_client();
-                    client
-                        .idm_group_unix_extend(gcopt.name.as_str(), gcopt.gidnumber)
-                        .unwrap();
+                    if let Err(e) =
+                        client.idm_group_unix_extend(gcopt.name.as_str(), gcopt.gidnumber)
+                    {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             },
         } // end match

--- a/kanidm_tools/src/cli/recycle.rs
+++ b/kanidm_tools/src/cli/recycle.rs
@@ -27,22 +27,28 @@ impl RecycleOpt {
         match self {
             RecycleOpt::List(copt) => {
                 let client = copt.to_client();
-                let r = client.recycle_bin_list().unwrap();
-                for e in r {
-                    println!("{}", e);
+                match client.recycle_bin_list() {
+                    Ok(r) => r.iter().for_each(|e| println!("{}", e)),
+                    Err(e) => {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             }
             RecycleOpt::Get(nopt) => {
                 let client = nopt.copt.to_client();
-                let e = client.recycle_bin_get(nopt.name.as_str()).unwrap();
-                match e {
-                    Some(e) => println!("{}", e),
-                    None => println!("No matching entries"),
+                match client.recycle_bin_get(nopt.name.as_str()) {
+                    Ok(Some(e)) => println!("{}", e),
+                    Ok(None) => println!("No matching entries"),
+                    Err(e) => {
+                        eprintln!("Error -> {:?}", e);
+                    }
                 }
             }
             RecycleOpt::Revive(nopt) => {
                 let client = nopt.copt.to_client();
-                client.recycle_bin_revive(nopt.name.as_str()).unwrap();
+                if let Err(e) = client.recycle_bin_revive(nopt.name.as_str()) {
+                    eprintln!("Error -> {:?}", e);
+                }
             }
         }
     }

--- a/kanidm_unix_int/nss_kanidm/src/lib.rs
+++ b/kanidm_unix_int/nss_kanidm/src/lib.rs
@@ -1,4 +1,13 @@
 #![deny(warnings)]
+#![warn(unused_extern_crates)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 #[macro_use]
 extern crate libnss;
 #[macro_use]

--- a/kanidm_unix_int/pam_kanidm/src/lib.rs
+++ b/kanidm_unix_int/pam_kanidm/src/lib.rs
@@ -1,5 +1,14 @@
 #![deny(warnings)]
-extern crate libc;
+#![warn(unused_extern_crates)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
+// extern crate libc;
 
 mod pam;
 use crate::pam::constants::*;

--- a/kanidm_unix_int/src/cache.rs
+++ b/kanidm_unix_int/src/cache.rs
@@ -271,8 +271,12 @@ impl CacheLayer {
                     ClientError::Http(
                         StatusCode::UNAUTHORIZED,
                         Some(OperationError::NotAuthenticated),
+                        opid,
                     ) => {
-                        error!("transport unauthenticated, moving to offline");
+                        error!(
+                            "transport unauthenticated, moving to offline - eventid {}",
+                            opid
+                        );
                         // Something went wrong, mark offline.
                         let time = SystemTime::now().add(Duration::from_secs(15));
                         self.set_cachestate(CacheState::OfflineNextCheck(time))
@@ -282,14 +286,16 @@ impl CacheLayer {
                     ClientError::Http(
                         StatusCode::BAD_REQUEST,
                         Some(OperationError::NoMatchingEntries),
+                        opid,
                     )
                     | ClientError::Http(
                         StatusCode::BAD_REQUEST,
                         Some(OperationError::InvalidAccountState(_)),
+                        opid,
                     ) => {
                         // We wele able to contact the server but the entry has been removed, or
                         // is not longer a valid posix account.
-                        debug!("entry has been removed or is no longer a valid posix account, clearing from cache ...");
+                        debug!("entry has been removed or is no longer a valid posix account, clearing from cache ... - eventid {}", opid);
                         token
                             .map(|tok| self.delete_cache_usertoken(&tok.uuid))
                             // Now an option<result<t, _>>
@@ -335,8 +341,12 @@ impl CacheLayer {
                     ClientError::Http(
                         StatusCode::UNAUTHORIZED,
                         Some(OperationError::NotAuthenticated),
+                        opid,
                     ) => {
-                        error!("transport unauthenticated, moving to offline");
+                        error!(
+                            "transport unauthenticated, moving to offline - eventid {}",
+                            opid
+                        );
                         // Something went wrong, mark offline.
                         let time = SystemTime::now().add(Duration::from_secs(15));
                         self.set_cachestate(CacheState::OfflineNextCheck(time))
@@ -346,12 +356,14 @@ impl CacheLayer {
                     ClientError::Http(
                         StatusCode::BAD_REQUEST,
                         Some(OperationError::NoMatchingEntries),
+                        opid,
                     )
                     | ClientError::Http(
                         StatusCode::BAD_REQUEST,
                         Some(OperationError::InvalidAccountState(_)),
+                        opid,
                     ) => {
-                        debug!("entry has been removed or is no longer a valid posix group, clearing from cache ...");
+                        debug!("entry has been removed or is no longer a valid posix group, clearing from cache ... - eventid {}", opid);
                         token
                             .map(|tok| self.delete_cache_grouptoken(&tok.uuid))
                             // Now an option<result<t, _>>
@@ -620,8 +632,12 @@ impl CacheLayer {
                 ClientError::Http(
                     StatusCode::UNAUTHORIZED,
                     Some(OperationError::NotAuthenticated),
+                    opid,
                 ) => {
-                    error!("transport unauthenticated, moving to offline");
+                    error!(
+                        "transport unauthenticated, moving to offline - eventid {}",
+                        opid
+                    );
                     // Something went wrong, mark offline.
                     let time = SystemTime::now().add(Duration::from_secs(15));
                     self.set_cachestate(CacheState::OfflineNextCheck(time))
@@ -634,12 +650,17 @@ impl CacheLayer {
                 ClientError::Http(
                     StatusCode::BAD_REQUEST,
                     Some(OperationError::NoMatchingEntries),
+                    opid,
                 )
                 | ClientError::Http(
                     StatusCode::BAD_REQUEST,
                     Some(OperationError::InvalidAccountState(_)),
+                    opid,
                 ) => {
-                    error!("unknown account or is not a valid posix account");
+                    error!(
+                        "unknown account or is not a valid posix account - eventid {}",
+                        opid
+                    );
                     Ok(None)
                 }
                 er => {

--- a/kanidm_unix_int/src/daemon.rs
+++ b/kanidm_unix_int/src/daemon.rs
@@ -1,4 +1,13 @@
 #![deny(warnings)]
+#![warn(unused_extern_crates)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 #[macro_use]
 extern crate log;
 

--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -7,7 +7,7 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use crate::cache::Id;
-use std::sync::{Mutex, MutexGuard};
+use tokio::sync::{Mutex, MutexGuard};
 
 use kanidm::be::dbvalue::DbPasswordV1;
 use kanidm::credential::Password;

--- a/kanidm_unix_int/src/lib.rs
+++ b/kanidm_unix_int/src/lib.rs
@@ -1,5 +1,12 @@
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/kanidm_unix_int/tests/cache_layer_test.rs
+++ b/kanidm_unix_int/tests/cache_layer_test.rs
@@ -101,7 +101,7 @@ fn test_fixture(rsclient: &KanidmClient) -> () {
     assert!(res.is_ok());
     // Not recommended in production!
     rsclient
-        .idm_group_add_members("idm_admins", vec!["admin"])
+        .idm_group_add_members("idm_admins", &["admin"])
         .unwrap();
 
     // Create a new account
@@ -126,7 +126,7 @@ fn test_fixture(rsclient: &KanidmClient) -> () {
     // Setup a group
     rsclient.idm_group_create("testgroup1").unwrap();
     rsclient
-        .idm_group_add_members("testgroup1", vec!["testaccount1"])
+        .idm_group_add_members("testgroup1", &["testaccount1"])
         .unwrap();
     rsclient
         .idm_group_unix_extend("testgroup1", Some(20001))

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -63,12 +63,12 @@ macro_rules! try_from_entry {
         let uuid = $value.get_uuid().clone();
 
         Ok(Account {
-            uuid: uuid,
-            name: name,
-            displayname: displayname,
-            groups: groups,
-            primary: primary,
-            spn: spn,
+            uuid,
+            name,
+            displayname,
+            groups,
+            primary,
+            spn,
         })
     }};
 }

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -1,5 +1,12 @@
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Fixes #297 The unix resolver would exhibit an issue when running behind haproxy, that if kanidmd server was down, the loadbalancer would return 500's, but without the kanidm OPID header. This could cause the client to panic as an expect condition existed that disallowed progress if no OPID was present. Rather than inject an OPID from haproxy, the client should handle errors better. To achieve this I have added extra clippy lints from 1.45, which has led to a very large improvemennt to how client errors are handled throughout the codebase.

Note, clippy is still currently failing on Kanidmd due to the new lints which will be resolved in a future PR. 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
