### PR TITLE
62 idm qs cleanup

### DIFF
--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -26,17 +26,15 @@ use std::cell::Cell;
 use std::ops::DerefMut;
 use uuid::Uuid;
 
-use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInit, EntryNew, EntryReduced, EntrySealed};
 use crate::filter::{Filter, FilterValid, FilterValidResolved};
 use crate::modify::Modify;
-use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
+use crate::prelude::*;
 use crate::value::PartialValue;
 
 use crate::event::{
     CreateEvent, DeleteEvent, Event, EventOrigin, EventOriginId, ModifyEvent, SearchEvent,
 };
-use smartstring::alias::String as AttrString;
 
 // const ACP_RELATED_SEARCH_CACHE_MAX: usize = 2048;
 // const ACP_RELATED_SEARCH_CACHE_LOCAL: usize = 16;
@@ -1456,16 +1454,8 @@ mod tests {
         AccessControlCreate, AccessControlDelete, AccessControlModify, AccessControlProfile,
         AccessControlSearch, AccessControls, AccessControlsTransaction,
     };
-    use crate::audit::AuditScope;
-    use crate::entry::{Entry, EntryCommitted, EntryInit, EntryNew, EntryReduced};
-    // use crate::server::QueryServerWriteTransaction;
-
     use crate::event::{CreateEvent, DeleteEvent, ModifyEvent, SearchEvent};
-    // use crate::filter::Filter;
-    // use crate::proto_v1::Filter as ProtoFilter;
-    use crate::constants::{JSON_ADMIN_V1, JSON_ANONYMOUS_V1, JSON_TESTPERSON1, JSON_TESTPERSON2};
-    use crate::value::{PartialValue, Value};
-    use smartstring::alias::String as AttrString;
+    use crate::prelude::*;
 
     macro_rules! acp_from_entry_err {
         (

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -26,16 +26,13 @@
 //! [`filter`]: ../filter/index.html
 //! [`schema`]: ../schema/index.html
 
-use crate::audit::AuditScope;
 use crate::credential::Credential;
 use crate::filter::{Filter, FilterInvalid, FilterResolved, FilterValidResolved};
 use crate::ldap::ldap_attr_entry_map;
 use crate::modify::{Modify, ModifyInvalid, ModifyList, ModifyValid};
+use crate::prelude::*;
 use crate::repl::cid::Cid;
 use crate::schema::{SchemaAttribute, SchemaClass, SchemaTransaction};
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
 use crate::value::{IndexType, SyntaxType};
 use crate::value::{PartialValue, Value};
 use kanidm_proto::v1::Entry as ProtoEntry;
@@ -90,6 +87,10 @@ lazy_static! {
     static ref PVCLASS_TOMBSTONE: PartialValue = PartialValue::new_class("tombstone");
     static ref PVCLASS_RECYCLED: PartialValue = PartialValue::new_class("recycled");
 }
+
+pub type EntrySealedCommitted = Entry<EntrySealed, EntryCommitted>;
+pub type EntryInvalidCommitted = Entry<EntryInvalid, EntryCommitted>;
+pub type EntryTuple = (EntrySealedCommitted, EntryInvalidCommitted);
 
 // Entry should have a lifecycle of types. This is Raw (modifiable) and Entry (verified).
 // This way, we can move between them, but only certain actions are possible on either

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -1,7 +1,7 @@
-use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInit, EntryNew, EntryReduced, EntrySealed};
 use crate::filter::{Filter, FilterInvalid, FilterValid};
 use crate::idm::AuthState;
+use crate::prelude::*;
 use crate::schema::SchemaTransaction;
 use crate::value::PartialValue;
 use kanidm_proto::v1::Entry as ProtoEntry;
@@ -11,9 +11,6 @@ use kanidm_proto::v1::{
 };
 // use error::OperationError;
 use crate::modify::{ModifyInvalid, ModifyList, ModifyValid};
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
 use kanidm_proto::v1::OperationError;
 
 use crate::actors::v1_read::{

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -8,14 +8,11 @@
 //! [`Filter`]: struct.Filter.html
 //! [`Entry`]: ../entry/struct.Entry.html
 
-use crate::audit::AuditScope;
 use crate::be::{IdxKey, IdxKeyRef, IdxKeyToRef, IdxMeta};
 use crate::event::{Event, EventOriginId};
 use crate::ldap::ldap_attr_filter_map;
+use crate::prelude::*;
 use crate::schema::SchemaTransaction;
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
 use crate::value::{IndexType, PartialValue};
 use hashbrown::HashSet;
 use kanidm_proto::v1::Filter as ProtoFilter;
@@ -1276,16 +1273,13 @@ impl FilterResolved {
 
 #[cfg(test)]
 mod tests {
-    use crate::entry::{Entry, EntryInit, EntryNew, EntrySealed};
     use crate::event::{CreateEvent, Event};
     use crate::filter::{Filter, FilterInvalid, FILTER_DEPTH_MAX};
-    use crate::server::QueryServerTransaction;
-    use crate::value::{PartialValue, Value};
+    use crate::prelude::*;
     use std::cmp::{Ordering, PartialOrd};
     use std::collections::BTreeSet;
 
     use kanidm_proto::v1::Filter as ProtoFilter;
-    use kanidm_proto::v1::OperationError;
     use ldap3_server::simple::LdapFilter;
 
     #[test]

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -1,10 +1,10 @@
 use crate::entry::{Entry, EntryCommitted, EntryReduced, EntrySealed};
-use kanidm_proto::v1::OperationError;
+use crate::prelude::*;
 
 use kanidm_proto::v1::CredentialStatus;
+use kanidm_proto::v1::OperationError;
 use kanidm_proto::v1::UserAuthToken;
 
-use crate::audit::AuditScope;
 use crate::constants::UUID_ANONYMOUS;
 use crate::credential::policy::CryptoPolicy;
 use crate::credential::totp::TOTP;
@@ -12,7 +12,6 @@ use crate::credential::{softlock::CredSoftLockPolicy, Credential};
 use crate::idm::claim::Claim;
 use crate::idm::group::Group;
 use crate::modify::{ModifyInvalid, ModifyList};
-use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
 use crate::value::{PartialValue, Value};
 
 use std::time::Duration;

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -1,7 +1,7 @@
 use crate::idm::account::Account;
 use crate::idm::claim::Claim;
 use crate::idm::AuthState;
-use crate::{audit::AuditScope, value::Value};
+use crate::prelude::*;
 use kanidm_proto::v1::OperationError;
 use kanidm_proto::v1::{AuthAllowed, AuthCredential, AuthMech};
 
@@ -726,8 +726,6 @@ impl AuthSession {
 
 #[cfg(test)]
 mod tests {
-    use crate::audit::AuditScope;
-    use crate::constants::{JSON_ADMIN_V1, JSON_ANONYMOUS_V1};
     use crate::credential::policy::CryptoPolicy;
     use crate::credential::totp::{TOTP, TOTP_DEFAULT_STEP};
     use crate::credential::webauthn::WebauthnDomainConfig;
@@ -738,7 +736,7 @@ mod tests {
     };
     use crate::idm::delayed::DelayedAction;
     use crate::idm::AuthState;
-    use crate::value::Value;
+    use crate::prelude::*;
     pub use std::collections::BTreeSet as Set;
 
     use crate::utils::duration_from_epoch_now;

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -1,7 +1,6 @@
 use crate::actors::v1_write::IdmAccountSetPasswordMessage;
-use crate::audit::AuditScope;
 use crate::event::Event;
-use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
+use crate::prelude::*;
 
 use uuid::Uuid;
 

--- a/kanidmd/src/lib/idm/group.rs
+++ b/kanidmd/src/lib/idm/group.rs
@@ -1,8 +1,5 @@
-use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryReduced, EntrySealed};
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
+use crate::prelude::*;
 use crate::value::PartialValue;
 use kanidm_proto::v1::Group as ProtoGroup;
 use kanidm_proto::v1::OperationError;

--- a/kanidmd/src/lib/idm/radius.rs
+++ b/kanidmd/src/lib/idm/radius.rs
@@ -1,9 +1,9 @@
 use crate::idm::group::Group;
 use uuid::Uuid;
 
-use crate::audit::AuditScope;
+use crate::prelude::*;
+
 use crate::entry::{Entry, EntryCommitted, EntryReduced};
-use crate::server::QueryServerReadTransaction;
 use crate::value::PartialValue;
 use kanidm_proto::v1::OperationError;
 use kanidm_proto::v1::RadiusAuthToken;

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -73,8 +73,6 @@ pub struct IdmServerAuthTransaction<'a> {
     // Contains methods that require writes, but in the context of writing to
     // the idm in memory structures (maybe the query server too). This is
     // things like authentication
-    // _session_ticket: SemaphorePermit<'a>,
-    // sessions: BptreeMapWriteTxn<'a, Uuid, AuthSession>,
     session_ticket: &'a Semaphore,
     sessions: &'a BptreeMap<Uuid, AuthSession>,
 
@@ -110,7 +108,7 @@ pub struct IdmServerDelayed {
 }
 
 impl IdmServer {
-    // TODO #59: Make number of authsessions configurable!!!
+    // TODO: Make number of authsessions configurable!!!
     pub fn new(
         au: &mut AuditScope,
         qs: QueryServer,

--- a/kanidmd/src/lib/idm/unix.rs
+++ b/kanidmd/src/lib/idm/unix.rs
@@ -1,15 +1,9 @@
 use uuid::Uuid;
 
-use crate::audit::AuditScope;
-use crate::constants::UUID_ANONYMOUS;
 use crate::credential::policy::CryptoPolicy;
 use crate::credential::{softlock::CredSoftLockPolicy, Credential};
-use crate::entry::{Entry, EntryCommitted, EntryReduced, EntrySealed};
 use crate::modify::{ModifyInvalid, ModifyList};
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
-use crate::value::{PartialValue, Value};
+use crate::prelude::*;
 use kanidm_proto::v1::OperationError;
 use kanidm_proto::v1::{UnixGroupToken, UnixUserToken};
 

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -54,3 +54,21 @@ mod status;
 
 pub mod config;
 pub mod core;
+
+pub mod prelude {
+    pub use kanidm_proto::v1::OperationError;
+    pub use smartstring::alias::String as AttrString;
+    pub use uuid::Uuid;
+
+    pub use crate::audit::AuditScope;
+    pub use crate::constants::*;
+    pub use crate::entry::{
+        Entry, EntryCommitted, EntryInit, EntryInvalid, EntryInvalidCommitted, EntryNew,
+        EntryReduced, EntrySealed, EntrySealedCommitted, EntryTuple, EntryValid,
+    };
+    pub use crate::server::{
+        QueryServer, QueryServerReadTransaction, QueryServerTransaction,
+        QueryServerWriteTransaction,
+    };
+    pub use crate::value::{IndexType, PartialValue, SyntaxType, Value};
+}

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -68,10 +68,9 @@ macro_rules! setup_test {
 #[cfg(test)]
 macro_rules! run_test_no_init {
     ($test_fn:expr) => {{
-        use crate::audit::AuditScope;
         use crate::be::{Backend, BackendConfig};
+        use crate::prelude::*;
         use crate::schema::Schema;
-        use crate::server::QueryServer;
         use crate::utils::duration_from_epoch_now;
 
         use env_logger;
@@ -112,10 +111,9 @@ macro_rules! run_test_no_init {
 #[cfg(test)]
 macro_rules! run_test {
     ($test_fn:expr) => {{
-        use crate::audit::AuditScope;
         use crate::be::{Backend, BackendConfig};
+        use crate::prelude::*;
         use crate::schema::Schema;
-        use crate::server::QueryServer;
         #[allow(unused_imports)]
         use crate::utils::duration_from_epoch_now;
 
@@ -165,15 +163,13 @@ macro_rules! entry_str_to_account {
 
 macro_rules! run_idm_test_inner {
     ($test_fn:expr) => {{
-        use crate::audit::AuditScope;
         #[allow(unused_imports)]
         use crate::be::{Backend, BackendConfig};
         #[allow(unused_imports)]
         use crate::idm::server::{IdmServer, IdmServerDelayed};
+        use crate::prelude::*;
         #[allow(unused_imports)]
         use crate::schema::Schema;
-        #[allow(unused_imports)]
-        use crate::server::QueryServer;
         #[allow(unused_imports)]
         use crate::utils::duration_from_epoch_now;
 
@@ -241,11 +237,10 @@ macro_rules! run_create_test {
         $internal:expr,
         $check:expr
     ) => {{
-        use crate::audit::AuditScope;
         use crate::be::{Backend, BackendConfig};
         use crate::event::CreateEvent;
+        use crate::prelude::*;
         use crate::schema::Schema;
-        use crate::server::QueryServer;
         use crate::utils::duration_from_epoch_now;
 
         let mut au = AuditScope::new("run_create_test", uuid::Uuid::new_v4(), None);
@@ -296,11 +291,10 @@ macro_rules! run_modify_test {
         $internal:expr,
         $check:expr
     ) => {{
-        use crate::audit::AuditScope;
         use crate::be::{Backend, BackendConfig};
         use crate::event::ModifyEvent;
+        use crate::prelude::*;
         use crate::schema::Schema;
-        use crate::server::QueryServer;
         use crate::utils::duration_from_epoch_now;
 
         let mut au = AuditScope::new("run_modify_test", uuid::Uuid::new_v4(), None);
@@ -358,11 +352,10 @@ macro_rules! run_delete_test {
         $internal:expr,
         $check:expr
     ) => {{
-        use crate::audit::AuditScope;
         use crate::be::{Backend, BackendConfig};
         use crate::event::DeleteEvent;
+        use crate::prelude::*;
         use crate::schema::Schema;
-        use crate::server::QueryServer;
         use crate::utils::duration_from_epoch_now;
 
         let mut au = AuditScope::new("run_delete_test", uuid::Uuid::new_v4(), None);

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -1,9 +1,8 @@
-use crate::audit::AuditScope;
+use crate::prelude::*;
 use kanidm_proto::v1::Modify as ProtoModify;
 use kanidm_proto::v1::ModifyList as ProtoModifyList;
 
 use crate::schema::SchemaTransaction;
-use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
 use crate::value::{PartialValue, Value};
 use kanidm_proto::v1::{OperationError, SchemaError};
 

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -4,16 +4,11 @@
 // both change approaches.
 //
 //
-use crate::audit::AuditScope;
-use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew};
 use crate::event::{CreateEvent, ModifyEvent};
 use crate::plugins::Plugin;
+use crate::prelude::*;
 use crate::schema::SchemaTransaction;
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
-use crate::value::PartialValue;
-use kanidm_proto::v1::{ConsistencyError, OperationError, PluginError};
+use kanidm_proto::v1::{ConsistencyError, PluginError};
 
 use std::collections::BTreeMap;
 
@@ -196,11 +191,10 @@ impl Plugin for AttrUnique {
 
 #[cfg(test)]
 mod tests {
-    use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::modify::{Modify, ModifyList};
-    use crate::value::{PartialValue, Value};
-    use kanidm_proto::v1::{OperationError, PluginError};
-    use smartstring::alias::String as AttrString;
+    use crate::prelude::*;
+    use kanidm_proto::v1::PluginError;
+
     // Test entry in db, and same name, reject.
     #[test]
     fn test_pre_create_name_unique() {

--- a/kanidmd/src/lib/plugins/base.rs
+++ b/kanidmd/src/lib/plugins/base.rs
@@ -1,20 +1,11 @@
 use crate::plugins::Plugin;
 use hashbrown::HashSet;
 use std::collections::BTreeSet;
-use uuid::Uuid;
 
-use crate::audit::AuditScope;
-// use crate::constants::{STR_UUID_ADMIN, STR_UUID_ANONYMOUS, STR_UUID_DOES_NOT_EXIST};
-use crate::constants::{UUID_ADMIN, UUID_ANONYMOUS, UUID_DOES_NOT_EXIST};
-use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew};
 use crate::event::{CreateEvent, ModifyEvent};
 use crate::modify::Modify;
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
-use crate::value::{PartialValue, Value};
-use kanidm_proto::v1::{ConsistencyError, OperationError, PluginError};
-// use utils::uuid_from_now;
+use crate::prelude::*;
+use kanidm_proto::v1::{ConsistencyError, PluginError};
 
 lazy_static! {
     static ref CLASS_OBJECT: Value = Value::new_class("object");
@@ -244,16 +235,9 @@ impl Plugin for Base {
 
 #[cfg(test)]
 mod tests {
-    // #[macro_use]
-    // use crate::plugins::Plugin;
-    use crate::constants::JSON_ADMIN_V1;
-    use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::modify::{Modify, ModifyList};
-    use crate::server::QueryServerTransaction;
-    use crate::server::QueryServerWriteTransaction;
-    use crate::value::{PartialValue, Value};
-    use kanidm_proto::v1::{OperationError, PluginError};
-    use smartstring::alias::String as AttrString;
+    use crate::prelude::*;
+    use kanidm_proto::v1::PluginError;
 
     const JSON_ADMIN_ALLOW_ALL: &'static str = r#"{
         "attrs": {

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -6,12 +6,8 @@
 // relationships.
 use crate::plugins::Plugin;
 
-use crate::audit::AuditScope;
-use crate::constants::UUID_DOMAIN_INFO;
-use crate::entry::{Entry, EntryInvalid, EntryNew};
 use crate::event::CreateEvent;
-use crate::server::QueryServerWriteTransaction;
-use crate::value::{PartialValue, Value};
+use crate::prelude::*;
 use kanidm_proto::v1::OperationError;
 
 lazy_static! {
@@ -57,10 +53,8 @@ impl Plugin for Domain {
 
 #[cfg(test)]
 mod tests {
-    use crate::constants::UUID_DOMAIN_INFO;
-    use crate::server::QueryServerTransaction;
-    use crate::value::PartialValue;
-    // use uuid::Uuid;
+    // use crate::prelude::*;
+
     // test we can create and generate the id
     #[test]
     fn test_domain_generate_uuid() {

--- a/kanidmd/src/lib/plugins/gidnumber.rs
+++ b/kanidmd/src/lib/plugins/gidnumber.rs
@@ -1,17 +1,10 @@
 // A plugin that generates gid numbers on types that require them for posix
 // support.
 
-use crate::plugins::Plugin;
-
-use crate::audit::AuditScope;
-use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew};
 use crate::event::{CreateEvent, ModifyEvent};
-// use crate::server::QueryServerTransaction;
-use crate::server::QueryServerWriteTransaction;
+use crate::plugins::Plugin;
+use crate::prelude::*;
 use crate::utils::uuid_to_gid_u32;
-use crate::value::{PartialValue, Value};
-
-use kanidm_proto::v1::OperationError;
 
 /// Systemd dynamic units allocate between 61184–65519, most distros allocate
 /// system uids from 0 - 1000, and many others give user ids between 1000 to
@@ -106,12 +99,7 @@ impl Plugin for GidNumber {
 
 #[cfg(test)]
 mod tests {
-    use crate::audit::AuditScope;
-    use crate::entry::{Entry, EntryInit, EntryNew};
-    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
-    use crate::value::{PartialValue, Value};
-    use kanidm_proto::v1::OperationError;
-    use uuid::Uuid;
+    use crate::prelude::*;
 
     fn check_gid(
         au: &mut AuditScope,

--- a/kanidmd/src/lib/plugins/memberof.rs
+++ b/kanidmd/src/lib/plugins/memberof.rs
@@ -10,13 +10,11 @@
 // As a result, we first need to run refint to clean up all dangling references, then memberof
 // fixes the graph of memberships
 
-use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntrySealed};
 use crate::event::{CreateEvent, DeleteEvent, ModifyEvent};
+use crate::prelude::*;
 // use crate::modify::{Modify, ModifyList};
 use crate::plugins::Plugin;
-use crate::server::QueryServerTransaction;
-use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
 use crate::value::{PartialValue, Value};
 use kanidm_proto::v1::{ConsistencyError, OperationError};
 
@@ -417,14 +415,8 @@ impl Plugin for MemberOf {
 
 #[cfg(test)]
 mod tests {
-    // #[macro_use]
-    // use crate::plugins::Plugin;
-    use crate::entry::{Entry, EntryInit, EntryNew};
-    // use crate::error::OperationError;
     use crate::modify::{Modify, ModifyList};
-    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
-    use crate::value::{PartialValue, Value};
-    use smartstring::alias::String as AttrString;
+    use crate::prelude::*;
 
     const UUID_A: &'static str = "aaaaaaaa-f82e-4484-a407-181aa03bda5c";
     const UUID_B: &'static str = "bbbbbbbb-2438-4384-9891-48f4c8172e9b";

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -1,7 +1,6 @@
-use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntrySealed};
 use crate::event::{CreateEvent, DeleteEvent, ModifyEvent};
-use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
+use crate::prelude::*;
 use kanidm_proto::v1::{ConsistencyError, OperationError};
 
 mod attrunique;

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -1,12 +1,9 @@
 // Transform password import requests into proper kanidm credentials.
-use crate::audit::AuditScope;
 use crate::credential::{Credential, Password};
-use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew};
 use crate::event::{CreateEvent, ModifyEvent};
 use crate::plugins::Plugin;
-use crate::server::QueryServerWriteTransaction;
-use crate::value::Value;
-use kanidm_proto::v1::{OperationError, PluginError};
+use crate::prelude::*;
+use kanidm_proto::v1::PluginError;
 use std::convert::TryFrom;
 
 pub struct PasswordImport {}
@@ -129,12 +126,8 @@ mod tests {
     use crate::credential::policy::CryptoPolicy;
     use crate::credential::totp::{TOTP, TOTP_DEFAULT_STEP};
     use crate::credential::{Credential, CredentialType};
-    use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::modify::{Modify, ModifyList};
-    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
-    use crate::value::{PartialValue, Value};
-    use smartstring::alias::String as AttrString;
-    use uuid::Uuid;
+    use crate::prelude::*;
 
     const IMPORT_HASH: &'static str =
         "pbkdf2_sha256$36000$xIEozuZVAoYm$uW1b35DUKyhvQAf1mBqMvoBDcqSD06juzyO/nmyV0+w=";

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -1,15 +1,12 @@
 // System protected objects. Items matching specific requirements
 // may only have certain modifications performed.
-use crate::plugins::Plugin;
 
-use crate::audit::AuditScope;
-use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntrySealed};
+use crate::plugins::Plugin;
+use crate::prelude::*;
+
 use crate::event::{CreateEvent, DeleteEvent, ModifyEvent};
 use crate::modify::Modify;
-use crate::server::QueryServerWriteTransaction;
-use crate::value::{PartialValue, Value};
 use hashbrown::HashSet;
-use kanidm_proto::v1::OperationError;
 
 pub struct Protected {}
 
@@ -208,10 +205,7 @@ impl Plugin for Protected {
 
 #[cfg(test)]
 mod tests {
-    use crate::constants::JSON_ADMIN_V1;
-    use crate::entry::{Entry, EntryInit, EntryNew};
-    use crate::value::{PartialValue, Value};
-    use kanidm_proto::v1::OperationError;
+    use crate::prelude::*;
 
     const JSON_ADMIN_ALLOW_ALL: &'static str = r#"{
         "attrs": {

--- a/kanidmd/src/lib/plugins/refint.rs
+++ b/kanidmd/src/lib/plugins/refint.rs
@@ -12,18 +12,14 @@
 use hashbrown::HashSet as Set;
 use std::collections::BTreeSet;
 
-use crate::audit::AuditScope;
-use crate::entry::{Entry, EntryCommitted, EntrySealed};
+use crate::plugins::Plugin;
+use crate::prelude::*;
+
 use crate::event::{CreateEvent, DeleteEvent, ModifyEvent};
 use crate::filter::f_eq;
 use crate::modify::Modify;
-use crate::plugins::Plugin;
 use crate::schema::SchemaTransaction;
-use crate::server::QueryServerTransaction;
-use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
-use crate::value::{PartialValue, Value};
-use kanidm_proto::v1::{ConsistencyError, OperationError, PluginError};
-use uuid::Uuid;
+use kanidm_proto::v1::{ConsistencyError, PluginError};
 
 // NOTE: This *must* be after base.rs!!!
 
@@ -256,15 +252,9 @@ impl Plugin for ReferentialIntegrity {
 
 #[cfg(test)]
 mod tests {
-    // #[macro_use]
-    // use crate::plugins::Plugin;
-    use crate::constants::UUID_DOES_NOT_EXIST;
-    use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::modify::{Modify, ModifyList};
-    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
-    use crate::value::{PartialValue, Value};
-    use kanidm_proto::v1::{OperationError, PluginError};
-    use smartstring::alias::String as AttrString;
+    use crate::prelude::*;
+    use kanidm_proto::v1::PluginError;
 
     // The create references a uuid that doesn't exist - reject
     #[test]

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -1,14 +1,11 @@
 // Generate and manage spn's for all entries in the domain. Also deals with
 // the infrequent - but possible - case where a domain is renamed.
 use crate::plugins::Plugin;
+use crate::prelude::*;
 
-use crate::audit::AuditScope;
 use crate::constants::UUID_DOMAIN_INFO;
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntrySealed};
 use crate::event::{CreateEvent, ModifyEvent};
-use crate::server::{
-    QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
-};
 use crate::value::PartialValue;
 // use crate::value::{PartialValue, Value};
 use kanidm_proto::v1::{ConsistencyError, OperationError};
@@ -253,10 +250,7 @@ impl Plugin for Spn {
 
 #[cfg(test)]
 mod tests {
-    use crate::constants::UUID_ADMIN;
-    use crate::entry::{Entry, EntryInit, EntryNew};
-    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
-    use crate::value::{PartialValue, Value};
+    use crate::prelude::*;
 
     #[test]
     fn test_spn_generate_create() {

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -18,14 +18,11 @@
 
 use crate::audit::AuditScope;
 use crate::be::IdxKey;
-use crate::constants::*;
-use crate::entry::{Entry, EntryCommitted, EntryInit, EntryNew, EntrySealed};
-use crate::value::{IndexType, PartialValue, SyntaxType, Value};
+use crate::prelude::*;
 use kanidm_proto::v1::{ConsistencyError, OperationError, SchemaError};
 
 use hashbrown::HashMap;
 use hashbrown::HashSet;
-use smartstring::alias::String as AttrString;
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use uuid::Uuid;
@@ -1475,15 +1472,10 @@ impl Schema {
 
 #[cfg(test)]
 mod tests {
-    use crate::audit::AuditScope;
-    // use crate::constants::*;
-    use crate::entry::{Entry, EntryInit, EntryInvalid, EntryNew, EntryValid};
-    use kanidm_proto::v1::{ConsistencyError, SchemaError};
-    // use crate::filter::{Filter, FilterValid};
+    use crate::prelude::*;
     use crate::schema::SchemaTransaction;
     use crate::schema::{IndexType, Schema, SchemaAttribute, SchemaClass, SyntaxType};
-    use crate::value::{PartialValue, Value};
-    use smartstring::alias::String as AttrString;
+    use kanidm_proto::v1::{ConsistencyError, SchemaError};
     use uuid::Uuid;
 
     // use crate::proto_v1::Filter as ProtoFilter;

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -5,27 +5,21 @@
 // that otherwise can't be cloned. Think Mutex.
 use async_std::task;
 use concread::arcache::{ARCache, ARCacheReadTxn};
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use std::cell::Cell;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Semaphore, SemaphorePermit};
-use uuid::Uuid;
-
-use crate::audit::AuditScope;
-use crate::be::{Backend, BackendReadTransaction, BackendTransaction, BackendWriteTransaction};
 
 use crate::access::{
     AccessControlCreate, AccessControlDelete, AccessControlModify, AccessControlSearch,
     AccessControls, AccessControlsReadTransaction, AccessControlsTransaction,
     AccessControlsWriteTransaction,
 };
+use crate::be::{Backend, BackendReadTransaction, BackendTransaction, BackendWriteTransaction};
+use crate::prelude::*;
 // We use so many, we just import them all ...
-use crate::constants::*;
-use crate::entry::{
-    Entry, EntryCommitted, EntryInit, EntryInvalid, EntryNew, EntryReduced, EntrySealed,
-};
 use crate::event::{
     CreateEvent, DeleteEvent, Event, EventOrigin, EventOriginId, ExistsEvent, ModifyEvent,
     ReviveRecycledEvent, SearchEvent,
@@ -38,13 +32,7 @@ use crate::schema::{
     Schema, SchemaAttribute, SchemaClass, SchemaReadTransaction, SchemaTransaction,
     SchemaWriteTransaction,
 };
-use crate::value::{PartialValue, SyntaxType, Value};
-use kanidm_proto::v1::{ConsistencyError, OperationError, SchemaError};
-use smartstring::alias::String as AttrString;
-
-type EntrySealedCommitted = Entry<EntrySealed, EntryCommitted>;
-type EntryInvalidCommitted = Entry<EntryInvalid, EntryCommitted>;
-type EntryTuple = (EntrySealedCommitted, EntryInvalidCommitted);
+use kanidm_proto::v1::{ConsistencyError, SchemaError};
 
 const RESOLVE_FILTER_CACHE_MAX: usize = 4096;
 const RESOLVE_FILTER_CACHE_LOCAL: usize = 0;
@@ -99,7 +87,7 @@ pub struct QueryServerWriteTransaction<'a> {
     changed_schema: Cell<bool>,
     changed_acp: Cell<bool>,
     // Store the list of changed uuids for other invalidation needs?
-    changed_uuid: Cell<Vec<Uuid>>,
+    changed_uuid: Cell<HashSet<Uuid>>,
     _db_ticket: SemaphorePermit<'a>,
     _write_ticket: SemaphorePermit<'a>,
     resolve_filter_cache:
@@ -912,7 +900,7 @@ impl QueryServer {
             accesscontrols: self.accesscontrols.write(),
             changed_schema: Cell::new(false),
             changed_acp: Cell::new(false),
-            changed_uuid: Cell::new(Vec::new()),
+            changed_uuid: Cell::new(HashSet::new()),
             _db_ticket: db_ticket,
             _write_ticket: write_ticket,
             resolve_filter_cache: Cell::new(self.resolve_filter_cache.read()),
@@ -997,7 +985,7 @@ impl QueryServer {
             .initialise_idm(audit)
             .and_then(|_| ts_write_3.commit(audit))?;
 
-        ladmin_info!(audit, "ready to rock! 🤘");
+        ladmin_info!(audit, "ready to rock! 🪨  ");
         Ok(())
     }
 
@@ -2455,6 +2443,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
         self.be_txn.upgrade_reindex(audit, v)
     }
 
+    pub fn get_changed_uuids(&self) -> &HashSet<Uuid> {
+        unsafe { &(*self.changed_uuid.as_ptr()) }
+    }
+
     pub fn commit(mut self, audit: &mut AuditScope) -> Result<(), OperationError> {
         // This could be faster if we cache the set of classes changed
         // in an operation so we can check if we need to do the reload or not
@@ -2510,23 +2502,13 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::audit::AuditScope;
-    use crate::constants::{
-        CHANGELOG_MAX_AGE, JSON_ADMIN_V1, JSON_DOMAIN_INFO_V1, JSON_SYSTEM_CONFIG_V1,
-        JSON_SYSTEM_INFO_V1, RECYCLEBIN_MAX_AGE, SYSTEM_INDEX_VERSION, UUID_ADMIN,
-        UUID_DOMAIN_INFO,
-    };
     use crate::credential::policy::CryptoPolicy;
     use crate::credential::Credential;
-    use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::event::{CreateEvent, DeleteEvent, ModifyEvent, ReviveRecycledEvent, SearchEvent};
     use crate::modify::{Modify, ModifyList};
-    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
-    use crate::value::{PartialValue, Value};
-    use kanidm_proto::v1::{OperationError, SchemaError};
-    use smartstring::alias::String as AttrString;
+    use crate::prelude::*;
+    use kanidm_proto::v1::SchemaError;
     use std::time::Duration;
-    use uuid::Uuid;
 
     #[test]
     fn test_qs_create_user() {


### PR DESCRIPTION
Fixes #62 - this cleans up how we call the qs stack with the IDM components, and means that we can properly have these layered, allowing things like the password badlist set to be stored in COW on the IDMServer (Rather than the query server). 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
