### PR TITLE
277 radius not acc pw

### DIFF
--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -190,6 +190,7 @@ macro_rules! lperf_tag_segment {
             // Create a new perf event - this sets
             // us as the current active, and the parent
             // correctly.
+            #[allow(unused_unsafe)]
             let pe = unsafe { $au.new_perfevent($id) };
 
             // fun run time
@@ -200,7 +201,10 @@ macro_rules! lperf_tag_segment {
 
             // Now we are done, we put our parent back as
             // the active.
-            unsafe { $au.end_perfevent(pe, diff) };
+            #[allow(unused_unsafe)]
+            unsafe {
+                $au.end_perfevent(pe, diff)
+            };
 
             // Return the result. Hope this works!
             r

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -66,6 +66,10 @@ macro_rules! try_from_entry {
 
         let expire = $value.get_ava_single_datetime("account_expire");
 
+        let radius_secret = $value
+            .get_ava_single_radiuscred("radius_secret")
+            .map(|s| s.to_string());
+
         // Resolved by the caller
         let groups = $groups;
 
@@ -79,6 +83,7 @@ macro_rules! try_from_entry {
             primary,
             valid_from,
             expire,
+            radius_secret,
             spn,
         })
     }};
@@ -99,6 +104,7 @@ pub(crate) struct Account {
     pub primary: Option<Credential>,
     pub valid_from: Option<OffsetDateTime>,
     pub expire: Option<OffsetDateTime>,
+    pub radius_secret: Option<String>,
     // primary: Credential
     // app_creds: Vec<Credential>
     // account expiry? (as opposed to cred expiry)

--- a/kanidmd/src/lib/idm/unix.rs
+++ b/kanidmd/src/lib/idm/unix.rs
@@ -29,6 +29,7 @@ pub(crate) struct UnixUserAccount {
     cred: Option<Credential>,
     pub valid_from: Option<OffsetDateTime>,
     pub expire: Option<OffsetDateTime>,
+    pub radius_secret: Option<String>,
 }
 
 lazy_static! {
@@ -92,6 +93,10 @@ macro_rules! try_from_entry {
             .get_ava_single_credential("unix_password")
             .map(|v| v.clone());
 
+        let radius_secret = $value
+            .get_ava_single_radiuscred("radius_secret")
+            .map(|s| s.to_string());
+
         let valid_from = $value.get_ava_single_datetime("account_valid_from");
 
         let expire = $value.get_ava_single_datetime("account_expire");
@@ -108,6 +113,7 @@ macro_rules! try_from_entry {
             cred,
             valid_from,
             expire,
+            radius_secret,
         })
     }};
 }


### PR DESCRIPTION
Fixes #277 this prevents the radius password, or variations of it, being used as the main account or unix credential.

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
