### PR TITLE
Fix/ci missing libudev

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
 
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 
@@ -16,7 +16,6 @@ jobs:
       run: |
         sudo apt install -y \
           libpam0g-dev \
-          libssl1.0-dev \
           libudev-dev
 
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,8 @@ jobs:
       run: |
         sudo apt install -y \
           libpam0g-dev \
-          libssl1.0-dev
+          libssl1.0-dev \
+          libudev-dev
 
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
Fixes CI with authenticator library.

- [X] cargo fmt has been run
- [ ] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
