### PR TITLE
Automatically create .cache if it doesn't exist.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ dependencies = [
  "env_logger",
  "kanidm_client",
  "kanidm_proto",
+ "libc",
  "log",
  "qrcode",
  "rayon",

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -31,6 +31,7 @@ kanidm_client = { path = "../kanidm_client", version = "1.1.0-alpha.2" }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha.2" }
 rpassword = "5.0"
 structopt = { version = "0.3", default-features = false }
+libc = "0.2"
 log = "0.4"
 env_logger = "0.8"
 serde = "1.0"


### PR DESCRIPTION
Fixes #352 create .cache if it does not already exist. This also improves some of the warnings and path checking to make it clearer as to what is occuring, and also improves the umask behaviour to secure the token location.

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
