### PR TITLE
Add ability to pick a server role

### DIFF
--- a/kanidm_book/src/installing_the_server.md
+++ b/kanidm_book/src/installing_the_server.md
@@ -153,6 +153,19 @@ You will also need a config file in the volume named `server.toml` (Within the c
     #   it is non-standard (any port except 443)
     # origin = "https://idm.example.com"
     origin = "https://idm.example.com:8443"
+    #
+    #   The role of this server. This affects features available and how replication may interact.
+    #   Valid roles are:
+    #   - write_replica
+    #     This server provides all functionality of Kanidm. It allows authentication, writes, and
+    #     the web user interface to be served.
+    #   - write_replica_no_ui
+    #     This server is the same as a write_replica, but does NOT offer the web user interface.
+    #   - read_only_replica
+    #     This server will not writes initiated by clients. It supports authentication and reads,
+    #     and must have a replication agreement as a source of it's data.
+    #   Defaults to "write_replica".
+    # role = "write_replica"
 
 Then you can setup the initial admin account and initialise the database into your volume.
 

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -40,7 +40,6 @@ impl FromStr for ServerRole {
     }
 }
 
-
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Configuration {
     pub address: String,

--- a/kanidmd/src/lib/core/https.rs
+++ b/kanidmd/src/lib/core/https.rs
@@ -13,7 +13,7 @@ use crate::actors::v1_write::{
     InternalRegenerateRadiusMessage, InternalSshKeyCreateMessage, ModifyMessage,
     PurgeAttributeMessage, RemoveAttributeValueMessage, ReviveRecycledMessage, SetAttributeMessage,
 };
-use crate::config::{TlsConfiguration, ServerRole};
+use crate::config::{ServerRole, TlsConfiguration};
 use crate::event::AuthResult;
 use crate::filter::{Filter, FilterInvalid};
 use crate::idm::AuthState;

--- a/kanidmd/src/lib/core/https.rs
+++ b/kanidmd/src/lib/core/https.rs
@@ -13,7 +13,7 @@ use crate::actors::v1_write::{
     InternalRegenerateRadiusMessage, InternalSshKeyCreateMessage, ModifyMessage,
     PurgeAttributeMessage, RemoveAttributeValueMessage, ReviveRecycledMessage, SetAttributeMessage,
 };
-use crate::config::TlsConfiguration;
+use crate::config::{TlsConfiguration, ServerRole};
 use crate::event::AuthResult;
 use crate::filter::{Filter, FilterInvalid};
 use crate::idm::AuthState;
@@ -1282,6 +1282,7 @@ pub fn create_https_server(
     address: String,
     // opt_tls_params: Option<SslAcceptorBuilder>,
     opt_tls_params: Option<&TlsConfiguration>,
+    role: ServerRole,
     cookie_key: &[u8; 32],
     status_ref: &'static StatusActor,
     qe_w_ref: &'static QueryServerWriteV1,
@@ -1310,17 +1311,22 @@ pub fn create_https_server(
     );
 
     // Add routes
-    tserver.at("/").get(index_view);
-    tserver
-        .at("/pkg")
-        .serve_dir(env!("KANIDM_WEB_UI_PKG_PATH"))
-        .map_err(|e| {
-            error!(
-                "Failed to serve pkg dir {} -> {:?}",
-                env!("KANIDM_WEB_UI_PKG_PATH"),
-                e
-            );
-        })?;
+
+    // If we are no-ui, we remove this.
+    if !matches!(role, ServerRole::WriteReplicaNoUI) {
+        tserver.at("/").get(index_view);
+        tserver
+            .at("/pkg")
+            .serve_dir(env!("KANIDM_WEB_UI_PKG_PATH"))
+            .map_err(|e| {
+                error!(
+                    "Failed to serve pkg dir {} -> {:?}",
+                    env!("KANIDM_WEB_UI_PKG_PATH"),
+                    e
+                );
+            })?;
+    };
+
     tserver.at("/status").get(self::status);
 
     let mut raw_route = tserver.at("/v1/raw");

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -592,6 +592,7 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
         config.address,
         // opt_tls_params,
         config.tls_config.as_ref(),
+        config.role,
         &cookie_key,
         status_ref,
         server_write_ref,

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use kanidm::audit::LogLevel;
-use kanidm::config::Configuration;
+use kanidm::config::{Configuration, ServerRole};
 use kanidm::core::{
     backup_server_core, create_server_core, domain_rename_core, recover_account_core,
     reindex_server_core, restore_server_core, vacuum_server_core, verify_server_core,
@@ -45,6 +45,8 @@ struct ServerConfig {
     pub tls_key: Option<String>,
     pub log_level: Option<String>,
     pub origin: String,
+    #[serde(default)]
+    pub role: ServerRole,
 }
 
 impl ServerConfig {
@@ -210,6 +212,7 @@ async fn main() {
     config.update_ldapbind(&sconfig.ldapbindaddress);
     config.update_origin(&sconfig.origin.as_str());
     config.update_db_arc_size(sconfig.db_arc_size);
+    config.update_role(sconfig.role);
 
     // Apply any cli overrides, normally debug level.
     if let Some(dll) = opt.commonopt().debug.as_ref() {


### PR DESCRIPTION
Fixes #426 adds a configuration element for "role" which can define what features we expose from the server. 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
