### PR TITLE
Correctly return displayname

### DIFF
--- a/kanidmd/src/lib/idm/unix.rs
+++ b/kanidmd/src/lib/idm/unix.rs
@@ -155,7 +155,7 @@ impl UnixUserAccount {
         Ok(UnixUserToken {
             name: self.name.clone(),
             spn: self.spn.clone(),
-            displayname: self.name.clone(),
+            displayname: self.displayname.clone(),
             gidnumber: self.gidnumber,
             uuid: self.uuid.to_hyphenated_ref().to_string(),
             shell: self.shell.clone(),


### PR DESCRIPTION
Fixes #385, displayname was not correctly set into gecos due to a mistake in UnixUserAccount to UnixUserToken processing.

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
