### PR TITLE
202 totp cli enrollment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,7 +1631,7 @@ dependencies = [
  "url",
  "users",
  "uuid",
- "webauthn-authenticator-rs 0.3.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webauthn-authenticator-rs",
  "webauthn-rs",
  "zxcvbn",
 ]
@@ -1654,7 +1654,7 @@ dependencies = [
  "toml",
  "url",
  "uuid",
- "webauthn-authenticator-rs 0.3.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webauthn-authenticator-rs",
  "webauthn-rs",
 ]
 
@@ -1688,7 +1688,7 @@ dependencies = [
  "shellexpand",
  "structopt",
  "time 0.2.24",
- "webauthn-authenticator-rs 0.3.0-alpha.5",
+ "webauthn-authenticator-rs",
  "zxcvbn",
 ]
 
@@ -3628,23 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-authenticator-rs"
-version = "0.3.0-alpha.5"
-dependencies = [
- "authenticator",
- "log",
- "nom 4.2.3",
- "openssl",
- "serde_cbor",
- "serde_json",
- "url",
- "webauthn-rs",
-]
-
-[[package]]
-name = "webauthn-authenticator-rs"
-version = "0.3.0-alpha.5"
+version = "0.3.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f2a998d035484b3a3e21fd839d5c56e014fdf7756077ffbe209b1f09e6d265"
+checksum = "2240df596f30224b3268abac6fa1117f12312fc994bd49bab5e52752d73a9403"
 dependencies = [
  "authenticator",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,7 +1631,7 @@ dependencies = [
  "url",
  "users",
  "uuid",
- "webauthn-authenticator-rs",
+ "webauthn-authenticator-rs 0.3.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "webauthn-rs",
  "zxcvbn",
 ]
@@ -1654,7 +1654,7 @@ dependencies = [
  "toml",
  "url",
  "uuid",
- "webauthn-authenticator-rs",
+ "webauthn-authenticator-rs 0.3.0-alpha.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "webauthn-rs",
 ]
 
@@ -1688,7 +1688,7 @@ dependencies = [
  "shellexpand",
  "structopt",
  "time 0.2.24",
- "webauthn-authenticator-rs",
+ "webauthn-authenticator-rs 0.3.0-alpha.5",
  "zxcvbn",
 ]
 
@@ -3624,6 +3624,20 @@ checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webauthn-authenticator-rs"
+version = "0.3.0-alpha.5"
+dependencies = [
+ "authenticator",
+ "log",
+ "nom 4.2.3",
+ "openssl",
+ "serde_cbor",
+ "serde_json",
+ "url",
+ "webauthn-rs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "checked_int_cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1680,7 @@ dependencies = [
  "kanidm_client",
  "kanidm_proto",
  "log",
+ "qrcode",
  "rayon",
  "rpassword",
  "serde",
@@ -2346,6 +2353,15 @@ dependencies = [
  "lazy_static",
  "regex",
  "url",
+]
+
+[[package]]
+name = "qrcode"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
+dependencies = [
+ "checked_int_cast",
 ]
 
 [[package]]

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -771,6 +771,19 @@ fn test_server_rest_totp_auth_lifecycle() {
         assert!(rsclient_bad
             .auth_password_totp("demo_account", "sohdi3iuHo6mai7noh0a", 0)
             .is_err());
+
+        // Remove TOTP on the account.
+        rsclient
+            .idm_account_primary_credential_remove_totp("demo_account")
+            .unwrap(); // the result
+                       // Delay by one second to allow the account to recover from the
+                       // softlock.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // Check password auth.
+        let mut rsclient_good = rsclient.new_session().unwrap();
+        assert!(rsclient_good
+            .auth_simple_password("demo_account", "sohdi3iuHo6mai7noh0a")
+            .is_ok());
     });
 }
 

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -265,7 +265,7 @@ pub struct UnixUserToken {
 impl fmt::Display for UnixUserToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "---")?;
-        writeln!(f, "spn: {}", self.name)?;
+        writeln!(f, "spn: {}", self.spn)?;
         writeln!(f, "name: {}", self.name)?;
         writeln!(f, "displayname: {}", self.displayname)?;
         writeln!(f, "uuid: {}", self.uuid)?;

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -605,13 +605,17 @@ impl TOTPSecret {
             .replace("%3A", "")
             .replace(" ", "%20");
         let label = format!("{}:{}", issuer, accountname);
-        let secret = base32::encode(base32::Alphabet::RFC4648 { padding: false }, &self.secret);
         let algo = self.algo.to_string();
+        let secret = self.get_secret();
         let period = self.step;
         format!(
             "otpauth://totp/{}?secret={}&issuer={}&algorithm={}&digits=6&period={}",
             label, secret, issuer, algo, period
         )
+    }
+
+    pub fn get_secret(&self) -> String {
+        base32::encode(base32::Alphabet::RFC4648 { padding: false }, &self.secret)
     }
 }
 

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -446,7 +446,7 @@ impl fmt::Debug for AuthCredential {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthMech {
     Anonymous,
@@ -460,6 +460,17 @@ pub enum AuthMech {
 impl PartialEq for AuthMech {
     fn eq(&self, other: &Self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+impl fmt::Display for AuthMech {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthMech::Anonymous => write!(f, "Anonymous (no credentials)"),
+            AuthMech::Password => write!(f, "Passwold Only"),
+            AuthMech::PasswordMFA => write!(f, "TOTP or Token, and Password"),
+            AuthMech::Webauthn => write!(f, "Webauthn Token"),
+        }
     }
 }
 
@@ -484,7 +495,7 @@ pub struct AuthRequest {
 
 // Respond with the list of auth types and nonce, etc.
 // It can also contain a denied, or success.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthAllowed {
     Anonymous,
@@ -528,6 +539,17 @@ impl PartialOrd for AuthAllowed {
     }
 }
 
+impl fmt::Display for AuthAllowed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthAllowed::Anonymous => write!(f, "Anonymous (no credentials)"),
+            AuthAllowed::Password => write!(f, "Password"),
+            AuthAllowed::TOTP => write!(f, "TOTP"),
+            AuthAllowed::Webauthn(_) => write!(f, "Webauthn Token"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthState {
@@ -556,6 +578,7 @@ pub enum SetCredentialRequest {
     GeneratePassword,
     TOTPGenerate(String),
     TOTPVerify(Uuid, u32),
+    TOTPRemove,
     // Start the rego.
     WebauthnBegin(String),
     // Finish it.

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -42,5 +42,5 @@ qrcode = { version = "0.12", default-features = false }
 
 zxcvbn = "2.0"
 
-webauthn-authenticator-rs = "0.3.0-alpha.5"
-# webauthn-authenticator-rs = { path = "../../webauthn-authenticator-rs" }
+# webauthn-authenticator-rs = "0.3.0-alpha.5"
+webauthn-authenticator-rs = { path = "../../webauthn-authenticator-rs" }

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -42,5 +42,5 @@ qrcode = { version = "0.12", default-features = false }
 
 zxcvbn = "2.0"
 
-# webauthn-authenticator-rs = "0.3.0-alpha.5"
-webauthn-authenticator-rs = { path = "../../webauthn-authenticator-rs" }
+webauthn-authenticator-rs = "^0.3.0-alpha.6"
+# webauthn-authenticator-rs = { path = "../../webauthn-authenticator-rs" }

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0"
 shellexpand = "2.0"
 rayon = "1.2"
 time = "0.2"
+qrcode = { version = "0.12", default-features = false }
 
 zxcvbn = "2.0"
 

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -94,8 +94,11 @@ pub enum AccountCredential {
     GeneratePassword(AccountCredentialSet),
     #[structopt(name = "register_webauthn")]
     RegisterWebauthn(AccountNamedTagOpt),
-    #[structopt(name = "register_totp")]
+    /// Set the TOTP credential of the account. If a TOTP already exists, on a successful
+    /// registration, this will replace it.
+    #[structopt(name = "set_totp")]
     RegisterTOTP(AccountNamedTagOpt),
+    /// Remove TOTP from the account. If no TOTP exists, no action is taken.
     #[structopt(name = "remove_totp")]
     RemoveTOTP(AccountNamedTagOpt),
 }

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -561,6 +561,23 @@ impl Credential {
         }
     }
 
+    pub(crate) fn remove_totp(&self) -> Self {
+        let type_ = match &self.type_ {
+            CredentialType::PasswordMFA(pw, Some(_), wan) =>
+            if wan.is_empty() {
+                CredentialType::Password(pw.clone())
+            } else {
+                CredentialType::PasswordMFA(pw.clone(), None, wan.clone())
+            },
+            _ => self.type_.clone(),
+        };
+        Credential {
+            type_,
+            claims: self.claims.clone(),
+            uuid: self.uuid,
+        }
+    }
+
     pub(crate) fn new_from_password(pw: Password) -> Self {
         Credential {
             type_: CredentialType::Password(pw),

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -563,12 +563,13 @@ impl Credential {
 
     pub(crate) fn remove_totp(&self) -> Self {
         let type_ = match &self.type_ {
-            CredentialType::PasswordMFA(pw, Some(_), wan) =>
-            if wan.is_empty() {
-                CredentialType::Password(pw.clone())
-            } else {
-                CredentialType::PasswordMFA(pw.clone(), None, wan.clone())
-            },
+            CredentialType::PasswordMFA(pw, Some(_), wan) => {
+                if wan.is_empty() {
+                    CredentialType::Password(pw.clone())
+                } else {
+                    CredentialType::PasswordMFA(pw.clone(), None, wan.clone())
+                }
+            }
             _ => self.type_.clone(),
         };
         Credential {

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -246,6 +246,23 @@ impl Account {
         }
     }
 
+    pub(crate) fn gen_totp_remove_mod(
+        &self
+    ) -> Result<ModifyList<ModifyInvalid>, OperationError> {
+        match &self.primary {
+            // Change the cred
+            Some(primary) => {
+                let ncred = primary.remove_totp();
+                let vcred = Value::new_credential("primary", ncred);
+                Ok(ModifyList::new_purge_and_set("primary_credential", vcred))
+            }
+            None => {
+                // No credential exists, we can't supplementy it.
+                Err(OperationError::InvalidState)
+            }
+        }
+    }
+
     pub(crate) fn gen_webauthn_mod(
         &self,
         label: String,

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -246,9 +246,7 @@ impl Account {
         }
     }
 
-    pub(crate) fn gen_totp_remove_mod(
-        &self
-    ) -> Result<ModifyList<ModifyInvalid>, OperationError> {
+    pub(crate) fn gen_totp_remove_mod(&self) -> Result<ModifyList<ModifyInvalid>, OperationError> {
         match &self.primary {
             // Change the cred
             Some(primary) => {

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -319,7 +319,7 @@ impl CredHandler {
             CredHandler::Password(_) => vec![AuthAllowed::Password],
             // webauth
             // mfa
-            CredHandler::PasswordMFA(_) => vec![AuthAllowed::Password, AuthAllowed::TOTP],
+            CredHandler::PasswordMFA(_) => vec![AuthAllowed::TOTP],
             CredHandler::Webauthn(webauthn) => vec![AuthAllowed::Webauthn(webauthn.chal.clone())],
         }
     }

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -341,6 +341,40 @@ impl VerifyTOTPEvent {
 }
 
 #[derive(Debug)]
+pub struct RemoveTOTPEvent {
+    pub event: Event,
+    pub target: Uuid,
+}
+
+impl RemoveTOTPEvent {
+    /*
+    pub fn from_parts(
+        audit: &mut AuditScope,
+        qs: &QueryServerWriteTransaction,
+        uat: Option<&UserAuthToken>,
+        target: Uuid,
+    ) -> Result<Self, OperationError> {
+        let e = Event::from_rw_uat(audit, qs, uat)?;
+
+        Ok(RemoveTOTPEvent {
+            event: e,
+            target,
+        })
+    }
+    */
+
+    #[cfg(test)]
+    pub fn new_internal(target: Uuid) -> Self {
+        let e = Event::from_internal();
+
+        RemoveTOTPEvent {
+            event: e,
+            target,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct WebauthnInitRegisterEvent {
     pub event: Event,
     pub target: Uuid,

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -347,7 +347,6 @@ pub struct RemoveTOTPEvent {
 }
 
 impl RemoveTOTPEvent {
-    /*
     pub fn from_parts(
         audit: &mut AuditScope,
         qs: &QueryServerWriteTransaction,
@@ -356,21 +355,14 @@ impl RemoveTOTPEvent {
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, uat)?;
 
-        Ok(RemoveTOTPEvent {
-            event: e,
-            target,
-        })
+        Ok(RemoveTOTPEvent { event: e, target })
     }
-    */
 
     #[cfg(test)]
     pub fn new_internal(target: Uuid) -> Self {
         let e = Event::from_internal();
 
-        RemoveTOTPEvent {
-            event: e,
-            target,
-        }
+        RemoveTOTPEvent { event: e, target }
     }
 }
 


### PR DESCRIPTION
Fixes #202 - This adds support for enrolling and removing totp on the cli, as well as a rebuilt work flow for login to allow dynamic prompting of what credetials are required. 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
