### PR TITLE
320 filter double verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,7 @@ dependencies = [
  "serde_cbor",
  "serde_derive",
  "serde_json",
+ "smartstring",
  "sshkeys",
  "structopt",
  "tide",
@@ -3013,6 +3014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ada87540bf8ef4cf8a1789deb175626829bb59b1fefd816cf7f7f55efcdbae9"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3065,12 @@ checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
 dependencies = [
  "version_check 0.9.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -94,6 +94,8 @@ webauthn-rs = "0.3.0-alpha.1"
 libc = "0.2"
 users = "0.10"
 
+smartstring = { version = "0.2", features = ["serde"] }
+
 [features]
 # default = [ "libsqlite3-sys/bundled", "openssl/vendored" ]
 

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -71,7 +71,7 @@ impl AccessControlSearch {
                 ladmin_error!(audit, "Missing acp_search_attr");
                 OperationError::InvalidACPState("Missing acp_search_attr".to_string())
             })?
-            .map(|s| AttrString::from(s))
+            .map(AttrString::from)
             .collect();
 
         let acp = AccessControlProfile::try_from(audit, qs, value)?;
@@ -165,12 +165,12 @@ impl AccessControlCreate {
 
         let attrs = value
             .get_ava_as_str("acp_create_attr")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
 
         let classes = value
             .get_ava_as_str("acp_create_class")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
 
         Ok(AccessControlCreate {
@@ -198,11 +198,11 @@ impl AccessControlCreate {
             },
             classes: classes
                 .split_whitespace()
-                .map(|s| AttrString::from(s))
+                .map(AttrString::from)
                 .collect(),
             attrs: attrs
                 .split_whitespace()
-                .map(|s| AttrString::from(s))
+                .map(AttrString::from)
                 .collect(),
         }
     }
@@ -231,17 +231,17 @@ impl AccessControlModify {
 
         let presattrs = value
             .get_ava_as_str("acp_modify_presentattr")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
 
         let remattrs = value
             .get_ava_as_str("acp_modify_removedattr")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
 
         let classes = value
             .get_ava_as_str("acp_modify_class")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
 
         Ok(AccessControlModify {

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -196,14 +196,8 @@ impl AccessControlCreate {
                 receiver,
                 targetscope,
             },
-            classes: classes
-                .split_whitespace()
-                .map(AttrString::from)
-                .collect(),
-            attrs: attrs
-                .split_whitespace()
-                .map(AttrString::from)
-                .collect(),
+            classes: classes.split_whitespace().map(AttrString::from).collect(),
+            attrs: attrs.split_whitespace().map(AttrString::from).collect(),
         }
     }
 }

--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -1000,7 +1000,7 @@ impl QueryServerWriteV1 {
         // in the actual request.
         // NOTE: This is an iter for future requirements to be added
         let mods: Vec<_> = iter::once(Some(Modify::Present(
-            "class".to_string(),
+            "class".into(),
             Value::new_class("person"),
         )))
         .filter_map(|v| v)
@@ -1042,14 +1042,14 @@ impl QueryServerWriteV1 {
         // The filter_map here means we only create the mods if the gidnumber or shell are set
         // in the actual request.
         let mods: Vec<_> = iter::once(Some(Modify::Present(
-            "class".to_string(),
+            "class".into(),
             Value::new_class("posixaccount"),
         )))
         .chain(iter::once(gidnumber.map(|n| {
-            Modify::Present("gidnumber".to_string(), Value::new_uint32(n))
+            Modify::Present("gidnumber".into(), Value::new_uint32(n))
         })))
         .chain(iter::once(shell.map(|s| {
-            Modify::Present("loginshell".to_string(), Value::new_iutf8(s.as_str()))
+            Modify::Present("loginshell".into(), Value::new_iutf8(s.as_str()))
         })))
         .filter_map(|v| v)
         .collect();
@@ -1089,11 +1089,11 @@ impl QueryServerWriteV1 {
         // The filter_map here means we only create the mods if the gidnumber or shell are set
         // in the actual request.
         let mods: Vec<_> = iter::once(Some(Modify::Present(
-            "class".to_string(),
+            "class".into(),
             Value::new_class("posixgroup"),
         )))
         .chain(iter::once(gidnumber.map(|n| {
-            Modify::Present("gidnumber".to_string(), Value::new_uint32(n))
+            Modify::Present("gidnumber".into(), Value::new_uint32(n))
         })))
         .filter_map(|v| v)
         .collect();

--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -498,7 +498,7 @@ impl QueryServerWriteV1 {
                 let rev = match ReviveRecycledEvent::from_parts(
                     &mut audit,
                     msg.uat.as_ref(),
-                    msg.filter,
+                    &msg.filter,
                     &qs_write,
                 ) {
                     Ok(r) => r,

--- a/kanidmd/src/lib/be/dbentry.rs
+++ b/kanidmd/src/lib/be/dbentry.rs
@@ -1,9 +1,10 @@
 use crate::be::dbvalue::DbValueV1;
+use smartstring::alias::String as AttrString;
 use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbEntryV1 {
-    pub attrs: BTreeMap<String, Vec<DbValueV1>>,
+    pub attrs: BTreeMap<AttrString, Vec<DbValueV1>>,
 }
 
 // REMEMBER: If you add a new version here, you MUST

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -195,9 +195,9 @@ macro_rules! get_idl {
             let db_r = $self.db.get_idl($audit, $attr, $itype, $idx_key)?;
             if let Some(ref idl) = db_r {
                 let ncache_key = IdlCacheKey {
-                    a: $attr.to_string(),
+                    a: $attr.into(),
                     i: $itype.clone(),
-                    k: $idx_key.to_string(),
+                    k: $idx_key.into(),
                 };
                 $self.idl_cache.insert(ncache_key, Box::new(idl.clone()))
             }
@@ -647,9 +647,9 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
     ) -> Result<(), OperationError> {
         lperf_trace_segment!(audit, "be::idl_arc_sqlite::write_idl", || {
             let cache_key = IdlCacheKey {
-                a: attr.to_string(),
+                a: attr.into(),
                 i: itype.clone(),
-                k: idx_key.to_string(),
+                k: idx_key.into(),
             };
             // On idl == 0 the db will remove this, and synthesise an empty IDL on a miss
             // but we can cache this as a new empty IDL instead, so that we can avoid the

--- a/kanidmd/src/lib/be/idxkey.rs
+++ b/kanidmd/src/lib/be/idxkey.rs
@@ -1,4 +1,5 @@
 use crate::value::IndexType;
+use smartstring::alias::String as AttrString;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
@@ -7,7 +8,7 @@ use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IdxKey {
-    pub attr: String,
+    pub attr: AttrString,
     pub itype: IndexType,
 }
 
@@ -67,7 +68,7 @@ impl<'a> Hash for (dyn IdxKeyToRef + 'a) {
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct IdlCacheKey {
-    pub a: String,
+    pub a: AttrString,
     pub i: IndexType,
     pub k: String,
 }

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -403,9 +403,7 @@ impl Credential {
                 .map(|label| {
                     let mut webauthn_map = map.clone();
 
-                    if let Some(cred) = 
-                    webauthn_map
-                        .get_mut(label) {
+                    if let Some(cred) = webauthn_map.get_mut(label) {
                         cred.counter = counter
                     };
                     webauthn_map

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -24,6 +24,7 @@ use crate::actors::v1_write::{CreateMessage, DeleteMessage, ModifyMessage};
 // use crate::schema::SchemaTransaction;
 
 use ldap3_server::simple::LdapFilter;
+use smartstring::alias::String as AttrString;
 use std::collections::BTreeSet;
 use std::time::Duration;
 use uuid::Uuid;
@@ -264,7 +265,7 @@ pub struct SearchEvent {
     pub filter: Filter<FilterValid>,
     // This is the original filter, for the purpose of ACI checking.
     pub filter_orig: Filter<FilterValid>,
-    pub attrs: Option<BTreeSet<String>>,
+    pub attrs: Option<BTreeSet<AttrString>>,
 }
 
 impl SearchEvent {
@@ -296,7 +297,7 @@ impl SearchEvent {
         msg: InternalSearchMessage,
         qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
-        let r_attrs: Option<BTreeSet<String>> = msg.attrs.map(|vs| {
+        let r_attrs: Option<BTreeSet<AttrString>> = msg.attrs.map(|vs| {
             vs.into_iter()
                 .filter_map(|a| qs.get_schema().normalise_attr_if_exists(a.as_str()))
                 .collect()
@@ -330,7 +331,7 @@ impl SearchEvent {
         msg: InternalSearchRecycledMessage,
         qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
-        let r_attrs: Option<BTreeSet<String>> = msg.attrs.map(|vs| {
+        let r_attrs: Option<BTreeSet<AttrString>> = msg.attrs.map(|vs| {
             vs.into_iter()
                 .filter_map(|a| qs.get_schema().normalise_attr_if_exists(a.as_str()))
                 .collect()
@@ -468,7 +469,7 @@ impl SearchEvent {
         qs: &QueryServerReadTransaction,
         euat: &UserAuthToken,
         lf: &LdapFilter,
-        attrs: Option<BTreeSet<String>>,
+        attrs: Option<BTreeSet<AttrString>>,
     ) -> Result<Self, OperationError> {
         let event = Event::from_ro_uat(audit, qs, Some(euat))?;
         // Kanidm Filter from LdapFilter

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -277,14 +277,10 @@ impl SearchEvent {
         let f = Filter::from_ro(audit, &event, &msg.req.filter, qs)?;
         // We do need to do this twice to account for the ignore_hidden
         // changes.
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         Ok(SearchEvent {
             event,
             filter,
@@ -315,24 +311,14 @@ impl SearchEvent {
 
         let event = Event::from_ro_uat(audit, qs, msg.uat.as_ref())?;
 
-        let filter = msg
-            .filter
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(|e| {
-                lrequest_error!(audit, "filter schema violation -> {:?}", e);
-                OperationError::SchemaViolation(e)
-            })?;
         let filter_orig = msg.filter.validate(qs.get_schema()).map_err(|e| {
-            lrequest_error!(audit, "filter_orig schema violation -> {:?}", e);
+            lrequest_error!(audit, "filter schema violation -> {:?}", e);
             OperationError::SchemaViolation(e)
         })?;
+        let filter = filter_orig.clone().into_ignore_hidden();
 
         Ok(SearchEvent {
             event,
-            // We do need to do this twice to account for the ignore_hidden
-            // changes.
             filter,
             filter_orig,
             attrs: r_attrs,
@@ -357,17 +343,12 @@ impl SearchEvent {
         }
 
         let event = Event::from_ro_uat(audit, qs, msg.uat.as_ref())?;
-        let filter = msg
-            .filter
-            .clone()
-            .into_recycled()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = msg
             .filter
-            .into_recycled()
             .validate(qs.get_schema())
+            .map(|f| f.into_recycled())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone();
 
         Ok(SearchEvent {
             event,
@@ -383,12 +364,10 @@ impl SearchEvent {
         qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         let event = Event::from_ro_uat(audit, qs, uat)?;
-        let filter = filter!(f_self())
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = filter_all!(f_self())
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
 
         Ok(SearchEvent {
             event,
@@ -405,12 +384,10 @@ impl SearchEvent {
         qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         let event = Event::from_ro_uat(audit, qs, uat)?;
-        let filter = filter!(f_eq("uuid", PartialValue::new_uuid(target_uuid)))
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = filter_all!(f_eq("uuid", PartialValue::new_uuid(target_uuid)))
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         Ok(SearchEvent {
             event,
             filter,
@@ -462,10 +439,12 @@ impl SearchEvent {
         e: Entry<EntrySealed, EntryCommitted>,
         filter: Filter<FilterInvalid>,
     ) -> Self {
+        let filter_orig = filter.into_valid();
+        let filter = filter_orig.clone().into_recycled();
         SearchEvent {
             event: Event::from_impersonate_entry(e),
-            filter: filter.clone().into_recycled().into_valid(),
-            filter_orig: filter.into_valid(),
+            filter,
+            filter_orig,
             attrs: None,
         }
     }
@@ -478,7 +457,7 @@ impl SearchEvent {
     ) -> Self {
         SearchEvent {
             event: Event::from_impersonate_entry(e),
-            filter: filter.clone().into_ignore_hidden().into_valid(),
+            filter: filter.clone().into_valid().into_ignore_hidden(),
             filter_orig: filter.into_valid(),
             attrs: None,
         }
@@ -494,14 +473,10 @@ impl SearchEvent {
         let event = Event::from_ro_uat(audit, qs, Some(euat))?;
         // Kanidm Filter from LdapFilter
         let f = Filter::from_ldap_ro(audit, &event, &lf, qs)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         Ok(SearchEvent {
             event,
             filter,
@@ -641,14 +616,10 @@ impl DeleteEvent {
     ) -> Result<Self, OperationError> {
         let event = Event::from_rw_uat(audit, qs, msg.uat.as_ref())?;
         let f = Filter::from_rw(audit, &event, &msg.req.filter, qs)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         Ok(DeleteEvent {
             event,
             filter,
@@ -663,14 +634,10 @@ impl DeleteEvent {
         qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         let event = Event::from_rw_uat(audit, qs, uat)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         Ok(DeleteEvent {
             event,
             filter,
@@ -736,14 +703,10 @@ impl ModifyEvent {
         let event = Event::from_rw_uat(audit, qs, msg.uat.as_ref())?;
         let f = Filter::from_rw(audit, &event, &msg.req.filter, qs)?;
         let m = ModifyList::from(audit, &msg.req.modlist, qs)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         let modlist = m
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
@@ -769,14 +732,10 @@ impl ModifyEvent {
 
         let m = ModifyList::from(audit, &proto_ml, qs)?;
         let event = Event::from_rw_uat(audit, qs, uat)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         let modlist = m
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
@@ -802,14 +761,10 @@ impl ModifyEvent {
         let f = Filter::join_parts_and(f_uuid, filter);
 
         let event = Event::from_rw_uat(audit, qs, uat)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         let modlist = ml
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
@@ -836,14 +791,10 @@ impl ModifyEvent {
         let f = Filter::join_parts_and(f_uuid, filter);
 
         let event = Event::from_rw_uat(audit, qs, uat)?;
-        let filter = f
-            .clone()
-            .into_ignore_hidden()
-            .validate(qs.get_schema())
-            .map_err(OperationError::SchemaViolation)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
+        let filter = filter_orig.clone().into_ignore_hidden();
         let modlist = ml
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
@@ -1162,13 +1113,13 @@ impl ReviveRecycledEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
         uat: Option<&UserAuthToken>,
-        filter: Filter<FilterInvalid>,
+        filter: &Filter<FilterInvalid>,
         qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
         let event = Event::from_rw_uat(audit, qs, uat)?;
         let filter = filter
-            .into_recycled()
             .validate(qs.get_schema())
+            .map(|f| f.into_recycled())
             .map_err(OperationError::SchemaViolation)?;
         Ok(ReviveRecycledEvent { event, filter })
     }

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -1440,6 +1440,7 @@ mod tests {
     use crate::server::QueryServer;
     use crate::utils::duration_from_epoch_now;
     use async_std::task;
+    use smartstring::alias::String as AttrString;
     use std::convert::TryFrom;
     use std::time::Duration;
     use uuid::Uuid;
@@ -1646,7 +1647,7 @@ mod tests {
             ModifyEvent::new_internal_invalid(
                 filter!(f_eq("name", PartialValue::new_iname("admin"))),
                 ModifyList::new_list(vec![Modify::Present(
-                    "primary_credential".to_string(),
+                    AttrString::from("primary_credential"),
                     v_cred,
                 )]),
             )
@@ -2021,8 +2022,11 @@ mod tests {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
-                        Modify::Present("class".to_string(), Value::new_class("posixaccount")),
-                        Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
+                        Modify::Present(
+                            AttrString::from("class"),
+                            Value::new_class("posixaccount"),
+                        ),
+                        Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
                     ]),
                 )
             };
@@ -2097,8 +2101,11 @@ mod tests {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
-                        Modify::Present("class".to_string(), Value::new_class("posixaccount")),
-                        Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
+                        Modify::Present(
+                            AttrString::from("class"),
+                            Value::new_class("posixaccount"),
+                        ),
+                        Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
                     ]),
                 )
             };
@@ -2140,7 +2147,7 @@ mod tests {
             let me_purge_up = unsafe {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
-                    ModifyList::new_list(vec![Modify::Purged("unix_password".to_string())]),
+                    ModifyList::new_list(vec![Modify::Purged(AttrString::from("unix_password"))]),
                 )
             };
             assert!(idms_prox_write.qs_write.modify(au, &me_purge_up).is_ok());
@@ -2312,7 +2319,7 @@ mod tests {
                     ModifyEvent::new_internal_invalid(
                         filter!(f_eq("name", PartialValue::new_iname("admin"))),
                         ModifyList::new_list(vec![Modify::Present(
-                            "password_import".to_string(),
+                            AttrString::from("password_import"),
                             Value::from("{SSHA512}JwrSUHkI7FTAfHRVR6KoFlSN0E3dmaQWARjZ+/UsShYlENOqDtFVU77HJLLrY2MuSp0jve52+pwtdVl2QUAHukQ0XUf5LDtM")
                         )]),
                     )
@@ -2356,9 +2363,12 @@ mod tests {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
-                        Modify::Present("class".to_string(), Value::new_class("posixaccount")),
-                        Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
-                        Modify::Present("unix_password".to_string(), v_cred),
+                        Modify::Present(
+                            AttrString::from("class"),
+                            Value::new_class("posixaccount"),
+                        ),
+                        Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
+                        Modify::Present(AttrString::from("unix_password"), v_cred),
                     ]),
                 )
             };
@@ -2418,8 +2428,8 @@ mod tests {
             ModifyEvent::new_internal_invalid(
                 filter!(f_eq("name", PartialValue::new_iname("admin"))),
                 ModifyList::new_list(vec![
-                    Modify::Present("account_expire".to_string(), v_expire),
-                    Modify::Present("account_valid_from".to_string(), v_valid_from),
+                    Modify::Present(AttrString::from("account_expire"), v_expire),
+                    Modify::Present(AttrString::from("account_valid_from"), v_valid_from),
                 ]),
             )
         };
@@ -2509,8 +2519,11 @@ mod tests {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
-                        Modify::Present("class".to_string(), Value::new_class("posixaccount")),
-                        Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
+                        Modify::Present(
+                            AttrString::from("class"),
+                            Value::new_class("posixaccount"),
+                        ),
+                        Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
                     ]),
                 )
             };
@@ -2849,8 +2862,11 @@ mod tests {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
-                        Modify::Present("class".to_string(), Value::new_class("posixaccount")),
-                        Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
+                        Modify::Present(
+                            AttrString::from("class"),
+                            Value::new_class("posixaccount"),
+                        ),
+                        Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
                     ]),
                 )
             };

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -8,6 +8,7 @@ use async_std::task;
 use kanidm_proto::v1::{OperationError, UserAuthToken};
 use ldap3_server::simple::*;
 use regex::Regex;
+use smartstring::alias::String as AttrString;
 use std::collections::BTreeSet;
 use std::iter;
 use std::time::SystemTime;
@@ -454,14 +455,13 @@ fn operationerr_to_ldapresultcode(e: OperationError) -> (LdapResultCode, String)
 }
 
 #[inline]
-pub(crate) fn ldap_attr_filter_map(input: &str) -> String {
+pub(crate) fn ldap_attr_filter_map(input: &str) -> AttrString {
     let lin = input.to_lowercase();
-    match lin.as_str() {
+    AttrString::from(match lin.as_str() {
         "entryuuid" => "uuid",
         "objectclass" => "class",
         a => a,
-    }
-    .to_string()
+    })
 }
 
 #[inline]
@@ -489,6 +489,7 @@ mod tests {
     // use uuid::Uuid;
     use crate::ldap::LdapServer;
     use async_std::task;
+    use smartstring::alias::String as AttrString;
 
     const TEST_PASSWORD: &'static str = "ntaoeuntnaoeuhraohuercahu😍";
 
@@ -506,8 +507,11 @@ mod tests {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("admin"))),
                     ModifyList::new_list(vec![
-                        Modify::Present("class".to_string(), Value::new_class("posixaccount")),
-                        Modify::Present("gidnumber".to_string(), Value::new_uint32(2001)),
+                        Modify::Present(
+                            AttrString::from("class"),
+                            Value::new_class("posixaccount"),
+                        ),
+                        Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
                     ]),
                 )
             };

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -185,7 +185,7 @@ impl Plugin for AttrUnique {
             // We do a fully in memory check.
             if get_cand_attr_set(au, &all_cand, attr.as_str()).is_err() {
                 res.push(Err(ConsistencyError::DuplicateUniqueAttribute(
-                    attr.clone(),
+                    attr.to_string(),
                 )))
             }
         }
@@ -202,6 +202,7 @@ mod tests {
     use crate::modify::{Modify, ModifyList};
     use crate::value::{PartialValue, Value};
     use kanidm_proto::v1::{OperationError, PluginError};
+    use smartstring::alias::String as AttrString;
     // Test entry in db, and same name, reject.
     #[test]
     fn test_pre_create_name_unique() {
@@ -296,8 +297,8 @@ mod tests {
                 PartialValue::new_iname("testgroup_b")
             ),])),
             ModifyList::new_list(vec![
-                Modify::Purged("name".to_string()),
-                Modify::Present("name".to_string(), Value::new_iname("testgroup_a"))
+                Modify::Purged(AttrString::from("name")),
+                Modify::Present(AttrString::from("name"), Value::new_iname("testgroup_a"))
             ]),
             None,
             |_, _| {}
@@ -339,8 +340,8 @@ mod tests {
                 f_eq("name", PartialValue::new_iname("testgroup_b")),
             ])),
             ModifyList::new_list(vec![
-                Modify::Purged("name".to_string()),
-                Modify::Present("name".to_string(), Value::new_iname("testgroup"))
+                Modify::Purged(AttrString::from("name")),
+                Modify::Present(AttrString::from("name"), Value::new_iname("testgroup"))
             ]),
             None,
             |_, _| {}

--- a/kanidmd/src/lib/plugins/base.rs
+++ b/kanidmd/src/lib/plugins/base.rs
@@ -253,6 +253,7 @@ mod tests {
     use crate::server::QueryServerWriteTransaction;
     use crate::value::{PartialValue, Value};
     use kanidm_proto::v1::{OperationError, PluginError};
+    use smartstring::alias::String as AttrString;
 
     const JSON_ADMIN_ALLOW_ALL: &'static str = r#"{
         "attrs": {
@@ -546,7 +547,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Present(
-                "uuid".to_string(),
+                AttrString::from("uuid"),
                 Value::from("f15a7219-1d15-44e3-a7b4-bec899c07788")
             )]),
             None,
@@ -575,7 +576,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Removed(
-                "uuid".to_string(),
+                AttrString::from("uuid"),
                 PartialValue::new_uuids("f15a7219-1d15-44e3-a7b4-bec899c07788").unwrap()
             )]),
             None,
@@ -603,7 +604,7 @@ mod tests {
             Err(OperationError::SystemProtectedAttribute),
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
-            ModifyList::new_list(vec![Modify::Purged("uuid".to_string())]),
+            ModifyList::new_list(vec![Modify::Purged(AttrString::from("uuid"))]),
             None,
             |_, _| {}
         );

--- a/kanidmd/src/lib/plugins/memberof.rs
+++ b/kanidmd/src/lib/plugins/memberof.rs
@@ -424,6 +424,7 @@ mod tests {
     use crate::modify::{Modify, ModifyList};
     use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
     use crate::value::{PartialValue, Value};
+    use smartstring::alias::String as AttrString;
 
     const UUID_A: &'static str = "aaaaaaaa-f82e-4484-a407-181aa03bda5c";
     const UUID_B: &'static str = "bbbbbbbb-2438-4384-9891-48f4c8172e9b";
@@ -745,7 +746,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_A).unwrap())),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s(&UUID_B).unwrap()
             )]),
             None,
@@ -780,7 +781,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_A).unwrap())),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s(&UUID_B).unwrap()
             )]),
             None,
@@ -833,7 +834,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_B).unwrap())),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s(&UUID_C).unwrap()
             )]),
             None,
@@ -889,7 +890,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_C).unwrap())),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s(&UUID_A).unwrap()
             )]),
             None,
@@ -955,7 +956,7 @@ mod tests {
                 f_eq("uuid", PartialValue::new_uuids(&UUID_D).unwrap()),
             ])),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s(&UUID_A).unwrap()
             )]),
             None,
@@ -1023,7 +1024,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_A).unwrap())),
             ModifyList::new_list(vec![Modify::Removed(
-                "member".to_string(),
+                AttrString::from("member"),
                 PartialValue::new_refer_s(&UUID_B).unwrap()
             )]),
             None,
@@ -1061,7 +1062,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_A).unwrap())),
             ModifyList::new_list(vec![Modify::Removed(
-                "member".to_string(),
+                AttrString::from("member"),
                 PartialValue::new_refer_s(&UUID_B).unwrap()
             )]),
             None,
@@ -1118,7 +1119,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_B).unwrap())),
             ModifyList::new_list(vec![Modify::Removed(
-                "member".to_string(),
+                AttrString::from("member"),
                 PartialValue::new_refer_s(&UUID_C).unwrap()
             )]),
             None,
@@ -1185,7 +1186,7 @@ mod tests {
             preload,
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_C).unwrap())),
             ModifyList::new_list(vec![Modify::Removed(
-                "member".to_string(),
+                AttrString::from("member"),
                 PartialValue::new_refer_s(&UUID_A).unwrap()
             )]),
             None,
@@ -1271,11 +1272,11 @@ mod tests {
             filter!(f_eq("uuid", PartialValue::new_uuids(&UUID_C).unwrap())),
             ModifyList::new_list(vec![
                 Modify::Removed(
-                    "member".to_string(),
+                    AttrString::from("member"),
                     PartialValue::new_refer_s(&UUID_A).unwrap()
                 ),
                 Modify::Removed(
-                    "member".to_string(),
+                    AttrString::from("member"),
                     PartialValue::new_refer_s(&UUID_D).unwrap()
                 ),
             ]),

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -133,6 +133,7 @@ mod tests {
     use crate::modify::{Modify, ModifyList};
     use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
     use crate::value::{PartialValue, Value};
+    use smartstring::alias::String as AttrString;
     use uuid::Uuid;
 
     const IMPORT_HASH: &'static str =
@@ -183,7 +184,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iutf8("testperson"))),
             ModifyList::new_list(vec![Modify::Present(
-                "password_import".to_string(),
+                AttrString::from("password_import"),
                 Value::from(IMPORT_HASH)
             )]),
             None,
@@ -217,7 +218,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iutf8("testperson"))),
             ModifyList::new_list(vec![Modify::Present(
-                "password_import".to_string(),
+                AttrString::from("password_import"),
                 Value::from(IMPORT_HASH)
             )]),
             None,
@@ -254,7 +255,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iutf8("testperson"))),
             ModifyList::new_list(vec![Modify::Present(
-                "password_import".to_string(),
+                AttrString::from("password_import"),
                 Value::from(IMPORT_HASH)
             )]),
             None,

--- a/kanidmd/src/lib/plugins/refint.rs
+++ b/kanidmd/src/lib/plugins/refint.rs
@@ -264,6 +264,7 @@ mod tests {
     use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
     use crate::value::{PartialValue, Value};
     use kanidm_proto::v1::{OperationError, PluginError};
+    use smartstring::alias::String as AttrString;
 
     // The create references a uuid that doesn't exist - reject
     #[test]
@@ -404,7 +405,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
             )]),
             None,
@@ -434,7 +435,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
             )]),
             None,
@@ -477,10 +478,13 @@ mod tests {
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![
                 Modify::Present(
-                    "member".to_string(),
+                    AttrString::from("member"),
                     Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
                 ),
-                Modify::Present("member".to_string(), Value::new_refer(*UUID_DOES_NOT_EXIST)),
+                Modify::Present(
+                    AttrString::from("member"),
+                    Value::new_refer(*UUID_DOES_NOT_EXIST)
+                ),
             ]),
             None,
             |_, _| {}
@@ -518,7 +522,7 @@ mod tests {
             Ok(()),
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
-            ModifyList::new_list(vec![Modify::Purged("member".to_string())]),
+            ModifyList::new_list(vec![Modify::Purged(AttrString::from("member"))]),
             None,
             |_, _| {}
         );
@@ -545,7 +549,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_a"))),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
             )]),
             None,
@@ -586,7 +590,7 @@ mod tests {
             preload,
             filter!(f_eq("name", PartialValue::new_iname("testgroup_b"))),
             ModifyList::new_list(vec![Modify::Present(
-                "member".to_string(),
+                AttrString::from("member"),
                 Value::new_refer_s("d2b496bd-8493-47b7-8142-f568b5cf47ee").unwrap()
             )]),
             None,

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -441,7 +441,7 @@ impl SchemaClass {
         // name
         let name = value
             .get_ava_single_str("classname")
-            .map(|s| AttrString::from(s))
+            .map(AttrString::from)
             .ok_or_else(|| {
                 ladmin_error!(audit, "missing classname");
                 OperationError::InvalidSchemaState("missing classname".to_string())
@@ -449,7 +449,7 @@ impl SchemaClass {
         // description
         let description = value
             .get_ava_single_str("description")
-            .map(|s| s.to_string())
+            .map(String::from)
             .ok_or_else(|| {
                 ladmin_error!(audit, "missing description");
                 OperationError::InvalidSchemaState("missing description".to_string())
@@ -458,19 +458,19 @@ impl SchemaClass {
         // These are all "optional" lists of strings.
         let systemmay = value
             .get_ava_as_str("systemmay")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
         let systemmust = value
             .get_ava_as_str("systemmust")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
         let may = value
             .get_ava_as_str("may")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
         let must = value
             .get_ava_as_str("must")
-            .map(|i| i.map(|s| AttrString::from(s)).collect())
+            .map(|i| i.map(AttrString::from).collect())
             .unwrap_or_else(Vec::new);
 
         Ok(SchemaClass {

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -25,6 +25,7 @@ use kanidm_proto::v1::{ConsistencyError, OperationError, SchemaError};
 
 use hashbrown::HashMap;
 use hashbrown::HashSet;
+use smartstring::alias::String as AttrString;
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use uuid::Uuid;
@@ -55,30 +56,30 @@ lazy_static! {
 /// [`Attributes`]: struct.SchemaAttribute.html
 /// [`Classes`]: struct.SchemaClass.html
 pub struct Schema {
-    classes: CowCell<HashMap<String, SchemaClass>>,
-    attributes: CowCell<HashMap<String, SchemaAttribute>>,
-    unique_cache: CowCell<Vec<String>>,
-    ref_cache: CowCell<HashMap<String, SchemaAttribute>>,
+    classes: CowCell<HashMap<AttrString, SchemaClass>>,
+    attributes: CowCell<HashMap<AttrString, SchemaAttribute>>,
+    unique_cache: CowCell<Vec<AttrString>>,
+    ref_cache: CowCell<HashMap<AttrString, SchemaAttribute>>,
 }
 
 /// A writable transaction of the working schema set. You should not change this directly,
 /// the writability is for the server internally to allow reloading of the schema. Changes
 /// you make will be lost when the server re-reads the schema from disk.
 pub struct SchemaWriteTransaction<'a> {
-    classes: CowCellWriteTxn<'a, HashMap<String, SchemaClass>>,
-    attributes: CowCellWriteTxn<'a, HashMap<String, SchemaAttribute>>,
+    classes: CowCellWriteTxn<'a, HashMap<AttrString, SchemaClass>>,
+    attributes: CowCellWriteTxn<'a, HashMap<AttrString, SchemaAttribute>>,
 
-    unique_cache: CowCellWriteTxn<'a, Vec<String>>,
-    ref_cache: CowCellWriteTxn<'a, HashMap<String, SchemaAttribute>>,
+    unique_cache: CowCellWriteTxn<'a, Vec<AttrString>>,
+    ref_cache: CowCellWriteTxn<'a, HashMap<AttrString, SchemaAttribute>>,
 }
 
 /// A readonly transaction of the working schema set.
 pub struct SchemaReadTransaction {
-    classes: CowCellReadTxn<HashMap<String, SchemaClass>>,
-    attributes: CowCellReadTxn<HashMap<String, SchemaAttribute>>,
+    classes: CowCellReadTxn<HashMap<AttrString, SchemaClass>>,
+    attributes: CowCellReadTxn<HashMap<AttrString, SchemaAttribute>>,
 
-    unique_cache: CowCellReadTxn<Vec<String>>,
-    ref_cache: CowCellReadTxn<HashMap<String, SchemaAttribute>>,
+    unique_cache: CowCellReadTxn<Vec<AttrString>>,
+    ref_cache: CowCellReadTxn<HashMap<AttrString, SchemaAttribute>>,
 }
 
 /// An item reperesenting an attribute and the rules that enforce it. These rules enforce if an
@@ -92,7 +93,7 @@ pub struct SchemaReadTransaction {
 pub struct SchemaAttribute {
     // Is this ... used?
     // class: Vec<String>,
-    pub name: String,
+    pub name: AttrString,
     pub uuid: Uuid,
     // Perhaps later add aliases?
     pub description: String,
@@ -124,7 +125,7 @@ impl SchemaAttribute {
         // name
         let name = value
             .get_ava_single_str("attributename")
-            .map(|s| s.to_string())
+            .map(|s| s.into())
             .ok_or_else(|| {
                 ladmin_error!(audit, "missing attributename");
                 OperationError::InvalidSchemaState("missing attributename".to_string())
@@ -410,14 +411,14 @@ impl SchemaAttribute {
 pub struct SchemaClass {
     // Is this used?
     // class: Vec<String>,
-    pub name: String,
+    pub name: AttrString,
     pub uuid: Uuid,
     pub description: String,
     // This allows modification of system types to be extended in custom ways
-    pub systemmay: Vec<String>,
-    pub may: Vec<String>,
-    pub systemmust: Vec<String>,
-    pub must: Vec<String>,
+    pub systemmay: Vec<AttrString>,
+    pub may: Vec<AttrString>,
+    pub systemmust: Vec<AttrString>,
+    pub must: Vec<AttrString>,
 }
 
 impl SchemaClass {
@@ -440,7 +441,7 @@ impl SchemaClass {
         // name
         let name = value
             .get_ava_single_str("classname")
-            .map(|s| s.to_string())
+            .map(|s| AttrString::from(s))
             .ok_or_else(|| {
                 ladmin_error!(audit, "missing classname");
                 OperationError::InvalidSchemaState("missing classname".to_string())
@@ -457,19 +458,19 @@ impl SchemaClass {
         // These are all "optional" lists of strings.
         let systemmay = value
             .get_ava_as_str("systemmay")
-            .map(|i| i.map(|s| s.to_string()).collect())
+            .map(|i| i.map(|s| AttrString::from(s)).collect())
             .unwrap_or_else(Vec::new);
         let systemmust = value
             .get_ava_as_str("systemmust")
-            .map(|i| i.map(|s| s.to_string()).collect())
+            .map(|i| i.map(|s| AttrString::from(s)).collect())
             .unwrap_or_else(Vec::new);
         let may = value
             .get_ava_as_str("may")
-            .map(|i| i.map(|s| s.to_string()).collect())
+            .map(|i| i.map(|s| AttrString::from(s)).collect())
             .unwrap_or_else(Vec::new);
         let must = value
             .get_ava_as_str("must")
-            .map(|i| i.map(|s| s.to_string()).collect())
+            .map(|i| i.map(|s| AttrString::from(s)).collect())
             .unwrap_or_else(Vec::new);
 
         Ok(SchemaClass {
@@ -485,11 +486,11 @@ impl SchemaClass {
 }
 
 pub trait SchemaTransaction {
-    fn get_classes(&self) -> &HashMap<String, SchemaClass>;
-    fn get_attributes(&self) -> &HashMap<String, SchemaAttribute>;
+    fn get_classes(&self) -> &HashMap<AttrString, SchemaClass>;
+    fn get_attributes(&self) -> &HashMap<AttrString, SchemaAttribute>;
 
-    fn get_attributes_unique(&self) -> &Vec<String>;
-    fn get_reference_types(&self) -> &HashMap<String, SchemaAttribute>;
+    fn get_attributes_unique(&self) -> &Vec<AttrString>;
+    fn get_reference_types(&self) -> &HashMap<AttrString, SchemaAttribute>;
 
     fn validate(&self, _audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
         let mut res = Vec::new();
@@ -513,16 +514,16 @@ pub trait SchemaTransaction {
                             // We have the attribute, ensure it's not a phantom.
                             if attr.phantom {
                                 res.push(Err(ConsistencyError::SchemaClassPhantomAttribute(
-                                    class.name.clone(),
-                                    a.clone(),
+                                    class.name.to_string(),
+                                    a.to_string(),
                                 )))
                             }
                         }
                         None => {
                             // No such attr, something is missing!
                             res.push(Err(ConsistencyError::SchemaClassMissingAttribute(
-                                class.name.clone(),
-                                a.clone(),
+                                class.name.to_string(),
+                                a.to_string(),
                             )))
                         }
                     }
@@ -541,12 +542,12 @@ pub trait SchemaTransaction {
         }
     }
 
-    fn normalise_attr_name(&self, an: &str) -> String {
+    fn normalise_attr_name(&self, an: &str) -> AttrString {
         // Will duplicate.
-        an.to_lowercase()
+        AttrString::from(an.to_lowercase())
     }
 
-    fn normalise_attr_if_exists(&self, an: &str) -> Option<String> {
+    fn normalise_attr_if_exists(&self, an: &str) -> Option<AttrString> {
         if self.get_attributes().contains_key(an) {
             Some(self.normalise_attr_name(an))
         } else {
@@ -649,9 +650,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             // Bootstrap in definitions of our own schema types
             // First, add all the needed core attributes for schema parsing
             self.attributes.insert(
-                String::from("class"),
+                AttrString::from("class"),
                 SchemaAttribute {
-                    name: String::from("class"),
+                    name: AttrString::from("class"),
                     uuid: *UUID_SCHEMA_ATTR_CLASS,
                     description: String::from("The set of classes defining an object"),
                     multivalue: true,
@@ -662,9 +663,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("uuid"),
+                AttrString::from("uuid"),
                 SchemaAttribute {
-                    name: String::from("uuid"),
+                    name: AttrString::from("uuid"),
                     uuid: *UUID_SCHEMA_ATTR_UUID,
                     description: String::from("The universal unique id of the object"),
                     multivalue: false,
@@ -677,9 +678,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("last_modified_cid"),
+                AttrString::from("last_modified_cid"),
                 SchemaAttribute {
-                    name: String::from("last_modified_cid"),
+                    name: AttrString::from("last_modified_cid"),
                     uuid: *UUID_SCHEMA_ATTR_LAST_MOD_CID,
                     description: String::from("The cid of the last change to this object"),
                     multivalue: false,
@@ -692,9 +693,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("name"),
+                AttrString::from("name"),
                 SchemaAttribute {
-                    name: String::from("name"),
+                    name: AttrString::from("name"),
                     uuid: *UUID_SCHEMA_ATTR_NAME,
                     description: String::from("The shortform name of an object"),
                     multivalue: false,
@@ -705,9 +706,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("spn"),
+                AttrString::from("spn"),
                 SchemaAttribute {
-                    name: String::from("spn"),
+                    name: AttrString::from("spn"),
                     uuid: *UUID_SCHEMA_ATTR_SPN,
                     description: String::from(
                         "The service principle name of an object, unique across all domain trusts",
@@ -720,9 +721,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("attributename"),
+                AttrString::from("attributename"),
                 SchemaAttribute {
-                    name: String::from("attributename"),
+                    name: AttrString::from("attributename"),
                     uuid: *UUID_SCHEMA_ATTR_ATTRIBUTENAME,
                     description: String::from("The name of a schema attribute"),
                     multivalue: false,
@@ -733,9 +734,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("classname"),
+                AttrString::from("classname"),
                 SchemaAttribute {
-                    name: String::from("classname"),
+                    name: AttrString::from("classname"),
                     uuid: *UUID_SCHEMA_ATTR_CLASSNAME,
                     description: String::from("The name of a schema class"),
                     multivalue: false,
@@ -746,9 +747,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("description"),
+                AttrString::from("description"),
                 SchemaAttribute {
-                    name: String::from("description"),
+                    name: AttrString::from("description"),
                     uuid: *UUID_SCHEMA_ATTR_DESCRIPTION,
                     description: String::from("A description of an attribute, object or class"),
                     multivalue: true,
@@ -758,8 +759,8 @@ impl<'a> SchemaWriteTransaction<'a> {
                     syntax: SyntaxType::UTF8STRING,
                 },
             );
-            self.attributes.insert(String::from("multivalue"), SchemaAttribute {
-                name: String::from("multivalue"),
+            self.attributes.insert(AttrString::from("multivalue"), SchemaAttribute {
+                name: AttrString::from("multivalue"),
                 uuid: *UUID_SCHEMA_ATTR_MULTIVALUE,
                 description: String::from("If true, this attribute is able to store multiple values rather than just a single value."),
                 multivalue: false,
@@ -768,8 +769,8 @@ impl<'a> SchemaWriteTransaction<'a> {
                 index: vec![],
                 syntax: SyntaxType::BOOLEAN,
             });
-            self.attributes.insert(String::from("phantom"), SchemaAttribute {
-                name: String::from("phantom"),
+            self.attributes.insert(AttrString::from("phantom"), SchemaAttribute {
+                name: AttrString::from("phantom"),
                 uuid: *UUID_SCHEMA_ATTR_PHANTOM,
                 description: String::from("If true, this attribute must NOT be present in any may/must sets of a class as. This represents generated attributes."),
                 multivalue: false,
@@ -778,8 +779,8 @@ impl<'a> SchemaWriteTransaction<'a> {
                 index: vec![],
                 syntax: SyntaxType::BOOLEAN,
             });
-            self.attributes.insert(String::from("unique"), SchemaAttribute {
-                name: String::from("unique"),
+            self.attributes.insert(AttrString::from("unique"), SchemaAttribute {
+                name: AttrString::from("unique"),
                 uuid: *UUID_SCHEMA_ATTR_UNIQUE,
                 description: String::from("If true, this attribute must store a unique value through out the database."),
                 multivalue: false,
@@ -789,9 +790,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 syntax: SyntaxType::BOOLEAN,
             });
             self.attributes.insert(
-                String::from("index"),
+                AttrString::from("index"),
                 SchemaAttribute {
-                    name: String::from("index"),
+                    name: AttrString::from("index"),
                     uuid: *UUID_SCHEMA_ATTR_INDEX,
                     description: String::from(
                         "Describe the indexes to apply to instances of this attribute.",
@@ -804,9 +805,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("syntax"),
+                AttrString::from("syntax"),
                 SchemaAttribute {
-                    name: String::from("syntax"),
+                    name: AttrString::from("syntax"),
                     uuid: *UUID_SCHEMA_ATTR_SYNTAX,
                     description: String::from(
                         "Describe the syntax of this attribute. This affects indexing and sorting.",
@@ -819,9 +820,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("systemmay"),
+                AttrString::from("systemmay"),
                 SchemaAttribute {
-                    name: String::from("systemmay"),
+                    name: AttrString::from("systemmay"),
                     uuid: *UUID_SCHEMA_ATTR_SYSTEMMAY,
                     description: String::from(
                         "A list of system provided optional attributes this class can store.",
@@ -834,9 +835,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("may"),
+                AttrString::from("may"),
                 SchemaAttribute {
-                    name: String::from("may"),
+                    name: AttrString::from("may"),
                     uuid: *UUID_SCHEMA_ATTR_MAY,
                     description: String::from(
                         "A user modifiable list of optional attributes this class can store.",
@@ -849,9 +850,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("systemmust"),
+                AttrString::from("systemmust"),
                 SchemaAttribute {
-                    name: String::from("systemmust"),
+                    name: AttrString::from("systemmust"),
                     uuid: *UUID_SCHEMA_ATTR_SYSTEMMUST,
                     description: String::from(
                         "A list of system provided required attributes this class must store.",
@@ -864,9 +865,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("must"),
+                AttrString::from("must"),
                 SchemaAttribute {
-                    name: String::from("must"),
+                    name: AttrString::from("must"),
                     uuid: *UUID_SCHEMA_ATTR_MUST,
                     description: String::from(
                         "A user modifiable list of required attributes this class must store.",
@@ -881,9 +882,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             // SYSINFO attrs
             // ACP attributes.
             self.attributes.insert(
-                String::from("acp_enable"),
+                AttrString::from("acp_enable"),
                 SchemaAttribute {
-                    name: String::from("acp_enable"),
+                    name: AttrString::from("acp_enable"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_ENABLE,
                     description: String::from("A flag to determine if this ACP is active for application. True is enabled, and enforce. False is checked but not enforced."),
                     multivalue: false,
@@ -895,9 +896,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
 
             self.attributes.insert(
-                String::from("acp_receiver"),
+                AttrString::from("acp_receiver"),
                 SchemaAttribute {
-                    name: String::from("acp_receiver"),
+                    name: AttrString::from("acp_receiver"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_RECEIVER,
                     description: String::from(
                         "Who the ACP applies to, constraining or allowing operations.",
@@ -910,9 +911,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("acp_targetscope"),
+                AttrString::from("acp_targetscope"),
                 SchemaAttribute {
-                    name: String::from("acp_targetscope"),
+                    name: AttrString::from("acp_targetscope"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_TARGETSCOPE,
                     description: String::from(
                         "The effective targets of the ACP, IE what will be acted upon.",
@@ -925,9 +926,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("acp_search_attr"),
+                AttrString::from("acp_search_attr"),
                 SchemaAttribute {
-                    name: String::from("acp_search_attr"),
+                    name: AttrString::from("acp_search_attr"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_SEARCH_ATTR,
                     description: String::from("The attributes that may be viewed or searched by the reciever on targetscope."),
                     multivalue: true,
@@ -938,9 +939,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("acp_create_class"),
+                AttrString::from("acp_create_class"),
                 SchemaAttribute {
-                    name: String::from("acp_create_class"),
+                    name: AttrString::from("acp_create_class"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_CREATE_CLASS,
                     description: String::from(
                         "The set of classes that can be created on a new entry.",
@@ -953,9 +954,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("acp_create_attr"),
+                AttrString::from("acp_create_attr"),
                 SchemaAttribute {
-                    name: String::from("acp_create_attr"),
+                    name: AttrString::from("acp_create_attr"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_CREATE_ATTR,
                     description: String::from(
                         "The set of attribute types that can be created on an entry.",
@@ -969,9 +970,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
 
             self.attributes.insert(
-                String::from("acp_modify_removedattr"),
+                AttrString::from("acp_modify_removedattr"),
                 SchemaAttribute {
-                    name: String::from("acp_modify_removedattr"),
+                    name: AttrString::from("acp_modify_removedattr"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_MODIFY_REMOVEDATTR,
                     description: String::from("The set of attribute types that could be removed or purged in a modification."),
                     multivalue: true,
@@ -982,9 +983,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("acp_modify_presentattr"),
+                AttrString::from("acp_modify_presentattr"),
                 SchemaAttribute {
-                    name: String::from("acp_modify_presentattr"),
+                    name: AttrString::from("acp_modify_presentattr"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_MODIFY_PRESENTATTR,
                     description: String::from("The set of attribute types that could be added or asserted in a modification."),
                     multivalue: true,
@@ -995,9 +996,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("acp_modify_class"),
+                AttrString::from("acp_modify_class"),
                 SchemaAttribute {
-                    name: String::from("acp_modify_class"),
+                    name: AttrString::from("acp_modify_class"),
                     uuid: *UUID_SCHEMA_ATTR_ACP_MODIFY_CLASS,
                     description: String::from("The set of class values that could be asserted or added to an entry. Only applies to modify::present operations on class."),
                     multivalue: true,
@@ -1009,9 +1010,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
             // MO/Member
             self.attributes.insert(
-                String::from("memberof"),
+                AttrString::from("memberof"),
                 SchemaAttribute {
-                    name: String::from("memberof"),
+                    name: AttrString::from("memberof"),
                     uuid: *UUID_SCHEMA_ATTR_MEMBEROF,
                     description: String::from("reverse group membership of the object"),
                     multivalue: true,
@@ -1022,9 +1023,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("directmemberof"),
+                AttrString::from("directmemberof"),
                 SchemaAttribute {
-                    name: String::from("directmemberof"),
+                    name: AttrString::from("directmemberof"),
                     uuid: *UUID_SCHEMA_ATTR_DIRECTMEMBEROF,
                     description: String::from("reverse direct group membership of the object"),
                     multivalue: true,
@@ -1035,9 +1036,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("member"),
+                AttrString::from("member"),
                 SchemaAttribute {
-                    name: String::from("member"),
+                    name: AttrString::from("member"),
                     uuid: *UUID_SCHEMA_ATTR_MEMBER,
                     description: String::from("List of members of the group"),
                     multivalue: true,
@@ -1049,9 +1050,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
             // Migration related
             self.attributes.insert(
-                String::from("version"),
+                AttrString::from("version"),
                 SchemaAttribute {
-                    name: String::from("version"),
+                    name: AttrString::from("version"),
                     uuid: *UUID_SCHEMA_ATTR_VERSION,
                     description: String::from(
                         "The systems internal migration version for provided objects",
@@ -1065,9 +1066,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
             // Domain for sysinfo
             self.attributes.insert(
-                String::from("domain"),
+                AttrString::from("domain"),
                 SchemaAttribute {
-                    name: String::from("domain"),
+                    name: AttrString::from("domain"),
                     uuid: *UUID_SCHEMA_ATTR_DOMAIN,
                     description: String::from("A DNS Domain name entry."),
                     multivalue: true,
@@ -1078,9 +1079,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("claim"),
+                AttrString::from("claim"),
                 SchemaAttribute {
-                    name: String::from("claim"),
+                    name: AttrString::from("claim"),
                     uuid: *UUID_SCHEMA_ATTR_CLAIM,
                     description: String::from("The spn of a claim this entry holds"),
                     multivalue: true,
@@ -1091,9 +1092,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("password_import"),
+                AttrString::from("password_import"),
                 SchemaAttribute {
-                    name: String::from("password_import"),
+                    name: AttrString::from("password_import"),
                     uuid: *UUID_SCHEMA_ATTR_PASSWORD_IMPORT,
                     description: String::from("An imported password hash from an external system."),
                     multivalue: true,
@@ -1106,9 +1107,9 @@ impl<'a> SchemaWriteTransaction<'a> {
 
             // LDAP Masking Phantoms
             self.attributes.insert(
-                String::from("dn"),
+                AttrString::from("dn"),
                 SchemaAttribute {
-                    name: String::from("dn"),
+                    name: AttrString::from("dn"),
                     uuid: *UUID_SCHEMA_ATTR_DN,
                     description: String::from("An LDAP Compatible DN"),
                     multivalue: false,
@@ -1119,9 +1120,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("entryuuid"),
+                AttrString::from("entryuuid"),
                 SchemaAttribute {
-                    name: String::from("entryuuid"),
+                    name: AttrString::from("entryuuid"),
                     uuid: *UUID_SCHEMA_ATTR_ENTRYUUID,
                     description: String::from("An LDAP Compatible entryUUID"),
                     multivalue: false,
@@ -1132,9 +1133,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.attributes.insert(
-                String::from("objectclass"),
+                AttrString::from("objectclass"),
                 SchemaAttribute {
-                    name: String::from("objectclass"),
+                    name: AttrString::from("objectclass"),
                     uuid: *UUID_SCHEMA_ATTR_OBJECTCLASS,
                     description: String::from("An LDAP Compatible objectClass"),
                     multivalue: true,
@@ -1147,72 +1148,72 @@ impl<'a> SchemaWriteTransaction<'a> {
             // end LDAP masking phantoms
 
             self.classes.insert(
-                String::from("attributetype"),
+                AttrString::from("attributetype"),
                 SchemaClass {
-                    name: String::from("attributetype"),
+                    name: AttrString::from("attributetype"),
                     uuid: *UUID_SCHEMA_CLASS_ATTRIBUTETYPE,
                     description: String::from("Definition of a schema attribute"),
-                    systemmay: vec![String::from("phantom"), String::from("index")],
+                    systemmay: vec![AttrString::from("phantom"), AttrString::from("index")],
                     may: vec![],
                     systemmust: vec![
-                        String::from("class"),
-                        String::from("attributename"),
-                        String::from("multivalue"),
-                        String::from("unique"),
-                        String::from("syntax"),
-                        String::from("description"),
+                        AttrString::from("class"),
+                        AttrString::from("attributename"),
+                        AttrString::from("multivalue"),
+                        AttrString::from("unique"),
+                        AttrString::from("syntax"),
+                        AttrString::from("description"),
                     ],
                     must: vec![],
                 },
             );
             self.classes.insert(
-                String::from("classtype"),
+                AttrString::from("classtype"),
                 SchemaClass {
-                    name: String::from("classtype"),
+                    name: AttrString::from("classtype"),
                     uuid: *UUID_SCHEMA_CLASS_CLASSTYPE,
                     description: String::from("Definition of a schema classtype"),
                     systemmay: vec![
-                        String::from("systemmay"),
-                        String::from("may"),
-                        String::from("systemmust"),
-                        String::from("must"),
+                        AttrString::from("systemmay"),
+                        AttrString::from("may"),
+                        AttrString::from("systemmust"),
+                        AttrString::from("must"),
                     ],
                     may: vec![],
                     systemmust: vec![
-                        String::from("class"),
-                        String::from("classname"),
-                        String::from("description"),
+                        AttrString::from("class"),
+                        AttrString::from("classname"),
+                        AttrString::from("description"),
                     ],
                     must: vec![],
                 },
             );
             self.classes.insert(
-                String::from("object"),
+                AttrString::from("object"),
                 SchemaClass {
-                    name: String::from("object"),
+                    name: AttrString::from("object"),
                     uuid: *UUID_SCHEMA_CLASS_OBJECT,
                     description: String::from(
                         "A system created class that all objects must contain",
                     ),
-                    systemmay: vec![String::from("description")],
+                    systemmay: vec![AttrString::from("description")],
                     may: vec![],
                     systemmust: vec![
-                        String::from("class"),
-                        String::from("uuid"),
-                        String::from("last_modified_cid"),
+                        AttrString::from("class"),
+                        AttrString::from("uuid"),
+                        AttrString::from("last_modified_cid"),
                     ],
                     must: vec![],
                 },
             );
             self.classes.insert(
-                String::from("memberof"),
+                AttrString::from("memberof"),
                 SchemaClass {
-                    name: String::from("memberof"),
+                    name: AttrString::from("memberof"),
                     uuid: *UUID_SCHEMA_CLASS_MEMBEROF,
                     description: String::from("Class that is dynamically added to recepients of memberof or directmemberof"),
                     systemmay: vec![
-                        "memberof".to_string(),
-                        "directmemberof".to_string()
+                        AttrString::from("memberof"),
+                        AttrString::from("directmemberof")
                     ],
                     may: vec![],
                     systemmust: vec![],
@@ -1220,9 +1221,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.classes.insert(
-                String::from("extensibleobject"),
+                AttrString::from("extensibleobject"),
                 SchemaClass {
-                    name: String::from("extensibleobject"),
+                    name: AttrString::from("extensibleobject"),
                     uuid: *UUID_SCHEMA_CLASS_EXTENSIBLEOBJECT,
                     description: String::from(
                         "A class type that has green hair and turns off all rules ...",
@@ -1235,9 +1236,9 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
             /* These two classes are core to the entry lifecycle for recycling and tombstoning */
             self.classes.insert(
-                String::from("recycled"),
+                AttrString::from("recycled"),
                 SchemaClass {
-                    name: String::from("recycled"),
+                    name: AttrString::from("recycled"),
                     uuid: *UUID_SCHEMA_CLASS_RECYCLED,
                     description: String::from("An object that has been deleted, but still recoverable via the revive operation. Recycled objects are not modifiable, only revivable."),
                     systemmay: vec![],
@@ -1247,31 +1248,31 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.classes.insert(
-                String::from("tombstone"),
+                AttrString::from("tombstone"),
                 SchemaClass {
-                    name: String::from("tombstone"),
+                    name: AttrString::from("tombstone"),
                     uuid: *UUID_SCHEMA_CLASS_TOMBSTONE,
                     description: String::from("An object that is purged from the recycle bin. This is a system internal state. Tombstones have no attributes beside UUID."),
                     systemmay: vec![],
                     may: vec![],
                     systemmust: vec![
-                        String::from("class"),
-                        String::from("uuid"),
+                        AttrString::from("class"),
+                        AttrString::from("uuid"),
                     ],
                     must: vec![],
                 },
             );
             // sysinfo
             self.classes.insert(
-                String::from("system_info"),
+                AttrString::from("system_info"),
                 SchemaClass {
-                    name: String::from("system_info"),
+                    name: AttrString::from("system_info"),
                     uuid: *UUID_SCHEMA_CLASS_SYSTEM_INFO,
                     description: String::from("System metadata object class"),
                     systemmay: vec![],
                     may: vec![],
                     systemmust: vec![
-                        String::from("version"),
+                        AttrString::from("version"),
                         // Needed when we implement principalnames?
                         // String::from("domain"),
                         // String::from("hostname"),
@@ -1281,37 +1282,40 @@ impl<'a> SchemaWriteTransaction<'a> {
             );
             // ACP
             self.classes.insert(
-                String::from("access_control_profile"),
+                AttrString::from("access_control_profile"),
                 SchemaClass {
-                    name: String::from("access_control_profile"),
+                    name: AttrString::from("access_control_profile"),
                     uuid: *UUID_SCHEMA_CLASS_ACCESS_CONTROL_PROFILE,
                     description: String::from("System Access Control Profile Class"),
-                    systemmay: vec!["acp_enable".to_string(), "description".to_string()],
+                    systemmay: vec![
+                        AttrString::from("acp_enable"),
+                        AttrString::from("description"),
+                    ],
                     may: vec![],
                     systemmust: vec![
-                        "acp_receiver".to_string(),
-                        "acp_targetscope".to_string(),
-                        "name".to_string(),
+                        AttrString::from("acp_receiver"),
+                        AttrString::from("acp_targetscope"),
+                        AttrString::from("name"),
                     ],
                     must: vec![],
                 },
             );
             self.classes.insert(
-                String::from("access_control_search"),
+                AttrString::from("access_control_search"),
                 SchemaClass {
-                    name: String::from("access_control_search"),
+                    name: AttrString::from("access_control_search"),
                     uuid: *UUID_SCHEMA_CLASS_ACCESS_CONTROL_SEARCH,
                     description: String::from("System Access Control Search Class"),
                     systemmay: vec![],
                     may: vec![],
-                    systemmust: vec!["acp_search_attr".to_string()],
+                    systemmust: vec![AttrString::from("acp_search_attr")],
                     must: vec![],
                 },
             );
             self.classes.insert(
-                String::from("access_control_delete"),
+                AttrString::from("access_control_delete"),
                 SchemaClass {
-                    name: String::from("access_control_delete"),
+                    name: AttrString::from("access_control_delete"),
                     uuid: *UUID_SCHEMA_CLASS_ACCESS_CONTROL_DELETE,
                     description: String::from("System Access Control DELETE Class"),
                     systemmay: vec![],
@@ -1321,15 +1325,15 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.classes.insert(
-                String::from("access_control_modify"),
+                AttrString::from("access_control_modify"),
                 SchemaClass {
-                    name: String::from("access_control_modify"),
+                    name: AttrString::from("access_control_modify"),
                     uuid: *UUID_SCHEMA_CLASS_ACCESS_CONTROL_MODIFY,
                     description: String::from("System Access Control Modify Class"),
                     systemmay: vec![
-                        "acp_modify_removedattr".to_string(),
-                        "acp_modify_presentattr".to_string(),
-                        "acp_modify_class".to_string(),
+                        AttrString::from("acp_modify_removedattr"),
+                        AttrString::from("acp_modify_presentattr"),
+                        AttrString::from("acp_modify_class"),
                     ],
                     may: vec![],
                     systemmust: vec![],
@@ -1337,14 +1341,14 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.classes.insert(
-                String::from("access_control_create"),
+                AttrString::from("access_control_create"),
                 SchemaClass {
-                    name: String::from("access_control_create"),
+                    name: AttrString::from("access_control_create"),
                     uuid: *UUID_SCHEMA_CLASS_ACCESS_CONTROL_CREATE,
                     description: String::from("System Access Control Create Class"),
                     systemmay: vec![
-                        "acp_create_class".to_string(),
-                        "acp_create_attr".to_string(),
+                        AttrString::from("acp_create_class"),
+                        AttrString::from("acp_create_attr"),
                     ],
                     may: vec![],
                     systemmust: vec![],
@@ -1352,9 +1356,9 @@ impl<'a> SchemaWriteTransaction<'a> {
                 },
             );
             self.classes.insert(
-                String::from("system"),
+                AttrString::from("system"),
                 SchemaClass {
-                    name: String::from("system"),
+                    name: AttrString::from("system"),
                     uuid: *UUID_SCHEMA_CLASS_SYSTEM,
                     description: String::from("A class denoting that a type is system generated and protected. It has special internal behaviour."),
                     systemmay: vec![],
@@ -1377,37 +1381,37 @@ impl<'a> SchemaWriteTransaction<'a> {
 }
 
 impl<'a> SchemaTransaction for SchemaWriteTransaction<'a> {
-    fn get_attributes_unique(&self) -> &Vec<String> {
+    fn get_attributes_unique(&self) -> &Vec<AttrString> {
         &(*self.unique_cache)
     }
 
-    fn get_reference_types(&self) -> &HashMap<String, SchemaAttribute> {
+    fn get_reference_types(&self) -> &HashMap<AttrString, SchemaAttribute> {
         &(*self.ref_cache)
     }
 
-    fn get_classes(&self) -> &HashMap<String, SchemaClass> {
+    fn get_classes(&self) -> &HashMap<AttrString, SchemaClass> {
         &(*self.classes)
     }
 
-    fn get_attributes(&self) -> &HashMap<String, SchemaAttribute> {
+    fn get_attributes(&self) -> &HashMap<AttrString, SchemaAttribute> {
         &(*self.attributes)
     }
 }
 
 impl SchemaTransaction for SchemaReadTransaction {
-    fn get_attributes_unique(&self) -> &Vec<String> {
+    fn get_attributes_unique(&self) -> &Vec<AttrString> {
         &(*self.unique_cache)
     }
 
-    fn get_reference_types(&self) -> &HashMap<String, SchemaAttribute> {
+    fn get_reference_types(&self) -> &HashMap<AttrString, SchemaAttribute> {
         &(*self.ref_cache)
     }
 
-    fn get_classes(&self) -> &HashMap<String, SchemaClass> {
+    fn get_classes(&self) -> &HashMap<AttrString, SchemaClass> {
         &(*self.classes)
     }
 
-    fn get_attributes(&self) -> &HashMap<String, SchemaAttribute> {
+    fn get_attributes(&self) -> &HashMap<AttrString, SchemaAttribute> {
         &(*self.attributes)
     }
 }
@@ -1480,6 +1484,7 @@ mod tests {
     use crate::schema::SchemaTransaction;
     use crate::schema::{IndexType, Schema, SchemaAttribute, SchemaClass, SyntaxType};
     use crate::value::{PartialValue, Value};
+    use smartstring::alias::String as AttrString;
     use uuid::Uuid;
 
     // use crate::proto_v1::Filter as ProtoFilter;
@@ -1752,7 +1757,7 @@ mod tests {
         // Test single value string
         let single_value_string = SchemaAttribute {
             // class: vec![String::from("attributetype")],
-            name: String::from("single_value"),
+            name: AttrString::from("single_value"),
             uuid: Uuid::new_v4(),
             description: String::from(""),
             multivalue: false,
@@ -1781,7 +1786,7 @@ mod tests {
 
         let multi_value_string = SchemaAttribute {
             // class: vec![String::from("attributetype")],
-            name: String::from("mv_string"),
+            name: AttrString::from("mv_string"),
             uuid: Uuid::new_v4(),
             description: String::from(""),
             multivalue: true,
@@ -1799,7 +1804,7 @@ mod tests {
 
         let multi_value_boolean = SchemaAttribute {
             // class: vec![String::from("attributetype")],
-            name: String::from("mv_bool"),
+            name: AttrString::from("mv_bool"),
             uuid: Uuid::new_v4(),
             description: String::from(""),
             multivalue: true,
@@ -1831,7 +1836,7 @@ mod tests {
         // syntax_id and index_type values
         let single_value_syntax = SchemaAttribute {
             // class: vec![String::from("attributetype")],
-            name: String::from("sv_syntax"),
+            name: AttrString::from("sv_syntax"),
             uuid: Uuid::new_v4(),
             description: String::from(""),
             multivalue: false,
@@ -1856,7 +1861,7 @@ mod tests {
 
         let single_value_index = SchemaAttribute {
             // class: vec![String::from("attributetype")],
-            name: String::from("sv_index"),
+            name: AttrString::from("sv_index"),
             uuid: Uuid::new_v4(),
             description: String::from(""),
             multivalue: false,
@@ -2236,10 +2241,10 @@ mod tests {
 
         // Attempt to create a class with a phantom attribute, should be refused.
         let class = SchemaClass {
-            name: String::from("testobject"),
+            name: AttrString::from("testobject"),
             uuid: Uuid::new_v4(),
             description: String::from("test object"),
-            systemmay: vec!["claim".to_string()],
+            systemmay: vec![AttrString::from("claim")],
             may: vec![],
             systemmust: vec![],
             must: vec![],


### PR DESCRIPTION
Fixes #320, remove double verification of filters. In addition this replaces attr strings with smartstring to allow better inling due to their static and compact nature. 

- [ x ] cargo fmt has been run
- [x] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
