### PR TITLE
Making clippy happy

### DIFF
--- a/designs/auth_proto_rewrite_late_2020.rst
+++ b/designs/auth_proto_rewrite_late_2020.rst
@@ -101,7 +101,7 @@ An improved design will have Credential become an enum representing the valid au
         Anonymous,
         Password(),
         GeneratedPassword(),
-        PasswordMFA(),
+        PasswordMfa(),
         PasswordWebauthn(),
         Webauthn(),
         WebauthnVerified(),
@@ -160,7 +160,7 @@ the correct way to handle these).
         Anonymous,
         Password,
         // This covers PasswordWebauthn as well.
-        PasswordMFA,
+        PasswordMfa,
         Webauthn,
         WebauthnVerified,
         PasswordWebauthnVerified,

--- a/designs/credential-display.rst
+++ b/designs/credential-display.rst
@@ -24,7 +24,7 @@ An example of this display for the CLI:
     expire_at: <date>
 
     - <credential_id>
-    type: Password|APIKey|PasswordMFA
+    type: Password|APIKey|PasswordMfa
     locked: true|false
     valid_from: <date>
     expire_at: <date>

--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -463,12 +463,12 @@ impl KanidmAsyncClient {
             Err(e) => return Err(e),
         };
 
-        if !mechs.contains(&AuthMech::PasswordMFA) {
-            debug!("PasswordMFA mech not presented");
+        if !mechs.contains(&AuthMech::PasswordMfa) {
+            debug!("PasswordMfa mech not presented");
             return Err(ClientError::AuthenticationFailed);
         }
 
-        let state = match self.auth_step_begin(AuthMech::PasswordMFA).await {
+        let state = match self.auth_step_begin(AuthMech::PasswordMfa).await {
             Ok(s) => s,
             Err(e) => return Err(e),
         };

--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -368,7 +368,7 @@ impl KanidmAsyncClient {
 
     pub async fn auth_step_totp(&mut self, totp: u32) -> Result<AuthResponse, ClientError> {
         let auth_req = AuthRequest {
-            step: AuthStep::Cred(AuthCredential::TOTP(totp)),
+            step: AuthStep::Cred(AuthCredential::Totp(totp)),
         };
         let r: Result<AuthResponse, _> = self.perform_auth_post_request("/v1/auth", auth_req).await;
 
@@ -473,7 +473,7 @@ impl KanidmAsyncClient {
             Err(e) => return Err(e),
         };
 
-        if !state.contains(&AuthAllowed::TOTP) {
+        if !state.contains(&AuthAllowed::Totp) {
             debug!("TOTP step not offered.");
             return Err(ClientError::AuthenticationFailed);
         }
@@ -818,8 +818,8 @@ impl KanidmAsyncClient {
         &self,
         id: &str,
         label: &str,
-    ) -> Result<(Uuid, TOTPSecret), ClientError> {
-        let r = SetCredentialRequest::TOTPGenerate(label.to_string());
+    ) -> Result<(Uuid, TotpSecret), ClientError> {
+        let r = SetCredentialRequest::TotpGenerate(label.to_string());
         let res: Result<SetCredentialResponse, ClientError> = self
             .perform_put_request(
                 format!("/v1/account/{}/_credential/primary", id).as_str(),
@@ -827,7 +827,7 @@ impl KanidmAsyncClient {
             )
             .await;
         match res {
-            Ok(SetCredentialResponse::TOTPCheck(u, s)) => Ok((u, s)),
+            Ok(SetCredentialResponse::TotpCheck(u, s)) => Ok((u, s)),
             Ok(_) => Err(ClientError::EmptyResponse),
             Err(e) => Err(e),
         }
@@ -840,7 +840,7 @@ impl KanidmAsyncClient {
         otp: u32,
         session: Uuid,
     ) -> Result<bool, ClientError> {
-        let r = SetCredentialRequest::TOTPVerify(session, otp);
+        let r = SetCredentialRequest::TotpVerify(session, otp);
         let res: Result<SetCredentialResponse, ClientError> = self
             .perform_put_request(
                 format!("/v1/account/{}/_credential/primary", id).as_str(),
@@ -849,7 +849,7 @@ impl KanidmAsyncClient {
             .await;
         match res {
             Ok(SetCredentialResponse::Success) => Ok(true),
-            Ok(SetCredentialResponse::TOTPCheck(u, s)) => Err(ClientError::TOTPVerifyFailed(u, s)),
+            Ok(SetCredentialResponse::TotpCheck(u, s)) => Err(ClientError::TotpVerifyFailed(u, s)),
             Ok(_) => Err(ClientError::EmptyResponse),
             Err(e) => Err(e),
         }
@@ -859,7 +859,7 @@ impl KanidmAsyncClient {
         &self,
         id: &str,
     ) -> Result<bool, ClientError> {
-        let r = SetCredentialRequest::TOTPRemove;
+        let r = SetCredentialRequest::TotpRemove;
         let res: Result<SetCredentialResponse, ClientError> = self
             .perform_put_request(
                 format!("/v1/account/{}/_credential/primary", id).as_str(),

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -45,7 +45,7 @@ pub enum ClientError {
     Transport(reqwest::Error),
     AuthenticationFailed,
     EmptyResponse,
-    TOTPVerifyFailed(Uuid, TOTPSecret),
+    TotpVerifyFailed(Uuid, TotpSecret),
     JSONDecode(reqwest::Error, String),
     JSONEncode(SerdeJsonError),
     SystemError,
@@ -555,7 +555,7 @@ impl KanidmClient {
         &self,
         id: &str,
         label: &str,
-    ) -> Result<(Uuid, TOTPSecret), ClientError> {
+    ) -> Result<(Uuid, TotpSecret), ClientError> {
         tokio_block_on(
             self.asclient
                 .idm_account_primary_credential_generate_totp(id, label),

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -57,9 +57,9 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     config.address = format!("127.0.0.1:{}", port);
     config.secure_cookies = false;
     config.integration_test_config = Some(int_config);
-    // config.log_level = Some(LogLevel::Quiet as u32);
-    config.log_level = Some(LogLevel::Verbose as u32);
-    //config.log_level = Some(LogLevel::FullTrace as u32);
+    config.log_level = Some(LogLevel::Quiet as u32);
+    // config.log_level = Some(LogLevel::Verbose as u32);
+    // config.log_level = Some(LogLevel::FullTrace as u32);
     config.threads = 1;
 
     let t_handle = thread::spawn(move || {

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -10,6 +10,7 @@ use kanidm_client::{KanidmClient, KanidmClientBuilder};
 use async_std::task;
 use tokio::sync::mpsc;
 
+pub const ADMIN_TEST_USER: &str = "admin";
 pub const ADMIN_TEST_PASSWORD: &str = "integration test admin password";
 static PORT_ALLOC: AtomicU16 = AtomicU16::new(18080);
 
@@ -47,6 +48,7 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     };
 
     let int_config = Box::new(IntegrationTestConfig {
+        admin_user: ADMIN_TEST_USER.to_string(),
         admin_password: ADMIN_TEST_PASSWORD.to_string(),
     });
 

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -56,7 +56,7 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     config.secure_cookies = false;
     config.integration_test_config = Some(int_config);
     config.log_level = Some(LogLevel::Quiet as u32);
-    // config.log_level = Some(LogLevel::Verbose as u32);
+    config.log_level = Some(LogLevel::Verbose as u32);
     config.threads = 1;
 
     // config.log_level = Some(LogLevel::FullTrace as u32);

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -56,8 +56,8 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     config.secure_cookies = false;
     config.integration_test_config = Some(int_config);
     // config.log_level = Some(LogLevel::Quiet as u32);
-    // config.log_level = Some(LogLevel::Verbose as u32);
-    config.log_level = Some(LogLevel::FullTrace as u32);
+    config.log_level = Some(LogLevel::Verbose as u32);
+    //config.log_level = Some(LogLevel::FullTrace as u32);
     config.threads = 1;
 
     let t_handle = thread::spawn(move || {

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -55,11 +55,11 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     config.address = format!("127.0.0.1:{}", port);
     config.secure_cookies = false;
     config.integration_test_config = Some(int_config);
-    config.log_level = Some(LogLevel::Quiet as u32);
-    config.log_level = Some(LogLevel::Verbose as u32);
+    // config.log_level = Some(LogLevel::Quiet as u32);
+    // config.log_level = Some(LogLevel::Verbose as u32);
+    config.log_level = Some(LogLevel::FullTrace as u32);
     config.threads = 1;
 
-    // config.log_level = Some(LogLevel::FullTrace as u32);
     let t_handle = thread::spawn(move || {
         // Spawn a thread for the test runner, this should have a unique
         // port....

--- a/kanidm_client/tests/default_entries.rs
+++ b/kanidm_client/tests/default_entries.rs
@@ -227,13 +227,6 @@ fn test_modify_group(rsclient: &KanidmClient, group_names: &[&str], is_modificab
 #[test]
 fn test_default_entries_rbac_users() {
     run_test(|mut rsclient: KanidmClient| {
-        use std::{thread, time};
-
-        let wait_seconds = time::Duration::from_millis(5000);
-        //let now = time::Instant::now();
-
-        thread::sleep(wait_seconds);
-
         rsclient
             .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();

--- a/kanidm_client/tests/default_entries.rs
+++ b/kanidm_client/tests/default_entries.rs
@@ -5,7 +5,7 @@ use kanidm_client::KanidmClient;
 use kanidm_proto::v1::{Filter, Modify, ModifyList};
 
 mod common;
-use crate::common::{run_test, ADMIN_TEST_PASSWORD};
+use crate::common::{run_test, ADMIN_TEST_PASSWORD, ADMIN_TEST_USER};
 
 static USER_READABLE_ATTRS: [&str; 9] = [
     "name",
@@ -113,7 +113,7 @@ fn is_attr_writable(rsclient: &KanidmClient, id: &str, attr: &str) -> Option<boo
 fn add_all_attrs(mut rsclient: &mut KanidmClient, id: &str, group_name: &str) {
     // Extend with posix attrs to test read attr: gidnumber and loginshell
     rsclient
-        .idm_group_add_members("idm_admins", &["admin"])
+        .idm_group_add_members("idm_admins", &[ADMIN_TEST_USER])
         .unwrap();
     rsclient
         .idm_account_unix_extend(id, None, Some(&"/bin/bash"))
@@ -136,7 +136,7 @@ fn add_all_attrs(mut rsclient: &mut KanidmClient, id: &str, group_name: &str) {
             .idm_account_radius_credential_regenerate(id)
             .unwrap();
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
     }
 }
@@ -155,10 +155,13 @@ fn create_user_with_all_attrs(
 
 fn login_account(rsclient: &mut KanidmClient, id: &str) -> () {
     rsclient
-        .idm_group_add_members("idm_people_account_password_import_priv", &["admin"])
+        .idm_group_add_members(
+            "idm_people_account_password_import_priv",
+            &[ADMIN_TEST_USER],
+        )
         .unwrap();
     rsclient
-        .idm_group_add_members("idm_people_extend_priv", &["admin"])
+        .idm_group_add_members("idm_people_extend_priv", &[ADMIN_TEST_USER])
         .unwrap();
 
     rsclient
@@ -224,8 +227,15 @@ fn test_modify_group(rsclient: &KanidmClient, group_names: &[&str], is_modificab
 #[test]
 fn test_default_entries_rbac_users() {
     run_test(|mut rsclient: KanidmClient| {
+        use std::{thread, time};
+
+        let wait_seconds = time::Duration::from_millis(5000);
+        //let now = time::Instant::now();
+
+        thread::sleep(wait_seconds);
+
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
 
         create_user_with_all_attrs(&mut rsclient, "self_account", Some("self_group"));
@@ -263,7 +273,7 @@ fn test_default_entries_rbac_users() {
 fn test_default_entries_rbac_account_managers() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
 
         create_user(&rsclient, "account_manager", "idm_account_manage_priv");
@@ -295,7 +305,7 @@ fn test_default_entries_rbac_account_managers() {
 fn test_default_entries_rbac_group_managers() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
 
         create_user(&rsclient, "group_manager", "idm_group_manage_priv");
@@ -336,7 +346,7 @@ fn test_default_entries_rbac_group_managers() {
 fn test_default_entries_rbac_admins_access_control_entries() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         static ACP_COMMON_ATTRS: [&str; 4] =
             ["name", "description", "acp_receiver", "acp_targetscope"];
@@ -384,7 +394,7 @@ fn test_default_entries_rbac_admins_access_control_entries() {
 fn test_default_entries_rbac_admins_schema_entries() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         let default_classnames: HashSet<String> = [
             "access_control_create",
@@ -495,7 +505,7 @@ fn test_default_entries_rbac_admins_schema_entries() {
 fn test_default_entries_rbac_admins_group_entries() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         create_user(&rsclient, "test", "test_group");
 
@@ -511,7 +521,7 @@ fn test_default_entries_rbac_admins_group_entries() {
 fn test_default_entries_rbac_admins_ha_accounts() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
 
         static MAIN_ATTRS: [&str; 3] = ["name", "displayname", "primary_credential"];
@@ -524,7 +534,7 @@ fn test_default_entries_rbac_admins_ha_accounts() {
 fn test_default_entries_rbac_admins_recycle_accounts() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         create_user(&rsclient, "test", "test_group");
 
@@ -543,7 +553,7 @@ fn test_default_entries_rbac_admins_recycle_accounts() {
 fn test_default_entries_rbac_people_managers() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
 
         create_user(&rsclient, "read_people_manager", "idm_people_read_priv");
@@ -564,7 +574,7 @@ fn test_default_entries_rbac_people_managers() {
 
         let _ = rsclient.logout();
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         create_user(&rsclient, "write_people_manager", "idm_people_write_priv");
         login_account(&mut rsclient, "write_people_manager");
@@ -582,7 +592,7 @@ fn test_default_entries_rbac_people_managers() {
 fn test_default_entries_rbac_anonymous_entry() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         create_user_with_all_attrs(&mut rsclient, "test", Some("test_group"));
         rsclient
@@ -607,7 +617,7 @@ fn test_default_entries_rbac_anonymous_entry() {
 fn test_default_entries_rbac_radius_servers() {
     run_test(|mut rsclient: KanidmClient| {
         rsclient
-            .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+            .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
             .unwrap();
         create_user(&rsclient, "radius_server", "idm_radius_servers");
         create_user_with_all_attrs(&mut rsclient, "test", Some("test_group"));

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -46,7 +46,7 @@ fn test_server_modify() {
     run_test(|mut rsclient: KanidmClient| {
         // Build a self mod.
 
-        let f = Filter::SelfUUID;
+        let f = Filter::SelfUuid;
         let m = ModifyList::new_list(vec![
             Modify::Purged("displayname".to_string()),
             Modify::Present("displayname".to_string(), "test".to_string()),

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 
 use log::debug;
 
-use kanidm::credential::totp::TOTP;
+use kanidm::credential::totp::Totp;
 use kanidm_client::KanidmClient;
 use kanidm_proto::v1::{CredentialDetailType, Entry, Filter, Modify, ModifyList};
 
@@ -761,7 +761,7 @@ fn test_server_rest_totp_auth_lifecycle() {
             .idm_account_primary_credential_generate_totp("demo_account", "demo")
             .unwrap();
 
-        let r_tok: TOTP = tok.into();
+        let r_tok: Totp = tok.into();
         let totp = r_tok
             .do_totp_duration_from_epoch(
                 &SystemTime::now()

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -960,7 +960,7 @@ fn test_server_rest_webauthn_mfa_auth_lifecycle() {
             .auth_webauthn_complete(auth)
             .expect("Failed to authenticate");
 
-        // Set a password to cause the state to change to PasswordMFA
+        // Set a password to cause the state to change to PasswordMfa
         assert!(rsclient
             .idm_account_primary_credential_set_password("demo_account", "sohdi3iuHo6mai7noh0a")
             .is_ok());

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -286,7 +286,7 @@ pub enum CredentialDetailType {
     GeneratedPassword,
     Webauthn(Vec<String>),
     /// totp, webauthn
-    PasswordMFA(bool, Vec<String>),
+    PasswordMfa(bool, Vec<String>),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -317,7 +317,7 @@ impl fmt::Display for CredentialDetail {
                     write!(f, "")
                 }
             }
-            CredentialDetailType::PasswordMFA(totp, labels) => {
+            CredentialDetailType::PasswordMfa(totp, labels) => {
                 writeln!(f, "password: set")?;
                 if *totp {
                     writeln!(f, "totp: enabled")?;
@@ -516,7 +516,7 @@ impl fmt::Debug for AuthCredential {
 pub enum AuthMech {
     Anonymous,
     Password,
-    PasswordMFA,
+    PasswordMfa,
     Webauthn,
     // WebauthnVerified,
     // PasswordWebauthnVerified
@@ -533,7 +533,7 @@ impl fmt::Display for AuthMech {
         match self {
             AuthMech::Anonymous => write!(f, "Anonymous (no credentials)"),
             AuthMech::Password => write!(f, "Passwold Only"),
-            AuthMech::PasswordMFA => write!(f, "TOTP or Token, and Password"),
+            AuthMech::PasswordMfa => write!(f, "TOTP or Token, and Password"),
             AuthMech::Webauthn => write!(f, "Webauthn Token"),
         }
     }

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -49,7 +49,7 @@ pub enum ConsistencyError {
     MemberOfInvalid(u64),
     InvalidAttributeType(String),
     DuplicateUniqueAttribute(String),
-    InvalidSPN(u64),
+    InvalidSpn(u64),
     SqliteIntegrityFailure,
 }
 
@@ -69,20 +69,20 @@ pub enum OperationError {
     FilterUuidResolution,
     InvalidAttributeName(String),
     InvalidAttribute(String),
-    InvalidDBState,
+    InvalidDbState,
     InvalidCacheState,
     InvalidValueState,
-    InvalidEntryID,
+    InvalidEntryId,
     InvalidRequestState,
     InvalidState,
     InvalidEntryState,
     InvalidUuid,
     InvalidReplCID,
-    InvalidACPState(String),
+    InvalidAcpState(String),
     InvalidSchemaState(String),
     InvalidAccountState(String),
     BackendEngine,
-    SQLiteError, //(RusqliteError)
+    SqliteError, //(RusqliteError)
     FsError,
     SerdeJsonError,
     SerdeCborError,
@@ -391,7 +391,7 @@ pub enum Filter {
     #[serde(alias = "AndNot")]
     AndNot(Box<Filter>),
     #[serde(rename = "self", alias = "Self")]
-    SelfUUID,
+    SelfUuid,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -18,7 +18,7 @@ impl AccountOpt {
                 AccountCredential::RegisterWebauthn(acs) => acs.copt.debug,
                 AccountCredential::RemoveWebauthn(acs) => acs.copt.debug,
                 AccountCredential::RegisterTotp(acs) => acs.copt.debug,
-                AccountCredential::RemoveTOTP(acs) => acs.copt.debug,
+                AccountCredential::RemoveTotp(acs) => acs.copt.debug,
                 AccountCredential::Status(acs) => acs.copt.debug,
             },
             AccountOpt::Radius(acopt) => match acopt {
@@ -213,7 +213,7 @@ impl AccountOpt {
                         }
                     }
                 }
-                AccountCredential::RemoveTOTP(acsopt) => {
+                AccountCredential::RemoveTotp(acsopt) => {
                     let client = acsopt.copt.to_client();
                     match client.idm_account_primary_credential_remove_totp(
                         acsopt.aopts.account_id.as_str(),

--- a/kanidm_tools/src/cli/login.rs
+++ b/kanidm_tools/src/cli/login.rs
@@ -246,7 +246,7 @@ impl LoginOpt {
             let res = match choice {
                 AuthAllowed::Anonymous => client.auth_step_anonymous(),
                 AuthAllowed::Password => self.do_password(&mut client),
-                AuthAllowed::TOTP => self.do_totp(&mut client),
+                AuthAllowed::Totp => self.do_totp(&mut client),
                 AuthAllowed::Webauthn(chal) => self.do_webauthn(&mut client, chal.clone()),
             };
 

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -164,7 +164,7 @@ pub enum AccountCredential {
     RegisterTotp(AccountNamedTagOpt),
     /// Remove TOTP from the account. If no TOTP exists, no action is taken.
     #[structopt(name = "remove_totp")]
-    RemoveTOTP(AccountNamedOpt),
+    RemoveTotp(AccountNamedOpt),
     /// Show the status of the accounts credentials.
     #[structopt(name = "status")]
     Status(AccountNamedOpt),

--- a/kanidm_unix_int/tests/cache_layer_test.rs
+++ b/kanidm_unix_int/tests/cache_layer_test.rs
@@ -21,6 +21,7 @@ use async_std::task;
 use tokio::sync::mpsc;
 
 static PORT_ALLOC: AtomicU16 = AtomicU16::new(28080);
+const ADMIN_TEST_USER: &str = "admin";
 const ADMIN_TEST_PASSWORD: &str = "integration test admin password";
 const TESTACCOUNT1_PASSWORD_A: &str = "password a for account1 test";
 const TESTACCOUNT1_PASSWORD_B: &str = "password b for account1 test";
@@ -55,6 +56,7 @@ fn run_test(fix_fn: fn(&mut KanidmClient) -> (), test_fn: fn(CacheLayer, KanidmA
     };
 
     let int_config = Box::new(IntegrationTestConfig {
+        admin_user: ADMIN_TEST_USER.to_string(),
         admin_password: ADMIN_TEST_PASSWORD.to_string(),
     });
 

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -70,7 +70,7 @@ impl AccessControlSearch {
     ) -> Result<Self, OperationError> {
         if !value.attribute_value_pres("class", &CLASS_ACS) {
             ladmin_error!(audit, "class access_control_search not present.");
-            return Err(OperationError::InvalidACPState(
+            return Err(OperationError::InvalidAcpState(
                 "Missing access_control_search".to_string(),
             ));
         }
@@ -79,7 +79,7 @@ impl AccessControlSearch {
             .get_ava_as_str("acp_search_attr")
             .ok_or_else(|| {
                 ladmin_error!(audit, "Missing acp_search_attr");
-                OperationError::InvalidACPState("Missing acp_search_attr".to_string())
+                OperationError::InvalidAcpState("Missing acp_search_attr".to_string())
             })?
             .map(AttrString::from)
             .collect();
@@ -125,7 +125,7 @@ impl AccessControlDelete {
     ) -> Result<Self, OperationError> {
         if !value.attribute_value_pres("class", &CLASS_ACD) {
             ladmin_error!(audit, "class access_control_delete not present.");
-            return Err(OperationError::InvalidACPState(
+            return Err(OperationError::InvalidAcpState(
                 "Missing access_control_delete".to_string(),
             ));
         }
@@ -168,7 +168,7 @@ impl AccessControlCreate {
     ) -> Result<Self, OperationError> {
         if !value.attribute_value_pres("class", &CLASS_ACC) {
             ladmin_error!(audit, "class access_control_create not present.");
-            return Err(OperationError::InvalidACPState(
+            return Err(OperationError::InvalidAcpState(
                 "Missing access_control_create".to_string(),
             ));
         }
@@ -228,7 +228,7 @@ impl AccessControlModify {
     ) -> Result<Self, OperationError> {
         if !value.attribute_value_pres("class", &CLASS_ACM) {
             ladmin_error!(audit, "class access_control_modify not present.");
-            return Err(OperationError::InvalidACPState(
+            return Err(OperationError::InvalidAcpState(
                 "Missing access_control_modify".to_string(),
             ));
         }
@@ -306,7 +306,7 @@ impl AccessControlProfile {
         // Assert we have class access_control_profile
         if !value.attribute_value_pres("class", &CLASS_ACP) {
             ladmin_error!(audit, "class access_control_profile not present.");
-            return Err(OperationError::InvalidACPState(
+            return Err(OperationError::InvalidAcpState(
                 "Missing access_control_profile".to_string(),
             ));
         }
@@ -316,7 +316,7 @@ impl AccessControlProfile {
             .get_ava_single_str("name")
             .ok_or_else(|| {
                 ladmin_error!(audit, "Missing name");
-                OperationError::InvalidACPState("Missing name".to_string())
+                OperationError::InvalidAcpState("Missing name".to_string())
             })?
             .to_string();
         // copy uuid
@@ -328,7 +328,7 @@ impl AccessControlProfile {
             .cloned()
             .ok_or_else(|| {
                 ladmin_error!(audit, "Missing acp_receiver");
-                OperationError::InvalidACPState("Missing acp_receiver".to_string())
+                OperationError::InvalidAcpState("Missing acp_receiver".to_string())
             })?;
         // targetscope, and turn to real filter
         let targetscope_f: ProtoFilter = value
@@ -337,7 +337,7 @@ impl AccessControlProfile {
             .cloned()
             .ok_or_else(|| {
                 ladmin_error!(audit, "Missing acp_targetscope");
-                OperationError::InvalidACPState("Missing acp_targetscope".to_string())
+                OperationError::InvalidAcpState("Missing acp_targetscope".to_string())
             })?;
 
         let event = Event::from_internal();

--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -8,8 +8,8 @@ use crate::event::{
     ReviveRecycledEvent,
 };
 use crate::idm::event::{
-    GeneratePasswordEvent, GenerateTOTPEvent, PasswordChangeEvent, RegenerateRadiusSecretEvent,
-    RemoveTOTPEvent, RemoveWebauthnEvent, UnixPasswordChangeEvent, VerifyTOTPEvent,
+    GeneratePasswordEvent, GenerateTotpEvent, PasswordChangeEvent, RegenerateRadiusSecretEvent,
+    RemoveTotpEvent, RemoveWebauthnEvent, UnixPasswordChangeEvent, VerifyTotpEvent,
     WebauthnDoRegisterEvent, WebauthnInitRegisterEvent,
 };
 use crate::modify::{Modify, ModifyInvalid, ModifyList};
@@ -602,8 +602,8 @@ impl QueryServerWriteV1 {
                             .and_then(|r| idms_prox_write.commit(&mut audit).map(|_| r))
                             .map(SetCredentialResponse::Token)
                     }
-                    SetCredentialRequest::TOTPGenerate(label) => {
-                        let gte = GenerateTOTPEvent::from_parts(
+                    SetCredentialRequest::TotpGenerate(label) => {
+                        let gte = GenerateTotpEvent::from_parts(
                             &mut audit,
                             &idms_prox_write.qs_write,
                             msg.uat.as_ref(),
@@ -622,8 +622,8 @@ impl QueryServerWriteV1 {
                             .generate_account_totp(&mut audit, &gte, ct)
                             .and_then(|r| idms_prox_write.commit(&mut audit).map(|_| r))
                     }
-                    SetCredentialRequest::TOTPVerify(uuid, chal) => {
-                        let vte = VerifyTOTPEvent::from_parts(
+                    SetCredentialRequest::TotpVerify(uuid, chal) => {
+                        let vte = VerifyTotpEvent::from_parts(
                             &mut audit,
                             &idms_prox_write.qs_write,
                             msg.uat.as_ref(),
@@ -643,8 +643,8 @@ impl QueryServerWriteV1 {
                             .verify_account_totp(&mut audit, &vte, ct)
                             .and_then(|r| idms_prox_write.commit(&mut audit).map(|_| r))
                     }
-                    SetCredentialRequest::TOTPRemove => {
-                        let rte = RemoveTOTPEvent::from_parts(
+                    SetCredentialRequest::TotpRemove => {
+                        let rte = RemoveTotpEvent::from_parts(
                             &mut audit,
                             &idms_prox_write.qs_write,
                             msg.uat.as_ref(),

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -590,7 +590,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
             entries.try_for_each(|e| {
                 ltrace!(au, "Inserting {:?} to cache", e.get_id());
                 if e.get_id() == 0 {
-                    Err(OperationError::InvalidEntryID)
+                    Err(OperationError::InvalidEntryId)
                 } else {
                     (*self.allids).insert_id(e.get_id());
                     self.entry_cache
@@ -627,7 +627,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
             idl.try_for_each(|i| {
                 ltrace!(au, "Removing {:?} from cache", i);
                 if i == 0 {
-                    Err(OperationError::InvalidEntryID)
+                    Err(OperationError::InvalidEntryId)
                 } else {
                     (*self.allids).remove_id(i);
                     self.entry_cache.remove_dirty(i);

--- a/kanidmd/src/lib/be/idl_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_sqlite.rs
@@ -1259,7 +1259,7 @@ impl IdlSqlite {
         cfg: &BackendConfig,
         vacuum: bool,
     ) -> Result<Self, OperationError> {
-        if cfg.path == "" {
+        if cfg.path.is_empty() {
             debug_assert!(cfg.pool_size == 1);
         }
         // If provided, set the page size to match the tuning we want. By default we use 4096. The VACUUM

--- a/kanidmd/src/lib/be/idl_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_sqlite.rs
@@ -36,13 +36,13 @@ impl TryFrom<IdSqliteEntry> for IdRawEntry {
 
     fn try_from(value: IdSqliteEntry) -> Result<Self, Self::Error> {
         if value.id <= 0 {
-            return Err(OperationError::InvalidEntryID);
+            return Err(OperationError::InvalidEntryId);
         }
         Ok(IdRawEntry {
             id: value
                 .id
                 .try_into()
-                .map_err(|_| OperationError::InvalidEntryID)?,
+                .map_err(|_| OperationError::InvalidEntryId)?,
             data: value.data,
         })
     }
@@ -53,13 +53,13 @@ impl TryFrom<IdRawEntry> for IdSqliteEntry {
 
     fn try_from(value: IdRawEntry) -> Result<Self, Self::Error> {
         if value.id == 0 {
-            return Err(OperationError::InvalidEntryID);
+            return Err(OperationError::InvalidEntryId);
         }
         Ok(IdSqliteEntry {
             id: value
                 .id
                 .try_into()
-                .map_err(|_| OperationError::InvalidEntryID)?,
+                .map_err(|_| OperationError::InvalidEntryId)?,
             data: value.data,
         })
     }
@@ -109,7 +109,7 @@ pub trait IdlSqliteTransaction {
                     .prepare("SELECT id, data FROM id2entry")
                     .map_err(|e| {
                         ladmin_error!(au, "SQLite Error {:?}", e);
-                        OperationError::SQLiteError
+                        OperationError::SqliteError
                     })?;
                 let id2entry_iter = stmt
                     .query_map([], |row| {
@@ -120,13 +120,13 @@ pub trait IdlSqliteTransaction {
                     })
                     .map_err(|e| {
                         ladmin_error!(au, "SQLite Error {:?}", e);
-                        OperationError::SQLiteError
+                        OperationError::SqliteError
                     })?;
                 id2entry_iter
                     .map(|v| {
                         v.map_err(|e| {
                             ladmin_error!(au, "SQLite Error {:?}", e);
-                            OperationError::SQLiteError
+                            OperationError::SqliteError
                         })
                         .and_then(|ise| {
                             // Convert the idsqlite to id raw
@@ -141,7 +141,7 @@ pub trait IdlSqliteTransaction {
                     .prepare("SELECT id, data FROM id2entry WHERE id = :idl")
                     .map_err(|e| {
                         ladmin_error!(au, "SQLite Error {:?}", e);
-                        OperationError::SQLiteError
+                        OperationError::SqliteError
                     })?;
 
                 // TODO #258: Can this actually just load in a single select?
@@ -151,12 +151,12 @@ pub trait IdlSqliteTransaction {
 
                 /*
                 let decompressed: Result<Vec<i64>, _> = idli.into_iter()
-                    .map(|u| i64::try_from(u).map_err(|_| OperationError::InvalidEntryID))
+                    .map(|u| i64::try_from(u).map_err(|_| OperationError::InvalidEntryId))
                     .collect();
                 */
 
                 for id in idli {
-                    let iid = i64::try_from(id).map_err(|_| OperationError::InvalidEntryID)?;
+                    let iid = i64::try_from(id).map_err(|_| OperationError::InvalidEntryId)?;
                     let id2entry_iter = stmt
                         .query_map(&[&iid], |row| {
                             Ok(IdSqliteEntry {
@@ -166,14 +166,14 @@ pub trait IdlSqliteTransaction {
                         })
                         .map_err(|e| {
                             ladmin_error!(au, "SQLite Error {:?}", e);
-                            OperationError::SQLiteError
+                            OperationError::SqliteError
                         })?;
 
                     let r: Result<Vec<_>, _> = id2entry_iter
                         .map(|v| {
                             v.map_err(|e| {
                                 ladmin_error!(au, "SQLite Error {:?}", e);
-                                OperationError::SQLiteError
+                                OperationError::SqliteError
                             })
                             .and_then(|ise| {
                                 // Convert the idsqlite to id raw
@@ -201,13 +201,13 @@ pub trait IdlSqliteTransaction {
             .prepare("SELECT COUNT(name) from sqlite_master where name = :tname")
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
         let i: Option<i64> = stmt
             .query_row(&[(":tname", &tname)], |row| row.get(0))
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
         if i.unwrap_or(0) == 0 {
@@ -238,7 +238,7 @@ pub trait IdlSqliteTransaction {
             );
             let mut stmt = self.get_conn().prepare(query.as_str()).map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
             let idl_raw: Option<Vec<u8>> = stmt
                 .query_row(&[(":idx_key", &idx_key)], |row| row.get(0))
@@ -246,7 +246,7 @@ pub trait IdlSqliteTransaction {
                 .optional()
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             let idl = match idl_raw {
@@ -274,7 +274,7 @@ pub trait IdlSqliteTransaction {
                 .prepare("SELECT uuid FROM idx_name2uuid WHERE name = :name")
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
             let uuid_raw: Option<String> = stmt
                 .query_row(&[(":name", &name)], |row| row.get(0))
@@ -282,7 +282,7 @@ pub trait IdlSqliteTransaction {
                 .optional()
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             let uuid = uuid_raw.as_ref().and_then(|u| Uuid::parse_str(u).ok());
@@ -305,7 +305,7 @@ pub trait IdlSqliteTransaction {
                 .prepare("SELECT spn FROM idx_uuid2spn WHERE uuid = :uuid")
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
             let spn_raw: Option<Vec<u8>> = stmt
                 .query_row(&[(":uuid", &uuids)], |row| row.get(0))
@@ -313,7 +313,7 @@ pub trait IdlSqliteTransaction {
                 .optional()
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             let spn: Option<Value> = match spn_raw {
@@ -346,7 +346,7 @@ pub trait IdlSqliteTransaction {
                 .prepare("SELECT rdn FROM idx_uuid2rdn WHERE uuid = :uuid")
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
             let rdn: Option<String> = stmt
                 .query_row(&[(":uuid", &uuids)], |row| row.get(0))
@@ -354,7 +354,7 @@ pub trait IdlSqliteTransaction {
                 .optional()
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             ltrace!(audit, "Got rdn for uuid {:?} -> {:?}", uuid, rdn);
@@ -377,7 +377,7 @@ pub trait IdlSqliteTransaction {
                 })
                 // If no sid, we return none.
             })
-            .map_err(|_| OperationError::SQLiteError)?;
+            .map_err(|_| OperationError::SqliteError)?;
 
         Ok(match data {
             Some(d) => Some(
@@ -401,7 +401,7 @@ pub trait IdlSqliteTransaction {
                 })
                 // If no sid, we return none.
             })
-            .map_err(|_| OperationError::SQLiteError)?;
+            .map_err(|_| OperationError::SqliteError)?;
 
         Ok(match data {
             Some(d) => Some(
@@ -533,19 +533,19 @@ impl IdlSqliteWriteTransaction {
         let mut stmt = self
             .conn
             .prepare("SELECT MAX(id) as id_max FROM id2entry")
-            .map_err(|_| OperationError::SQLiteError)?;
+            .map_err(|_| OperationError::SqliteError)?;
         // This exists checks for if any rows WERE returned
         // that way we know to shortcut or not.
-        let v = stmt.exists([]).map_err(|_| OperationError::SQLiteError)?;
+        let v = stmt.exists([]).map_err(|_| OperationError::SqliteError)?;
 
         if v {
             // We have some rows, let get max!
             let i: Option<i64> = stmt
                 .query_row([], |row| row.get(0))
-                .map_err(|_| OperationError::SQLiteError)?;
+                .map_err(|_| OperationError::SqliteError)?;
             i.unwrap_or(0)
                 .try_into()
-                .map_err(|_| OperationError::InvalidEntryID)
+                .map_err(|_| OperationError::InvalidEntryId)
         } else {
             // No rows are present, return a 0.
             Ok(0)
@@ -608,7 +608,7 @@ impl IdlSqliteWriteTransaction {
             .prepare("INSERT OR REPLACE INTO id2entry (id, data) VALUES(:id, :data)")
             .map_err(|e| {
                 ladmin_error!(au, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
         entries.try_for_each(|e| {
@@ -621,7 +621,7 @@ impl IdlSqliteWriteTransaction {
                 .map(|_| ())
                 .map_err(|e| {
                     ladmin_error!(au, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })
             })
         })
@@ -638,18 +638,18 @@ impl IdlSqliteWriteTransaction {
                 .prepare("DELETE FROM id2entry WHERE id = :id")
                 .map_err(|e| {
                     ladmin_error!(au, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             idl.try_for_each(|id| {
                 let iid: i64 = id
                     .try_into()
-                    .map_err(|_| OperationError::InvalidEntryID)
+                    .map_err(|_| OperationError::InvalidEntryId)
                     .and_then(|i| {
                         if i > 0 {
                             Ok(i)
                         } else {
-                            Err(OperationError::InvalidEntryID)
+                            Err(OperationError::InvalidEntryId)
                         }
                     })?;
 
@@ -657,7 +657,7 @@ impl IdlSqliteWriteTransaction {
 
                 stmt.execute(&[&iid]).map(|_| ()).map_err(|e| {
                     ladmin_error!(au, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })
             })
         })
@@ -671,17 +671,17 @@ impl IdlSqliteWriteTransaction {
             .prepare("DELETE FROM id2entry WHERE id = :id")
             .map_err(|e| {
                 ladmin_error!(au, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
         let iid: i64 = id
             .try_into()
-            .map_err(|_| OperationError::InvalidEntryID)
+            .map_err(|_| OperationError::InvalidEntryId)
             .and_then(|i| {
                 if i > 0 {
                     Ok(i)
                 } else {
-                    Err(OperationError::InvalidEntryID)
+                    Err(OperationError::InvalidEntryId)
                 }
             })?;
 
@@ -689,7 +689,7 @@ impl IdlSqliteWriteTransaction {
 
         stmt.execute(&[&iid]).map(|_| ()).map_err(|e| {
             ladmin_error!(au, "SQLite Error {:?}", e);
-            OperationError::SQLiteError
+            OperationError::SqliteError
         })
         // })
     }
@@ -718,7 +718,7 @@ impl IdlSqliteWriteTransaction {
                     .and_then(|mut stmt| stmt.execute(&[(":key", &idx_key)]))
                     .map_err(|e| {
                         ladmin_error!(audit, "SQLite Error {:?}", e);
-                        OperationError::SQLiteError
+                        OperationError::SqliteError
                     })
             } else {
                 ltrace!(audit, "writing idl -> {}", idl);
@@ -745,7 +745,7 @@ impl IdlSqliteWriteTransaction {
                     })
                     .map_err(|e| {
                         ladmin_error!(audit, "SQLite Error {:?}", e);
-                        OperationError::SQLiteError
+                        OperationError::SqliteError
                     })
             }
             // Get rid of the sqlite rows usize
@@ -762,7 +762,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -785,7 +785,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -800,7 +800,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -813,7 +813,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -840,7 +840,7 @@ impl IdlSqliteWriteTransaction {
                     .map(|_| ())
                     .map_err(|e| {
                         ladmin_error!(audit, "SQLite Error {:?}", e);
-                        OperationError::SQLiteError
+                        OperationError::SqliteError
                     })
             }
             None => self
@@ -850,7 +850,7 @@ impl IdlSqliteWriteTransaction {
                 .map(|_| ())
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 }),
         }
     }
@@ -864,7 +864,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -883,7 +883,7 @@ impl IdlSqliteWriteTransaction {
                 .map(|_| ())
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 }),
             None => self
                 .conn
@@ -892,7 +892,7 @@ impl IdlSqliteWriteTransaction {
                 .map(|_| ())
                 .map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 }),
         }
     }
@@ -919,7 +919,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -929,18 +929,18 @@ impl IdlSqliteWriteTransaction {
             .prepare("SELECT name from sqlite_master where type='table' and name LIKE 'idx_%'")
             .map_err(|e| {
                 ladmin_error!(audit, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
         let idx_table_iter = stmt.query_map([], |row| row.get(0)).map_err(|e| {
             ladmin_error!(audit, "SQLite Error {:?}", e);
-            OperationError::SQLiteError
+            OperationError::SqliteError
         })?;
 
         let r: Result<_, _> = idx_table_iter
             .map(|v| {
                 v.map_err(|e| {
                     ladmin_error!(audit, "SQLite Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })
             })
             .collect();
@@ -958,7 +958,7 @@ impl IdlSqliteWriteTransaction {
                 .and_then(|mut stmt| stmt.execute([]).map(|_| ()))
                 .map_err(|e| {
                     ladmin_error!(audit, "sqlite error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })
         })
     }
@@ -970,7 +970,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 ladmin_error!(audit, "sqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -988,7 +988,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 eprintln!("CRITICAL: rusqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -1006,7 +1006,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 eprintln!("CRITICAL: rusqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -1024,7 +1024,7 @@ impl IdlSqliteWriteTransaction {
             .map(|_| ())
             .map_err(|e| {
                 eprintln!("CRITICAL: rusqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 
@@ -1044,7 +1044,7 @@ impl IdlSqliteWriteTransaction {
                 })
                 // If no sid, we return none.
             })
-            .map_err(|_| OperationError::SQLiteError)?;
+            .map_err(|_| OperationError::SqliteError)?;
 
         Ok(match data {
             Some(d) => Some(
@@ -1089,7 +1089,7 @@ impl IdlSqliteWriteTransaction {
     pub(crate) fn set_db_index_version(&self, v: i64) -> Result<(), OperationError> {
         self.set_db_version_key(DBV_INDEXV, v).map_err(|e| {
             eprintln!("CRITICAL: rusqlite error {:?}", e);
-            OperationError::SQLiteError
+            OperationError::SqliteError
         })
     }
 
@@ -1097,22 +1097,22 @@ impl IdlSqliteWriteTransaction {
         ltrace!(au, "Building allids...");
         let mut stmt = self.conn.prepare("SELECT id FROM id2entry").map_err(|e| {
             ladmin_error!(au, "SQLite Error {:?}", e);
-            OperationError::SQLiteError
+            OperationError::SqliteError
         })?;
         let res = stmt.query_map([], |row| row.get(0)).map_err(|e| {
             ladmin_error!(au, "SQLite Error {:?}", e);
-            OperationError::SQLiteError
+            OperationError::SqliteError
         })?;
         res.map(|v| {
             v.map_err(|e| {
                 ladmin_error!(au, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
             .and_then(|id: i64| {
                 // Convert the idsqlite to id raw
                 id.try_into().map_err(|e| {
                     ladmin_error!(au, "I64 Parse Error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })
             })
         })
@@ -1143,7 +1143,7 @@ impl IdlSqliteWriteTransaction {
             )
             .map_err(|e| {
                 ladmin_error!(audit, "sqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
         // If the table is empty, populate the versions as 0.
@@ -1174,7 +1174,7 @@ impl IdlSqliteWriteTransaction {
                 })
                 .map_err(|e| {
                     ladmin_error!(audit, "sqlite error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             dbv_id2entry = 1;
@@ -1197,7 +1197,7 @@ impl IdlSqliteWriteTransaction {
                 )
                 .map_err(|e| {
                     ladmin_error!(audit, "sqlite error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             dbv_id2entry = 2;
@@ -1216,7 +1216,7 @@ impl IdlSqliteWriteTransaction {
                 )
                 .map_err(|e| {
                     ladmin_error!(audit, "sqlite error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
             dbv_id2entry = 3;
             ladmin_info!(
@@ -1242,7 +1242,7 @@ impl IdlSqliteWriteTransaction {
         self.set_db_version_key(DBV_ID2ENTRY, dbv_id2entry)
             .map_err(|e| {
                 ladmin_error!(audit, "sqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
         // NOTE: Indexing is configured in a different step!
@@ -1279,48 +1279,48 @@ impl IdlSqlite {
 
             let vconn = Connection::open_with_flags(cfg.path.as_str(), flags).map_err(|e| {
                 ladmin_error!(audit, "rusqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
             vconn
                 .pragma_update(None, "journal_mode", &"DELETE")
                 .map_err(|e| {
                     ladmin_error!(audit, "rusqlite journal_mode update error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             vconn.close().map_err(|e| {
                 ladmin_error!(audit, "rusqlite db close error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
             let vconn = Connection::open_with_flags(cfg.path.as_str(), flags).map_err(|e| {
                 ladmin_error!(audit, "rusqlite error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
             vconn
                 .pragma_update(None, "page_size", &(cfg.fstype as u32))
                 .map_err(|e| {
                     ladmin_error!(audit, "rusqlite page_size update error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             vconn.execute_batch("VACUUM").map_err(|e| {
                 ladmin_error!(audit, "rusqlite vacuum error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
             vconn
                 .pragma_update(None, "journal_mode", &"WAL")
                 .map_err(|e| {
                     ladmin_error!(audit, "rusqlite journal_mode update error {:?}", e);
-                    OperationError::SQLiteError
+                    OperationError::SqliteError
                 })?;
 
             vconn.close().map_err(|e| {
                 ladmin_error!(audit, "rusqlite db close error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })?;
 
             limmediate_warning!(audit, "NOTICE: db vacuum complete\n");
@@ -1341,7 +1341,7 @@ impl IdlSqlite {
         // Look at max_size and thread_pool here for perf later
         let pool = builder2.build(manager).map_err(|e| {
             ladmin_error!(audit, "r2d2 error {:?}", e);
-            OperationError::SQLiteError
+            OperationError::SqliteError
         })?;
 
         Ok(IdlSqlite { pool })
@@ -1355,7 +1355,7 @@ impl IdlSqlite {
             .query_row("select count(id) from id2entry", [], |row| row.get(0))
             .map_err(|e| {
                 ltrace!(au, "SQLite Error {:?}", e);
-                OperationError::SQLiteError
+                OperationError::SqliteError
             })
     }
 

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -1375,7 +1375,7 @@ impl Backend {
         info!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
         // If in memory, reduce pool to 1
-        if &cfg.path == "" {
+        if cfg.path.is_empty() {
             cfg.pool_size = 1;
         }
 

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -121,7 +121,7 @@ impl IdRawEntry {
     ) -> Result<Entry<EntrySealed, EntryCommitted>, OperationError> {
         let db_e = serde_cbor::from_slice(self.data.as_slice())
             .map_err(|_| OperationError::SerdeCborError)?;
-        // let id = u64::try_from(self.id).map_err(|_| OperationError::InvalidEntryID)?;
+        // let id = u64::try_from(self.id).map_err(|_| OperationError::InvalidEntryId)?;
         Entry::from_dbentry(au, db_e, self.id).map_err(|_| OperationError::CorruptedEntry(self.id))
     }
 }
@@ -836,10 +836,10 @@ impl<'a> BackendWriteTransaction<'a> {
                 .iter()
                 .map(|e| {
                     let id = i64::try_from(e.get_id())
-                        .map_err(|_| OperationError::InvalidEntryID)
+                        .map_err(|_| OperationError::InvalidEntryId)
                         .and_then(|id| {
                             if id == 0 {
-                                Err(OperationError::InvalidEntryID)
+                                Err(OperationError::InvalidEntryId)
                             } else {
                                 Ok(id)
                             }

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IntegrationTestConfig {
+    pub admin_user: String,
     pub admin_password: String,
 }
 

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -661,7 +661,7 @@ impl Credential {
             }
             CredentialType::PasswordMfa(_pw, totp, wan) => {
                 if let Some(r_totp) = totp {
-                    Some(CredSoftLockPolicy::TOTP(r_totp.step))
+                    Some(CredSoftLockPolicy::Totp(r_totp.step))
                 } else if !wan.is_empty() {
                     Some(CredSoftLockPolicy::Webauthn)
                 } else {

--- a/kanidmd/src/lib/credential/softlock.rs
+++ b/kanidmd/src/lib/credential/softlock.rs
@@ -63,7 +63,7 @@ const ONEDAY: u64 = 86400;
 #[derive(Debug, Clone)]
 pub enum CredSoftLockPolicy {
     Password,
-    TOTP(u64),
+    Totp(u64),
     Webauthn,
 }
 
@@ -89,7 +89,7 @@ impl CredSoftLockPolicy {
                     LockState::Locked(count, reset_at, reset_at)
                 }
             }
-            CredSoftLockPolicy::TOTP(step) => {
+            CredSoftLockPolicy::Totp(step) => {
                 // reset at is based on the next step ending.
                 let next_window_end = ct.as_secs() + step;
                 let rem = next_window_end % step;
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_credential_softlock_policy_totp() {
-        let policy = CredSoftLockPolicy::TOTP(TOTP_DEFAULT_STEP);
+        let policy = CredSoftLockPolicy::Totp(TOTP_DEFAULT_STEP);
 
         assert!(
             policy.failure_next_state(1, Duration::from_secs(10))

--- a/kanidmd/src/lib/credential/softlock.rs
+++ b/kanidmd/src/lib/credential/softlock.rs
@@ -170,10 +170,7 @@ impl CredSoftLock {
 
     /// Is this credential valid to proceed at this point in time.
     pub fn is_valid(&self) -> bool {
-        match self.state {
-            LockState::Locked(_count, _reset_at, _unlock_at) => false,
-            _ => true,
-        }
+        !matches!(self.state, LockState::Locked(_count, _reset_at, _unlock_at))
     }
 
     /// Document a failure of authentication at this time.

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -249,10 +249,7 @@ impl Event {
     }
 
     pub fn is_internal(&self) -> bool {
-        match self.origin {
-            EventOrigin::Internal => true,
-            _ => false,
-        }
+        matches!(self.origin, EventOrigin::Internal)
     }
 
     pub fn get_uuid(&self) -> Option<Uuid> {

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -78,7 +78,7 @@ pub fn f_andnot(fc: FC) -> FC {
 
 #[allow(dead_code)]
 pub fn f_self<'a>() -> FC<'a> {
-    FC::SelfUUID
+    FC::SelfUuid
 }
 
 #[allow(dead_code)]
@@ -119,7 +119,7 @@ pub enum FC<'a> {
     And(Vec<FC<'a>>),
     Inclusion(Vec<FC<'a>>),
     AndNot(Box<FC<'a>>),
-    SelfUUID,
+    SelfUuid,
     // Not(Box<FC>),
 }
 
@@ -135,7 +135,7 @@ enum FilterComp {
     And(Vec<FilterComp>),
     Inclusion(Vec<FilterComp>),
     AndNot(Box<FilterComp>),
-    SelfUUID,
+    SelfUuid,
     // Does this mean we can add a true not to the type now?
     // Not(Box<FilterComp>),
 }
@@ -288,7 +288,7 @@ impl Filter<FilterValid> {
             >,
         >,
     ) -> Result<Filter<FilterValidResolved>, OperationError> {
-        // Given a filter, resolve Not and SelfUUID to real terms.
+        // Given a filter, resolve Not and SelfUuid to real terms.
         //
         // The benefit of moving optimisation to this step is from various inputs, we can
         // get to a resolved + optimised filter, and then we can cache those outputs in many
@@ -549,7 +549,7 @@ impl FilterComp {
             FC::And(v) => FilterComp::And(v.into_iter().map(FilterComp::new).collect()),
             FC::Inclusion(v) => FilterComp::Inclusion(v.into_iter().map(FilterComp::new).collect()),
             FC::AndNot(b) => FilterComp::AndNot(Box::new(FilterComp::new(*b))),
-            FC::SelfUUID => FilterComp::SelfUUID,
+            FC::SelfUuid => FilterComp::SelfUuid,
         }
     }
 
@@ -597,7 +597,7 @@ impl FilterComp {
             FilterComp::And(vs) => vs.iter().for_each(|f| f.get_attr_set(r_set)),
             FilterComp::Inclusion(vs) => vs.iter().for_each(|f| f.get_attr_set(r_set)),
             FilterComp::AndNot(f) => f.get_attr_set(r_set),
-            FilterComp::SelfUUID => {
+            FilterComp::SelfUuid => {
                 r_set.insert("uuid");
             }
         }
@@ -717,9 +717,9 @@ impl FilterComp {
                     .validate(schema)
                     .map(|r_filter| FilterComp::AndNot(Box::new(r_filter)))
             }
-            FilterComp::SelfUUID => {
+            FilterComp::SelfUuid => {
                 // Pretty hard to mess this one up ;)
-                Ok(FilterComp::SelfUUID)
+                Ok(FilterComp::SelfUuid)
             }
         }
     }
@@ -773,7 +773,7 @@ impl FilterComp {
                     .ok_or(OperationError::ResourceLimit)?;
                 FilterComp::AndNot(Box::new(Self::from_ro(audit, l, qs, ndepth, elems)?))
             }
-            ProtoFilter::SelfUUID => FilterComp::SelfUUID,
+            ProtoFilter::SelfUuid => FilterComp::SelfUuid,
         })
     }
 
@@ -827,7 +827,7 @@ impl FilterComp {
 
                 FilterComp::AndNot(Box::new(Self::from_rw(audit, l, qs, ndepth, elems)?))
             }
-            ProtoFilter::SelfUUID => FilterComp::SelfUUID,
+            ProtoFilter::SelfUuid => FilterComp::SelfUuid,
         })
     }
 
@@ -1039,7 +1039,7 @@ impl FilterResolved {
                     idxmeta,
                 )))
             }
-            FilterComp::SelfUUID => panic!("Not possible to resolve SelfUUID in from_invalid!"),
+            FilterComp::SelfUuid => panic!("Not possible to resolve SelfUuid in from_invalid!"),
         }
     }
 
@@ -1095,7 +1095,7 @@ impl FilterResolved {
                 FilterResolved::resolve_idx((*f).clone(), ev, idxmeta)
                     .map(|fi| FilterResolved::AndNot(Box::new(fi)))
             }
-            FilterComp::SelfUUID => ev.get_uuid().map(|uuid| {
+            FilterComp::SelfUuid => ev.get_uuid().map(|uuid| {
                 let uuid_s = AttrString::from("uuid");
                 let idxkref = IdxKeyRef::new(&uuid_s, &IndexType::EQUALITY);
                 let idx = idxmeta.contains(&idxkref as &dyn IdxKeyToRef);
@@ -1141,7 +1141,7 @@ impl FilterResolved {
                     .map(|fi| FilterResolved::AndNot(Box::new(fi)))
             }
 
-            FilterComp::SelfUUID => ev.get_uuid().map(|uuid| {
+            FilterComp::SelfUuid => ev.get_uuid().map(|uuid| {
                 FilterResolved::Eq(
                     AttrString::from("uuid"),
                     PartialValue::new_uuid(uuid),

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -326,7 +326,7 @@ impl Filter<FilterValid> {
                         None => f.fast_optimise(),
                     }
                 })
-                .ok_or(OperationError::FilterUUIDResolution)?,
+                .ok_or(OperationError::FilterUuidResolution)?,
             },
         };
 
@@ -1176,10 +1176,7 @@ impl FilterResolved {
                 let (f_list_inc, mut f_list_new): (Vec<_>, Vec<_>) = f_list
                     .iter()
                     .map(|f_ref| f_ref.optimise())
-                    .partition(|f| match f {
-                        FilterResolved::Inclusion(_) => true,
-                        _ => false,
-                    });
+                    .partition(|f| matches!(f, FilterResolved::Inclusion(_)));
 
                 f_list_inc.into_iter().for_each(|fc| {
                     if let FilterResolved::Inclusion(mut l) = fc {
@@ -1196,10 +1193,7 @@ impl FilterResolved {
                 let (f_list_and, mut f_list_new): (Vec<_>, Vec<_>) = f_list
                     .iter()
                     .map(|f_ref| f_ref.optimise())
-                    .partition(|f| match f {
-                        FilterResolved::And(_) => true,
-                        _ => false,
-                    });
+                    .partition(|f| matches!(f,FilterResolved::And(_)));
 
                 // now, iterate over this list - for each "and" term, fold
                 // it's elements to this level.
@@ -1237,10 +1231,7 @@ impl FilterResolved {
                     // Optimise all inner items.
                     .map(|f_ref| f_ref.optimise())
                     // Split out inner-or terms to fold into this term.
-                    .partition(|f| match f {
-                        FilterResolved::Or(_) => true,
-                        _ => false,
-                    });
+                    .partition(|f| matches!(f,FilterResolved::Or(_)));
 
                 // Append the inner terms.
                 f_list_or.into_iter().for_each(|fc| {
@@ -1267,10 +1258,7 @@ impl FilterResolved {
     }
 
     pub fn is_andnot(&self) -> bool {
-        match self {
-            FilterResolved::AndNot(_) => true,
-            _ => false,
-        }
+        matches!(self, FilterResolved::AndNot(_))
     }
 }
 

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -1193,7 +1193,7 @@ impl FilterResolved {
                 let (f_list_and, mut f_list_new): (Vec<_>, Vec<_>) = f_list
                     .iter()
                     .map(|f_ref| f_ref.optimise())
-                    .partition(|f| matches!(f,FilterResolved::And(_)));
+                    .partition(|f| matches!(f, FilterResolved::And(_)));
 
                 // now, iterate over this list - for each "and" term, fold
                 // it's elements to this level.
@@ -1231,7 +1231,7 @@ impl FilterResolved {
                     // Optimise all inner items.
                     .map(|f_ref| f_ref.optimise())
                     // Split out inner-or terms to fold into this term.
-                    .partition(|f| matches!(f,FilterResolved::Or(_)));
+                    .partition(|f| matches!(f, FilterResolved::Or(_)));
 
                 // Append the inner terms.
                 f_list_or.into_iter().for_each(|fc| {

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -7,7 +7,7 @@ use kanidm_proto::v1::UserAuthToken;
 use crate::audit::AuditScope;
 use crate::constants::UUID_ANONYMOUS;
 use crate::credential::policy::CryptoPolicy;
-use crate::credential::totp::TOTP;
+use crate::credential::totp::Totp;
 use crate::credential::{softlock::CredSoftLockPolicy, Credential};
 use crate::idm::claim::Claim;
 use crate::idm::group::Group;
@@ -261,7 +261,7 @@ impl Account {
 
     pub(crate) fn gen_totp_mod(
         &self,
-        token: TOTP,
+        token: Totp,
     ) -> Result<ModifyList<ModifyInvalid>, OperationError> {
         match &self.primary {
             // Change the cred

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -265,13 +265,13 @@ impl UnixUserAuthEvent {
 }
 
 #[derive(Debug)]
-pub struct GenerateTOTPEvent {
+pub struct GenerateTotpEvent {
     pub event: Event,
     pub target: Uuid,
     pub label: String,
 }
 
-impl GenerateTOTPEvent {
+impl GenerateTotpEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
         qs: &QueryServerWriteTransaction,
@@ -281,7 +281,7 @@ impl GenerateTOTPEvent {
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, uat)?;
 
-        Ok(GenerateTOTPEvent {
+        Ok(GenerateTotpEvent {
             event: e,
             target,
             label,
@@ -292,7 +292,7 @@ impl GenerateTOTPEvent {
     pub fn new_internal(target: Uuid) -> Self {
         let e = Event::from_internal();
 
-        GenerateTOTPEvent {
+        GenerateTotpEvent {
             event: e,
             target,
             label: "internal_token".to_string(),
@@ -301,14 +301,14 @@ impl GenerateTOTPEvent {
 }
 
 #[derive(Debug)]
-pub struct VerifyTOTPEvent {
+pub struct VerifyTotpEvent {
     pub event: Event,
     pub target: Uuid,
     pub session: Uuid,
     pub chal: u32,
 }
 
-impl VerifyTOTPEvent {
+impl VerifyTotpEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
         qs: &QueryServerWriteTransaction,
@@ -319,7 +319,7 @@ impl VerifyTOTPEvent {
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, uat)?;
 
-        Ok(VerifyTOTPEvent {
+        Ok(VerifyTotpEvent {
             event: e,
             target,
             session,
@@ -331,7 +331,7 @@ impl VerifyTOTPEvent {
     pub fn new_internal(target: Uuid, session: Uuid, chal: u32) -> Self {
         let e = Event::from_internal();
 
-        VerifyTOTPEvent {
+        VerifyTotpEvent {
             event: e,
             target,
             session,
@@ -341,12 +341,12 @@ impl VerifyTOTPEvent {
 }
 
 #[derive(Debug)]
-pub struct RemoveTOTPEvent {
+pub struct RemoveTotpEvent {
     pub event: Event,
     pub target: Uuid,
 }
 
-impl RemoveTOTPEvent {
+impl RemoveTotpEvent {
     pub fn from_parts(
         audit: &mut AuditScope,
         qs: &QueryServerWriteTransaction,
@@ -355,14 +355,14 @@ impl RemoveTOTPEvent {
     ) -> Result<Self, OperationError> {
         let e = Event::from_rw_uat(audit, qs, uat)?;
 
-        Ok(RemoveTOTPEvent { event: e, target })
+        Ok(RemoveTotpEvent { event: e, target })
     }
 
     #[cfg(test)]
     pub fn new_internal(target: Uuid) -> Self {
         let e = Event::from_internal();
 
-        RemoveTOTPEvent { event: e, target }
+        RemoveTotpEvent { event: e, target }
     }
 }
 

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -8,10 +8,10 @@ use crate::event::{AuthEvent, AuthEventStep, AuthResult};
 use crate::idm::account::Account;
 use crate::idm::authsession::AuthSession;
 use crate::idm::event::{
-    CredentialStatusEvent, GeneratePasswordEvent, GenerateTOTPEvent, LdapAuthEvent,
-    PasswordChangeEvent, RadiusAuthTokenEvent, RegenerateRadiusSecretEvent, RemoveTOTPEvent,
+    CredentialStatusEvent, GeneratePasswordEvent, GenerateTotpEvent, LdapAuthEvent,
+    PasswordChangeEvent, RadiusAuthTokenEvent, RegenerateRadiusSecretEvent, RemoveTotpEvent,
     RemoveWebauthnEvent, UnixGroupTokenEvent, UnixPasswordChangeEvent, UnixUserAuthEvent,
-    UnixUserTokenEvent, VerifyTOTPEvent, WebauthnDoRegisterEvent, WebauthnInitRegisterEvent,
+    UnixUserTokenEvent, VerifyTotpEvent, WebauthnDoRegisterEvent, WebauthnInitRegisterEvent,
 };
 use crate::idm::mfareg::{MfaRegCred, MfaRegNext, MfaRegSession};
 use crate::idm::radius::RadiusAccount;
@@ -1303,7 +1303,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
     pub fn generate_account_totp(
         &mut self,
         au: &mut AuditScope,
-        gte: &GenerateTOTPEvent,
+        gte: &GenerateTotpEvent,
         ct: Duration,
     ) -> Result<SetCredentialResponse, OperationError> {
         let account = self.target_to_account(au, &gte.target)?;
@@ -1327,7 +1327,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
     pub fn verify_account_totp(
         &mut self,
         au: &mut AuditScope,
-        vte: &VerifyTOTPEvent,
+        vte: &VerifyTotpEvent,
         ct: Duration,
     ) -> Result<SetCredentialResponse, OperationError> {
         let sessionid = vte.session;
@@ -1346,7 +1346,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
                 e
             })?;
 
-        if let (MfaRegNext::Success, Some(MfaRegCred::TOTP(token))) = (&next, opt_cred) {
+        if let (MfaRegNext::Success, Some(MfaRegCred::Totp(token))) = (&next, opt_cred) {
             // Purge the session.
             let session = self
                 .mfareg_sessions
@@ -1385,7 +1385,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
     pub fn remove_account_totp(
         &mut self,
         au: &mut AuditScope,
-        rte: &RemoveTOTPEvent,
+        rte: &RemoveTotpEvent,
     ) -> Result<SetCredentialResponse, OperationError> {
         ltrace!(au, "Attempting to remove totp -> {:?}", rte.target);
 
@@ -1542,15 +1542,15 @@ mod tests {
         AUTH_SESSION_TIMEOUT, MFAREG_SESSION_TIMEOUT, UUID_ADMIN, UUID_ANONYMOUS,
     };
     use crate::credential::policy::CryptoPolicy;
-    use crate::credential::totp::TOTP;
+    use crate::credential::totp::Totp;
     use crate::credential::{Credential, Password};
     use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::event::{AuthEvent, AuthResult, CreateEvent, ModifyEvent};
     use crate::idm::delayed::{DelayedAction, WebauthnCounterIncrement};
     use crate::idm::event::{
-        GenerateTOTPEvent, PasswordChangeEvent, RadiusAuthTokenEvent, RegenerateRadiusSecretEvent,
-        RemoveTOTPEvent, RemoveWebauthnEvent, UnixGroupTokenEvent, UnixPasswordChangeEvent,
-        UnixUserAuthEvent, UnixUserTokenEvent, VerifyTOTPEvent, WebauthnDoRegisterEvent,
+        GenerateTotpEvent, PasswordChangeEvent, RadiusAuthTokenEvent, RegenerateRadiusSecretEvent,
+        RemoveTotpEvent, RemoveWebauthnEvent, UnixGroupTokenEvent, UnixPasswordChangeEvent,
+        UnixUserAuthEvent, UnixUserTokenEvent, VerifyTotpEvent, WebauthnDoRegisterEvent,
         WebauthnInitRegisterEvent,
     };
     use crate::idm::AuthState;
@@ -2323,7 +2323,7 @@ mod tests {
             let mut idms_prox_write = idms.proxy_write(ct.clone());
 
             // verify with no session (fail)
-            let vte1 = VerifyTOTPEvent::new_internal(UUID_ADMIN.clone(), Uuid::new_v4(), 0);
+            let vte1 = VerifyTotpEvent::new_internal(UUID_ADMIN.clone(), Uuid::new_v4(), 0);
 
             match idms_prox_write.verify_account_totp(au, &vte1, ct.clone()) {
                 Err(e) => {
@@ -2333,18 +2333,18 @@ mod tests {
             };
 
             // reg, expire session, attempt verify (fail)
-            let gte1 = GenerateTOTPEvent::new_internal(UUID_ADMIN.clone());
+            let gte1 = GenerateTotpEvent::new_internal(UUID_ADMIN.clone());
 
             let res = idms_prox_write
                 .generate_account_totp(au, &gte1, ct.clone())
                 .unwrap();
             let sesid = match res {
-                SetCredentialResponse::TOTPCheck(id, _) => id,
+                SetCredentialResponse::TotpCheck(id, _) => id,
                 _ => panic!("invalid state!"),
             };
             idms_prox_write.expire_mfareg_sessions(expire.clone());
 
-            let vte2 = VerifyTOTPEvent::new_internal(UUID_ADMIN.clone(), sesid, 0);
+            let vte2 = VerifyTotpEvent::new_internal(UUID_ADMIN.clone(), sesid, 0);
 
             match idms_prox_write.verify_account_totp(au, &vte1, ct.clone()) {
                 Err(e) => {
@@ -2358,16 +2358,16 @@ mod tests {
                 .generate_account_totp(au, &gte1, ct.clone())
                 .unwrap();
             let (sesid, tok) = match res {
-                SetCredentialResponse::TOTPCheck(id, tok) => (id, tok),
+                SetCredentialResponse::TotpCheck(id, tok) => (id, tok),
                 _ => panic!("invalid state!"),
             };
             // get the correct otp
-            let r_tok: TOTP = tok.into();
+            let r_tok: Totp = tok.into();
             let chal = r_tok
                 .do_totp_duration_from_epoch(&ct)
                 .expect("Failed to do totp?");
             // attempt the verify
-            let vte3 = VerifyTOTPEvent::new_internal(UUID_ADMIN.clone(), sesid, chal);
+            let vte3 = VerifyTotpEvent::new_internal(UUID_ADMIN.clone(), sesid, chal);
 
             match idms_prox_write.verify_account_totp(au, &vte3, ct.clone()) {
                 Err(e) => assert!(e == OperationError::InvalidState),
@@ -2386,16 +2386,16 @@ mod tests {
                 .generate_account_totp(au, &gte1, ct.clone())
                 .unwrap();
             let (sesid, tok) = match res {
-                SetCredentialResponse::TOTPCheck(id, tok) => (id, tok),
+                SetCredentialResponse::TotpCheck(id, tok) => (id, tok),
                 _ => panic!("invalid state!"),
             };
             // get the correct otp
-            let r_tok: TOTP = tok.into();
+            let r_tok: Totp = tok.into();
             let chal = r_tok
                 .do_totp_duration_from_epoch(&ct)
                 .expect("Failed to do totp?");
             // attempt the verify
-            let vte3 = VerifyTOTPEvent::new_internal(UUID_ANONYMOUS.clone(), sesid, chal);
+            let vte3 = VerifyTotpEvent::new_internal(UUID_ANONYMOUS.clone(), sesid, chal);
 
             match idms_prox_write.verify_account_totp(au, &vte3, ct.clone()) {
                 Err(e) => assert!(e == OperationError::InvalidRequestState),
@@ -2407,14 +2407,14 @@ mod tests {
                 .generate_account_totp(au, &gte1, ct.clone())
                 .unwrap();
             let (_sesid, _tok) = match res {
-                SetCredentialResponse::TOTPCheck(id, tok) => (id, tok),
+                SetCredentialResponse::TotpCheck(id, tok) => (id, tok),
                 _ => panic!("invalid state!"),
             };
 
             // We can reuse the OTP/Vte2 from before, since we want the invalid otp.
             match idms_prox_write.verify_account_totp(au, &vte2, ct.clone()) {
                 // On failure we get back another attempt to setup the token.
-                Ok(SetCredentialResponse::TOTPCheck(_id, _tok)) => {}
+                Ok(SetCredentialResponse::TotpCheck(_id, _tok)) => {}
                 _ => panic!(),
             };
             idms_prox_write.expire_mfareg_sessions(expire.clone());
@@ -2425,16 +2425,16 @@ mod tests {
                 .generate_account_totp(au, &gte1, ct.clone())
                 .unwrap();
             let (sesid, tok) = match res {
-                SetCredentialResponse::TOTPCheck(id, tok) => (id, tok),
+                SetCredentialResponse::TotpCheck(id, tok) => (id, tok),
                 _ => panic!("invalid state!"),
             };
             // We can't reuse the OTP/Vte from before, since the token seed changes
-            let r_tok: TOTP = tok.into();
+            let r_tok: Totp = tok.into();
             let chal = r_tok
                 .do_totp_duration_from_epoch(&ct)
                 .expect("Failed to do totp?");
             // attempt the verify
-            let vte3 = VerifyTOTPEvent::new_internal(UUID_ADMIN.clone(), sesid, chal);
+            let vte3 = VerifyTotpEvent::new_internal(UUID_ADMIN.clone(), sesid, chal);
 
             match idms_prox_write.verify_account_totp(au, &vte3, ct.clone()) {
                 Ok(SetCredentialResponse::Success) => {}
@@ -2443,7 +2443,7 @@ mod tests {
             idms_prox_write.expire_mfareg_sessions(expire.clone());
 
             // Test removing the TOTP and then authing with password only.
-            let rte = RemoveTOTPEvent::new_internal(UUID_ADMIN.clone());
+            let rte = RemoveTotpEvent::new_internal(UUID_ADMIN.clone());
             idms_prox_write.remove_account_totp(au, &rte).unwrap();
             assert!(idms_prox_write.commit(au).is_ok());
 

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -432,6 +432,7 @@ fn ldap_domain_to_dc(input: &str) -> String {
     input.split('.').for_each(|dc| {
         output.push_str("dc=");
         output.push_str(dc);
+        #[allow(clippy::single_char_add_str)]
         output.push_str(",");
     });
     // Remove the last ','

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -111,7 +111,7 @@ impl LdapServer {
     ) -> Result<Vec<LdapMsg>, OperationError> {
         ladmin_info!(au, "Attempt LDAP Search for {}", uat.spn);
         // If the request is "", Base, Present("objectclass"), [], then we want the rootdse.
-        if sr.base == "" && sr.scope == LdapSearchScope::Base {
+        if sr.base.is_empty() && sr.scope == LdapSearchScope::Base {
             ladmin_info!(au, "LDAP Search success - RootDSE");
             Ok(vec![
                 sr.gen_result_entry(self.rootdse.clone()),
@@ -299,12 +299,12 @@ impl LdapServer {
         lsecurity!(
             au,
             "Attempt LDAP Bind for {}",
-            if dn == "" { "anonymous" } else { dn }
+            if dn.is_empty() { "anonymous" } else { dn }
         );
         let mut idm_write = idms.write_async().await;
 
-        let target_uuid: Uuid = if dn == "" {
-            if pw == "" {
+        let target_uuid: Uuid = if dn.is_empty() {
+            if pw.is_empty() {
                 lsecurity!(au, "✅ LDAP Bind success anonymous");
                 *UUID_ANONYMOUS
             } else {
@@ -324,7 +324,7 @@ impl LdapServer {
 
             ltrace!(au, "rdn val is -> {:?}", rdn);
 
-            if rdn == "" {
+            if rdn.is_empty() {
                 // That's weird ...
                 return Err(OperationError::NoMatchingEntries);
             }

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -430,10 +430,11 @@ impl LdapServer {
 fn ldap_domain_to_dc(input: &str) -> String {
     let mut output: String = String::new();
     input.split('.').for_each(|dc| {
-        output.push_str("dc=");
-        output.push_str(dc);
-        #[allow(clippy::single_char_add_str)]
-        output.push_str(",");
+        // output.push_str("dc=");
+        // output.push_str(dc);
+        // #[allow(clippy::single_char_add_str)]
+        // output.push_str(",");
+        output.push_str(concat!("dc=", dc, ","));
     });
     // Remove the last ','
     output.pop();

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 // #![deny(clippy::panic)]
-#![allow(clippy::unreachable)]
+#![deny(clippy::unreachable)]
 #![deny(clippy::await_holding_lock)]
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 // #![deny(clippy::panic)]
-#![deny(clippy::unreachable)]
+#![allow(clippy::unreachable)]
 #![deny(clippy::await_holding_lock)]
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -270,7 +270,7 @@ mod tests {
                     .get_ava_single_credential("primary_credential")
                     .expect("failed to get primary cred.");
                 match &c.type_ {
-                    CredentialType::PasswordMFA(_pw, totp, webauthn) => {
+                    CredentialType::PasswordMfa(_pw, totp, webauthn) => {
                         assert!(totp.is_some());
                         assert!(webauthn.is_empty());
                     }

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -127,7 +127,7 @@ impl Plugin for PasswordImport {
 #[cfg(test)]
 mod tests {
     use crate::credential::policy::CryptoPolicy;
-    use crate::credential::totp::{TOTP, TOTP_DEFAULT_STEP};
+    use crate::credential::totp::{Totp, TOTP_DEFAULT_STEP};
     use crate::credential::{Credential, CredentialType};
     use crate::entry::{Entry, EntryInit, EntryNew};
     use crate::modify::{Modify, ModifyList};
@@ -241,7 +241,7 @@ mod tests {
         }"#,
         );
 
-        let totp = TOTP::generate_secure("test_totp".to_string(), TOTP_DEFAULT_STEP);
+        let totp = Totp::generate_secure("test_totp".to_string(), TOTP_DEFAULT_STEP);
         let p = CryptoPolicy::minimum();
         let c = Credential::new_password_only(&p, "password")
             .unwrap()

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -222,7 +222,7 @@ impl Plugin for Spn {
                         e.get_uuid()
                     );
                     debug_assert!(false);
-                    r.push(Err(ConsistencyError::InvalidSPN(e.get_id())));
+                    r.push(Err(ConsistencyError::InvalidSpn(e.get_id())));
                     continue;
                 }
             };
@@ -238,12 +238,12 @@ impl Plugin for Spn {
                             g_spn,
                         );
                         debug_assert!(false);
-                        r.push(Err(ConsistencyError::InvalidSPN(e.get_id())))
+                        r.push(Err(ConsistencyError::InvalidSpn(e.get_id())))
                     }
                 }
                 None => {
                     ladmin_error!(au, "Entry {:?} does not contain an SPN", e.get_uuid(),);
-                    r.push(Err(ConsistencyError::InvalidSPN(e.get_id())))
+                    r.push(Err(ConsistencyError::InvalidSpn(e.get_id())))
                 }
             }
         }

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -1969,7 +1969,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                         Err(e) => Err(OperationError::SchemaViolation(e)),
                     }
                 } else {
-                    Err(OperationError::InvalidDBState)
+                    Err(OperationError::InvalidDbState)
                 }
             }
             Err(e) => {
@@ -2034,7 +2034,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                         Ok(())
                     }
                 } else {
-                    Err(OperationError::InvalidDBState)
+                    Err(OperationError::InvalidDbState)
                 }
             }
             Err(er) => {

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -288,10 +288,7 @@ impl PartialValue {
     }
 
     pub fn is_utf8(&self) -> bool {
-        match self {
-            PartialValue::Utf8(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Utf8(_))
     }
 
     pub fn new_iutf8(s: &str) -> Self {
@@ -315,17 +312,11 @@ impl PartialValue {
     */
 
     pub fn is_iutf8(&self) -> bool {
-        match self {
-            PartialValue::Iutf8(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Iutf8(_))
     }
 
     pub fn is_iname(&self) -> bool {
-        match self {
-            PartialValue::Iname(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Iname(_))
     }
 
     pub fn new_bool(b: bool) -> Self {
@@ -744,10 +735,7 @@ impl Value {
     }
 
     pub fn is_utf8(&self) -> bool {
-        match self.pv {
-            PartialValue::Utf8(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Utf8(_))
     }
 
     pub fn new_iutf8(s: &str) -> Self {
@@ -758,10 +746,7 @@ impl Value {
     }
 
     pub fn is_insensitive_utf8(&self) -> bool {
-        match self.pv {
-            PartialValue::Iutf8(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Iutf8(_))
     }
 
     pub fn new_iname(s: &str) -> Self {
@@ -772,10 +757,7 @@ impl Value {
     }
 
     pub fn is_iname(&self) -> bool {
-        match self.pv {
-            PartialValue::Iname(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Iname(_))
     }
 
     pub fn new_uuid(u: Uuid) -> Self {
@@ -801,10 +783,7 @@ impl Value {
 
     // Is this correct? Should ref be seperate?
     pub fn is_uuid(&self) -> bool {
-        match self.pv {
-            PartialValue::Uuid(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Uuid(_))
     }
 
     pub fn new_class(s: &str) -> Self {
@@ -837,10 +816,7 @@ impl Value {
 
     #[inline]
     pub fn is_bool(&self) -> bool {
-        match self.pv {
-            PartialValue::Bool(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Bool(_))
     }
 
     pub fn new_syntaxs(s: &str) -> Option<Self> {
@@ -851,10 +827,7 @@ impl Value {
     }
 
     pub fn is_syntax(&self) -> bool {
-        match self.pv {
-            PartialValue::Syntax(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Syntax(_))
     }
 
     pub fn new_indexs(s: &str) -> Option<Self> {
@@ -865,10 +838,7 @@ impl Value {
     }
 
     pub fn is_index(&self) -> bool {
-        match self.pv {
-            PartialValue::Index(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Index(_))
     }
 
     pub fn new_refer(u: Uuid) -> Self {
@@ -893,10 +863,7 @@ impl Value {
     }
 
     pub fn is_refer(&self) -> bool {
-        match self.pv {
-            PartialValue::Refer(_) => true,
-            _ => false,
-        }
+        matches!(self.pv, PartialValue::Refer(_))
     }
 
     pub fn new_json_filter(s: &str) -> Option<Self> {
@@ -925,10 +892,7 @@ impl Value {
     }
 
     pub fn is_credential(&self) -> bool {
-        match &self.pv {
-            PartialValue::Cred(_) => true,
-            _ => false,
-        }
+        matches!(&self.pv, PartialValue::Cred(_))
     }
 
     pub fn to_credential(&self) -> Option<&Credential> {

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -331,10 +331,7 @@ impl PartialValue {
     }
 
     pub fn is_bool(&self) -> bool {
-        match self {
-            PartialValue::Bool(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Bool(_))
     }
 
     pub fn new_uuid(u: Uuid) -> Self {
@@ -353,10 +350,7 @@ impl PartialValue {
     }
 
     pub fn is_uuid(&self) -> bool {
-        match self {
-            PartialValue::Uuid(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Uuid(_))
     }
 
     pub fn new_refer(u: Uuid) -> Self {
@@ -375,10 +369,7 @@ impl PartialValue {
     }
 
     pub fn is_refer(&self) -> bool {
-        match self {
-            PartialValue::Refer(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Refer(_))
     }
 
     pub fn new_indexs(s: &str) -> Option<Self> {
@@ -390,10 +381,7 @@ impl PartialValue {
     }
 
     pub fn is_index(&self) -> bool {
-        match self {
-            PartialValue::Index(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Index(_))
     }
 
     pub fn new_syntaxs(s: &str) -> Option<Self> {
@@ -405,10 +393,7 @@ impl PartialValue {
     }
 
     pub fn is_syntax(&self) -> bool {
-        match self {
-            PartialValue::Syntax(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Syntax(_))
     }
 
     pub fn new_json_filter(s: &str) -> Option<Self> {
@@ -420,10 +405,7 @@ impl PartialValue {
     }
 
     pub fn is_json_filter(&self) -> bool {
-        match self {
-            PartialValue::JsonFilt(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::JsonFilt(_))
     }
 
     pub fn new_credential_tag(s: &str) -> Self {
@@ -431,10 +413,7 @@ impl PartialValue {
     }
 
     pub fn is_credential(&self) -> bool {
-        match self {
-            PartialValue::Cred(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Cred(_))
     }
 
     pub fn new_radius_string() -> Self {
@@ -442,10 +421,7 @@ impl PartialValue {
     }
 
     pub fn is_radius_string(&self) -> bool {
-        match self {
-            PartialValue::RadiusCred => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::RadiusCred)
     }
 
     pub fn new_sshkey_tag(s: String) -> Self {
@@ -457,10 +433,7 @@ impl PartialValue {
     }
 
     pub fn is_sshkey(&self) -> bool {
-        match self {
-            PartialValue::SshKey(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::SshKey(_))
     }
 
     pub fn new_spn_s(s: &str) -> Option<Self> {
@@ -482,10 +455,7 @@ impl PartialValue {
     }
 
     pub fn is_spn(&self) -> bool {
-        match self {
-            PartialValue::Spn(_, _) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Spn(_, _))
     }
 
     pub fn new_uint32(u: u32) -> Self {
@@ -497,10 +467,7 @@ impl PartialValue {
     }
 
     pub fn is_uint32(&self) -> bool {
-        match self {
-            PartialValue::Uint32(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Uint32(_))
     }
 
     pub fn new_cid(c: Cid) -> Self {
@@ -512,10 +479,7 @@ impl PartialValue {
     }
 
     pub fn is_cid(&self) -> bool {
-        match self {
-            PartialValue::Cid(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Cid(_))
     }
 
     pub fn new_nsuniqueid_s(s: &str) -> Self {
@@ -523,10 +487,7 @@ impl PartialValue {
     }
 
     pub fn is_nsuniqueid(&self) -> bool {
-        match self {
-            PartialValue::Nsuniqueid(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::Nsuniqueid(_))
     }
 
     pub fn new_datetime_epoch(ts: Duration) -> Self {
@@ -541,10 +502,7 @@ impl PartialValue {
     }
 
     pub fn is_datetime(&self) -> bool {
-        match self {
-            PartialValue::DateTime(_) => true,
-            _ => false,
-        }
+        matches!(self, PartialValue::DateTime(_))
     }
 
     pub fn to_str(&self) -> Option<&str> {
@@ -1358,10 +1316,7 @@ impl Value {
                 }
             }
             PartialValue::Cred(_) => match &self.data {
-                Some(v) => match v.as_ref() {
-                    DataValue::Cred(_) => true,
-                    _ => false,
-                },
+                Some(v) => matches!(v.as_ref(), DataValue::Cred(_)),
                 None => false,
             },
             PartialValue::SshKey(_) => match &self.data {
@@ -1374,10 +1329,7 @@ impl Value {
                 None => false,
             },
             PartialValue::RadiusCred => match &self.data {
-                Some(v) => match v.as_ref() {
-                    DataValue::RadiusCred(_) => true,
-                    _ => false,
-                },
+                Some(v) => matches!(v.as_ref(), DataValue::RadiusCred(_)),
                 None => false,
             },
             PartialValue::Nsuniqueid(s) => NSUNIQUEID_RE.is_match(s),

--- a/kanidmd_web_ui/src/login.rs
+++ b/kanidmd_web_ui/src/login.rs
@@ -20,7 +20,6 @@ extern "C" {
 pub struct LoginApp {
     link: ComponentLink<Self>,
     inputvalue: String,
-    #[allow(dead_code)]
     lstorage: StorageService,
     ft: Option<FetchTask>,
     session_id: String,
@@ -263,7 +262,7 @@ impl Component for LoginApp {
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        ConsoleService::log(&"create".to_string());
+        ConsoleService::log("create");
 
         // First we need to work out what state we are in.
         let lstorage = StorageService::new(yew::services::storage::Area::Local).unwrap();

--- a/kanidmd_web_ui/src/login.rs
+++ b/kanidmd_web_ui/src/login.rs
@@ -329,7 +329,7 @@ impl Component for LoginApp {
                     Ok(totp) => {
                         self.state = LoginState::Totp(TotpState::Disabled);
                         let authreq = AuthRequest {
-                            step: AuthStep::Cred(AuthCredential::TOTP(totp)),
+                            step: AuthStep::Cred(AuthCredential::Totp(totp)),
                         };
                         self.auth_step(authreq);
                     }
@@ -412,7 +412,7 @@ impl Component for LoginApp {
                                     // Go to the password view.
                                     self.state = LoginState::Password(true);
                                 }
-                                AuthAllowed::TOTP => {
+                                AuthAllowed::Totp => {
                                     self.state = LoginState::Totp(TotpState::Enabled);
                                 }
                                 AuthAllowed::Webauthn(challenge) => {

--- a/kanidmd_web_ui/src/login.rs
+++ b/kanidmd_web_ui/src/login.rs
@@ -20,6 +20,7 @@ extern "C" {
 pub struct LoginApp {
     link: ComponentLink<Self>,
     inputvalue: String,
+    #[allow(dead_code)]
     lstorage: StorageService,
     ft: Option<FetchTask>,
     session_id: String,
@@ -262,7 +263,7 @@ impl Component for LoginApp {
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        ConsoleService::log(format!("create").as_str());
+        ConsoleService::log(&"create".to_string());
 
         // First we need to work out what state we are in.
         let lstorage = StorageService::new(yew::services::storage::Area::Local).unwrap();


### PR DESCRIPTION
Fixes a load of `cargo clippy` complaints. 

Replaces the use of the string username `"admin"` in tests with a single common variable - same as the password is for same tests.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

All the above tests were run on rust 1.49.0 across:

 - openSUSE Tumbleweed
 - openSUSE Leap 15.2
 - Ubuntu Bionic 
 - macOS Big Sur on M1
 - Debian Buster