### PR TITLE
Improve error message when socket not found

### DIFF
--- a/kanidm_unix_int/src/daemon_status.rs
+++ b/kanidm_unix_int/src/daemon_status.rs
@@ -13,6 +13,7 @@ extern crate log;
 
 use log::debug;
 use structopt::StructOpt;
+use std::path::PathBuf;
 
 // use futures::executor::block_on;
 
@@ -44,15 +45,20 @@ fn main() {
 
     let req = ClientRequest::Status;
 
-    match call_daemon_blocking(cfg.sock_path.as_str(), req) {
-        Ok(r) => match r {
-            ClientResponse::Ok => info!("working!"),
-            _ => {
-                error!("Error: unexpected response -> {:?}", r);
+    let spath = PathBuf::from(cfg.sock_path.as_str());
+    if !spath.exists() {
+        error!("kanidm_unixd socket {} does not exist - is the service running?", cfg.sock_path)
+    } else {
+        match call_daemon_blocking(cfg.sock_path.as_str(), req) {
+            Ok(r) => match r {
+                ClientResponse::Ok => info!("working!"),
+                _ => {
+                    error!("Error: unexpected response -> {:?}", r);
+                }
+            },
+            Err(e) => {
+                error!("Error -> {:?}", e);
             }
-        },
-        Err(e) => {
-            error!("Error -> {:?}", e);
         }
     }
 }


### PR DESCRIPTION
Fixes #407 adds a clearer error message when the kanidm_unixd socket is not found, as well as possible resolution. 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
