### PR TITLE
fix displayname

### DIFF
--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -160,7 +160,7 @@ impl Account {
         Some(UserAuthToken {
             name: self.name.clone(),
             spn: self.spn.clone(),
-            displayname: self.name.clone(),
+            displayname: self.displayname.clone(),
             uuid: self.uuid.to_hyphenated_ref().to_string(),
             // application: None,
             groups: self.groups.iter().map(|g| g.to_proto()).collect(),


### PR DESCRIPTION
Fixes #385 - this fixes the user auth token to have the correct displayname.

@vDorst

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
