### PR TITLE
Aligns some wording with the code of conduct

### DIFF
--- a/kanidm_rlm_python/kanidmradius.py
+++ b/kanidm_rlm_python/kanidmradius.py
@@ -8,7 +8,6 @@ MAJOR, MINOR, _, _, _ = sys.version_info
 
 if MAJOR >= 3:
     import configparser
-    # Absolutely fuck you python3
     from functools import reduce
 else:
     import ConfigParser as configparser

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -691,7 +691,7 @@ impl<'a> BackendTransaction for BackendReadTransaction<'a> {
 
     #[allow(clippy::mut_from_ref)]
     fn get_idlayer(&self) -> &mut IdlArcSqliteReadTransaction<'a> {
-        // OKAY here be the cursed bullshit. We know that in our application
+        // OKAY here be the cursed thing. We know that in our application
         // that during a transaction, that we are the only holder of the
         // idlayer, so we KNOW it can be mut, and we know every thing it
         // returns is a copy anyway. But if we permeate that mut up, it prevents

--- a/kanidmd/src/lib/constants/uuids.rs
+++ b/kanidmd/src/lib/constants/uuids.rs
@@ -120,7 +120,7 @@ pub const _STR_UUID_SCHEMA_ATTR_ACCOUNT_EXPIRE: &str = "00000000-0000-0000-0000-
 pub const _STR_UUID_SCHEMA_ATTR_ACCOUNT_VALID_FROM: &str = "00000000-0000-0000-0000-ffff00000073";
 
 // System and domain infos
-// I'd like to strongly criticise william of the past for fucking up these allocations.
+// I'd like to strongly criticise william of the past for making poor choices about these allocations.
 pub const STR_UUID_SYSTEM_INFO: &str = "00000000-0000-0000-0000-ffffff000001";
 pub const STR_UUID_DOMAIN_INFO: &str = "00000000-0000-0000-0000-ffffff000025";
 // DO NOT allocate here, allocate below.

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -1574,7 +1574,7 @@ mod tests {
                     &anon_init,
                     Duration::from_secs(TEST_CURRENT_TIME),
                 ));
-                /* Some weird lifetime shit happens here ... */
+                /* Some weird lifetime things happen here ... */
 
                 let sid = match r1 {
                     Ok(ar) => {


### PR DESCRIPTION

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
