### PR TITLE
Fix home directory aliases to use correct trim statement.

### DIFF
--- a/kanidm_unix_int/src/tasks_daemon.rs
+++ b/kanidm_unix_int/src/tasks_daemon.rs
@@ -125,7 +125,11 @@ fn create_home_directory(info: &HomeDirectoryInfo, home_prefix: &str) -> Result<
     // Does the aliases exist
     for alias in info.aliases.iter() {
         // Sanity check the alias.
-        let alias = alias.replace(".", "").replace("/", "").replace("\\", "");
+        // let alias = alias.replace(".", "").replace("/", "").replace("\\", "");
+        let alias = alias
+            .trim_start_matches('.')
+            .replace("/", "")
+            .replace("\\", "");
         let alias_path_raw = format!("{}{}", home_prefix, alias);
         let alias_path = Path::new(&alias_path_raw);
 


### PR DESCRIPTION
Fixes #378 - Fixes the alias path safety so that the resultant path name is correct. 

cc @Flakebi 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
