### PR TITLE
Add python3 support to radius

### DIFF
--- a/kanidm_rlm_python/Dockerfile
+++ b/kanidm_rlm_python/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER william@blackhats.net.au
 EXPOSE 1812 1813
 
 RUN zypper install -y timezone freeradius-client freeradius-server freeradius-server-ldap \
-    freeradius-server-python openldap2-client freeradius-server-utils hostname \
-    python2 python2-requests && \
+    freeradius-server-python3 openldap2-client freeradius-server-utils hostname \
+    python3 python3-requests python3-devel && \
     zypper clean
 
 # Copy the python module to /etc/raddb
@@ -13,14 +13,14 @@ COPY kanidmradius.py /etc/raddb/
 COPY entrypoint.py /entrypoint.py
 
 # Copy in the python changes, as well as the default/inner-tunnel changes
-COPY mod-python /etc/raddb/mods-available/python
+COPY mod-python3 /etc/raddb/mods-available/python3
 COPY eap /etc/raddb/mods-available/eap
 COPY cache /etc/raddb/mods-available/cache
 COPY default /etc/raddb/sites-available/default
 COPY inner-tunnel /etc/raddb/sites-available/inner-tunnel
 
 # Enable the python and cache module.
-RUN ln -s ../mods-available/python /etc/raddb/mods-enabled/python
+RUN ln -s ../mods-available/python3 /etc/raddb/mods-enabled/python3
 # RUN ln -s ../mods-available/cache /etc/raddb/mods-enabled/cache
 
 # Allows radiusd (?) to write to the directory
@@ -36,4 +36,4 @@ WORKDIR /etc/raddb
 VOLUME /data
 
 USER radiusd
-CMD [ "/usr/bin/python2", "/entrypoint.py" ]
+CMD [ "/usr/bin/python3", "/entrypoint.py" ]

--- a/kanidm_rlm_python/config.ini
+++ b/kanidm_rlm_python/config.ini
@@ -1,7 +1,8 @@
 [kanidm_client]
 url =
-strict = false
-ca = /data/ca.crt
+strict = true
+# Only if you want to check a specific ca root with strict = true
+# ca = /data/ca.crt
 user =
 secret =
 

--- a/kanidm_rlm_python/default
+++ b/kanidm_rlm_python/default
@@ -325,7 +325,7 @@ authorize {
 	#
 	#  If you want to have a log of authentication requests,
 	#  un-comment the following line.
-#	auth_log
+    auth_log
 
 	#
 	#  The chap module will set 'Auth-Type := CHAP' if we are
@@ -426,11 +426,11 @@ authorize {
     # }
     # cache
     # if (notfound) {
-    #     python
+    #     python3
     # }
     # cache
 
-    python
+    python3
 
 	#
 	#  Enforce daily limits on time spent logged in.

--- a/kanidm_rlm_python/inner-tunnel
+++ b/kanidm_rlm_python/inner-tunnel
@@ -158,11 +158,11 @@ authorize {
     # }
     # cache
     # if (notfound) {
-    #     python
+    #     python3
     # }
     # cache
 
-    python
+    python3
 
 	#
 	#  Enforce daily limits on time spent logged in.

--- a/kanidm_rlm_python/kanidmradius.py
+++ b/kanidm_rlm_python/kanidmradius.py
@@ -8,6 +8,8 @@ MAJOR, MINOR, _, _, _ = sys.version_info
 
 if MAJOR >= 3:
     import configparser
+    # Absolutely fuck you python3
+    from functools import reduce
 else:
     import ConfigParser as configparser
 
@@ -28,7 +30,7 @@ GROUPS = [
 
 REQ_GROUP = CONFIG.get("radiusd", "required_group")
 if CONFIG.getboolean("kanidm_client", "strict"):
-    CA = CONFIG.get("kanidm_client", "ca")
+    CA = CONFIG.get("kanidm_client", "ca", fallback=True)
 else:
     CA = False
 USER = CONFIG.get("kanidm_client", "user")

--- a/kanidm_rlm_python/mod-python3
+++ b/kanidm_rlm_python/mod-python3
@@ -6,14 +6,14 @@
 # rlm_python is called for a section which does not have
 # a function defined, it will return NOOP.
 #
-python {
+python3 {
 	#  Path to the python modules
 	#
 	#  Note that due to limitations on Python, this configuration
 	#  item is GLOBAL TO THE SERVER.  That is, you cannot have two
 	#  instances of the python module, each with a different path.
 	#
-        python_path="/usr/lib64/python2.7:/usr/lib/python2.7:/usr/lib/python2.7/site-packages:/usr/lib64/python2.7/site-packages:/usr/lib64/python2.7/lib-dynload:/etc/raddb"
+    python_path="/usr/lib64/python3.6:/usr/lib/python3.6:/usr/lib/python3.6/site-packages:/usr/lib64/python3.6/site-packages:/usr/lib64/python3.6/lib-dynload:/etc/raddb"
 
 	module = kanidmradius
 


### PR DESCRIPTION
Support py3 rlm from latest opensuse/leap  

- [ - ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ - ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
