### PR TITLE
Complete MFA and Webauthn handlers

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -1068,6 +1068,23 @@ impl KanidmClient {
         }
     }
 
+    pub fn idm_account_primary_credential_remove_webauthn(
+        &self,
+        id: &str,
+        label: &str,
+    ) -> Result<bool, ClientError> {
+        let r = SetCredentialRequest::WebauthnRemove(label.to_string());
+        let res: Result<SetCredentialResponse, ClientError> = self.perform_put_request(
+            format!("/v1/account/{}/_credential/primary", id).as_str(),
+            r,
+        );
+        match res {
+            Ok(SetCredentialResponse::Success) => Ok(true),
+            Ok(_) => Err(ClientError::EmptyResponse),
+            Err(e) => Err(e),
+        }
+    }
+
     pub fn idm_account_radius_credential_get(
         &self,
         id: &str,

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -583,6 +583,8 @@ pub enum SetCredentialRequest {
     WebauthnBegin(String),
     // Finish it.
     WebauthnRegister(Uuid, RegisterPublicKeyCredential),
+    // Remove
+    WebauthnRemove(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -16,6 +16,7 @@ impl AccountOpt {
                 AccountCredential::SetPassword(acs) => acs.copt.debug,
                 AccountCredential::GeneratePassword(acs) => acs.copt.debug,
                 AccountCredential::RegisterWebauthn(acs) => acs.copt.debug,
+                AccountCredential::RemoveWebauthn(acs) => acs.copt.debug,
                 AccountCredential::RegisterTOTP(acs) => acs.copt.debug,
                 AccountCredential::RemoveTOTP(acs) => acs.copt.debug,
             },
@@ -123,6 +124,20 @@ impl AccountOpt {
                         }
                         Err(e) => {
                             eprintln!("Error Completing -> {:?}", e);
+                        }
+                    }
+                }
+                AccountCredential::RemoveWebauthn(acsopt) => {
+                    let client = acsopt.copt.to_client();
+                    match client.idm_account_primary_credential_remove_webauthn(
+                        acsopt.aopts.account_id.as_str(),
+                        acsopt.tag.as_str(),
+                    ) {
+                        Ok(_) => {
+                            println!("Webauthn removal success.");
+                        }
+                        Err(e) => {
+                            eprintln!("Error Removing Webauthn from account -> {:?}", e);
                         }
                     }
                 }

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -156,6 +156,8 @@ pub enum AccountCredential {
     GeneratePassword(AccountCredentialSet),
     #[structopt(name = "register_webauthn")]
     RegisterWebauthn(AccountNamedTagOpt),
+    #[structopt(name = "remove_webauthn")]
+    RemoveWebauthn(AccountNamedTagOpt),
     /// Set the TOTP credential of the account. If a TOTP already exists, on a successful
     /// registration, this will replace it.
     #[structopt(name = "set_totp")]

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -274,6 +274,24 @@ impl Account {
         Ok(ModifyList::new_purge_and_set("primary_credential", vcred))
     }
 
+    pub(crate) fn gen_webauthn_remove_mod(
+        &self,
+        label: &str,
+    ) -> Result<ModifyList<ModifyInvalid>, OperationError> {
+        match &self.primary {
+            // Change the cred
+            Some(primary) => {
+                let ncred = primary.remove_webauthn(label)?;
+                let vcred = Value::new_credential("primary", ncred);
+                Ok(ModifyList::new_purge_and_set("primary_credential", vcred))
+            }
+            None => {
+                // No credential exists, we can't remove what is not real.
+                Err(OperationError::InvalidState)
+            }
+        }
+    }
+
     #[allow(clippy::ptr_arg)]
     pub(crate) fn gen_webauthn_counter_mod(
         &self,

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -440,6 +440,42 @@ impl WebauthnDoRegisterEvent {
     }
 }
 
+#[derive(Debug)]
+pub struct RemoveWebauthnEvent {
+    pub event: Event,
+    pub target: Uuid,
+    pub label: String,
+}
+
+impl RemoveWebauthnEvent {
+    pub fn from_parts(
+        audit: &mut AuditScope,
+        qs: &QueryServerWriteTransaction,
+        uat: Option<&UserAuthToken>,
+        target: Uuid,
+        label: String,
+    ) -> Result<Self, OperationError> {
+        let e = Event::from_rw_uat(audit, qs, uat)?;
+
+        Ok(RemoveWebauthnEvent {
+            event: e,
+            target,
+            label,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_internal(target: Uuid, label: String) -> Self {
+        let e = Event::from_internal();
+
+        RemoveWebauthnEvent {
+            event: e,
+            target,
+            label,
+        }
+    }
+}
+
 pub struct LdapAuthEvent {
     // pub event: Event,
     pub target: Uuid,


### PR DESCRIPTION
Fixes #357 - this allows the password MFA handler to correct handle a mixed totp or webauthn credential with passwords. This is likely the "majority" of accounts we will see on the service. 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
