### PR TITLE
Account valid-from and expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "structopt",
+ "time 0.2.22",
  "zxcvbn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e727cebd055ab2861a854f79def078c4b99ea722d54c6800a0e274389882d4c"
+checksum = "b5bfd63f6fc8fd2925473a147d3f4d252c712291efdde0d7057b25146563402c"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4f9586c9a3151c4b49b19e82ba163dd073614dd057e53c969e1a4db5b52720"
+checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1561,7 +1561,7 @@ dependencies = [
  "structopt",
  "tide",
  "tide-rustls",
- "time 0.1.44",
+ "time 0.2.22",
  "tokio",
  "tokio-openssl",
  "tokio-util",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
 
 [[package]]
 name = "libnss"
@@ -2141,18 +2141,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
+checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
+checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe74897791e156a0cd8cce0db31b9b2198e67877316bf3086c3acd187f719f0"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -2256,9 +2256,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -3056,6 +3056,7 @@ checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
 dependencies = [
  "const_fn",
  "libc",
+ "serde",
  "standback",
  "stdweb",
  "time-macros",

--- a/designs/account_policy.rst
+++ b/designs/account_policy.rst
@@ -1,0 +1,122 @@
+Account Policy and Lockouts
+---------------------------
+
+For accounts we need to be able to define securite constraints and limits to prevent malicious use
+or attacks from succeeding. While these attacks may have similar sources or goals, the defences
+to them may vary.
+
+A list (not comprehensive) of these include:
+
+* Credential Stuffing
+* Phishing (Site Impersonation)
+* Key Logging / Physical Discovery
+* Common Password / Spray
+* Brute Force
+
+Credential Policies
+===================
+
+As the majority of the attacks listed can be prevented with TOTP, and all effectively defeated with
+Webauthn, it's essential that policies can exist that allow an administrator to set requirements
+on accounts to what level of authentication they require to protect resources.
+
+Credential Polcies are inherited from groups, as groups grant rights and claims to other resources.
+Since it is these resources and privileges we wish to protect, logically the credential policy becomes
+part of the group that should be protected.
+
+When multiple credential policies exist that may be conflicting, the "stricter" policy is enforced
+as a group in the set requires it.
+
+The strength of credentials is today sorted as:
+
+* (weakest)
+* Password
+* GeneratedPassword
+* Webauthn (with out verification)
+* TOTP + Password
+* Webauthn + Password
+* WebauthnVerified
+* WebauthnVerified + Password
+* (strongest)
+
+Rate Limiting
+======================
+
+Rate Limiting is the process of delaying authentication responses to slow the number of attempts
+against an account to deter attackers. This is often used to prevent attackers from bruteforcing
+passwords at a high rate.
+
+The best defence again these attacks is MFA. Due to the design of Kanidm, the second factor
+(ie the webauthn token or the otp) is always checked *before* the password, meaning that the
+attacker is unable to attack the password *unless* they also have the corresponding MFA token.
+
+However, not all accounts will have MFA enabled, which means that defences are still required to
+prevent these attacks for password-only accounts. Accounts protected with TOTP must also be rate
+limited according to NIST sp800 63b. Webauthn does *not* require ratelimiting as a single factor
+or multi factor device.
+
+As an account can only have a single proceeding authentication session at a time, this provides
+serialisation and rate limiting per account of the service. However, as Kanidm will in the future
+support multiple, distributed replicas, we must consider an architecture that allows eventually
+consistent behaviour.
+
+NIST SP800 63b recommends that after 100 failed attempts that the account be locked. Due to the
+eventually consistent nature, this poses a challenge, namely that:
+
+* Synchronising this account lock may not be instant, allowing further attempts on parallel servers.
+* That read only servers may exist in the system which can not write to the entries.
+* A malicious party may intentionally send incorrect values to force an account to lock.
+
+To account for this for accounts with TOTP:
+
+* After an 5 incorrect TOTP's within the time window, the account is locked for 60 seconds. This prevents bruteforce of the TOTP.
+
+For accounts with password-only:
+
+* After 5 incorrect attempts the account is rate limited by an increasing time window within the API. This limit delays the response to the auth (regardless of success)
+* After X attempts, the account is soft locked on the affected server only for a time window of Y increasing up to Z.
+* If the attempts continue, the account is hard locked and signalled to an external system that this has occured.
+
+The value of X should be less than 100, so that the NIST guidelines can be met. This is beacuse when there are
+many replicas, each replica maintains it's own locking state, so "eventually" as each replica is attempted to be
+bruteforced, then they will all eventually soft lock the account. In larger environments, we require
+external signalling to coordinate the locking of the account.
+
+In the future, this can also be informed by:
+
+* IP/GEOIP from past login's to determine if the behaviour is expected.
+* HTTP/Browser ID to determine if it's "likely" the person in question.
+
+These can then assist with choosing to lock or allow an auth to proceed in the face of an attack.
+
+FUTURE:
+* Delayed notification about suspect login?
+
+Hard Lock + Expiry/Active Time Limits
+=====================================
+
+It must be possible to expire an account so it no longer operates (IE temporary contractor) or
+accounts that can only operate after a known point in time (Student enrollments and their course
+commencment date).
+
+This expiry must exist at the account level, but also on issued token/api password levels. This allows revocation of
+individual tokens, but also the expiry of the account and all tokens as a whole. This expiry may be
+undone, allowing the credentials to become valid once again.
+
+On the account, this is represented by two date times. AuthAllowFrom and AuthAllowUntil. These
+are stored on the server in unix epoch to account for timezones and geographic distribution.
+
+* Interaction with already issued tokens.
+    * it prevents them from working?
+
+Application Passwords / Issued Oauth Tokens
+===========================================
+
+* Relates to claims
+* Need their own expirys
+* Need ratelimit as above?
+
+
+
+
+

--- a/designs/account_policy.rst
+++ b/designs/account_policy.rst
@@ -92,6 +92,8 @@ These can then assist with choosing to lock or allow an auth to proceed in the f
 FUTURE:
 * Delayed notification about suspect login?
 
+Ratelimit on unix auth
+
 Hard Lock + Expiry/Active Time Limits
 =====================================
 
@@ -108,6 +110,10 @@ are stored on the server in unix epoch to account for timezones and geographic d
 
 * Interaction with already issued tokens.
     * it prevents them from working?
+
+Must prevent creation of radius auth tokens
+
+Must prevent login via unix.
 
 Application Passwords / Issued Oauth Tokens
 ===========================================

--- a/kanidm_book/src/accounts_and_groups.md
+++ b/kanidm_book/src/accounts_and_groups.md
@@ -31,6 +31,8 @@ strength, random, machine only password.
     kanidm account credential generate_password  --name admin idm_admin
     Generated password for idm_admin: tqoReZfz....
 
+## Creating Accounts
+
 We can now use the idm_admin to create initial groups and accounts.
 
     kanidm group create demo_group --name idm_admin
@@ -78,6 +80,42 @@ An example can be easily shown with:
     kanidm group add_members group_1 group_2 --name idm_admin
     kanidm group add_members group2 nest_example --name idm_admin
     kanidm account get nest_example --name anonymous
+
+## Account Validity
+
+Kanidm supports accounts that are only able to be authenticated between specific datetime
+windows. This takes the form of a "valid from" attribute that defines the earliest start
+date where authentication can succeed, and an expiry date where the account will no longer
+allow authentication.
+
+This can be displayed with:
+
+    kanidm account validity show demo_user --name idm_admin
+    valid after: 2020-09-25T21:22:04+10:00
+    expire: 2020-09-25T01:22:04+10:00
+
+These datetimes are stored in the server as UTC, but presented according to your local system time
+to aid correct understanding of when the events will occur.
+
+To set the values, an account with account management permission is required (for example, idm_admin).
+Again, these values will correctly translated from the entered local timezone to UTC.
+
+    # Set the earliest time the account can start authenticating
+    kanidm account validity begin_from demo_user '2020-09-25T11:22:04+00:00' --name idm_admin
+    # Set the expiry or end date of the account
+    kanidm account validity expire_at demo_user '2020-09-25T11:22:04+00:00' --name idm_admin
+
+To unset or remove these values the following can be used:
+
+    kanidm account validity begin_from demo_user any|clear --name idm_admin
+    kanidm account validity expire_at demo_user never|clear --name idm_admin
+
+To "lock" an account, you can set the expire_at value to the past or unix epoch. Even in the situation
+where the "valid from" is *after* the expire_at, the expire_at will be respected.
+
+    kanidm account validity expire_at demo_user 1970-01-01T00:00:00+00:00 --name idm_admin
+
+These validity settings impact all authentication functions of the account (kanidm, ldap, radius).
 
 ## Why Can't I Change admin With idm_admin?
 

--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -287,6 +287,17 @@ impl KanidmAsyncClient {
         Ok(Some((r.youare, r.uat)))
     }
 
+    pub async fn idm_account_set_attr(
+        &self,
+        id: &str,
+        attr: &str,
+        values: &[&str],
+    ) -> Result<bool, ClientError> {
+        let m: Vec<_> = values.iter().map(|v| (*v).to_string()).collect();
+        self.perform_put_request(format!("/v1/account/{}/_attr/{}", id, attr).as_str(), m)
+            .await
+    }
+
     pub async fn idm_account_unix_token_get(&self, id: &str) -> Result<UnixUserToken, ClientError> {
         // Format doesn't work in async
         // format!("/v1/account/{}/_unix/_token", id).as_str()

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -767,6 +767,28 @@ impl KanidmClient {
         )
     }
 
+    pub fn idm_account_get_attr(
+        &self,
+        id: &str,
+        attr: &str,
+    ) -> Result<Option<Vec<String>>, ClientError> {
+        self.perform_get_request(format!("/v1/account/{}/_attr/{}", id, attr).as_str())
+    }
+
+    pub fn idm_account_purge_attr(&self, id: &str, attr: &str) -> Result<bool, ClientError> {
+        self.perform_delete_request(format!("/v1/account/{}/_attr/{}", id, attr).as_str())
+    }
+
+    pub fn idm_account_set_attr(
+        &self,
+        id: &str,
+        attr: &str,
+        values: &[&str],
+    ) -> Result<bool, ClientError> {
+        let m: Vec<_> = values.iter().map(|v| (*v).to_string()).collect();
+        self.perform_put_request(format!("/v1/account/{}/_attr/{}", id, attr).as_str(), m)
+    }
+
     pub fn idm_account_primary_credential_import_password(
         &self,
         id: &str,

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -342,7 +342,7 @@ impl KanidmClient {
     }
 
     pub fn get_token(&self) -> Option<&str> {
-        self.bearer_token.as_ref().map(|s| s.as_str())
+        self.bearer_token.as_deref()
     }
 
     pub fn logout(&mut self) -> Result<(), reqwest::Error> {

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -772,6 +772,8 @@ fn test_server_rest_totp_auth_lifecycle() {
     });
 }
 
+// Test setting account expiry
+
 // Test the self version of the radius path.
 
 // Test hitting all auth-required endpoints and assert they give unauthorized.

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -251,6 +251,9 @@ pub struct UnixUserToken {
     pub shell: Option<String>,
     pub groups: Vec<UnixGroupToken>,
     pub sshkeys: Vec<String>,
+    // The default value of bool is false.
+    #[serde(default)]
+    pub valid: bool,
 }
 
 impl fmt::Display for UnixUserToken {

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -37,5 +37,6 @@ serde = "1.0"
 serde_json = "1.0"
 shellexpand = "2.0"
 rayon = "1.2"
+time = "0.2"
 
 zxcvbn = "2.0"

--- a/kanidm_tools/src/cli/common.rs
+++ b/kanidm_tools/src/cli/common.rs
@@ -58,14 +58,13 @@ impl CommonOpt {
             None => client_builder,
         };
 
-        let client = match client_builder.build() {
+        match client_builder.build() {
             Ok(c) => c,
             Err(e) => {
                 error!("Failed to build client instance -- {:?}", e);
                 std::process::exit(1);
             }
-        };
-        client
+        }
     }
 
     pub fn to_client(&self) -> KanidmClient {
@@ -79,7 +78,7 @@ impl CommonOpt {
             }
         };
 
-        if tokens.len() == 0 {
+        if tokens.is_empty() {
             error!(
                 "No valid authentication tokens found. Please login with the 'login' subcommand."
             );
@@ -100,6 +99,7 @@ impl CommonOpt {
             }
             None => {
                 if tokens.len() == 1 {
+                    #[allow(clippy::expect_used)]
                     let (f_uname, f_token) = tokens.iter().next().expect("Memory Corruption");
                     // else pick the first token
                     info!("Authenticated as {}", f_uname);

--- a/kanidm_tools/src/cli/login.rs
+++ b/kanidm_tools/src/cli/login.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use structopt::StructOpt;
 
-static TOKEN_PATH: &'static str = "~/.cache/kanidm_tokens";
+static TOKEN_PATH: &str = "~/.cache/kanidm_tokens";
 
 pub fn read_tokens() -> Result<BTreeMap<String, String>, ()> {
     let token_path: String = shellexpand::tilde(TOKEN_PATH).into_owned();
@@ -50,7 +50,7 @@ impl LoginOpt {
     pub fn exec(&self) {
         let mut client = self.copt.to_unauth_client();
 
-        let (r, username) = match self.copt.username.as_ref().map(|s| s.as_str()) {
+        let (r, username) = match self.copt.username.as_deref() {
             None | Some("anonymous") => (client.auth_anonymous(), "anonymous".to_string()),
             Some(username) => {
                 let password = match rpassword::prompt_password_stderr("Enter password: ") {

--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -718,6 +718,7 @@ mod tests {
             shell: None,
             groups: Vec::new(),
             sshkeys: vec!["key-a".to_string()],
+            valid: true,
         };
 
         let id_name = Id::Name("testuser".to_string());
@@ -890,6 +891,7 @@ mod tests {
             shell: None,
             groups: vec![gt1.clone(), gt2],
             sshkeys: vec!["key-a".to_string()],
+            valid: true,
         };
 
         // First, add the groups.
@@ -944,6 +946,7 @@ mod tests {
             shell: None,
             groups: Vec::new(),
             sshkeys: vec!["key-a".to_string()],
+            valid: true,
         };
 
         // Test that with no account, is false
@@ -1046,6 +1049,7 @@ mod tests {
             shell: None,
             groups: Vec::new(),
             sshkeys: vec!["key-a".to_string()],
+            valid: true,
         };
 
         let ut2 = UnixUserToken {
@@ -1057,6 +1061,7 @@ mod tests {
             shell: None,
             groups: Vec::new(),
             sshkeys: vec!["key-a".to_string()],
+            valid: true,
         };
 
         let id_name = Id::Name("testuser".to_string());

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -66,7 +66,7 @@ r2d2 = "0.8"
 r2d2_sqlite = "0.16"
 
 structopt = { version = "0.3", default-features = false }
-time = "0.1"
+time = { version = "0.2", features = ["serde", "std"] }
 
 hashbrown = "0.8"
 concread = "^0.2.3"

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -561,9 +561,16 @@ impl QueryServerReadV1 {
                     }
                 };
 
+                let ct = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .map_err(|e| {
+                        ladmin_error!(audit, "Clock Error -> {:?}", e);
+                        OperationError::InvalidState
+                    })?;
+
                 ltrace!(audit, "Begin event {:?}", rate);
 
-                idm_read.get_unixusertoken(&mut audit, &rate)
+                idm_read.get_unixusertoken(&mut audit, &rate, ct)
             }
         );
         self.log.send(audit).map_err(|_| {

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -500,9 +500,16 @@ impl QueryServerReadV1 {
                     }
                 };
 
+                let ct = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .map_err(|e| {
+                        ladmin_error!(audit, "Clock Error -> {:?}", e);
+                        OperationError::InvalidState
+                    })?;
+
                 ltrace!(audit, "Begin event {:?}", rate);
 
-                idm_read.get_radiusauthtoken(&mut audit, &rate)
+                idm_read.get_radiusauthtoken(&mut audit, &rate, ct)
             }
         );
         self.log.send(audit).map_err(|_| {

--- a/kanidmd/src/lib/be/dbvalue.rs
+++ b/kanidmd/src/lib/be/dbvalue.rs
@@ -67,6 +67,7 @@ pub enum DbValueV1 {
     UI(u32),
     CI(DbCidV1),
     NU(String),
+    DT(String),
 }
 
 #[cfg(test)]

--- a/kanidmd/src/lib/constants/acp.rs
+++ b/kanidmd/src/lib/constants/acp.rs
@@ -97,7 +97,9 @@ pub const JSON_IDM_SELF_ACP_READ_V1: &str = r#"{
             "radius_secret",
             "gidnumber",
             "loginshell",
-            "uuid"
+            "uuid",
+            "account_expire",
+            "account_valid_from"
         ]
     }
 }"#;
@@ -331,7 +333,7 @@ pub const JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &str = r#"{
             "{\"and\": [{\"eq\": [\"class\",\"account\"]}, {\"andnot\": {\"or\": [{\"eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"eq\": [\"class\", \"tombstone\"]}, {\"eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": [
-            "class", "name", "spn", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof", "mail", "gidnumber"
+            "class", "name", "spn", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof", "mail", "gidnumber", "account_expire", "account_valid_from"
         ]
     }
 }"#;
@@ -353,10 +355,10 @@ pub const JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &str = r#"{
             "{\"and\": [{\"eq\": [\"class\",\"account\"]}, {\"andnot\": {\"or\": [{\"eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"eq\": [\"class\", \"tombstone\"]}, {\"eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_modify_removedattr": [
-            "name", "displayname", "ssh_publickey", "primary_credential", "mail"
+            "name", "displayname", "ssh_publickey", "primary_credential", "mail", "account_expire", "account_valid_from"
         ],
         "acp_modify_presentattr": [
-            "name", "displayname", "ssh_publickey", "primary_credential", "mail"
+            "name", "displayname", "ssh_publickey", "primary_credential", "mail", "account_expire", "account_valid_from"
         ]
     }
 }"#;
@@ -385,7 +387,9 @@ pub const JSON_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
             "description",
             "primary_credential",
             "ssh_publickey",
-            "mail"
+            "mail",
+            "account_expire",
+            "account_valid_from"
         ],
         "acp_create_class": [
             "object", "account"
@@ -434,7 +438,7 @@ pub const JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &str = r#"{
             "{\"and\": [{\"eq\": [\"class\",\"account\"]}, {\"eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"andnot\": {\"or\": [{\"eq\": [\"class\", \"tombstone\"]}, {\"eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": [
-            "class", "name", "spn", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof"
+            "class", "name", "spn", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof", "account_expire", "account_valid_from"
         ]
     }
 }"#;
@@ -456,10 +460,10 @@ pub const JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &str = r#"{
             "{\"and\": [{\"eq\": [\"class\",\"account\"]}, {\"eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"andnot\": {\"or\": [{\"eq\": [\"class\", \"tombstone\"]}, {\"eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_modify_removedattr": [
-            "name", "displayname", "ssh_publickey", "primary_credential"
+            "name", "displayname", "ssh_publickey", "primary_credential", "account_expire", "account_valid_from"
         ],
         "acp_modify_presentattr": [
-            "name", "displayname", "ssh_publickey", "primary_credential"
+            "name", "displayname", "ssh_publickey", "primary_credential", "account_expire", "account_valid_from"
         ]
     }
 }"#;
@@ -758,7 +762,9 @@ pub const JSON_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
             "displayname",
             "description",
             "primary_credential",
-            "ssh_publickey"
+            "ssh_publickey",
+            "account_expire",
+            "account_valid_from"
         ],
         "acp_create_class": [
             "object", "account"

--- a/kanidmd/src/lib/constants/mod.rs
+++ b/kanidmd/src/lib/constants/mod.rs
@@ -13,7 +13,7 @@ pub use crate::constants::system_config::*;
 pub use crate::constants::uuids::*;
 
 // Increment this as we add new schema types and values!!!
-pub const SYSTEM_INDEX_VERSION: i64 = 11;
+pub const SYSTEM_INDEX_VERSION: i64 = 12;
 // On test builds, define to 60 seconds
 #[cfg(test)]
 pub const PURGE_FREQUENCY: u64 = 60;

--- a/kanidmd/src/lib/constants/schema.rs
+++ b/kanidmd/src/lib/constants/schema.rs
@@ -436,6 +436,7 @@ pub const JSON_SCHEMA_ATTR_ACCOUNT_EXPIRE: &str = r#"{
       "description": [
         "The datetime after which this accounnt no longer may authenticate."
       ],
+      "index": [],
       "unique": [
         "false"
       ],
@@ -464,6 +465,7 @@ pub const JSON_SCHEMA_ATTR_ACCOUNT_VALID_FROM: &str = r#"{
       "description": [
         "The datetime after which this account may commence authenticating."
       ],
+      "index": [],
       "unique": [
         "false"
       ],

--- a/kanidmd/src/lib/constants/schema.rs
+++ b/kanidmd/src/lib/constants/schema.rs
@@ -484,7 +484,6 @@ pub const JSON_SCHEMA_ATTR_ACCOUNT_VALID_FROM: &str = r#"{
     }
 }"#;
 
-
 // === classes ===
 
 pub const JSON_SCHEMA_CLASS_PERSON: &str = r#"

--- a/kanidmd/src/lib/constants/schema.rs
+++ b/kanidmd/src/lib/constants/schema.rs
@@ -426,6 +426,65 @@ pub const JSON_SCHEMA_ATTR_NSUNIQUEID: &str = r#"{
     }
 }"#;
 
+pub const JSON_SCHEMA_ATTR_ACCOUNT_EXPIRE: &str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The datetime after which this accounnt no longer may authenticate."
+      ],
+      "unique": [
+        "false"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "account_expire"
+      ],
+      "syntax": [
+        "DATETIME"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000072"
+      ]
+    }
+}"#;
+
+pub const JSON_SCHEMA_ATTR_ACCOUNT_VALID_FROM: &str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The datetime after which this account may commence authenticating."
+      ],
+      "unique": [
+        "false"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "account_valid_from"
+      ],
+      "syntax": [
+        "DATETIME"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000073"
+      ]
+    }
+}"#;
+
+
+// === classes ===
+
 pub const JSON_SCHEMA_CLASS_PERSON: &str = r#"
   {
     "attrs": {
@@ -499,7 +558,9 @@ pub const JSON_SCHEMA_CLASS_ACCOUNT: &str = r#"
       "systemmay": [
         "primary_credential",
         "ssh_publickey",
-        "radius_secret"
+        "radius_secret",
+        "account_expire",
+        "account_valid_from"
       ],
       "systemmust": [
         "displayname",

--- a/kanidmd/src/lib/constants/uuids.rs
+++ b/kanidmd/src/lib/constants/uuids.rs
@@ -116,6 +116,9 @@ pub const STR_UUID_SCHEMA_ATTR_NICE: &str = "00000000-0000-0000-0000-ffff0000006
 pub const STR_UUID_SCHEMA_ATTR_ENTRYUUID: &str = "00000000-0000-0000-0000-ffff00000070";
 pub const STR_UUID_SCHEMA_ATTR_OBJECTCLASS: &str = "00000000-0000-0000-0000-ffff00000071";
 
+pub const _STR_UUID_SCHEMA_ATTR_ACCOUNT_EXPIRE: &str = "00000000-0000-0000-0000-ffff00000072";
+pub const _STR_UUID_SCHEMA_ATTR_ACCOUNT_VALID_FROM: &str = "00000000-0000-0000-0000-ffff00000073";
+
 // System and domain infos
 // I'd like to strongly criticise william of the past for fucking up these allocations.
 pub const STR_UUID_SYSTEM_INFO: &str = "00000000-0000-0000-0000-ffffff000001";

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -51,6 +51,7 @@ use std::collections::BTreeSet;
 // use std::collections::BTreeMap as Map;
 use hashbrown::HashMap as Map;
 use hashbrown::HashSet;
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 // use std::convert::TryFrom;
@@ -1581,6 +1582,11 @@ impl<VALID, STATE> Entry<VALID, STATE> {
     pub fn get_ava_single_radiuscred(&self, attr: &str) -> Option<&str> {
         self.get_ava_single(attr)
             .and_then(|a| a.get_radius_secret())
+    }
+
+    #[inline(always)]
+    pub fn get_ava_single_datetime(&self, attr: &str) -> Option<OffsetDateTime> {
+        self.get_ava_single(attr).and_then(|a| a.to_datetime())
     }
 
     #[inline(always)]

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -160,11 +160,6 @@ impl Account {
     pub fn is_within_valid_time(&self, ct: Duration) -> bool {
         let cot = OffsetDateTime::unix_epoch() + ct;
 
-        eprintln!("🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟");
-        eprintln!("{:?}", self.valid_from);
-        eprintln!("{:?}", cot);
-        eprintln!("{:?}", self.expire);
-
         let vmin = if let Some(vft) = &self.valid_from {
             // If current time greater than strat time window
             vft < &cot
@@ -179,7 +174,6 @@ impl Account {
             // If not present, we are not expired
             true
         };
-        eprintln!("{:?} && {:?}", vmin, vmax);
         // Mix the results
         vmin && vmax
     }

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -14,6 +14,8 @@ use crate::modify::{ModifyInvalid, ModifyList};
 use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
 use crate::value::{PartialValue, Value};
 
+use std::time::Duration;
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 lazy_static! {
@@ -58,6 +60,10 @@ macro_rules! try_from_entry {
                 "Missing attribute: spn".to_string(),
             ))?;
 
+        let valid_from = $value.get_ava_single_datetime("account_valid_from");
+
+        let expire = $value.get_ava_single_datetime("account_expire");
+
         // Resolved by the caller
         let groups = $groups;
 
@@ -69,6 +75,8 @@ macro_rules! try_from_entry {
             displayname,
             groups,
             primary,
+            valid_from,
+            expire,
             spn,
         })
     }};
@@ -87,6 +95,8 @@ pub(crate) struct Account {
     pub uuid: Uuid,
     pub groups: Vec<Group>,
     pub primary: Option<Credential>,
+    pub valid_from: Option<OffsetDateTime>,
+    pub expire: Option<OffsetDateTime>,
     // primary: Credential
     // app_creds: Vec<Credential>
     // account expiry? (as opposed to cred expiry)
@@ -145,6 +155,33 @@ impl Account {
             lim_pmax: 256,
             lim_fmax: 32,
         })
+    }
+
+    pub fn is_within_valid_time(&self, ct: Duration) -> bool {
+        let cot = OffsetDateTime::unix_epoch() + ct;
+
+        eprintln!("🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟🥟");
+        eprintln!("{:?}", self.valid_from);
+        eprintln!("{:?}", cot);
+        eprintln!("{:?}", self.expire);
+
+        let vmin = if let Some(vft) = &self.valid_from {
+            // If current time greater than strat time window
+            vft < &cot
+        } else {
+            // We have no time, not expired.
+            true
+        };
+        let vmax = if let Some(ext) = &self.expire {
+            // If exp greater than ct then expired.
+            &cot < ext
+        } else {
+            // If not present, we are not expired
+            true
+        };
+        eprintln!("{:?} && {:?}", vmin, vmax);
+        // Mix the results
+        vmin && vmax
     }
 
     pub fn is_anonymous(&self) -> bool {

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -1835,4 +1835,38 @@ mod tests {
             idms_delayed.is_empty_or_panic();
         })
     }
+
+    #[test]
+    fn test_idm_account_valid_from_expire() {
+        run_idm_test!(|_qs: &QueryServer,
+                       idms: &IdmServer,
+                       idms_delayed: &mut IdmServerDelayed,
+                       au: &mut AuditScope| {
+            // Any account taht is not yet valrid / expired can't auth.
+            unimplemented!();
+        })
+    }
+
+    #[test]
+    fn test_idm_unix_valid_from_expire() {
+        run_idm_test!(|_qs: &QueryServer,
+                       idms: &IdmServer,
+                       idms_delayed: &mut IdmServerDelayed,
+                       au: &mut AuditScope| {
+            // Any account that is expired can't unix auth.
+            unimplemented!();
+        })
+    }
+
+    #[test]
+    fn test_idm_radius_valid_from_expire() {
+        run_idm_test!(|_qs: &QueryServer,
+                       idms: &IdmServer,
+                       idms_delayed: &mut IdmServerDelayed,
+                       au: &mut AuditScope| {
+            // Any account not valid/expiry should not return
+            // a radius packet.
+            unimplemented!();
+        })
+    }
 }

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -200,6 +200,7 @@ impl SchemaAttribute {
             SyntaxType::UINT32 => v.is_uint32(),
             SyntaxType::CID => v.is_cid(),
             SyntaxType::NSUNIQUEID => v.is_nsuniqueid(),
+            SyntaxType::DATETIME => v.is_datetime(),
         };
         if r {
             Ok(())
@@ -369,6 +370,15 @@ impl SchemaAttribute {
             SyntaxType::NSUNIQUEID => ava.iter().fold(Ok(()), |acc, v| {
                 acc.and_then(|_| {
                     if v.is_nsuniqueid() {
+                        Ok(())
+                    } else {
+                        Err(SchemaError::InvalidAttributeSyntax(a.to_string()))
+                    }
+                })
+            }),
+            SyntaxType::DATETIME => ava.iter().fold(Ok(()), |acc, v| {
+                acc.and_then(|_| {
+                    if v.is_datetime() {
                         Ok(())
                     } else {
                         Err(SchemaError::InvalidAttributeSyntax(a.to_string()))

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -490,8 +490,7 @@ pub trait QueryServerTransaction {
                         .ok_or_else(|| OperationError::InvalidAttribute("Invalid uint32 syntax".to_string())),
                     SyntaxType::CID => Err(OperationError::InvalidAttribute("CIDs are generated and not able to be set.".to_string())),
                     SyntaxType::NSUNIQUEID => Ok(Value::new_nsuniqueid_s(value)),
-                    SyntaxType::DATETIME => 
-                    Value::new_datetime_s(value)
+                    SyntaxType::DATETIME => Value::new_datetime_s(value)
                         .ok_or_else(|| OperationError::InvalidAttribute("Invalid DateTime (rfc3339) syntax".to_string())),
                 }
             }
@@ -572,17 +571,17 @@ pub trait QueryServerTransaction {
                         .ok_or_else(|| {
                             OperationError::InvalidAttribute("Invalid spn syntax".to_string())
                         }),
-                    SyntaxType::UINT32 => 
-                    PartialValue::new_uint32_str(value).ok_or_else(|| {
+                    SyntaxType::UINT32 => PartialValue::new_uint32_str(value).ok_or_else(|| {
                         OperationError::InvalidAttribute("Invalid uint32 syntax".to_string())
                     }),
                     SyntaxType::CID => PartialValue::new_cid_s(value).ok_or_else(|| {
                         OperationError::InvalidAttribute("Invalid cid syntax".to_string())
                     }),
                     SyntaxType::NSUNIQUEID => Ok(PartialValue::new_nsuniqueid_s(value)),
-                    SyntaxType::DATETIME => 
-                    PartialValue::new_datetime_s(value).ok_or_else(|| {
-                        OperationError::InvalidAttribute("Invalid DateTime (rfc3339) syntax".to_string())
+                    SyntaxType::DATETIME => PartialValue::new_datetime_s(value).ok_or_else(|| {
+                        OperationError::InvalidAttribute(
+                            "Invalid DateTime (rfc3339) syntax".to_string(),
+                        )
                     }),
                 }
             }

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -490,6 +490,9 @@ pub trait QueryServerTransaction {
                         .ok_or_else(|| OperationError::InvalidAttribute("Invalid uint32 syntax".to_string())),
                     SyntaxType::CID => Err(OperationError::InvalidAttribute("CIDs are generated and not able to be set.".to_string())),
                     SyntaxType::NSUNIQUEID => Ok(Value::new_nsuniqueid_s(value)),
+                    SyntaxType::DATETIME => 
+                    Value::new_datetime_s(value)
+                        .ok_or_else(|| OperationError::InvalidAttribute("Invalid DateTime (rfc3339) syntax".to_string())),
                 }
             }
             None => {
@@ -569,13 +572,18 @@ pub trait QueryServerTransaction {
                         .ok_or_else(|| {
                             OperationError::InvalidAttribute("Invalid spn syntax".to_string())
                         }),
-                    SyntaxType::UINT32 => PartialValue::new_uint32_str(value).ok_or_else(|| {
+                    SyntaxType::UINT32 => 
+                    PartialValue::new_uint32_str(value).ok_or_else(|| {
                         OperationError::InvalidAttribute("Invalid uint32 syntax".to_string())
                     }),
                     SyntaxType::CID => PartialValue::new_cid_s(value).ok_or_else(|| {
                         OperationError::InvalidAttribute("Invalid cid syntax".to_string())
                     }),
                     SyntaxType::NSUNIQUEID => Ok(PartialValue::new_nsuniqueid_s(value)),
+                    SyntaxType::DATETIME => 
+                    PartialValue::new_datetime_s(value).ok_or_else(|| {
+                        OperationError::InvalidAttribute("Invalid DateTime (rfc3339) syntax".to_string())
+                    }),
                 }
             }
             None => {
@@ -1964,6 +1972,8 @@ impl<'a> QueryServerWriteTransaction<'a> {
             JSON_SCHEMA_ATTR_BADLIST_PASSWORD,
             JSON_SCHEMA_ATTR_LOGINSHELL,
             JSON_SCHEMA_ATTR_UNIX_PASSWORD,
+            JSON_SCHEMA_ATTR_ACCOUNT_EXPIRE,
+            JSON_SCHEMA_ATTR_ACCOUNT_VALID_FROM,
             JSON_SCHEMA_CLASS_PERSON,
             JSON_SCHEMA_CLASS_GROUP,
             JSON_SCHEMA_CLASS_ACCOUNT,

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -1671,7 +1671,9 @@ mod tests {
 
         // Manually craft
         let inv1 = Value {
-            pv: PartialValue::DateTime(OffsetDateTime::now_local()),
+            pv: PartialValue::DateTime(
+                OffsetDateTime::now_utc().to_offset(time::UtcOffset::east_hours(10)),
+            ),
             data: None,
         };
         assert!(!inv1.validate());

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -8,6 +8,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
+use time::OffsetDateTime;
 
 use sshkeys::PublicKey as SshPublicKey;
 use std::cmp::Ordering;
@@ -124,6 +125,7 @@ pub enum SyntaxType {
     UINT32,
     CID,
     NSUNIQUEID,
+    DATETIME,
 }
 
 impl TryFrom<&str> for SyntaxType {
@@ -148,6 +150,7 @@ impl TryFrom<&str> for SyntaxType {
             "UINT32" => Ok(SyntaxType::UINT32),
             "CID" => Ok(SyntaxType::CID),
             "NSUNIQUEID" => Ok(SyntaxType::NSUNIQUEID),
+            "DATETIME" => Ok(SyntaxType::DATETIME),
             _ => Err(()),
         }
     }
@@ -174,6 +177,7 @@ impl TryFrom<usize> for SyntaxType {
             13 => Ok(SyntaxType::CID),
             14 => Ok(SyntaxType::UTF8STRING_INAME),
             15 => Ok(SyntaxType::NSUNIQUEID),
+            16 => Ok(SyntaxType::DATETIME),
             _ => Err(()),
         }
     }
@@ -198,6 +202,7 @@ impl SyntaxType {
             SyntaxType::CID => 13,
             SyntaxType::UTF8STRING_INAME => 14,
             SyntaxType::NSUNIQUEID => 15,
+            SyntaxType::DATETIME => 16,
         }
     }
 }
@@ -224,6 +229,7 @@ impl fmt::Display for SyntaxType {
                 SyntaxType::UINT32 => "UINT32",
                 SyntaxType::CID => "CID",
                 SyntaxType::NSUNIQUEID => "NSUNIQUEID",
+                SyntaxType::DATETIME => "DATETIME",
             }
         )
     }
@@ -267,6 +273,7 @@ pub enum PartialValue {
     Uint32(u32),
     Cid(Cid),
     Nsuniqueid(String),
+    DateTime(OffsetDateTime),
 }
 
 impl PartialValue {
@@ -529,6 +536,20 @@ impl PartialValue {
         }
     }
 
+    pub fn new_datetime_s(s: &str) -> Option<Self> {
+        OffsetDateTime::parse(s, time::Format::Rfc3339)
+            .ok()
+            .map(|odt| odt.to_offset(time::UtcOffset::UTC))
+            .map(PartialValue::DateTime)
+    }
+
+    pub fn is_datetime(&self) -> bool {
+        match self {
+            PartialValue::DateTime(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn to_str(&self) -> Option<&str> {
         match self {
             PartialValue::Utf8(s) => Some(s.as_str()),
@@ -578,6 +599,10 @@ impl PartialValue {
             PartialValue::Uint32(u) => u.to_string(),
             // This will never work, we don't allow equality searching on Cid's
             PartialValue::Cid(_) => "_".to_string(),
+            PartialValue::DateTime(odt) => {
+                debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                odt.format(time::Format::Rfc3339)
+            }
         }
     }
 
@@ -1041,6 +1066,19 @@ impl Value {
         self.pv.is_nsuniqueid()
     }
 
+    pub fn new_datetime_s(s: &str) -> Option<Self> {
+        PartialValue::new_datetime_s(s).map(|pv| {
+            Value {
+                pv,
+                data: None,
+            }
+        })
+    }
+
+    pub fn is_datetime(&self) -> bool {
+        self.pv.is_datetime()
+    }
+
     pub fn contains(&self, s: &PartialValue) -> bool {
         self.pv.contains(s)
     }
@@ -1133,6 +1171,16 @@ impl Value {
                 pv: PartialValue::Nsuniqueid(s),
                 data: None,
             }),
+            DbValueV1::DT(s) => 
+                PartialValue::new_datetime_s(&s)
+                    .ok_or(())
+                    .map(|pv|
+                        Value {
+                            pv,
+                            data: None,
+                        }
+                    ),
+
         }
     }
 
@@ -1200,6 +1248,12 @@ impl Value {
                 t: c.ts,
             }),
             PartialValue::Nsuniqueid(s) => DbValueV1::NU(s.clone()),
+            PartialValue::DateTime(odt) => {
+                debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                DbValueV1::DT(
+                    odt.format(time::Format::Rfc3339)
+                )
+            }
         }
     }
 
@@ -1328,6 +1382,10 @@ impl Value {
             PartialValue::Spn(n, r) => format!("{}@{}", n, r),
             PartialValue::Uint32(u) => u.to_string(),
             PartialValue::Cid(c) => format!("{:?}_{}_{}", c.ts, c.d_uuid, c.s_uuid),
+            PartialValue::DateTime(odt) => {
+                debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                odt.format(time::Format::Rfc3339)
+            }
         }
     }
 
@@ -1368,6 +1426,8 @@ impl Value {
                 None => false,
             },
             PartialValue::Nsuniqueid(s) => NSUNIQUEID_RE.is_match(s),
+            PartialValue::DateTime(odt) =>
+                odt.offset() == time::UtcOffset::UTC,
             _ => true,
         }
     }
@@ -1396,6 +1456,10 @@ impl Value {
             PartialValue::Spn(n, r) => vec![format!("{}@{}", n, r)],
             PartialValue::Uint32(u) => vec![u.to_string()],
             PartialValue::Cid(_) => vec![],
+            PartialValue::DateTime(odt) => {
+                debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                vec![odt.format(time::Format::Rfc3339)]
+            }
         }
     }
 }
@@ -1584,6 +1648,32 @@ mod tests {
         assert!(!inv2.validate());
         assert!(val1.validate());
         assert!(val2.validate());
+    }
+
+    #[test]
+    fn test_value_datetime() {
+        // Datetimes must always convert to UTC, and must always be rfc3339
+        let val1 = Value::new_datetime_s("2020-09-25T11:22:02+10:00").expect("Must be valid");
+        assert!(val1.validate());
+        let val2 = Value::new_datetime_s("2020-09-25T01:22:02+00:00").expect("Must be valid");
+        assert!(val2.validate());
+        assert!(Value::new_datetime_s("2020-09-25T01:22:02").is_none());
+        assert!(Value::new_datetime_s("2020-09-25").is_none());
+        assert!(Value::new_datetime_s("2020-09-25T01:22:02+10").is_none());
+        assert!(Value::new_datetime_s("2020-09-25 01:22:02+00:00").is_none());
+
+        // Manually craft
+        let inv1 = Value {
+            pv: PartialValue::DateTime(OffsetDateTime::now_local()),
+            data: None
+        };
+        assert!(!inv1.validate());
+
+        let val3 = Value {
+            pv: PartialValue::DateTime(OffsetDateTime::now_utc()),
+            data: None
+        };
+        assert!(val3.validate());
     }
 
     /*


### PR DESCRIPTION
Fixes #59 account policy and lockout. This is achived with a valid_from and expire attribute that are timestamps. Cli tools are added to manage these.

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ x ] design document included (if relevant)
