### PR TITLE
Change root user check to warning due to container run times

### DIFF
--- a/kanidm_book/src/installing_the_server.md
+++ b/kanidm_book/src/installing_the_server.md
@@ -61,3 +61,33 @@ Now we can run the server so that it can accept connections. This defaults to us
 If you are interested to run our latest code from development, you can do this by changing the
 docker tag to `kanidm/server:devel`.
 
+# Running as non-root in docker
+
+By default the above commands will run kanidmd as "root" in the container to make the onboarding
+smoother. However, this is not recommended in production for security reasons.
+
+You should allocate a uidnumber/gidnumber for the service to run as that is unique on your host
+system. In this example we use `1000:1000`
+
+You will need to adjust the permissions on the /data volume to ensure that the process
+can manage the files. Kanidm requires the ability to write to the /data directory to create
+the sqlite files. This uid/gidnumber should match the above. You could consider the following
+changes to help isolate these changes:
+
+    docker run --rm -i -t -v kanidmd:/data opensuse/leap:latest /bin/sh
+    # mkdir /data/db/
+    # chown 1000:1000 /data/db/
+    # chmod 750 /data/db/
+    # sed -i -e "s/db_path.*/db_path = \"\/data\/db\/kanidm.db\"/g" /data/server.toml
+    # chown root:root /data/server.toml
+    # chmod 644 /data/server.toml
+
+You can then use this with run the kanidm server in docker with a user.
+
+    docker run --rm -i -t -u 1000:1000 -v kanidmd:/data kanidm/server:latest /sbin/kanidmd ...
+
+> **HINT**
+> You need to use the uidnumber/gidnumber to the `-u` argument, as the container can't resolve
+> usernames from the host system.
+
+

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -162,8 +162,9 @@ async fn main() {
     let cegid = get_effective_gid();
 
     if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
-        eprintln!("ERROR: Refusing to run - this process must not operate as root.");
-        std::process::exit(1);
+        eprintln!("WARNING: This is running as uid == 0 (root) which may be a security risk.");
+        // eprintln!("ERROR: Refusing to run - this process must not operate as root.");
+        // std::process::exit(1);
     }
 
     if cuid != ceuid || cgid != cegid {


### PR DESCRIPTION
Fixes #327 - In container run times, the default is to run as root. This may be user with virtualised containers or even to just smooth the "first run" process rather than requiring a user for the process and volumes.

- [ - ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
