### PR TITLE
Basic documentation for monitoring

### DIFF
--- a/kanidm_book/src/SUMMARY.md
+++ b/kanidm_book/src/SUMMARY.md
@@ -1,18 +1,26 @@
 # Summary
 
 [Introduction to Kanidm](./intro.md)
+
+Getting started with Kanidm
+
 - [Installing the Server](./installing_the_server.md)
 - [Administrative Tasks](./administrivia.md)
 - [Interacting with the Server](./client_tools.md)
 - [Accounts and Groups](./accounts_and_groups.md)
-- [Posix Accounts and Groups](./posix_accounts.md)
-- [Pam and nsswitch](./pam_and_nsswitch.md)
-- [SSH Key Distribution](./ssh_key_dist.md)
-- [RADIUS](./radius.md)
+
+Additional information
+
+- [Legacy Applications - LDAP](./ldap.md)
+- [Monitoring the platform](./monitoring.md)
+- [PAM and nsswitch](./pam_and_nsswitch.md)
 - [Password Quality and Badlisting](./password_quality.md)
+- [POSIX Accounts and Groups](./posix_accounts.md)
+- [RADIUS](./radius.md)
 - [Recycle Bin](./recycle_bin.md)
-- [Legacy Applications -- LDAP](./ldap.md)
 - [Security Hardening](./security_hardening.md)
+- [SSH Key Distribution](./ssh_key_dist.md)
+
 -----------
 [Why TLS?](./why_tls.md)
 

--- a/kanidm_book/src/client_tools.md
+++ b/kanidm_book/src/client_tools.md
@@ -1,6 +1,6 @@
 # Interacting with the Server
 
-To interact with Kanidm as an administration, you'll need to use our command line tools
+To interact with Kanidm as an administrator, you'll need to use our command line tools
 
 ## From (experimental) packages
 

--- a/kanidm_book/src/client_tools.md
+++ b/kanidm_book/src/client_tools.md
@@ -1,6 +1,6 @@
 # Interacting with the Server
 
-To interact with Kanidm as an administrator, you'll need to use our command line tools
+To interact with Kanidm as an administration, you'll need to use our command line tools
 
 ## From (experimental) packages
 

--- a/kanidm_book/src/monitoring.md
+++ b/kanidm_book/src/monitoring.md
@@ -1,0 +1,15 @@
+# Monitoring the platform
+
+The monitoring design of Kanidm is still very much in its infancy - [take part in the dicussion here!](https://github.com/kanidm/kanidm/issues/216).
+
+## kanidmd
+
+kanidmd currently responds to HTTP GET requests at the `/status` endpoint with a JSON object of either "true" or "false". `true` indicates that the platform is responding to requests. 
+
+| URL | `<hostname>/status` |
+| --- | --- |
+| Example URL | `https://example.com/status` |
+| Expected response | One of either `true` or `false` (without quotes) |
+| Additional Headers | x-kanidm-opid
+| Content Type | application/json |
+| Cookies | kanidm-session |


### PR DESCRIPTION
Fixes #403 - adds basic documentation for monitoring

- [x] cargo fmt has been run
- [-] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [-] design document included (if relevant)
