### PR TITLE
fixing broken action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Update package manager
-      run: apt-get update
+      run: sudo apt-get update
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,9 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update package manager
+      run: apt-get update
+
     - name: Install dependencies
       run: |
-        sudo apt install -y \
+        sudo apt-get install -y \
           libpam0g-dev \
           libudev-dev \
           libssl-dev \


### PR DESCRIPTION
Github action broke last time I did a PR because `apt-get update` needs to be run.

Fixing.