### PR TITLE
Fix typo in kanidm_unixd socket path

### DIFF
--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -176,7 +176,7 @@ To debug the pam module interactions add `debug` to the module arguments such as
 
 ### Check the socket permissions
 
-Check that the /var/run/kanidm.sock is 777, and that non-root readers can see it with
+Check that the /var/run/kanidm-unixd/sock is 777, and that non-root readers can see it with
 ls or other tools.
 
 ### Check you can access the kanidm server


### PR DESCRIPTION
The path is /var/run/kanidm-unixd/sock, not /var/run/kanidm.sock.

- [x] cargo fmt has been run ← this fails in `kanidmd/src/lib/macros.rs` at line 18 btw (on nightly)
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
