### PR TITLE
Change obs link to the direct link to be able to install on SLES 15.2

### DIFF
--- a/kanidm_book/src/client_tools.md
+++ b/kanidm_book/src/client_tools.md
@@ -22,7 +22,7 @@ the clients with:
 Leap 15.2 is still not fully supported with Kanidm. For an experimental client, you can
 try the development repository. Using zypper you can add the repository with:
 
-    zypper ar obs://home:firstyear:kanidm home_firstyear_kanidm
+    zypper ar https://download.opensuse.org/repositories/home:/firstyear:/kanidm/openSUSE_Leap_15.2/ home_firstyear_kanidm
     zypper mr -f home_firstyear_kanidm
 
 Then you need to referesh your metadata and install the clients.


### PR DESCRIPTION
Fixes #

The obs links returns with Guessed platform = SLES_$releasever which results in the following link for SLES systems, would be possible to chage to the direct link to be acceptable in SLES 15.2 without issues for test purpose?

https://download.opensuse.org/repositories/home:/firstyear:/kanidm/SLES_15.2

Which results in the following error

Repository 'home_firstyear_kanidm2' is invalid.
[home_firstyear_kanidm|https://download.opensuse.org/repositories/home:/firstyear:/kanidm/SLES_15.2] Valid metadata not found at specified URL
History:
 - [home_firstyear_kanidm|https://download.opensuse.org/repositories/home:/firstyear:/kanidm/SLES_15.2] Repository type can't be determined.

Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'home_firstyear_kanidm2' because of the above error.
Some of the repositories have not been refreshed because of an error.


- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
