### PR TITLE
250 cookie to auth bearer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fernet"
+version = "0.1.3"
+source = "git+https://github.com/mozilla-services/fernet-rs.git#401fde478c63e868f126ff7c92abad1f96107ca4"
+dependencies = [
+ "base64",
+ "byteorder",
+ "getrandom",
+ "openssl",
+ "zeroize",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1547,7 @@ dependencies = [
  "concread",
  "criterion",
  "env_logger",
+ "fernet",
  "futures",
  "futures-util",
  "hashbrown 0.8.2",
@@ -2959,6 +2972,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +3575,27 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/kanidm_book/src/client_tools.md
+++ b/kanidm_book/src/client_tools.md
@@ -48,10 +48,21 @@ After you check out the source (see github), navigate to:
 Now you can check your instance is working. You may need to provide a CA certificate for verification
 with the -C parameter:
 
+    kanidm login --name anonymous
     kanidm self whoami -C ../path/to/ca.pem -H https://localhost:8443 --name anonymous
     kanidm self whoami -H https://localhost:8443 --name anonymous
 
 Now you can take some time to look at what commands are available - please ask for help at anytime.
+
+## Authenticating a user with the command line
+
+To authenticate as a user for use with the command line, you need to use the `login` command
+to establish a session token.
+
+    kanidm login --name USERNAME
+    kanidm login --name admin
+
+Once complete, you can use kanidm without reauthenticating for a period of time for administration.
 
 ## Kandim configuration
 
@@ -65,3 +76,4 @@ You can configure kanidm to help make commands simpler by modifying ~/.config/ka
 Once configured, you can test this with:
 
     kanidm self whoami --name anonymous
+

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -336,6 +336,15 @@ impl KanidmClient {
         builder.build()
     }
 
+    pub fn set_token(&mut self, new_token: String) {
+        let mut new_token = Some(new_token);
+        std::mem::swap(&mut self.bearer_token, &mut new_token);
+    }
+
+    pub fn get_token(&self) -> Option<&str> {
+        self.bearer_token.as_ref().map(|s| s.as_str())
+    }
+
     pub fn logout(&mut self) -> Result<(), reqwest::Error> {
         // hack - we have to replace our reqwest client because that's the only way
         // to currently flush the cookie store. To achieve this we need to rebuild

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -277,6 +277,7 @@ impl KanidmClientBuilder {
             client,
             addr: address,
             builder: self,
+            bearer_token: None,
         })
     }
 
@@ -315,6 +316,7 @@ impl KanidmClientBuilder {
             client,
             addr: address,
             builder: self,
+            bearer_token: None,
         })
     }
 }
@@ -324,6 +326,7 @@ pub struct KanidmClient {
     client: reqwest::blocking::Client,
     addr: String,
     builder: KanidmClientBuilder,
+    bearer_token: Option<String>,
 }
 
 impl KanidmClient {
@@ -357,7 +360,15 @@ impl KanidmClient {
         let response = self
             .client
             .post(dest.as_str())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .header(CONTENT_TYPE, APPLICATION_JSON);
+
+        let response = if let Some(token) = &self.bearer_token {
+            response.bearer_auth(token)
+        } else {
+            response
+        };
+
+        let response = response
             .body(req_string)
             .send()
             .map_err(ClientError::Transport)?;
@@ -391,7 +402,15 @@ impl KanidmClient {
         let response = self
             .client
             .put(dest.as_str())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .header(CONTENT_TYPE, APPLICATION_JSON);
+
+        let response = if let Some(token) = &self.bearer_token {
+            response.bearer_auth(token)
+        } else {
+            response
+        };
+
+        let response = response
             .body(req_string)
             .send()
             .map_err(ClientError::Transport)?;
@@ -415,11 +434,15 @@ impl KanidmClient {
 
     fn perform_get_request<T: DeserializeOwned>(&self, dest: &str) -> Result<T, ClientError> {
         let dest = format!("{}{}", self.addr, dest);
-        let response = self
-            .client
-            .get(dest.as_str())
-            .send()
-            .map_err(ClientError::Transport)?;
+        let response = self.client.get(dest.as_str());
+
+        let response = if let Some(token) = &self.bearer_token {
+            response.bearer_auth(token)
+        } else {
+            response
+        };
+
+        let response = response.send().map_err(ClientError::Transport)?;
 
         let opid = response
             .headers()
@@ -440,11 +463,14 @@ impl KanidmClient {
 
     fn perform_delete_request(&self, dest: &str) -> Result<bool, ClientError> {
         let dest = format!("{}{}", self.addr, dest);
-        let response = self
-            .client
-            .delete(dest.as_str())
-            .send()
-            .map_err(ClientError::Transport)?;
+        let response = self.client.delete(dest.as_str());
+        let response = if let Some(token) = &self.bearer_token {
+            response.bearer_auth(token)
+        } else {
+            response
+        };
+
+        let response = response.send().map_err(ClientError::Transport)?;
 
         let opid = response
             .headers()
@@ -467,11 +493,15 @@ impl KanidmClient {
     // Can't use generic get due to possible un-auth case.
     pub fn whoami(&self) -> Result<Option<(Entry, UserAuthToken)>, ClientError> {
         let whoami_dest = format!("{}/v1/self", self.addr);
-        let response = self
-            .client
-            .get(whoami_dest.as_str())
-            .send()
-            .map_err(ClientError::Transport)?;
+        let response = self.client.get(whoami_dest.as_str());
+
+        let response = if let Some(token) = &self.bearer_token {
+            response.bearer_auth(token)
+        } else {
+            response
+        };
+
+        let response = response.send().map_err(ClientError::Transport)?;
 
         let opid = response
             .headers()
@@ -495,7 +525,7 @@ impl KanidmClient {
     }
 
     // auth
-    pub fn auth_anonymous(&self) -> Result<UserAuthToken, ClientError> {
+    pub fn auth_anonymous(&mut self) -> Result<(), ClientError> {
         // TODO #251: Check state for auth continue contains anonymous.
         let _state = match self.auth_step_init("anonymous") {
             Ok(s) => s,
@@ -510,19 +540,16 @@ impl KanidmClient {
         let r = r?;
 
         match r.state {
-            AuthState::Success(uat) => {
-                debug!("==> Authed as uat; {:?}", uat);
-                Ok(uat)
+            AuthState::Success(token) => {
+                // set the bearer.
+                self.bearer_token = Some(token);
+                Ok(())
             }
             _ => Err(ClientError::AuthenticationFailed),
         }
     }
 
-    pub fn auth_simple_password(
-        &self,
-        ident: &str,
-        password: &str,
-    ) -> Result<UserAuthToken, ClientError> {
+    pub fn auth_simple_password(&mut self, ident: &str, password: &str) -> Result<(), ClientError> {
         let _state = match self.auth_step_init(ident) {
             Ok(s) => s,
             Err(e) => return Err(e),
@@ -536,20 +563,21 @@ impl KanidmClient {
         let r = r?;
 
         match r.state {
-            AuthState::Success(uat) => {
-                debug!("==> Authed as uat; {:?}", uat);
-                Ok(uat)
+            AuthState::Success(token) => {
+                // set the bearer.
+                self.bearer_token = Some(token);
+                Ok(())
             }
             _ => Err(ClientError::AuthenticationFailed),
         }
     }
 
     pub fn auth_password_totp(
-        &self,
+        &mut self,
         ident: &str,
         password: &str,
         totp: u32,
-    ) -> Result<UserAuthToken, ClientError> {
+    ) -> Result<(), ClientError> {
         let _state = match self.auth_step_init(ident) {
             Ok(s) => s,
             Err(e) => return Err(e),
@@ -566,9 +594,10 @@ impl KanidmClient {
         let r = r?;
 
         match r.state {
-            AuthState::Success(uat) => {
-                debug!("==> Authed as uat; {:?}", uat);
-                Ok(uat)
+            AuthState::Success(token) => {
+                // set the bearer.
+                self.bearer_token = Some(token);
+                Ok(())
             }
             _ => Err(ClientError::AuthenticationFailed),
         }

--- a/kanidm_client/tests/default_entries.rs
+++ b/kanidm_client/tests/default_entries.rs
@@ -334,7 +334,7 @@ fn test_default_entries_rbac_group_managers() {
 // read and write access control entries.
 #[test]
 fn test_default_entries_rbac_admins_access_control_entries() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         rsclient
             .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
             .unwrap();
@@ -382,7 +382,7 @@ fn test_default_entries_rbac_admins_access_control_entries() {
 // TODO #252: write schema entries
 #[test]
 fn test_default_entries_rbac_admins_schema_entries() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         rsclient
             .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
             .unwrap();
@@ -493,7 +493,7 @@ fn test_default_entries_rbac_admins_schema_entries() {
 // create new accounts (to bootstrap the system).
 #[test]
 fn test_default_entries_rbac_admins_group_entries() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         rsclient
             .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
             .unwrap();
@@ -509,7 +509,7 @@ fn test_default_entries_rbac_admins_group_entries() {
 // modify high access accounts as an escalation for security sensitive accounts.
 #[test]
 fn test_default_entries_rbac_admins_ha_accounts() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         rsclient
             .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
             .unwrap();
@@ -522,7 +522,7 @@ fn test_default_entries_rbac_admins_ha_accounts() {
 // recover from the recycle bin
 #[test]
 fn test_default_entries_rbac_admins_recycle_accounts() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         rsclient
             .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
             .unwrap();

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -15,7 +15,7 @@ const UNIX_TEST_PASSWORD: &str = "unix test user password";
 
 #[test]
 fn test_server_create() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let e: Entry = serde_json::from_str(
             r#"{
             "attrs": {
@@ -41,7 +41,7 @@ fn test_server_create() {
 
 #[test]
 fn test_server_modify() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         // Build a self mod.
 
         let f = Filter::SelfUUID;
@@ -65,7 +65,7 @@ fn test_server_modify() {
 
 #[test]
 fn test_server_whoami_anonymous() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         // First show we are un-authenticated.
         let pre_res = rsclient.whoami();
         // This means it was okay whoami, but no uat attached.
@@ -87,7 +87,7 @@ fn test_server_whoami_anonymous() {
 
 #[test]
 fn test_server_whoami_admin_simple_password() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         // First show we are un-authenticated.
         let pre_res = rsclient.whoami();
         // This means it was okay whoami, but no uat attached.
@@ -108,7 +108,7 @@ fn test_server_whoami_admin_simple_password() {
 
 #[test]
 fn test_server_search() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         // First show we are un-authenticated.
         let pre_res = rsclient.whoami();
         // This means it was okay whoami, but no uat attached.
@@ -159,7 +159,7 @@ fn test_server_admin_change_simple_password() {
 // Add a test for resetting another accounts pws via the rest api
 #[test]
 fn test_server_admin_reset_simple_password() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
         // Create a diff account
@@ -197,7 +197,7 @@ fn test_server_admin_reset_simple_password() {
         );
         assert!(res.is_ok());
         // Check it stuck.
-        let tclient = rsclient.new_session().expect("failed to build new session");
+        let mut tclient = rsclient.new_session().expect("failed to build new session");
         assert!(tclient
             .auth_simple_password("testperson", "tai4eCohtae9aegheo3Uw0oobahVighaig6heeli")
             .is_ok());
@@ -206,7 +206,7 @@ fn test_server_admin_reset_simple_password() {
         let res = rsclient.idm_account_primary_credential_set_generated("testperson");
         assert!(res.is_ok());
         let gpw = res.unwrap();
-        let tclient = rsclient.new_session().expect("failed to build new session");
+        let mut tclient = rsclient.new_session().expect("failed to build new session");
         assert!(tclient
             .auth_simple_password("testperson", gpw.as_str())
             .is_ok());
@@ -216,7 +216,7 @@ fn test_server_admin_reset_simple_password() {
 // test the rest group endpoint.
 #[test]
 fn test_server_rest_group_read() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -232,7 +232,7 @@ fn test_server_rest_group_read() {
 
 #[test]
 fn test_server_rest_group_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -302,7 +302,7 @@ fn test_server_rest_group_lifecycle() {
 
 #[test]
 fn test_server_rest_account_read() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -318,7 +318,7 @@ fn test_server_rest_account_read() {
 
 #[test]
 fn test_server_rest_schema_read() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -346,7 +346,7 @@ fn test_server_rest_schema_read() {
 // Test resetting a radius cred, and then checking/viewing it.
 #[test]
 fn test_server_radius_credential_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -389,7 +389,7 @@ fn test_server_radius_credential_lifecycle() {
 
 #[test]
 fn test_server_rest_account_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
         // To enable the admin to actually make some of these changes, we have
@@ -418,7 +418,7 @@ fn test_server_rest_account_lifecycle() {
 
 #[test]
 fn test_server_rest_sshkey_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -471,7 +471,7 @@ fn test_server_rest_sshkey_lifecycle() {
 
 #[test]
 fn test_server_rest_domain_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -494,7 +494,7 @@ fn test_server_rest_domain_lifecycle() {
 
 #[test]
 fn test_server_rest_posix_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
         // Not recommended in production!
@@ -567,11 +567,11 @@ fn test_server_rest_posix_lifecycle() {
 
 #[test]
 fn test_server_rest_posix_auth_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
         // Get an anon connection
-        let anon_rsclient = rsclient.new_session().unwrap();
+        let mut anon_rsclient = rsclient.new_session().unwrap();
         assert!(anon_rsclient.auth_anonymous().is_ok());
 
         // Not recommended in production!
@@ -628,7 +628,7 @@ fn test_server_rest_posix_auth_lifecycle() {
 
 #[test]
 fn test_server_rest_recycle_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -712,7 +712,7 @@ fn test_server_rest_account_import_password() {
 
 #[test]
 fn test_server_rest_totp_auth_lifecycle() {
-    run_test(|rsclient: KanidmClient| {
+    run_test(|mut rsclient: KanidmClient| {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
@@ -749,13 +749,13 @@ fn test_server_rest_totp_auth_lifecycle() {
 
         // Check a bad auth
         // Get a new connection
-        let rsclient_bad = rsclient.new_session().unwrap();
+        let mut rsclient_bad = rsclient.new_session().unwrap();
         assert!(rsclient_bad
             .auth_password_totp("demo_account", "sohdi3iuHo6mai7noh0a", 0)
             .is_err());
 
         // Check a good auth
-        let rsclient_good = rsclient.new_session().unwrap();
+        let mut rsclient_good = rsclient.new_session().unwrap();
         let totp = r_tok
             .do_totp_duration_from_epoch(
                 &SystemTime::now()

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -469,9 +469,10 @@ pub enum AuthAllowed {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthState {
-    // Everything is good, your cookie has been issued, and a token is set here
-    // for the client to view.
-    Success(UserAuthToken),
+    // Everything is good, your bearer header has been issued and is within
+    // the result.
+    // Success(UserAuthToken),
+    Success(String),
     // Something was bad, your session is terminated and no cookie.
     Denied(String),
     // Continue to auth, allowed mechanisms listed.

--- a/kanidm_tools/src/cli/common.rs
+++ b/kanidm_tools/src/cli/common.rs
@@ -57,7 +57,7 @@ impl CommonOpt {
             None => client_builder,
         };
 
-        let client = match client_builder.build() {
+        let mut client = match client_builder.build() {
             Ok(c) => c,
             Err(e) => {
                 error!("Failed to build client instance -- {:?}", e);

--- a/kanidm_tools/src/cli/common.rs
+++ b/kanidm_tools/src/cli/common.rs
@@ -1,3 +1,4 @@
+use crate::login::read_tokens;
 use kanidm_client::{KanidmClient, KanidmClientBuilder};
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -17,13 +18,13 @@ pub struct CommonOpt {
     #[structopt(short = "H", long = "url")]
     pub addr: Option<String>,
     #[structopt(short = "D", long = "name")]
-    pub username: String,
+    pub username: Option<String>,
     #[structopt(parse(from_os_str), short = "C", long = "ca")]
     pub ca_path: Option<PathBuf>,
 }
 
 impl CommonOpt {
-    pub fn to_client(&self) -> KanidmClient {
+    pub fn to_unauth_client(&self) -> KanidmClient {
         let config_path: String = shellexpand::tilde("~/.config/kanidm").into_owned();
 
         debug!("Attempting to use config {}", "/etc/kanidm/config");
@@ -57,31 +58,62 @@ impl CommonOpt {
             None => client_builder,
         };
 
-        let mut client = match client_builder.build() {
+        let client = match client_builder.build() {
             Ok(c) => c,
             Err(e) => {
                 error!("Failed to build client instance -- {:?}", e);
                 std::process::exit(1);
             }
         };
+        client
+    }
 
-        let r = if self.username == "anonymous" {
-            client.auth_anonymous()
-        } else {
-            let password = match rpassword::prompt_password_stderr("Enter password: ") {
-                Ok(p) => p,
-                Err(e) => {
-                    error!("Failed to create password prompt -- {:?}", e);
-                    std::process::exit(1);
-                }
-            };
-            client.auth_simple_password(self.username.as_str(), password.as_str())
+    pub fn to_client(&self) -> KanidmClient {
+        let mut client = self.to_unauth_client();
+        // Read the token file.
+        let tokens = match read_tokens() {
+            Ok(t) => t,
+            Err(_e) => {
+                error!("Error retrieving authentication token store");
+                std::process::exit(1);
+            }
         };
 
-        if r.is_err() {
-            println!("Error during authentication phase: {:?}", r);
+        if tokens.len() == 0 {
+            error!(
+                "No valid authentication tokens found. Please login with the 'login' subcommand."
+            );
             std::process::exit(1);
         }
+
+        // If we have a username, use that to select tokens
+        let token = match &self.username {
+            Some(username) => {
+                // Is it in the store?
+                match tokens.get(username) {
+                    Some(t) => t.clone(),
+                    None => {
+                        error!("No valid authentication tokens found for {}.", username);
+                        std::process::exit(1);
+                    }
+                }
+            }
+            None => {
+                if tokens.len() == 1 {
+                    let (f_uname, f_token) = tokens.iter().next().expect("Memory Corruption");
+                    // else pick the first token
+                    info!("Authenticated as {}", f_uname);
+                    f_token.clone()
+                } else {
+                    // Unable to select
+                    error!("Multiple authentication tokens exist. Please select one with --name.");
+                    std::process::exit(1);
+                }
+            }
+        };
+
+        // Set it into the client
+        client.set_token(token);
 
         client
     }

--- a/kanidm_tools/src/cli/group.rs
+++ b/kanidm_tools/src/cli/group.rs
@@ -33,6 +33,8 @@ pub enum GroupPosix {
 pub enum GroupOpt {
     #[structopt(name = "list")]
     List(CommonOpt),
+    #[structopt(name = "get")]
+    Get(Named),
     #[structopt(name = "create")]
     Create(Named),
     #[structopt(name = "delete")]
@@ -53,6 +55,7 @@ impl GroupOpt {
     pub fn debug(&self) -> bool {
         match self {
             GroupOpt::List(copt) => copt.debug,
+            GroupOpt::Get(gcopt) => gcopt.copt.debug,
             GroupOpt::Create(gcopt) => gcopt.copt.debug,
             GroupOpt::Delete(gcopt) => gcopt.copt.debug,
             GroupOpt::ListMembers(gcopt) => gcopt.copt.debug,
@@ -75,6 +78,15 @@ impl GroupOpt {
                     Err(e) => {
                         eprintln!("Error -> {:?}", e);
                     }
+                }
+            }
+            GroupOpt::Get(gcopt) => {
+                let client = gcopt.copt.to_client();
+                // idm_group_get
+                match client.idm_group_get(gcopt.name.as_str()) {
+                    Ok(Some(e)) => println!("{}", e),
+                    Ok(None) => println!("No matching entries"),
+                    Err(e) => eprintln!("Error -> {:?}", e),
                 }
             }
             GroupOpt::Create(gcopt) => {

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -15,12 +15,14 @@ use structopt::StructOpt;
 pub mod account;
 pub mod common;
 pub mod group;
+pub mod login;
 pub mod raw;
 pub mod recycle;
 
 use crate::account::AccountOpt;
 use crate::common::CommonOpt;
 use crate::group::GroupOpt;
+use crate::login::LoginOpt;
 use crate::raw::RawOpt;
 use crate::recycle::RecycleOpt;
 
@@ -79,8 +81,11 @@ impl SelfOpt {
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(about = "I am a program and I work, just pass `-h`")]
+#[structopt(about = "Kanidm Client Utility")]
 pub enum ClientOpt {
+    #[structopt(name = "login")]
+    /// Login to an account to use with future cli operations
+    Login(LoginOpt),
     #[structopt(name = "self")]
     /// Actions for the current authenticated account
     CSelf(SelfOpt),
@@ -102,6 +107,7 @@ impl ClientOpt {
     pub fn debug(&self) -> bool {
         match self {
             ClientOpt::Raw(ropt) => ropt.debug(),
+            ClientOpt::Login(lopt) => lopt.debug(),
             ClientOpt::CSelf(csopt) => csopt.debug(),
             ClientOpt::Account(aopt) => aopt.debug(),
             ClientOpt::Group(gopt) => gopt.debug(),
@@ -112,6 +118,7 @@ impl ClientOpt {
     pub fn exec(&self) {
         match self {
             ClientOpt::Raw(ropt) => ropt.exec(),
+            ClientOpt::Login(lopt) => lopt.exec(),
             ClientOpt::CSelf(csopt) => csopt.exec(),
             ClientOpt::Account(aopt) => aopt.exec(),
             ClientOpt::Group(gopt) => gopt.exec(),

--- a/kanidm_tools/src/cli/login.rs
+++ b/kanidm_tools/src/cli/login.rs
@@ -1,0 +1,101 @@
+use crate::common::CommonOpt;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use structopt::StructOpt;
+
+static TOKEN_PATH: &'static str = "~/.cache/kanidm_tokens";
+
+pub fn read_tokens() -> Result<BTreeMap<String, String>, ()> {
+    let token_path: String = shellexpand::tilde(TOKEN_PATH).into_owned();
+    // If the file does not exist, return Ok<map>
+    let file = match File::open(token_path) {
+        Ok(f) => f,
+        Err(e) => {
+            warn!("Can not read from {}, continuing ... {:?}", TOKEN_PATH, e);
+            return Ok(BTreeMap::new());
+        }
+    };
+    let reader = BufReader::new(file);
+
+    // Else try to read
+    serde_json::from_reader(reader).map_err(|e| {
+        error!("JSON/IO error -> {:?}", e);
+    })
+}
+
+pub fn write_tokens(tokens: &BTreeMap<String, String>) -> Result<(), ()> {
+    let token_path: String = shellexpand::tilde(TOKEN_PATH).into_owned();
+    let file = File::create(token_path).map_err(|e| {
+        error!("Can not write to {} -> {:?}", TOKEN_PATH, e);
+    })?;
+
+    let writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(writer, tokens).map_err(|e| {
+        error!("JSON/IO error -> {:?}", e);
+    })
+}
+
+#[derive(Debug, StructOpt)]
+pub struct LoginOpt {
+    #[structopt(flatten)]
+    pub copt: CommonOpt,
+}
+
+impl LoginOpt {
+    pub fn debug(&self) -> bool {
+        self.copt.debug
+    }
+
+    pub fn exec(&self) {
+        let mut client = self.copt.to_unauth_client();
+
+        let (r, username) = match self.copt.username.as_ref().map(|s| s.as_str()) {
+            None | Some("anonymous") => (client.auth_anonymous(), "anonymous".to_string()),
+            Some(username) => {
+                let password = match rpassword::prompt_password_stderr("Enter password: ") {
+                    Ok(p) => p,
+                    Err(e) => {
+                        error!("Failed to create password prompt -- {:?}", e);
+                        std::process::exit(1);
+                    }
+                };
+                (
+                    client.auth_simple_password(username, password.as_str()),
+                    username.to_string(),
+                )
+            }
+        };
+
+        if r.is_err() {
+            error!("Error during authentication phase: {:?}", r);
+            std::process::exit(1);
+        }
+
+        // Read the current tokens
+        let mut tokens = match read_tokens() {
+            Ok(t) => t,
+            Err(_e) => {
+                error!("Error retrieving authentication token store");
+                std::process::exit(1);
+            }
+        };
+        // Add our new one
+        match client.get_token() {
+            Some(t) => tokens.insert(username.clone(), t.to_string()),
+            None => {
+                error!("Error retrieving client session");
+                std::process::exit(1);
+            }
+        };
+
+        // write them out.
+        if let Err(_e) = write_tokens(&tokens) {
+            error!("Error persisting authentication token store");
+            std::process::exit(1);
+        };
+
+        // Success!
+        println!("Login Success for {}", username);
+    }
+}

--- a/kanidm_tools/src/ssh_authorizedkeys.rs
+++ b/kanidm_tools/src/ssh_authorizedkeys.rs
@@ -74,7 +74,7 @@ fn main() {
         None => client_builder,
     };
 
-    let client = match client_builder.build() {
+    let mut client = match client_builder.build() {
         Ok(c) => c,
         Err(e) => {
             error!("Failed to build client instance -- {:?}", e);

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -34,6 +34,7 @@ async-h1 = "2.0"
 # Temporary!
 # tide-rustls = "0.1"
 tide-rustls = { git = "https://github.com/http-rs/tide-rustls.git", rev = "c1f13a77e82369323274d832b8d3f33ba7c272c7" }
+fernet = { git = "https://github.com/mozilla-services/fernet-rs.git" }
 
 async-std = "1.6"
 

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::audit::AuditScope;
 
-use crate::event::{AuthEvent, SearchEvent, SearchResult, WhoamiResult};
+use crate::event::{AuthEvent, AuthResult, SearchEvent, SearchResult, WhoamiResult};
 use crate::idm::event::{
     RadiusAuthTokenEvent, UnixGroupTokenEvent, UnixUserAuthEvent, UnixUserTokenEvent,
 };
@@ -18,8 +18,8 @@ use crate::server::{QueryServer, QueryServerTransaction};
 
 use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidm_proto::v1::{
-    AuthRequest, AuthResponse, SearchRequest, SearchResponse, UnixGroupToken, UnixUserToken,
-    UserAuthToken, WhoamiResponse,
+    AuthRequest, SearchRequest, SearchResponse, UnixGroupToken, UnixUserToken, UserAuthToken,
+    WhoamiResponse,
 };
 
 use std::time::SystemTime;
@@ -219,7 +219,7 @@ impl QueryServerReadV1 {
         res
     }
 
-    pub async fn handle_auth(&self, msg: AuthMessage) -> Result<AuthResponse, OperationError> {
+    pub async fn handle_auth(&self, msg: AuthMessage) -> Result<AuthResult, OperationError> {
         // This is probably the first function that really implements logic
         // "on top" of the db server concept. In this case we check if
         // the credentials provided is sufficient to say if someone is
@@ -261,7 +261,8 @@ impl QueryServerReadV1 {
 
             lsecurity!(audit, "Sending auth result -> {:?}", r);
             // Build the result.
-            r.map(|r| r.response())
+            // r.map(|r| r.response())
+            r
         });
         // At the end of the event we send it for logging.
         self.log.send(audit).map_err(|_| {

--- a/kanidmd/src/lib/be/idxkey.rs
+++ b/kanidmd/src/lib/be/idxkey.rs
@@ -24,18 +24,18 @@ impl<'a> IdxKeyRef<'a> {
 }
 
 pub trait IdxKeyToRef {
-    fn keyref<'k>(&'k self) -> IdxKeyRef<'k>;
+    fn keyref(&self) -> IdxKeyRef<'_>;
 }
 
 impl<'a> IdxKeyToRef for IdxKeyRef<'a> {
-    fn keyref<'k>(&'k self) -> IdxKeyRef<'k> {
+    fn keyref(&self) -> IdxKeyRef<'_> {
         // Copy the self.
         *self
     }
 }
 
 impl IdxKeyToRef for IdxKey {
-    fn keyref<'a>(&'a self) -> IdxKeyRef<'a> {
+    fn keyref(&self) -> IdxKeyRef<'_> {
         IdxKeyRef {
             attr: self.attr.as_str(),
             itype: &self.itype,
@@ -88,18 +88,18 @@ impl<'a> IdlCacheKeyRef<'a> {
 */
 
 pub trait IdlCacheKeyToRef {
-    fn keyref<'k>(&'k self) -> IdlCacheKeyRef<'k>;
+    fn keyref(&self) -> IdlCacheKeyRef<'_>;
 }
 
 impl<'a> IdlCacheKeyToRef for IdlCacheKeyRef<'a> {
-    fn keyref<'k>(&'k self) -> IdlCacheKeyRef<'k> {
+    fn keyref(&self) -> IdlCacheKeyRef<'_> {
         // Copy the self
         *self
     }
 }
 
 impl IdlCacheKeyToRef for IdlCacheKey {
-    fn keyref<'k>(&'k self) -> IdlCacheKeyRef<'k> {
+    fn keyref(&self) -> IdlCacheKeyRef<'_> {
         IdlCacheKeyRef {
             a: self.a.as_str(),
             i: &self.i,

--- a/kanidmd/src/lib/core/https.rs
+++ b/kanidmd/src/lib/core/https.rs
@@ -73,7 +73,7 @@ impl RequestExtensions for tide::Request<AppState> {
                 // Take the token str and attempt to decrypt
                 // Attempt to re-inflate a UAT from bytes.
                 let uat: Option<UserAuthToken> = kref
-                    .decrypt(ts)
+                    .decrypt_with_ttl(ts, 3600)
                     .ok()
                     .and_then(|b| serde_json::from_slice(&b).ok());
                 uat
@@ -1024,10 +1024,7 @@ pub async fn auth(mut req: tide::Request<AppState>) -> tide::Result {
                         .map_err(|_| OperationError::InvalidSessionState)
                 }
             }
-            .map(|state| AuthResponse {
-                state,
-                sessionid: sessionid,
-            })
+            .map(|state| AuthResponse { state, sessionid })
         });
     to_tide_response(res, hvalue)
 }

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -1,14 +1,12 @@
 use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInit, EntryNew, EntryReduced, EntrySealed};
 use crate::filter::{Filter, FilterInvalid, FilterValid};
+use crate::idm::AuthState;
 use crate::schema::SchemaTransaction;
 use crate::value::PartialValue;
 use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidm_proto::v1::ModifyList as ProtoModifyList;
-use kanidm_proto::v1::{
-    AuthCredential, AuthResponse, AuthState, AuthStep, SearchResponse, UserAuthToken,
-    WhoamiResponse,
-};
+use kanidm_proto::v1::{AuthCredential, AuthStep, SearchResponse, UserAuthToken, WhoamiResponse};
 // use error::OperationError;
 use crate::modify::{ModifyInvalid, ModifyList, ModifyValid};
 use crate::server::{
@@ -1043,6 +1041,7 @@ pub struct AuthResult {
     pub state: AuthState,
 }
 
+/*
 impl AuthResult {
     pub fn response(self) -> AuthResponse {
         AuthResponse {
@@ -1051,6 +1050,7 @@ impl AuthResult {
         }
     }
 }
+*/
 
 pub struct WhoamiResult {
     youare: ProtoEntry,

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -1,8 +1,9 @@
 use crate::audit::AuditScope;
 use crate::idm::account::Account;
 use crate::idm::claim::Claim;
+use crate::idm::AuthState;
 use kanidm_proto::v1::OperationError;
-use kanidm_proto::v1::{AuthAllowed, AuthCredential, AuthState};
+use kanidm_proto::v1::{AuthAllowed, AuthCredential};
 
 use crate::credential::{totp::TOTP, Credential, Password};
 
@@ -420,6 +421,8 @@ impl AuthSession {
                     .account
                     .to_userauthtoken(&claims)
                     .ok_or(OperationError::InvalidState)?;
+
+                // Now encrypt and prepare the token for return to the client.
                 Ok(AuthState::Success(uat))
             }
             CredState::Continue(allowed) => {
@@ -464,7 +467,8 @@ mod tests {
     use crate::idm::authsession::{
         AuthSession, BAD_AUTH_TYPE_MSG, BAD_CREDENTIALS, BAD_PASSWORD_MSG, BAD_TOTP_MSG,
     };
-    use kanidm_proto::v1::{AuthAllowed, AuthCredential, AuthState};
+    use crate::idm::AuthState;
+    use kanidm_proto::v1::{AuthAllowed, AuthCredential};
     use std::time::Duration;
     // use async_std::task;
 

--- a/kanidmd/src/lib/idm/mod.rs
+++ b/kanidmd/src/lib/idm/mod.rs
@@ -9,3 +9,12 @@ pub(crate) mod radius;
 pub(crate) mod server;
 pub(crate) mod unix;
 // mod identity;
+
+use kanidm_proto::v1::{AuthAllowed, UserAuthToken};
+
+#[derive(Debug)]
+pub enum AuthState {
+    Success(UserAuthToken),
+    Denied(String),
+    Continue(Vec<AuthAllowed>),
+}

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -22,7 +22,8 @@ use crate::value::PartialValue;
 use crate::actors::v1_write::QueryServerWriteV1;
 use crate::idm::delayed::{DelayedAction, PasswordUpgrade, UnixPasswordUpgrade};
 
-use kanidm_proto::v1::AuthState;
+use crate::idm::AuthState;
+
 use kanidm_proto::v1::OperationError;
 use kanidm_proto::v1::RadiusAuthToken;
 // use kanidm_proto::v1::TOTPSecret as ProtoTOTPSecret;
@@ -110,6 +111,7 @@ impl IdmServer {
         // improves.
         let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(1));
         let (async_tx, async_rx) = unbounded();
+
         (
             IdmServer {
                 session_ticket: Arc::new(Semaphore::new(1)),
@@ -999,9 +1001,10 @@ mod tests {
     use crate::value::{PartialValue, Value};
     // use crate::idm::delayed::{PasswordUpgrade, DelayedAction};
 
+    use crate::idm::AuthState;
+    use kanidm_proto::v1::AuthAllowed;
     use kanidm_proto::v1::OperationError;
     use kanidm_proto::v1::SetCredentialResponse;
-    use kanidm_proto::v1::{AuthAllowed, AuthState};
 
     use crate::audit::AuditScope;
     use crate::idm::server::IdmServer;


### PR DESCRIPTION
Fixes #250, replacing cookies with auth-bearer tokens. This is done using fernet with randomised keys each startup. The reason for this is that in the future the size of the auth token may exceed cookie limits, so we must be able to understand and process auth bearer. Additionaly, this lets us store the tokens for say the kanidm cli as reqwest today can't persist a cookie jar. 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
