### PR TITLE
Dynamic crypto rounds

### DIFF
--- a/kanidmd/src/lib/credential/policy.rs
+++ b/kanidmd/src/lib/credential/policy.rs
@@ -1,0 +1,47 @@
+use super::Password;
+use std::time::Duration;
+
+const PBKDF2_MIN_NIST_COST: u64 = 10000;
+
+#[derive(Debug)]
+pub struct CryptoPolicy {
+    pub(crate) pbkdf2_cost: usize,
+}
+
+impl CryptoPolicy {
+    #[cfg(test)]
+    pub(crate) fn minimum() -> Self {
+        CryptoPolicy {
+            pbkdf2_cost: PBKDF2_MIN_NIST_COST as usize,
+        }
+    }
+
+    pub fn time_target(t: Duration) -> Self {
+        let r = match Password::bench_pbkdf2((PBKDF2_MIN_NIST_COST * 10) as usize) {
+            Some(bt) => {
+                let ubt = bt.as_nanos() as u64;
+
+                // Get the cost per thousand rounds
+                let per_thou = (PBKDF2_MIN_NIST_COST * 10) / 1000;
+                let t_per_thou = ubt / per_thou;
+                // eprintln!("{} / {}", ubt, per_thou);
+
+                // Now we need the attacker work in nanos
+                let attack_time = t.as_nanos() as u64;
+                let r = (attack_time / t_per_thou) * 1000;
+
+                // eprintln!("({} / {} ) * 1000", attack_time, t_per_thou);
+                // eprintln!("Maybe rounds -> {}", r);
+
+                if r < PBKDF2_MIN_NIST_COST {
+                    PBKDF2_MIN_NIST_COST as usize
+                } else {
+                    r as usize
+                }
+            }
+            None => PBKDF2_MIN_NIST_COST as usize,
+        };
+
+        CryptoPolicy { pbkdf2_cost: r }
+    }
+}

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -406,6 +406,7 @@ impl AuthSession {
 mod tests {
     use crate::audit::AuditScope;
     use crate::constants::{JSON_ADMIN_V1, JSON_ANONYMOUS_V1};
+    use crate::credential::policy::CryptoPolicy;
     use crate::credential::totp::{TOTP, TOTP_DEFAULT_STEP};
     use crate::credential::Credential;
     use crate::idm::authsession::{
@@ -492,7 +493,8 @@ mod tests {
         // create the ent
         let mut account = entry_str_to_account!(JSON_ADMIN_V1);
         // manually load in a cred
-        let cred = Credential::new_password_only("test_password").unwrap();
+        let p = CryptoPolicy::minimum();
+        let cred = Credential::new_password_only(&p, "test_password").unwrap();
         account.primary = Some(cred);
 
         // now check
@@ -549,7 +551,8 @@ mod tests {
         let pw_good = "test_password";
         let pw_bad = "bad_password";
 
-        let cred = Credential::new_password_only(pw_good)
+        let p = CryptoPolicy::minimum();
+        let cred = Credential::new_password_only(&p, pw_good)
             .unwrap()
             .update_totp(totp);
         // add totp also

--- a/kanidmd/src/lib/idm/unix.rs
+++ b/kanidmd/src/lib/idm/unix.rs
@@ -2,6 +2,7 @@ use uuid::Uuid;
 
 use crate::audit::AuditScope;
 use crate::constants::UUID_ANONYMOUS;
+use crate::credential::policy::CryptoPolicy;
 use crate::credential::Credential;
 use crate::entry::{Entry, EntryCommitted, EntryReduced, EntrySealed};
 use crate::modify::{ModifyInvalid, ModifyList};
@@ -153,8 +154,9 @@ impl UnixUserAccount {
     pub(crate) fn gen_password_mod(
         &self,
         cleartext: &str,
+        crypto_policy: &CryptoPolicy,
     ) -> Result<ModifyList<ModifyInvalid>, OperationError> {
-        let ncred = Credential::new_password_only(cleartext)?;
+        let ncred = Credential::new_password_only(crypto_policy, cleartext)?;
         let vcred = Value::new_credential("unix", ncred);
         Ok(ModifyList::new_purge_and_set("unix_password", vcred))
     }

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -126,6 +126,7 @@ impl Plugin for PasswordImport {
 
 #[cfg(test)]
 mod tests {
+    use crate::credential::policy::CryptoPolicy;
     use crate::credential::totp::{TOTP, TOTP_DEFAULT_STEP};
     use crate::credential::Credential;
     use crate::entry::{Entry, EntryInit, EntryNew};
@@ -205,7 +206,8 @@ mod tests {
         }"#,
         );
 
-        let c = Credential::new_password_only("password").unwrap();
+        let p = CryptoPolicy::minimum();
+        let c = Credential::new_password_only(&p, "password").unwrap();
         ea.add_ava("primary_credential", Value::new_credential("primary", c));
 
         let preload = vec![ea];
@@ -239,7 +241,8 @@ mod tests {
         );
 
         let totp = TOTP::generate_secure("test_totp".to_string(), TOTP_DEFAULT_STEP);
-        let c = Credential::new_password_only("password")
+        let p = CryptoPolicy::minimum();
+        let c = Credential::new_password_only(&p, "password")
             .unwrap()
             .update_totp(totp);
         ea.add_ava("primary_credential", Value::new_credential("primary", c));

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -2363,6 +2363,7 @@ mod tests {
         JSON_SYSTEM_INFO_V1, RECYCLEBIN_MAX_AGE, SYSTEM_INDEX_VERSION, UUID_ADMIN,
         UUID_DOMAIN_INFO,
     };
+    use crate::credential::policy::CryptoPolicy;
     use crate::credential::Credential;
     use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::event::{CreateEvent, DeleteEvent, ModifyEvent, ReviveRecycledEvent, SearchEvent};
@@ -3447,7 +3448,8 @@ mod tests {
             assert!(cr.is_ok());
 
             // Build the credential.
-            let cred = Credential::new_password_only("test_password").unwrap();
+            let p = CryptoPolicy::minimum();
+            let cred = Credential::new_password_only(&p, "test_password").unwrap();
             let v_cred = Value::new_credential("primary", cred);
             assert!(v_cred.validate());
 

--- a/project_docs/RELEASE_CHECKLIST.md
+++ b/project_docs/RELEASE_CHECKLIST.md
@@ -6,6 +6,7 @@
 * cargo audit
 * cargo outdated
 
+* upgrade crypto policy values if requires
 * bump index version in constants
 * check for breaking db entry changes.
 


### PR DESCRIPTION
Fixes #255 - this adds a crypto policy module for credentials so that on application launch we can configure the rounds in pbkdf2 or other types based on CPU performance. For example, the time target of 250ms in unix_int results in about 225000 rounds of pbkdf on my i7 laptop. For the main auth server, we take a more conservative 1ms attack factor, which results in us hitting the minimum today (10,000 rounds as per NIST), but we could change this value with benchmarking and other improvements.

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
