### PR TITLE
fixing #407 and #408 - improving log output for file not found events

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -145,15 +145,18 @@ impl KanidmClientBuilder {
         })
     }
 
-    pub fn read_options_from_optional_config<P: AsRef<Path>>(
+    pub fn read_options_from_optional_config<P: AsRef<Path> + std::fmt::Debug>(
         self,
         config_path: P,
     ) -> Result<Self, ()> {
         // If the file does not exist, we skip this function.
-        let mut f = match File::open(config_path) {
+        let mut f = match File::open(&config_path) {
             Ok(f) => f,
             Err(e) => {
-                debug!("Unable to open config file [{:?}], skipping ...", e);
+                debug!(
+                    "Unable to open config file {:#?} [{:?}], skipping ...",
+                    &config_path, e
+                );
                 return Ok(self);
             }
         };

--- a/kanidm_unix_int/src/unix_config.rs
+++ b/kanidm_unix_int/src/unix_config.rs
@@ -77,14 +77,17 @@ impl KanidmUnixdConfig {
         }
     }
 
-    pub fn read_options_from_optional_config<P: AsRef<Path>>(
+    pub fn read_options_from_optional_config<P: AsRef<Path> + std::fmt::Debug>(
         self,
         config_path: P,
     ) -> Result<Self, ()> {
-        let mut f = match File::open(config_path) {
+        let mut f = match File::open(&config_path) {
             Ok(f) => f,
             Err(e) => {
-                debug!("Unable to open config file [{:?}], skipping ...", e);
+                debug!(
+                    "Unable to open config file {:#?} [{:?}], skipping ...",
+                    &config_path, e
+                );
                 return Ok(self);
             }
         };


### PR DESCRIPTION
Fixes #407 and fixes #408

- [x] cargo fmt has been run
- [-] cargo clippy has been run
- [x] cargo test has been run and passes
- [-] book chapter included (if relevant)
- [-] design document included (if relevant)
