### PR TITLE
Unixd - NXCache of unknown items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,10 +1336,11 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
+ "opaque-debug 0.3.0",
  "polyval",
 ]
 
@@ -1397,6 +1398,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
 
 [[package]]
 name = "heck"
@@ -1773,6 +1777,7 @@ dependencies = [
  "libc",
  "libsqlite3-sys",
  "log",
+ "lru",
  "r2d2",
  "r2d2_sqlite",
  "reqwest",
@@ -1903,6 +1908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
+dependencies = [
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -2406,11 +2420,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fd92d8e0c06d08525d2e2643cc2b5c80c69ae8eb12c18272d501cd7079ccc0"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool 0.2.0",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -2956,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
+checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2966,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
@@ -3127,9 +3142,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3182,18 +3197,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -8,7 +8,9 @@ can be used on the machine for various interactive tasks.
 
 Kanidm provide a unix daemon that runs on any client that wants to use pam
 and nsswitch integration. This is provided as the daemon can cache the accounts
-for users who have unreliable networks or leave the site where kanidm is.
+for users who have unreliable networks or leave the site where kanidm is. The
+cache is also able to cache missing-entry responses to reduce network traffic
+and main server load.
 Additionally, the daemon means that the pam and nsswitch integration libraries
 can be small, helping to reduce the attack surface of the machine.
 

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -281,8 +281,10 @@ impl KanidmClientBuilder {
         let client = client_builder.build()?;
 
         // Now get the origin.
+        #[allow(clippy::expect_used)]
         let uri = Url::parse(&address).expect("can not fail");
 
+        #[allow(clippy::expect_used)]
         let origin = uri
             .host_str()
             .map(|h| format!("{}://{}", uri.scheme(), h))

--- a/kanidm_unix_int/Cargo.toml
+++ b/kanidm_unix_int/Cargo.toml
@@ -68,6 +68,8 @@ reqwest = { version = "0.10" }
 users = "0.10"
 async-std = "1.6"
 
+lru = "0.6"
+
 [features]
 # default = [ "libsqlite3-sys/bundled" ]
 

--- a/kanidm_unix_int/src/daemon.rs
+++ b/kanidm_unix_int/src/daemon.rs
@@ -408,6 +408,8 @@ async fn main() {
     // Undo it.
     let _ = unsafe { umask(before) };
 
+    // TODO: Setup a task that handles pre-fetching here.
+
     let server = async move {
         let mut incoming = listener.incoming();
         while let Some(socket_res) = incoming.next().await {

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -259,6 +259,7 @@ impl Account {
         Ok(ModifyList::new_purge_and_set("primary_credential", vcred))
     }
 
+    #[allow(clippy::ptr_arg)]
     pub(crate) fn gen_webauthn_counter_mod(
         &self,
         cid: &CredentialID,

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -89,7 +89,7 @@ impl CredHandler {
             }
             CredentialType::PasswordMFA(_, None, _) => Err(()),
             CredentialType::Webauthn(wan) => webauthn
-                .generate_challenge_authenticate(wan.values().map(|c| c.clone()).collect())
+                .generate_challenge_authenticate(wan.values().cloned().collect())
                 .map(|(chal, wan_state)| {
                     CredHandler::Webauthn(CredWebauthn {
                         chal,
@@ -103,7 +103,7 @@ impl CredHandler {
                         "Unable to create webauthn authentication challenge -> {:?}",
                         e
                     );
-                    ()
+                    // maps to unit.
                 }),
         }
     }
@@ -385,7 +385,7 @@ impl AuthSession {
     pub fn new(
         au: &mut AuditScope,
         account: Account,
-        _appid: Option<String>,
+        _appid: &Option<String>,
         webauthn: &Webauthn<WebauthnDomainConfig>,
         ct: Duration,
     ) -> (Option<Self>, AuthState) {

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -632,7 +632,7 @@ mod tests {
         let (session, state) = AuthSession::new(
             &mut audit,
             anon_account,
-            None,
+            &None,
             &webauthn,
             duration_from_epoch_now(),
         );
@@ -679,7 +679,7 @@ mod tests {
         let (session, state) = AuthSession::new(
             &mut audit,
             anon_account,
-            Some("NonExistantAppID".to_string()),
+            &Some("NonExistantAppID".to_string()),
             &webauthn,
             duration_from_epoch_now(),
         );
@@ -703,7 +703,7 @@ mod tests {
             let (session, state) = AuthSession::new(
                 $audit,
                 $account.clone(),
-                None,
+                &None,
                 $webauthn,
                 duration_from_epoch_now(),
             );
@@ -800,7 +800,7 @@ mod tests {
             let (session, state) = AuthSession::new(
                 $audit,
                 $account.clone(),
-                None,
+                &None,
                 $webauthn,
                 duration_from_epoch_now(),
             );
@@ -992,7 +992,7 @@ mod tests {
             let (session, state) = AuthSession::new(
                 $audit,
                 $account.clone(),
-                None,
+                &None,
                 $webauthn,
                 duration_from_epoch_now(),
             );

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -374,7 +374,7 @@ impl<'a> IdmServerWriteTransaction<'a> {
                 };
 
                 let (auth_session, state) = if is_valid {
-                    AuthSession::new(au, account, init.appid.clone(), self.webauthn, ct)
+                    AuthSession::new(au, account, &init.appid, self.webauthn, ct)
                 } else {
                     // it's softlocked, don't even bother.
                     lsecurity!(au, "Account is softlocked.");


### PR DESCRIPTION
Previously we would only cache "hits" - items that kanidm is aware
of and did know about. However, this mean querying a raw uid/gid
number that was not known to files or kanidm would result in kanidm
doing an online check each request.

This adds a NXcache to cache misses, so they can be served as misses,
faster, and to reduce load on the main kanidm servers.

Fixes #336

Fixes #

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
