### PR TITLE
vacuum

### DIFF
--- a/kanidm_book/src/administrivia.md
+++ b/kanidm_book/src/administrivia.md
@@ -94,6 +94,20 @@ definitions (this works even though the schema is in the same database!)
 
 Generally, reindexing is a rare action and should not normally be required.
 
+# Vacuum
+
+Vacuuming is the process of reclaiming un-used pages from the sqlite freelists, as well as performing
+some data reordering tasks that may make some queries more efficient . It is recommended that you
+vacuum after a reindex is performed or when you wish to reclaim space in the database file.
+
+Vacuum is also able to change the pagesize of the database. After changing pagesize in server.toml,
+you must run a vacuum for this to take effect.
+
+    docker stop <container name>
+    docker run --rm -i -t -v kanidmd:/data \
+        kanidm/server:latest /sbin/kanidmd vacuum -c /data/server.toml
+    docker start <container name>
+
 # Verification
 
 The server ships with a number of verification utilities to ensure that data is consistent such

--- a/kanidm_book/src/administrivia.md
+++ b/kanidm_book/src/administrivia.md
@@ -100,8 +100,8 @@ Vacuuming is the process of reclaiming un-used pages from the sqlite freelists, 
 some data reordering tasks that may make some queries more efficient . It is recommended that you
 vacuum after a reindex is performed or when you wish to reclaim space in the database file.
 
-Vacuum is also able to change the pagesize of the database. After changing pagesize in server.toml,
-you must run a vacuum for this to take effect.
+Vacuum is also able to change the pagesize of the database. After changing db\_fs\_type (which affects 
+pagesize) in server.toml, you must run a vacuum for this to take effect.
 
     docker stop <container name>
     docker run --rm -i -t -v kanidmd:/data \

--- a/kanidm_book/src/installing_the_server.md
+++ b/kanidm_book/src/installing_the_server.md
@@ -87,11 +87,12 @@ You will also need a config file in the volume named `server.toml` (Within the c
     db_path = "/data/kanidm.db"
     #   If you have a known filesystem, kanidm can tune sqlite to match. Valid choices are:
     #   [zfs, other]
-    #   If you are unsure about this leave it as the default (other).
-    #   zfs:
-    #   * sets sqlite pagesize to 64k. You must set recordsize=64k on the zfs filesystem.
-    #   other:
-    #   * sets sqlite pagesize to 4k, matching most filesystems block sizes.
+    #   If you are unsure about this leave it as the default (other). After changing this
+    #   value you must run a vacuum task.
+    #   - zfs:
+    #     * sets sqlite pagesize to 64k. You must set recordsize=64k on the zfs filesystem.
+    #   - other:
+    #     * sets sqlite pagesize to 4k, matching most filesystems block sizes.
     # db_fs_type = "zfs"
     #   TLS chain and key in pem format. Both must be commented, or both must be present
     # tls_chain = "/data/chain.pem"

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -846,8 +846,9 @@ impl IdlArcSqlite {
         path: &str,
         pool_size: u32,
         fstype: FsType,
+        vacuum: bool,
     ) -> Result<Self, OperationError> {
-        let db = IdlSqlite::new(audit, path, pool_size, fstype)?;
+        let db = IdlSqlite::new(audit, path, pool_size, fstype, vacuum)?;
         let entry_cache = ARCache::new(
             DEFAULT_CACHE_TARGET,
             pool_size as usize,

--- a/kanidmd/src/lib/be/idl_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_sqlite.rs
@@ -1360,7 +1360,7 @@ mod tests {
     #[test]
     fn test_idl_sqlite_verify() {
         let mut audit = AuditScope::new("run_test", uuid::Uuid::new_v4(), None);
-        let be = IdlSqlite::new(&mut audit, "", 1, FsType::Generic).unwrap();
+        let be = IdlSqlite::new(&mut audit, "", 1, FsType::Generic, false).unwrap();
         let be_w = be.write();
         let r = be_w.verify();
         assert!(r.len() == 0);

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -1449,7 +1449,7 @@ mod tests {
                 itype: IndexType::EQUALITY,
             });
 
-            let be = Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta)
+            let be = Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta, false)
                 .expect("Failed to setup backend");
 
             let mut be_txn = be.write();

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -1312,6 +1312,7 @@ impl Backend {
         mut pool_size: u32,
         fstype: FsType,
         idxmeta: Set<IdxKey>,
+        vacuum: bool,
     ) -> Result<Self, OperationError> {
         // If in memory, reduce pool to 1
         if path == "" {
@@ -1322,7 +1323,7 @@ impl Backend {
         lperf_trace_segment!(audit, "be::new", || {
             let be = Backend {
                 pool_size: pool_size as usize,
-                idlayer: Arc::new(IdlArcSqlite::new(audit, path, pool_size, fstype)?),
+                idlayer: Arc::new(IdlArcSqlite::new(audit, path, pool_size, fstype, vacuum)?),
                 idxmeta: Arc::new(CowCell::new(idxmeta)),
             };
 

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -22,7 +22,7 @@ macro_rules! run_test_no_init {
             let schema_txn = schema_outer.write_blocking();
             schema_txn.reload_idxmeta()
         };
-        let be = match Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta) {
+        let be = match Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta, false) {
             Ok(be) => be,
             Err(e) => {
                 audit.write_log();
@@ -66,7 +66,7 @@ macro_rules! run_test {
             let schema_txn = schema_outer.write_blocking();
             schema_txn.reload_idxmeta()
         };
-        let be = match Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta) {
+        let be = match Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta, false) {
             Ok(be) => be,
             Err(e) => {
                 audit.write_log();
@@ -138,7 +138,7 @@ macro_rules! run_idm_test {
             schema_txn.reload_idxmeta()
         };
         let be =
-            Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta).expect("Failed to init be");
+            Backend::new(&mut audit, "", 1, FsType::Generic, idxmeta, false).expect("Failed to init be");
 
         let test_server = QueryServer::new(be, schema_outer);
         test_server

--- a/kanidmd/src/lib/plugins/macros.rs
+++ b/kanidmd/src/lib/plugins/macros.rs
@@ -19,7 +19,7 @@ macro_rules! setup_test {
             let schema_txn = schema_outer.write_blocking();
             schema_txn.reload_idxmeta()
         };
-        let be = Backend::new($au, "", 1, FsType::Generic, idxmeta).expect("Failed to init BE");
+        let be = Backend::new($au, "", 1, FsType::Generic, idxmeta, false).expect("Failed to init BE");
 
         let qs = QueryServer::new(be, schema_outer);
         qs.initialise_helper($au, duration_from_epoch_now())

--- a/kanidmd/src/server/opt.rs
+++ b/kanidmd/src/server/opt.rs
@@ -66,6 +66,9 @@ enum KanidmdOpt {
     #[structopt(name = "reindex")]
     /// Reindex the database (offline)
     Reindex(CommonOpt),
+    #[structopt(name = "vacuum")]
+    /// Vacuum the database to reclaim space or change page_size (offline)
+    Vacuum(CommonOpt),
     #[structopt(name = "domain_name_change")]
     /// Change the IDM domain name
     DomainChange(DomainOpt),

--- a/kanidmd/src/server/opt.rs
+++ b/kanidmd/src/server/opt.rs
@@ -67,7 +67,7 @@ enum KanidmdOpt {
     /// Reindex the database (offline)
     Reindex(CommonOpt),
     #[structopt(name = "vacuum")]
-    /// Vacuum the database to reclaim space or change page_size (offline)
+    /// Vacuum the database to reclaim space or change db_fs_type/page_size (offline)
     Vacuum(CommonOpt),
     #[structopt(name = "domain_name_change")]
     /// Change the IDM domain name


### PR DESCRIPTION
Fixes #362 moves vacuum to a dedicated task. This is needed as previous vacuuming on startup on large databases could cause the server to fail to start. By making this a task it avoids this error case, and makes the vacuum more predictable, and only run when required.

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
