### PR TITLE
Add verification of name indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953d6851b04c62e12dd1d07fb99bf87094284e321db47ac3a4d861bb4054444b"
+checksum = "7a695f8f543f6c58f519d0006c069d244c269ef64291b9eead6ebe30ffc294f4"
 dependencies = [
  "ahash 0.7.2",
  "crossbeam",
@@ -636,6 +636,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.3",
  "smallvec",
+ "tokio",
 ]
 
 [[package]]

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -51,7 +51,7 @@ pub enum ConsistencyError {
     DuplicateUniqueAttribute(String),
     InvalidSpn(u64),
     SqliteIntegrityFailure,
-    BackendAllIDSSync,
+    BackendAllIdsSync,
     BackendIndexSync,
 }
 

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -51,6 +51,8 @@ pub enum ConsistencyError {
     DuplicateUniqueAttribute(String),
     InvalidSpn(u64),
     SqliteIntegrityFailure,
+    BackendAllIDSSync,
+    BackendIndexSync,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -62,7 +62,7 @@ structopt = { version = "0.3", default-features = false }
 time = { version = "0.2", features = ["serde", "std"] }
 
 hashbrown = "0.11"
-concread = "^0.2.9"
+concread = "^0.2.12"
 # concread = { version = "^0.2.9", path = "../../concread" }
 # concread = { version = "^0.2.9", features = ["simd_support"] }
 

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -281,6 +281,30 @@ macro_rules! uuid2rdn {
     }};
 }
 
+macro_rules! verify {
+    (
+        $self:expr,
+        $audit:expr
+    ) => {{
+        let mut r = $self.db.verify();
+        if r.is_empty() && !$self.is_dirty() {
+            // Check allids.
+            match $self.db.get_allids($audit) {
+                Ok(db_allids) => {
+                    if !db_allids.is_compressed() || !(*($self).allids).is_compressed() {
+                        r.push(Err(ConsistencyError::BackendAllIDSSync))
+                    }
+                    if db_allids != (*($self).allids) {
+                        r.push(Err(ConsistencyError::BackendAllIDSSync))
+                    }
+                }
+                Err(_) => r.push(Err(ConsistencyError::Unknown)),
+            };
+        };
+        r
+    }};
+}
+
 pub trait IdlArcSqliteTransaction {
     fn get_identry(
         &mut self,
@@ -313,7 +337,9 @@ pub trait IdlArcSqliteTransaction {
 
     fn get_db_d_uuid(&self) -> Result<Option<Uuid>, OperationError>;
 
-    fn verify(&self) -> Vec<Result<(), ConsistencyError>>;
+    fn verify(&self, audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>>;
+
+    fn is_dirty(&self) -> bool;
 
     fn name2uuid(
         &mut self,
@@ -378,8 +404,12 @@ impl<'a> IdlArcSqliteTransaction for IdlArcSqliteReadTransaction<'a> {
         self.db.get_db_d_uuid()
     }
 
-    fn verify(&self) -> Vec<Result<(), ConsistencyError>> {
-        self.db.verify()
+    fn verify(&self, audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
+        verify!(self, audit)
+    }
+
+    fn is_dirty(&self) -> bool {
+        false
     }
 
     fn name2uuid(
@@ -451,8 +481,12 @@ impl<'a> IdlArcSqliteTransaction for IdlArcSqliteWriteTransaction<'a> {
         self.db.get_db_d_uuid()
     }
 
-    fn verify(&self) -> Vec<Result<(), ConsistencyError>> {
-        self.db.verify()
+    fn verify(&self, audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
+        verify!(self, audit)
+    }
+
+    fn is_dirty(&self) -> bool {
+        self.entry_cache.is_dirty()
     }
 
     fn name2uuid(
@@ -804,6 +838,9 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
 
     pub unsafe fn purge_id2entry(&mut self, audit: &mut AuditScope) -> Result<(), OperationError> {
         self.db.purge_id2entry(audit).map(|()| {
+            let mut ids = IDLBitRange::new();
+            ids.compress();
+            std::mem::swap(self.allids.deref_mut(), &mut ids);
             self.entry_cache.clear();
         })
     }

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -292,10 +292,10 @@ macro_rules! verify {
             match $self.db.get_allids($audit) {
                 Ok(db_allids) => {
                     if !db_allids.is_compressed() || !(*($self).allids).is_compressed() {
-                        r.push(Err(ConsistencyError::BackendAllIDSSync))
+                        r.push(Err(ConsistencyError::BackendAllIdsSync))
                     }
                     if db_allids != (*($self).allids) {
-                        r.push(Err(ConsistencyError::BackendAllIDSSync))
+                        r.push(Err(ConsistencyError::BackendAllIdsSync))
                     }
                 }
                 Err(_) => r.push(Err(ConsistencyError::Unknown)),

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -921,7 +921,7 @@ impl Entry<EntrySealed, EntryCommitted> {
     }
 
     #[inline]
-    fn get_uuid2rdn(&self) -> String {
+    pub(crate) fn get_uuid2rdn(&self) -> String {
         self.attrs
             .get("spn")
             .and_then(|vs| {

--- a/kanidmd/src/lib/plugins/refint.rs
+++ b/kanidmd/src/lib/plugins/refint.rs
@@ -40,7 +40,8 @@ impl ReferentialIntegrity {
                     .to_ref_uuid()
                     .map(|uuid| f_eq("uuid", PartialValue::new_uuid(*uuid)))
                     .ok_or_else(|| {
-                        ladmin_error!(au, "ref value could not convert to reference uuid");
+                        ladmin_error!(au, "reference value could not convert to reference uuid.");
+                        ladmin_error!(au, "If you are sure the name/uuid/spn exist, and that this is in error, you should run a verify task.");
                         OperationError::InvalidAttribute(
                             "uuid could not become reference value".to_string(),
                         )

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -758,7 +758,7 @@ impl<'a> QueryServerReadTransaction<'a> {
         // If we fail after backend, we need to return NOW because we can't
         // assert any other faith in the DB states.
         //  * backend
-        let be_errs = self.get_be_txn().verify();
+        let be_errs = self.get_be_txn().verify(au);
 
         if !be_errs.is_empty() {
             return be_errs;
@@ -772,14 +772,11 @@ impl<'a> QueryServerReadTransaction<'a> {
         }
 
         //  * Indexing (req be + sch )
-        /*
-        idx_errs = self.get_be_txn()
-            .verify_indexes();
+        let idx_errs = self.get_be_txn().verify_indexes(au);
 
         if !idx_errs.is_empty() {
             return idx_errs;
         }
-         */
 
         // Ok BE passed, lets move on to the content.
         // Most of our checks are in the plugins, so we let them


### PR DESCRIPTION
Fixes #427 - This adds the ability to verify the name indexes so that issues like @yaleman discovered can be more easily detected. This also adds a better log message, prompting to run the verify task. 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
