### PR TITLE
Support zfs page size

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,6 @@
 * Triss Healy (NiryaAestus)
 * Samuel Cabrero (scabrero)
 
+## Acknowledgements
+
+* M. Gerstner

--- a/kanidm_book/src/installing_the_server.md
+++ b/kanidm_book/src/installing_the_server.md
@@ -27,6 +27,12 @@ You will also need a config file in `/data/server.toml`. It's contents should be
     # ldapbindaddress = "127.0.0.1:3636"
     # The path to the kanidm database.
     db_path = "/data/kanidm.db"
+    # If you have a known filesystem, kanidm can tune sqlite to match. Valid choices are:
+    # [zfs, other]
+    # If you are unsure about this, default to other
+    # zfs:
+    # * sets sqlite pagesize to 64k, you should set recordsize=64k on the zfs filesystem.
+    # db_fs_type = "zfs"
     # TLS ca, certificate and key in pem format. All three must be commented, or present
     # tls_ca = "/data/ca.pem"
     # tls_cert = "/data/cert.pem"

--- a/kanidmd/server.toml
+++ b/kanidmd/server.toml
@@ -1,6 +1,7 @@
 bindaddress = "127.0.0.1:8443"
 ldapbindaddress = "127.0.0.1:3636"
 db_path = "/tmp/kanidm.db"
+db_fs_type = "zfs"
 tls_ca = "../insecure/ca.pem"
 tls_cert = "../insecure/cert.pem"
 tls_key = "../insecure/key.pem"

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -1,6 +1,6 @@
 use crate::audit::AuditScope;
 use crate::be::idl_sqlite::{
-    IdlSqlite, IdlSqliteReadTransaction, IdlSqliteTransaction, IdlSqliteWriteTransaction,
+    FsType, IdlSqlite, IdlSqliteReadTransaction, IdlSqliteTransaction, IdlSqliteWriteTransaction,
 };
 use crate::be::{IdRawEntry, IDL};
 use crate::entry::{Entry, EntryCommitted, EntrySealed};
@@ -848,8 +848,13 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
 }
 
 impl IdlArcSqlite {
-    pub fn new(audit: &mut AuditScope, path: &str, pool_size: u32) -> Result<Self, OperationError> {
-        let db = IdlSqlite::new(audit, path, pool_size)?;
+    pub fn new(
+        audit: &mut AuditScope,
+        path: &str,
+        pool_size: u32,
+        fstype: FsType,
+    ) -> Result<Self, OperationError> {
+        let db = IdlSqlite::new(audit, path, pool_size, fstype)?;
         let entry_cache = Arc::new(
             DEFAULT_CACHE_TARGET,
             pool_size as usize,

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -20,6 +20,7 @@ pub struct Configuration {
     pub threads: usize,
     // db type later
     pub db_path: String,
+    pub db_fs_type: Option<String>,
     pub maximum_request: usize,
     pub secure_cookies: bool,
     pub tls_config: Option<TlsConfiguration>,
@@ -61,6 +62,7 @@ impl Configuration {
             ldapaddress: None,
             threads: num_cpus::get(),
             db_path: String::from(""),
+            db_fs_type: None,
             maximum_request: 262_144, // 256k
             // log type
             // log path
@@ -82,6 +84,10 @@ impl Configuration {
 
     pub fn update_db_path(&mut self, p: &str) {
         self.db_path = p.to_string();
+    }
+
+    pub fn update_db_fs_type(&mut self, p: &Option<String>) {
+        self.db_fs_type = p.as_ref().map(|v| v.to_lowercase());
     }
 
     pub fn update_bind(&mut self, b: &Option<String>) {

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -2,7 +2,7 @@
 macro_rules! run_test_no_init {
     ($test_fn:expr) => {{
         use crate::audit::AuditScope;
-        use crate::be::Backend;
+        use crate::be::{Backend, FsType};
         use crate::schema::Schema;
         use crate::server::QueryServer;
         use crate::utils::duration_from_epoch_now;
@@ -22,7 +22,7 @@ macro_rules! run_test_no_init {
             let schema_txn = schema_outer.write();
             schema_txn.reload_idxmeta()
         };
-        let be = match Backend::new(&mut audit, "", 1, idxmeta) {
+        let be = match Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta) {
             Ok(be) => be,
             Err(e) => {
                 audit.write_log();
@@ -46,7 +46,7 @@ macro_rules! run_test_no_init {
 macro_rules! run_test {
     ($test_fn:expr) => {{
         use crate::audit::AuditScope;
-        use crate::be::Backend;
+        use crate::be::{Backend, FsType};
         use crate::schema::Schema;
         use crate::server::QueryServer;
         use crate::utils::duration_from_epoch_now;
@@ -66,7 +66,7 @@ macro_rules! run_test {
             let schema_txn = schema_outer.write();
             schema_txn.reload_idxmeta()
         };
-        let be = match Backend::new(&mut audit, "", 1, idxmeta) {
+        let be = match Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta) {
             Ok(be) => be,
             Err(e) => {
                 audit.write_log();
@@ -116,7 +116,7 @@ macro_rules! entry_str_to_account {
 macro_rules! run_idm_test {
     ($test_fn:expr) => {{
         use crate::audit::AuditScope;
-        use crate::be::Backend;
+        use crate::be::{Backend, FsType};
         use crate::idm::server::IdmServer;
         use crate::schema::Schema;
         use crate::server::QueryServer;
@@ -137,7 +137,8 @@ macro_rules! run_idm_test {
             let schema_txn = schema_outer.write();
             schema_txn.reload_idxmeta()
         };
-        let be = Backend::new(&mut audit, "", 1, idxmeta).expect("Failed to init be");
+        let be =
+            Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta).expect("Failed to init be");
 
         let test_server = QueryServer::new(be, schema_outer);
         test_server

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -19,7 +19,7 @@ macro_rules! setup_test {
             let schema_txn = schema_outer.write();
             schema_txn.reload_idxmeta()
         };
-        let be = Backend::new($au, "", 1, idxmeta).expect("Failed to init BE");
+        let be = Backend::new($au, "", 1, FsType::Generic, idxmeta).expect("Failed to init BE");
 
         let qs = QueryServer::new(be, schema_outer);
         qs.initialise_helper($au, duration_from_epoch_now())
@@ -48,7 +48,7 @@ macro_rules! run_create_test {
         $check:expr
     ) => {{
         use crate::audit::AuditScope;
-        use crate::be::Backend;
+        use crate::be::{Backend, FsType};
         use crate::event::CreateEvent;
         use crate::schema::Schema;
         use crate::server::QueryServer;
@@ -103,7 +103,7 @@ macro_rules! run_modify_test {
         $check:expr
     ) => {{
         use crate::audit::AuditScope;
-        use crate::be::Backend;
+        use crate::be::{Backend, FsType};
         use crate::event::ModifyEvent;
         use crate::schema::Schema;
         use crate::server::QueryServer;
@@ -165,7 +165,7 @@ macro_rules! run_delete_test {
         $check:expr
     ) => {{
         use crate::audit::AuditScope;
-        use crate::be::Backend;
+        use crate::be::{Backend, FsType};
         use crate::event::DeleteEvent;
         use crate::schema::Schema;
         use crate::server::QueryServer;

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -33,6 +33,7 @@ struct ServerConfig {
     pub ldapbindaddress: Option<String>,
     // pub threads: Option<usize>,
     pub db_path: String,
+    pub db_fs_type: Option<String>,
     pub tls_ca: Option<String>,
     pub tls_cert: Option<String>,
     pub tls_key: Option<String>,
@@ -273,6 +274,7 @@ async fn main() {
 
     config.update_log_level(ll);
     config.update_db_path(&sconfig.db_path.as_str());
+    config.update_db_fs_type(&sconfig.db_fs_type);
     config.update_tls(&sconfig.tls_ca, &sconfig.tls_cert, &sconfig.tls_key);
     config.update_bind(&sconfig.bindaddress);
     config.update_ldapbind(&sconfig.ldapbindaddress);


### PR DESCRIPTION
Fixes #285 zfs pagesize. This allows setting fs-type options on the sqlite install. Today the only option is for zfs and the page size, but we can now add others as required.

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
