### PR TITLE
Fix Dockerfile to check return values.

### DIFF
--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -24,10 +24,10 @@ RUN ln -s -f /usr/bin/clang /usr/bin/cc && \
 
 RUN if [ "$(uname -m)" == "x86_64" ]; \
 		then export RUSTFLAGS='-Ctarget-cpu=haswell'; \
-	fi; \
+	fi && \
 	if [ "$(uname -m)" == "aarch64" ]; \
 		then export RUSTFLAGS=''; \
-	fi; \
+	fi && \
 	if [ "${SCCACHE_REDIS}" != "" ]; \
 		then \
 			export CC="/usr/bin/sccache /usr/bin/clang" && \
@@ -35,7 +35,7 @@ RUN if [ "$(uname -m)" == "x86_64" ]; \
 			sccache --start-server; \
 		else \
 			export CC="/usr/bin/clang"; \
-	fi; \
+	fi && \
 	export RUSTC_BOOTSTRAP=1 && \
 	echo $RUSTC_BOOTSTRAP && \
 	echo $RUSTC_WRAPPER && \
@@ -43,10 +43,10 @@ RUN if [ "$(uname -m)" == "x86_64" ]; \
 	echo $CC && \
 	cargo build \
 		--features=simd_support,libsqlite3-sys/bundled \
-		--release; \
+		--release && \
 	if [ "${SCCACHE_REDIS}" != "" ]; \
 		then sccache -s; \
-	fi; \
+	fi && \
 	ls -al /usr/src/kanidm/target/release/
 
 


### PR DESCRIPTION
Fixes #, check docker build return values.
Now it's possible, if part of build command fails, docker build will continue anyway. And if there are some artifacts in `/usr/src/kanidm/target/release/` they will be reused instead of newly build binaries  (which I suppose is reason of invalid docker images).

- [ - ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ - ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)

