### PR TITLE
Fix 421 - clearer debug messages when doing things

### DIFF
--- a/kanidm_tools/src/cli/login.rs
+++ b/kanidm_tools/src/cli/login.rs
@@ -27,7 +27,7 @@ pub fn read_tokens() -> Result<BTreeMap<String, String>, ()> {
         Ok(f) => f,
         Err(e) => {
             warn!(
-                "Cannot read from {} due to error: {:?} ... continuing.",
+                "Cannot read tokens from {} due to error: {:?} ... continuing.",
                 TOKEN_PATH, e
             );
             return Ok(BTreeMap::new());
@@ -37,7 +37,10 @@ pub fn read_tokens() -> Result<BTreeMap<String, String>, ()> {
 
     // Else try to read
     serde_json::from_reader(reader).map_err(|e| {
-        error!("JSON/IO error reading file {:?} -> {:?}", &token_path, e);
+        error!(
+            "JSON/IO error reading tokens from {:?} -> {:?}",
+            &token_path, e
+        );
     })
 }
 
@@ -80,7 +83,10 @@ pub fn write_tokens(tokens: &BTreeMap<String, String>) -> Result<(), ()> {
 
     let writer = BufWriter::new(file);
     serde_json::to_writer_pretty(writer, tokens).map_err(|e| {
-        error!("JSON/IO error writing file {:?} -> {:?}", &token_path, e);
+        error!(
+            "JSON/IO error writing tokens to file {:?} -> {:?}",
+            &token_path, e
+        );
     })
 }
 

--- a/kanidm_tools/src/cli/login.rs
+++ b/kanidm_tools/src/cli/login.rs
@@ -21,11 +21,15 @@ pub fn read_tokens() -> Result<BTreeMap<String, String>, ()> {
         return Ok(BTreeMap::new());
     }
 
+    debug!("Attempting to read tokens from {:?}", &token_path);
     // If the file does not exist, return Ok<map>
     let file = match File::open(&token_path) {
         Ok(f) => f,
         Err(e) => {
-            warn!("Can not read from {}, continuing ... {:?}", TOKEN_PATH, e);
+            warn!(
+                "Cannot read from {} due to error: {:?} ... continuing.",
+                TOKEN_PATH, e
+            );
             return Ok(BTreeMap::new());
         }
     };
@@ -33,7 +37,7 @@ pub fn read_tokens() -> Result<BTreeMap<String, String>, ()> {
 
     // Else try to read
     serde_json::from_reader(reader).map_err(|e| {
-        error!("JSON/IO error -> {:?}", e);
+        error!("JSON/IO error reading file {:?} -> {:?}", &token_path, e);
     })
 }
 
@@ -76,7 +80,7 @@ pub fn write_tokens(tokens: &BTreeMap<String, String>) -> Result<(), ()> {
 
     let writer = BufWriter::new(file);
     serde_json::to_writer_pretty(writer, tokens).map_err(|e| {
-        error!("JSON/IO error -> {:?}", e);
+        error!("JSON/IO error reading file {:?} -> {:?}", &token_path, e);
     })
 }
 

--- a/kanidm_tools/src/cli/login.rs
+++ b/kanidm_tools/src/cli/login.rs
@@ -80,7 +80,7 @@ pub fn write_tokens(tokens: &BTreeMap<String, String>) -> Result<(), ()> {
 
     let writer = BufWriter::new(file);
     serde_json::to_writer_pretty(writer, tokens).map_err(|e| {
-        error!("JSON/IO error reading file {:?} -> {:?}", &token_path, e);
+        error!("JSON/IO error writing file {:?} -> {:?}", &token_path, e);
     })
 }
 


### PR DESCRIPTION
Fixes #421 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

new output for when it fails
```
$ cargo run --bin kanidm -- account ssh list_publickeys --name idm_admin yaleman -d
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
     Running `/Users/yaleman/Projects/kanidm/target/debug/kanidm account ssh list_publickeys --name idm_admin yaleman -d`
[2021-04-25T01:18:53Z DEBUG kanidm_cli::common] Attempting to use config /etc/kanidm/config
[2021-04-25T01:18:53Z DEBUG kanidm_client] Unable to open config file "/etc/kanidm/config" [Os { code: 2, kind: NotFound, message: "No such file or directory" }], skipping ...
[2021-04-25T01:18:53Z DEBUG kanidm_cli::common] Attempting to use config /Users/yaleman/.config/kanidm
[2021-04-25T01:18:53Z DEBUG kanidm_cli::login] Attempting to read tokens from "/Users/yaleman/.cache/kanidm_tokens"
[2021-04-25T01:18:53Z ERROR kanidm_cli::login] JSON/IO error reading tokens from "/Users/yaleman/.cache/kanidm_tokens" -> Error("trailing comma", line: 3, column: 1)
[2021-04-25T01:18:53Z ERROR kanidm_cli::common] Error retrieving authentication token store
```
new output for when it works (my token was expired but this is irrelevant)
```
$ cargo run --bin kanidm -- account ssh list_publickeys --name idm_admin yaleman -d
   Compiling kanidm_tools v1.1.0-alpha.4 (/Users/yaleman/Projects/kanidm/kanidm_tools)
   Compiling kanidm_proto v1.1.0-alpha.4 (/Users/yaleman/Projects/kanidm/kanidm_proto)
   Compiling kanidm_client v1.1.0-alpha.4 (/Users/yaleman/Projects/kanidm/kanidm_client)
    Finished dev [unoptimized + debuginfo] target(s) in 6.47s
     Running `/Users/yaleman/Projects/kanidm/target/debug/kanidm account ssh list_publickeys --name idm_admin yaleman -d`
[2021-04-25T01:18:37Z DEBUG kanidm_cli::common] Attempting to use config /etc/kanidm/config
[2021-04-25T01:18:37Z DEBUG kanidm_client] Unable to open config file "/etc/kanidm/config" [Os { code: 2, kind: NotFound, message: "No such file or directory" }], skipping ...
[2021-04-25T01:18:37Z DEBUG kanidm_cli::common] Attempting to use config /Users/yaleman/.config/kanidm
[2021-04-25T01:18:37Z DEBUG kanidm_cli::login] Attempting to read tokens from "/Users/yaleman/.cache/kanidm_tokens"
[2021-04-25T01:18:37Z DEBUG kanidm_client::asynchronous] "https://kanidm.housenet.yaleman.org/v1/account/yaleman/_ssh_pubkeys"
[2021-04-25T01:18:37Z DEBUG kanidm_client::asynchronous] opid -> "c497005e-18ae-44d3-887f-9cd8960faa5c"
Error -> Http(401, Some(NotAuthenticated), "c497005e-18ae-44d3-887f-9cd8960faa5c")
```