### PR TITLE
Account softlocking and rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,27 +62,27 @@ checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "ahash"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adac150c2dd5a9c864d054e07bda5e6bc010cd10036ea5f17e82a2f5867f735"
+checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
 dependencies = [
  "const-random",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
 name = "arc-swap"
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
+checksum = "0659b83a146398616883aa5199cdd1b055ec088a83c9a338eab3534f33f0622e"
 dependencies = [
  "async-executor",
  "async-io",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "async-h1"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2b5cfe1804f48bb8dfb1b2391e6e9a3fbf89e07514dce3bddb03eb4d529db"
+checksum = "be805a675002e0918f7f85d72add747fcb69132d86b731bcf1f0626a2661241c"
 dependencies = [
  "async-std",
  "byte-pool",
@@ -178,13 +178,14 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.6"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bfd63f6fc8fd2925473a147d3f4d252c712291efdde0d7057b25146563402c"
+checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "libc",
  "log",
  "nb-connect",
  "once_cell",
@@ -192,6 +193,7 @@ dependencies = [
  "polling",
  "vec-arena",
  "waker-fn",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -434,16 +436,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
 dependencies = [
  "async-channel",
+ "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
  "once_cell",
- "waker-fn",
 ]
 
 [[package]]
@@ -515,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cfg-if"
@@ -561,11 +563,11 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc07496fe88312de3fd49d2bbb5cbc0c8b7e1c82ed56fc94549997f0b45e71"
+checksum = "d2242b1bac936b6a156d2056e3d98d2424d044dbf7bbdaa856c4e6d629cc5aa5"
 dependencies = [
- "ahash 0.4.5",
+ "ahash 0.4.6",
  "crossbeam",
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -586,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",
@@ -596,11 +598,11 @@ dependencies = [
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.0",
  "proc-macro-hack",
 ]
 
@@ -1001,9 +1003,12 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.3.5"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "femme"
@@ -1028,7 +1033,7 @@ source = "git+https://github.com/mozilla-services/fernet-rs.git#401fde478c63e868
 dependencies = [
  "base64",
  "byteorder",
- "getrandom",
+ "getrandom 0.1.15",
  "openssl",
  "zeroize",
 ]
@@ -1082,9 +1087,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1097,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1107,15 +1112,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1124,15 +1129,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
 
 [[package]]
 name = "futures-lite"
-version = "1.8.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db18c5f58083b54b0c416638ea73066722c2815c1e54dd8ba85ee3def593c3a"
+checksum = "381a7ad57b1bad34693f63f6f377e1abded7a9c85c9d3eb6771e11c60aaadab9"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1145,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1157,24 +1162,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1214,6 +1219,17 @@ name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1294,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -1344,13 +1360,15 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e703a631784b7881751ebff731cd645eb4c7f9b6288c19178ba9e1c4788d39"
+checksum = "3bc9a434e0182abff944d7d44190f02d141f269a3f31c45ac5368dc548bb934b"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-std",
  "cookie",
+ "futures-lite",
  "infer",
  "pin-project-lite",
  "rand",
@@ -1699,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libnss"
@@ -1884,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2052,9 +2070,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.11.0+1.1.1h"
+version = "111.12.0+1.1.1h"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
+checksum = "858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61"
 dependencies = [
  "cc",
 ]
@@ -2142,18 +2160,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2174,9 +2192,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
@@ -2192,14 +2210,14 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
+checksum = "ab773feb154f12c49ffcfd66ab8bdcf9a1843f950db48b0d8be9d4393783b058"
 dependencies = [
  "cfg-if",
  "libc",
  "log",
- "wepoll-sys-stjepang",
+ "wepoll-sys",
  "winapi 0.3.9",
 ]
 
@@ -2319,7 +2337,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -2342,7 +2360,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -2391,16 +2409,16 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2419,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 
 [[package]]
 name = "remove_dir_all"
@@ -2642,9 +2660,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -2661,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2672,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2828,9 +2846,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a71ea1ea5f8747d1af1979bfb7e65c3a025a70609f04ceb78425bc5adad8e6"
+checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
 dependencies = [
  "version_check",
 ]
@@ -2892,9 +2910,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2903,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2922,9 +2940,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "ea9c5432ff16d6152371f808fb5a871cd67368171b09bb21b43df8e4a47a3556"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2977,18 +2995,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3175,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]
@@ -3469,10 +3487,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys-stjepang"
-version = "1.0.8"
+name = "wepoll-sys"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
+checksum = "142bc2cba3fe88be1a8fcb55c727fa4cd5b0cf2d7438722792e22f26f04bc1e0"
 dependencies = [
  "cc",
 ]

--- a/kanidm_book/src/installing_the_server.md
+++ b/kanidm_book/src/installing_the_server.md
@@ -56,3 +56,8 @@ Now we can run the server so that it can accept connections. This defaults to us
 
     docker run -p 8443:8443 -v kanidmd:/data kanidm/server:latest
 
+# Development Version
+
+If you are interested to run our latest code from development, you can do this by changing the
+docker tag to `kanidm/server:devel`.
+

--- a/kanidm_unix_int/tests/cache_layer_test.rs
+++ b/kanidm_unix_int/tests/cache_layer_test.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
+use std::time::Duration;
 
 use kanidm::audit::LogLevel;
 use kanidm::config::{Configuration, IntegrationTestConfig};
@@ -403,6 +404,9 @@ fn test_cache_account_password() {
                 .expect("failed to authenticate");
             assert!(a1 == Some(false));
 
+            // We have to wait due to softlocking.
+            task::sleep(Duration::from_secs(1)).await;
+
             // Test authentication success.
             let a2 = cachelayer
                 .pam_account_authenticate("testaccount1", TESTACCOUNT1_PASSWORD_A)
@@ -427,6 +431,9 @@ fn test_cache_account_password() {
                 .expect("failed to authenticate");
             assert!(a3 == Some(false));
 
+            // We have to wait due to softlocking.
+            task::sleep(Duration::from_secs(1)).await;
+
             // test auth (new pw) success
             let a4 = cachelayer
                 .pam_account_authenticate("testaccount1", TESTACCOUNT1_PASSWORD_B)
@@ -443,6 +450,8 @@ fn test_cache_account_password() {
                 .await
                 .expect("failed to authenticate");
             assert!(a5 == Some(true));
+
+            // No softlock during offline.
 
             // Test auth failure.
             let a6 = cachelayer

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -69,7 +69,7 @@ structopt = { version = "0.3", default-features = false }
 time = { version = "0.2", features = ["serde", "std"] }
 
 hashbrown = "0.8"
-concread = "^0.2.3"
+concread = "^0.2.5"
 # concread = { path = "../../concread", features = ["asynch"] }
 # concread = { path = "../../concread" }
 # crossbeam = "0.7"

--- a/kanidmd/src/lib/credential/softlock.rs
+++ b/kanidmd/src/lib/credential/softlock.rs
@@ -1,0 +1,368 @@
+use std::time::Duration;
+
+/// Represents a temporary denial of the credential to authenticate. This is used
+/// to ratelimit and prevent bruteforcing of accounts. At an initial failure the
+/// SoftLock is created and the count set to 1, with a unlock_at set to 1 second
+/// later, and a reset_count_at: at a maximum time window for a cycle.
+///
+/// If the softlock already exists, and the failure count is 0, then this acts as the
+/// creation where the reset_count_at window is then set.
+///
+/// While current_time < unlock_at, all authentication attempts are denied with a
+/// message regarding the account being temporarily unavailable. Once
+/// unlock_at < current_time, authentication will be processed again. If a subsequent
+/// failure occurs, unlock_at is extended based on policy, and failure_count incremented.
+///
+/// If unlock_at < current_time, and authentication succeeds the login is allowed
+/// and no changes to failure_count or unlock_at are made.
+///
+/// If reset_count_at < current_time, then failure_count is reset to 0 before processing.
+///
+/// This allows handling of max_failure_count, so that when that value from policy is
+/// exceeded then unlock_at is set to reset_count_at to softlock until the cycle
+/// is over (see NIST sp800-63b.). For example, reset_count_at will be 24 hours after
+/// the first failed authentication attempt.
+///
+/// This also works for something like TOTP which allows a 60 second cycle for the
+/// reset_count_at and a max number of attempts in that window (say 5). with short
+/// delays in between (1 second).
+//
+//                                                  ┌────────────────────────┐
+//                                                  │reset_at < current_time │
+//                                                 ─└────────────────────────┘
+//                                                │                         │
+//                                                ▼
+//             ┌─────┐                         .─────.       ┌────┐         │
+//             │Valid│                        ╱       ╲      │Fail│
+//        ┌────┴─────┴───────────────────────(count = 0)─────┴────┴┐        │
+//        │                                   `.     ,'            │
+//        │                                     `───'              │        │
+//        │             ┌────────────────────────┐▲                │
+//        │             │reset_at < current_time │                 │        │
+//        │             └────────────────────────┘│                │
+//        │                      ┌ ─ ─ ─ ─ ─ ─ ─ ─                 │        │
+//        │                                                        │
+//        │                      ├─────┬───────┬──┐                ▼        │
+//        │                      │     │ Fail  │  │             .─────.
+//        │                      │     │count++│  │           ,'       `.   │
+//        ▼                   .─────.  └───────┘  │          ;  Locked   :
+// ┌────────────┐            ╱       ╲            └─────────▶: count > 0 ;◀─┤
+// │Auth Success│◀─┬─────┬──(Unlocked )                       ╲         ╱   │
+// └────────────┘  │Valid│   `.     ,'                         `.     ,'    │
+//                 └─────┘     `───'                             `───'      │
+//                               ▲                                 │        │
+//                               │                                 │        │
+//                               └─────┬──────────────────────────┬┴┬───────┴──────────────────┐
+//                                     │ expire_at < current_time │ │ current_time < expire_at │
+//                                     └──────────────────────────┘ └──────────────────────────┘
+//
+//
+
+const ONEDAY: u64 = 86400;
+
+#[derive(Debug, Clone)]
+pub enum CredSoftLockPolicy {
+    Password,
+    TOTP(u64),
+    Webauthn,
+}
+
+impl CredSoftLockPolicy {
+    /// Determine the next lock state after a failure based on this credentials
+    /// policy.
+    fn failure_next_state(&self, count: usize, ct: Duration) -> LockState {
+        match self {
+            CredSoftLockPolicy::Password => {
+                let next_day_end = ct.as_secs() + ONEDAY;
+                let rem = next_day_end % ONEDAY;
+                let reset_at = Duration::from_secs(next_day_end - rem);
+
+                if count < 3 {
+                    LockState::Locked(count, reset_at, ct + Duration::from_secs(1))
+                } else if count < 9 {
+                    LockState::Locked(count, reset_at, ct + Duration::from_secs(3))
+                } else if count < 25 {
+                    LockState::Locked(count, reset_at, ct + Duration::from_secs(5))
+                } else if count < 100 {
+                    LockState::Locked(count, reset_at, ct + Duration::from_secs(10))
+                } else {
+                    LockState::Locked(count, reset_at, reset_at)
+                }
+            }
+            CredSoftLockPolicy::TOTP(step) => {
+                // reset at is based on the next step ending.
+                let next_window_end = ct.as_secs() + step;
+                let rem = next_window_end % step;
+                let reset_at = Duration::from_secs(next_window_end - rem);
+                // We delay for 1 second, unless count is > 3, then we set
+                // unlock at to reset_at.
+                if count >= 3 {
+                    LockState::Locked(count, reset_at, reset_at)
+                } else {
+                    LockState::Locked(count, reset_at, ct + Duration::from_secs(1))
+                }
+            }
+            CredSoftLockPolicy::Webauthn => {
+                // we only lock for 1 second to slow them down.
+                // TODO: Could this be a DOS/Abuse vector?
+                LockState::Locked(
+                    count,
+                    ct + Duration::from_secs(1),
+                    ct + Duration::from_secs(1),
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LockState {
+    Init,
+    // count
+    // * Number of Failures in this cycle
+    // unlock_at
+    // * Time of next allowed check (works with delay)
+    // reset_count_at
+    // * The time to reset the state to init.
+    //     count  reset_at  unlock_at
+    Locked(usize, Duration, Duration),
+    Unlocked(usize, Duration),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CredSoftLock {
+    state: LockState,
+    // Policy (for determining delay times based on num failures, and when to reset?)
+    policy: CredSoftLockPolicy,
+}
+
+impl CredSoftLock {
+    pub fn new(policy: CredSoftLockPolicy) -> Self {
+        CredSoftLock {
+            state: LockState::Init,
+            policy,
+        }
+    }
+
+    pub fn apply_time_step(&mut self, ct: Duration) {
+        // Do a reset if needed?
+        let mut next_state = match self.state {
+            LockState::Init => LockState::Init,
+            LockState::Locked(count, reset_at, unlock_at) => {
+                if ct > reset_at {
+                    LockState::Init
+                } else if ct > unlock_at {
+                    LockState::Unlocked(count, reset_at)
+                } else {
+                    LockState::Locked(count, reset_at, unlock_at)
+                }
+            }
+            LockState::Unlocked(count, reset_at) => {
+                if ct > reset_at {
+                    LockState::Init
+                } else {
+                    LockState::Unlocked(count, reset_at)
+                }
+            }
+        };
+        std::mem::swap(&mut self.state, &mut next_state);
+    }
+
+    /// Is this credential valid to proceed at this point in time.
+    pub fn is_valid(&self) -> bool {
+        match self.state {
+            LockState::Locked(_count, _reset_at, _unlock_at) => false,
+            _ => true,
+        }
+    }
+
+    /// Document a failure of authentication at this time.
+    pub fn record_failure(&mut self, ct: Duration) {
+        let mut next_state = match self.state {
+            LockState::Init => {
+                self.policy.failure_next_state(1, ct)
+                // LockState::Locked(1, reset_at, unlock_at)
+            }
+            LockState::Locked(count, _reset_at, _unlock_at) => {
+                // We should never reach this but just in case ...
+                self.policy.failure_next_state(count + 1, ct)
+                // LockState::Locked(count + 1, reset_at, unlock_at)
+            }
+            LockState::Unlocked(count, _reset_at) => {
+                self.policy.failure_next_state(count + 1, ct)
+                // LockState::Locked(count + 1, reset_at, unlock_at)
+            }
+        };
+        std::mem::swap(&mut self.state, &mut next_state);
+    }
+
+    #[cfg(test)]
+    pub fn is_state_init(&self) -> bool {
+        match self.state {
+            LockState::Init => true,
+            _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    fn peek_state(&self) -> &LockState {
+        &self.state
+    }
+
+    /*
+    #[cfg(test)]
+    fn set_failure_count(&mut self, count: usize) {
+        let mut next_state = match self.state {
+            LockState::Init => panic!(),
+            LockState::Locked(_count, reset_at, unlock_at) => {
+                LockState::Locked(count, reset_at, unlock_at)
+            }
+            LockState::Unlocked(count, reset_at) => {
+                LockState::Unlocked(count, reset_at)
+            }
+        };
+        std::mem::swap(&mut self.state, &mut next_state);
+    }
+    */
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::credential::softlock::*;
+    use crate::credential::totp::TOTP_DEFAULT_STEP;
+
+    #[test]
+    fn test_credential_softlock_statemachine() {
+        // Check that given the set of inputs, correct decisions about
+        // locking are made, and the states can be moved through.
+        // ==> Check the init state.
+        let mut slock = CredSoftLock::new(CredSoftLockPolicy::Password);
+        assert!(slock.is_state_init());
+        assert!(slock.is_valid());
+        // A success does nothing, so we don't track them.
+        let ct = Duration::from_secs(10);
+        // Generate a failure
+        // ==> trans to locked
+        slock.record_failure(ct);
+        assert!(
+            slock.peek_state()
+                == &LockState::Locked(1, Duration::from_secs(ONEDAY), Duration::from_secs(10 + 1))
+        );
+        // It will now fail
+        // ==> trans ct < exp_at
+        slock.apply_time_step(ct);
+        assert!(!slock.is_valid());
+        // A few seconds later it will be okay.
+        // ==> trans ct < exp_at
+        let ct2 = ct + Duration::from_secs(2);
+        slock.apply_time_step(ct2);
+        assert!(slock.is_valid());
+        // Now trigger a failure now, we move back to locked.
+        // ==> trans fail unlock -> lock
+        slock.record_failure(ct2);
+        assert!(
+            slock.peek_state()
+                == &LockState::Locked(2, Duration::from_secs(ONEDAY), Duration::from_secs(10 + 3))
+        );
+        assert!(!slock.is_valid());
+        // Now check the reset_at behaviour. We need to check a locked and unlocked state.
+        let mut slock2 = slock.clone();
+        // This triggers the reset at from locked.
+        // ==> trans locked -> init
+        let ct3 = ct + Duration::from_secs(ONEDAY + 2);
+        slock.apply_time_step(ct3);
+        assert!(slock.is_state_init());
+        assert!(slock.is_valid());
+        // For slock2, we move to unlocked:
+        // ==> trans unlocked -> init
+        let ct4 = ct2 + Duration::from_secs(2);
+        slock2.apply_time_step(ct4);
+        eprintln!("{:?}", slock2.peek_state());
+        assert!(slock2.peek_state() == &LockState::Unlocked(2, Duration::from_secs(ONEDAY)));
+        slock2.apply_time_step(ct3);
+        assert!(slock2.is_state_init());
+        assert!(slock2.is_valid());
+    }
+
+    #[test]
+    fn test_credential_softlock_policy_password() {
+        let policy = CredSoftLockPolicy::Password;
+
+        assert!(
+            policy.failure_next_state(1, Duration::from_secs(0))
+                == LockState::Locked(1, Duration::from_secs(ONEDAY), Duration::from_secs(1))
+        );
+
+        assert!(
+            policy.failure_next_state(8, Duration::from_secs(0))
+                == LockState::Locked(8, Duration::from_secs(ONEDAY), Duration::from_secs(3))
+        );
+
+        assert!(
+            policy.failure_next_state(24, Duration::from_secs(0))
+                == LockState::Locked(24, Duration::from_secs(ONEDAY), Duration::from_secs(5))
+        );
+
+        assert!(
+            policy.failure_next_state(99, Duration::from_secs(0))
+                == LockState::Locked(99, Duration::from_secs(ONEDAY), Duration::from_secs(10))
+        );
+
+        assert!(
+            policy.failure_next_state(100, Duration::from_secs(0))
+                == LockState::Locked(
+                    100,
+                    Duration::from_secs(ONEDAY),
+                    Duration::from_secs(ONEDAY)
+                )
+        );
+    }
+
+    #[test]
+    fn test_credential_softlock_policy_totp() {
+        let policy = CredSoftLockPolicy::TOTP(TOTP_DEFAULT_STEP);
+
+        assert!(
+            policy.failure_next_state(1, Duration::from_secs(10))
+                == LockState::Locked(
+                    1,
+                    Duration::from_secs(TOTP_DEFAULT_STEP),
+                    Duration::from_secs(11)
+                )
+        );
+
+        assert!(
+            policy.failure_next_state(2, Duration::from_secs(10))
+                == LockState::Locked(
+                    2,
+                    Duration::from_secs(TOTP_DEFAULT_STEP),
+                    Duration::from_secs(11)
+                )
+        );
+
+        assert!(
+            policy.failure_next_state(3, Duration::from_secs(10))
+                == LockState::Locked(
+                    3,
+                    Duration::from_secs(TOTP_DEFAULT_STEP),
+                    Duration::from_secs(TOTP_DEFAULT_STEP)
+                )
+        );
+    }
+
+    #[test]
+    fn test_credential_softlock_policy_webauthn() {
+        let policy = CredSoftLockPolicy::Webauthn;
+
+        assert!(
+            policy.failure_next_state(1, Duration::from_secs(0))
+                == LockState::Locked(1, Duration::from_secs(1), Duration::from_secs(1))
+        );
+
+        // No matter how many failures, webauthn always only delays by 1 second.
+        assert!(
+            policy.failure_next_state(1000, Duration::from_secs(0))
+                == LockState::Locked(1000, Duration::from_secs(1), Duration::from_secs(1))
+        );
+    }
+}

--- a/kanidmd/src/lib/credential/totp.rs
+++ b/kanidmd/src/lib/credential/totp.rs
@@ -62,7 +62,7 @@ impl TOTPAlgo {
 pub struct TOTP {
     label: String,
     secret: Vec<u8>,
-    step: u64,
+    pub(crate) step: u64,
     algo: TOTPAlgo,
 }
 
@@ -196,7 +196,7 @@ impl TOTP {
 
 #[cfg(test)]
 mod tests {
-    use crate::credential::totp::{TOTPAlgo, TOTPError, TOTP};
+    use crate::credential::totp::{TOTPAlgo, TOTPError, TOTP, TOTP_DEFAULT_STEP};
     use std::time::Duration;
 
     #[test]
@@ -226,14 +226,14 @@ mod tests {
             vec![0x00, 0x00, 0x00, 0x00],
             TOTPAlgo::Sha1,
             1585368920,
-            30,
+            TOTP_DEFAULT_STEP,
             Ok(728926),
         );
         do_test(
             vec![0x00, 0xaa, 0xbb, 0xcc],
             TOTPAlgo::Sha1,
             1585369498,
-            30,
+            TOTP_DEFAULT_STEP,
             Ok(985074),
         );
     }
@@ -244,14 +244,14 @@ mod tests {
             vec![0x00, 0x00, 0x00, 0x00],
             TOTPAlgo::Sha256,
             1585369682,
-            30,
+            TOTP_DEFAULT_STEP,
             Ok(795483),
         );
         do_test(
             vec![0x00, 0xaa, 0xbb, 0xcc],
             TOTPAlgo::Sha256,
             1585369689,
-            30,
+            TOTP_DEFAULT_STEP,
             Ok(728402),
         );
     }
@@ -262,14 +262,14 @@ mod tests {
             vec![0x00, 0x00, 0x00, 0x00],
             TOTPAlgo::Sha512,
             1585369775,
-            30,
+            TOTP_DEFAULT_STEP,
             Ok(587735),
         );
         do_test(
             vec![0x00, 0xaa, 0xbb, 0xcc],
             TOTPAlgo::Sha512,
             1585369780,
-            30,
+            TOTP_DEFAULT_STEP,
             Ok(952181),
         );
     }

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -23,6 +23,7 @@ use crate::actors::v1_write::{CreateMessage, DeleteMessage, ModifyMessage};
 
 use ldap3_server::simple::LdapFilter;
 use std::collections::BTreeSet;
+use std::time::Duration;
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -171,6 +172,9 @@ impl Event {
         // TODO #64: Now apply claims from the uat into the Entry
         // to allow filtering.
 
+        // TODO #59: If the account is expiredy, do not allow the event
+        // to proceed
+
         let limits = EventLimits::from_uat(uat);
         Ok(Event {
             origin: EventOrigin::User(e),
@@ -196,6 +200,9 @@ impl Event {
         })?;
         // TODO #64: Now apply claims from the uat into the Entry
         // to allow filtering.
+
+        // TODO #59: If the account is expiredy, do not allow the event
+        // to proceed
 
         let limits = EventLimits::from_uat(uat);
         Ok(Event {
@@ -1039,6 +1046,7 @@ impl AuthEvent {
 pub struct AuthResult {
     pub sessionid: Uuid,
     pub state: AuthState,
+    pub delay: Option<Duration>,
 }
 
 /*

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -7,7 +7,7 @@ use crate::audit::AuditScope;
 use crate::constants::UUID_ANONYMOUS;
 use crate::credential::policy::CryptoPolicy;
 use crate::credential::totp::TOTP;
-use crate::credential::Credential;
+use crate::credential::{softlock::CredSoftLockPolicy, Credential};
 use crate::idm::claim::Claim;
 use crate::idm::group::Group;
 use crate::modify::{ModifyInvalid, ModifyList};
@@ -176,6 +176,19 @@ impl Account {
         };
         // Mix the results
         vmin && vmax
+    }
+
+    pub fn primary_cred_uuid(&self) -> Uuid {
+        match &self.primary {
+            Some(cred) => cred.uuid,
+            None => *UUID_ANONYMOUS,
+        }
+    }
+
+    pub fn primary_cred_softlock_policy(&self) -> Option<CredSoftLockPolicy> {
+        self.primary
+            .as_ref()
+            .and_then(|cred| cred.softlock_policy())
     }
 
     pub fn is_anonymous(&self) -> bool {


### PR DESCRIPTION
This provides bruteforce protection and ratelimiting to stop
classes of attacks. This impacts all areas where a password or
authentication is performed (unix, ldap, auth).

Fixes #324

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ x ] design document included (if relevant)
