### PR TITLE
379 change loginshell

### DIFF
--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -1085,8 +1085,14 @@ impl QueryServerWriteV1 {
             "class".into(),
             Value::new_class("posixaccount"),
         )))
+        .chain(iter::once(gidnumber.as_ref().map(|_| {
+            Modify::Purged("gidnumber".into())
+        })))
         .chain(iter::once(gidnumber.map(|n| {
             Modify::Present("gidnumber".into(), Value::new_uint32(n))
+        })))
+        .chain(iter::once(shell.as_ref().map(|_| {
+            Modify::Purged("loginshell".into())
         })))
         .chain(iter::once(shell.map(|s| {
             Modify::Present("loginshell".into(), Value::new_iutf8(s.as_str()))


### PR DESCRIPTION
Fixes #379 this fixes the generated internal modify to correct purge the previous login shell state to prevent attribute errors. This also adds a test to ensure the behaviour works. 

cc @Flakebi 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
