### PR TITLE
20210509 cleanup

### DIFF
--- a/kanidm_unix_int/nss_kanidm/src/lib.rs
+++ b/kanidm_unix_int/nss_kanidm/src/lib.rs
@@ -34,7 +34,7 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccounts;
-        call_daemon_blocking(cfg.sock_path.as_str(), req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req)
             .map(|r| match r {
                 ClientResponse::NssAccounts(l) => l.into_iter().map(passwd_from_nssuser).collect(),
                 _ => Vec::new(),
@@ -52,7 +52,7 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByUid(uid);
-        call_daemon_blocking(cfg.sock_path.as_str(), req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -72,7 +72,7 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByName(name);
-        call_daemon_blocking(cfg.sock_path.as_str(), req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -97,7 +97,7 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroups;
-        call_daemon_blocking(cfg.sock_path.as_str(), req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req)
             .map(|r| match r {
                 ClientResponse::NssGroups(l) => l.into_iter().map(group_from_nssgroup).collect(),
                 _ => Vec::new(),
@@ -115,7 +115,7 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByGid(gid);
-        call_daemon_blocking(cfg.sock_path.as_str(), req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)
@@ -135,7 +135,7 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByName(name);
-        call_daemon_blocking(cfg.sock_path.as_str(), req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)

--- a/kanidm_unix_int/pam_kanidm/src/lib.rs
+++ b/kanidm_unix_int/pam_kanidm/src/lib.rs
@@ -91,7 +91,7 @@ impl PamHooks for PamKanidm {
         let req = ClientRequest::PamAccountAllowed(account_id);
         // PamResultCode::PAM_IGNORE
 
-        match call_daemon_blocking(cfg.sock_path.as_str(), req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
             Ok(r) => match r {
                 ClientResponse::PamStatus(Some(true)) => {
                     // println!("PAM_SUCCESS");
@@ -200,7 +200,7 @@ impl PamHooks for PamKanidm {
         };
         let req = ClientRequest::PamAuthenticate(account_id, authtok);
 
-        match call_daemon_blocking(cfg.sock_path.as_str(), req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
             Ok(r) => match r {
                 ClientResponse::PamStatus(Some(true)) => {
                     // println!("PAM_SUCCESS");
@@ -291,7 +291,7 @@ impl PamHooks for PamKanidm {
         };
         let req = ClientRequest::PamAccountBeginSession(account_id);
 
-        match call_daemon_blocking(cfg.sock_path.as_str(), req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
             Ok(ClientResponse::Ok) => {
                 // println!("PAM_SUCCESS");
                 PamResultCode::PAM_SUCCESS

--- a/kanidm_unix_int/src/client_sync.rs
+++ b/kanidm_unix_int/src/client_sync.rs
@@ -12,7 +12,7 @@ const TIMEOUT: u64 = 2000;
 
 pub fn call_daemon_blocking(
     path: &str,
-    req: ClientRequest,
+    req: &ClientRequest,
 ) -> Result<ClientResponse, Box<dyn Error>> {
     let mut stream = UnixStream::connect(path)
         .and_then(|socket| {

--- a/kanidm_unix_int/src/daemon_status.rs
+++ b/kanidm_unix_int/src/daemon_status.rs
@@ -52,7 +52,7 @@ fn main() {
             cfg.sock_path
         )
     } else {
-        match call_daemon_blocking(cfg.sock_path.as_str(), req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
             Ok(r) => match r {
                 ClientResponse::Ok => info!("working!"),
                 _ => {

--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -343,8 +343,7 @@ impl<'a> DbTxn<'a> {
             )
             .map_err(|e| {
                 debug!("sqlite delete account_t duplicate failure -> {:?}", e);
-            })
-            .map(|c| c)?;
+            })?;
 
         if updated == 0 {
             let mut stmt = self.conn
@@ -683,7 +682,7 @@ impl<'a> fmt::Debug for DbTxn<'a> {
 
 impl<'a> Drop for DbTxn<'a> {
     // Abort
-    fn drop(self: &mut Self) {
+    fn drop(&mut self) {
         if !self.committed {
             // debug!("Aborting BE WR txn");
             #[allow(clippy::expect_used)]

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -393,6 +393,7 @@ pub trait AccessControlsTransaction<'a> {
     fn get_modify(&self) -> &Vec<AccessControlModify>;
     fn get_delete(&self) -> &Vec<AccessControlDelete>;
     // fn get_acp_related_search_cache(&self) -> &mut ARCacheReadTxn<'a, Uuid, Vec<Uuid>>;
+    #[allow(clippy::mut_from_ref)]
     fn get_acp_resolve_filter_cache(
         &self,
     ) -> &mut ARCacheReadTxn<'a, (EventOriginId, Filter<FilterValid>), Filter<FilterValidResolved>>;

--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -483,6 +483,7 @@ impl AuditScope {
         })
     }
 
+    #[allow(clippy::unreachable)]
     pub(crate) unsafe fn new_perfevent(&mut self, id: &str) -> &'static mut PerfEvent {
         // Does an active event currently exist?
         if self.active_perf.is_none() {
@@ -519,7 +520,6 @@ impl AuditScope {
                 let idx = iparent.contains.len() - 1;
                 iparent.contains.get_unchecked_mut(idx).as_mut() as *mut PerfEvent
             } else {
-                #[allow(clippy::unreachable)]
                 unreachable!("Invalid parent state");
             };
             // Alloc in the vec, set parnt to active, then get a mut pointer

--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -62,19 +62,19 @@ impl fmt::Display for LogTag {
 }
 
 macro_rules! lqueue {
-    ($au:expr, $tag:expr, $($arg:tt)*) => ({
+    ($audit:expr, $tag:expr, $($arg:tt)*) => ({
         use crate::audit::{LogTag, AUDIT_LINE_SIZE};
         if cfg!(test) {
             println!($($arg)*)
         }
-        if ($au.level & $tag as u32) == $tag as u32 {
+        if ($audit.level & $tag as u32) == $tag as u32 {
             use std::fmt;
             // We have to buffer the string to over-alloc it.
             let mut output = String::with_capacity(AUDIT_LINE_SIZE);
             match fmt::write(&mut output, format_args!($($arg)*)) {
-                Ok(_) => $au.log_event($tag, output),
+                Ok(_) => $audit.log_event($tag, output),
                 Err(e) => {
-                    $au.log_event(
+                    $audit.log_event(
                         LogTag::AdminError,
                         format!("CRITICAL UNABLE TO WRITE LOG EVENT - {:?}", e)
                     )
@@ -85,103 +85,103 @@ macro_rules! lqueue {
 }
 
 macro_rules! ltrace {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::Trace, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::Trace, $($arg)*)
     })
 }
 
 macro_rules! lfilter {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::FilterTrace, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::FilterTrace, $($arg)*)
     })
 }
 
 macro_rules! lfilter_info {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::FilterInfo, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::FilterInfo, $($arg)*)
     })
 }
 
 /*
 macro_rules! lfilter_warning {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::FilterWarning, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::FilterWarning, $($arg)*)
     })
 }
 */
 
 macro_rules! lfilter_error {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::FilterError, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::FilterError, $($arg)*)
     })
 }
 
 macro_rules! ladmin_error {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::AdminError, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::AdminError, $($arg)*)
     })
 }
 
 macro_rules! ladmin_warning {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::AdminWarning, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::AdminWarning, $($arg)*)
     })
 }
 
 macro_rules! ladmin_info {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::AdminInfo, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::AdminInfo, $($arg)*)
     })
 }
 
 macro_rules! lrequest_error {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::RequestError, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::RequestError, $($arg)*)
     })
 }
 
 macro_rules! lsecurity {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::SecurityInfo, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::SecurityInfo, $($arg)*)
     })
 }
 
 macro_rules! lsecurity_critical {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::SecurityCritical, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::SecurityCritical, $($arg)*)
     })
 }
 
 macro_rules! lsecurity_access {
-    ($au:expr, $($arg:tt)*) => ({
-        lqueue!($au, LogTag::SecurityAccess, $($arg)*)
+    ($audit:expr, $($arg:tt)*) => ({
+        lqueue!($audit, LogTag::SecurityAccess, $($arg)*)
     })
 }
 
 macro_rules! lperf_op_segment {
-    ($au:expr, $id:expr, $fun:expr) => {{
+    ($audit:expr, $id:expr, $fun:expr) => {{
         use crate::audit::LogTag;
-        lperf_tag_segment!($au, $id, LogTag::PerfOp, $fun)
+        lperf_tag_segment!($audit, $id, LogTag::PerfOp, $fun)
     }};
 }
 
 macro_rules! lperf_trace_segment {
-    ($au:expr, $id:expr, $fun:expr) => {{
+    ($audit:expr, $id:expr, $fun:expr) => {{
         use crate::audit::LogTag;
-        lperf_tag_segment!($au, $id, LogTag::PerfTrace, $fun)
+        lperf_tag_segment!($audit, $id, LogTag::PerfTrace, $fun)
     }};
 }
 
 macro_rules! lperf_segment {
-    ($au:expr, $id:expr, $fun:expr) => {{
+    ($audit:expr, $id:expr, $fun:expr) => {{
         use crate::audit::LogTag;
-        lperf_tag_segment!($au, $id, LogTag::PerfCoarse, $fun)
+        lperf_tag_segment!($audit, $id, LogTag::PerfCoarse, $fun)
     }};
 }
 
 macro_rules! lperf_tag_segment {
-    ($au:expr, $id:expr, $tag:expr, $fun:expr) => {{
-        if ($au.level & $tag as u32) == $tag as u32 {
+    ($audit:expr, $id:expr, $tag:expr, $fun:expr) => {{
+        if ($audit.level & $tag as u32) == $tag as u32 {
             use std::time::Instant;
 
             // start timer.
@@ -191,7 +191,7 @@ macro_rules! lperf_tag_segment {
             // us as the current active, and the parent
             // correctly.
             #[allow(unused_unsafe)]
-            let pe = unsafe { $au.new_perfevent($id) };
+            let pe = unsafe { $audit.new_perfevent($id) };
 
             // fun run time
             let r = $fun();
@@ -203,7 +203,7 @@ macro_rules! lperf_tag_segment {
             // the active.
             #[allow(unused_unsafe)]
             unsafe {
-                $au.end_perfevent(pe, diff)
+                $audit.end_perfevent(pe, diff)
             };
 
             // Return the result. Hope this works!
@@ -216,9 +216,9 @@ macro_rules! lperf_tag_segment {
 
 /*
 macro_rules! limmediate_error {
-    ($au:expr, $($arg:tt)*) => ({
+    ($audit:expr, $($arg:tt)*) => ({
         use crate::audit::LogTag;
-        if ($au.level & LogTag::AdminError as u32) == LogTag::AdminError as u32 {
+        if ($audit.level & LogTag::AdminError as u32) == LogTag::AdminError as u32 {
             eprintln!($($arg)*)
         }
     })
@@ -226,9 +226,9 @@ macro_rules! limmediate_error {
 */
 
 macro_rules! limmediate_warning {
-    ($au:expr, $($arg:tt)*) => ({
+    ($audit:expr, $($arg:tt)*) => ({
         use crate::audit::LogTag;
-        if ($au.level & LogTag::AdminWarning as u32) == LogTag::AdminWarning as u32 {
+        if ($audit.level & LogTag::AdminWarning as u32) == LogTag::AdminWarning as u32 {
             eprint!($($arg)*)
         }
     })

--- a/kanidmd/src/lib/be/idl_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_sqlite.rs
@@ -1357,6 +1357,7 @@ impl IdlSqlite {
 
     pub(crate) fn get_allids_count(&self, au: &mut AuditScope) -> Result<u64, OperationError> {
         ltrace!(au, "Counting allids...");
+        #[allow(clippy::expect_used)]
         self.pool
             .try_get()
             .expect("Unable to get connection from pool!!!")

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -710,12 +710,12 @@ pub trait BackendTransaction {
                                 audit,
                                 "Invalid name2uuid state -> incorrect uuid association"
                             );
-                            return Err(ConsistencyError::BackendIndexSync);
+                            Err(ConsistencyError::BackendIndexSync)
                         }
                     }
                     r => {
                         ladmin_error!(audit, "Invalid name2uuid state -> {:?}", r);
-                        return Err(ConsistencyError::BackendIndexSync);
+                        Err(ConsistencyError::BackendIndexSync)
                     }
                 }
             })?;

--- a/kanidmd/src/lib/core/ldaps.rs
+++ b/kanidmd/src/lib/core/ldaps.rs
@@ -1,4 +1,4 @@
-use crate::actors::v1_read::{LdapRequestMessage, QueryServerReadV1};
+use crate::actors::v1_read::QueryServerReadV1;
 use crate::ldap::{LdapBoundToken, LdapResponseState};
 use core::pin::Pin;
 use openssl::ssl::{Ssl, SslAcceptor, SslAcceptorBuilder};
@@ -47,13 +47,7 @@ async fn client_process<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
         // Start the event
         let eventid = Uuid::new_v4();
         let uat = session.uat.clone();
-        let qs_result = qe_r_ref
-            .handle_ldaprequest(LdapRequestMessage {
-                eventid,
-                protomsg,
-                uat,
-            })
-            .await;
+        let qs_result = qe_r_ref.handle_ldaprequest(eventid, protomsg, uat).await;
 
         match qs_result {
             Some(LdapResponseState::Unbind) => return,

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -239,6 +239,12 @@ impl<STATE> Entry<EntryInit, STATE> {
     }
 }
 
+impl Default for Entry<EntryInit, EntryNew> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Entry<EntryInit, EntryNew> {
     pub fn new() -> Self {
         Entry {
@@ -1291,6 +1297,12 @@ impl Entry<EntrySealed, EntryCommitted> {
         })
     }
 
+    /// # Safety
+    /// This function bypasses the access control validation logic and should NOT
+    /// be used without special care and attention to ensure that no private data
+    /// is leaked incorrectly to clients. Generally this is ONLY used inside of
+    /// the access control processing functions which correctly applies the reduction
+    /// steps.
     pub unsafe fn into_reduced(self) -> Entry<EntryReduced, EntryCommitted> {
         Entry {
             valid: EntryReduced {

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -1244,6 +1244,11 @@ impl FilterResolved {
                 } else {
                     // sort, but reverse so that sub-optimal elements are earlier
                     // to promote fast-failure.
+                    // We have to allow this on clippy, which attempts to suggest:
+                    //   f_list_new.sort_unstable_by_key(|&b| Reverse(b))
+                    // However, because these are references, it causes a lifetime
+                    // issue, and fails to compile.
+                    #[allow(clippy::unnecessary_sort_by)]
                     f_list_new.sort_unstable_by(|a, b| b.cmp(a));
                     f_list_new.dedup();
 

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -1,4 +1,3 @@
-use crate::actors::v1_write::IdmAccountSetPasswordMessage;
 use crate::event::Event;
 use crate::prelude::*;
 
@@ -26,16 +25,17 @@ impl PasswordChangeEvent {
 
     pub fn from_idm_account_set_password(
         audit: &mut AuditScope,
+        uat: Option<&UserAuthToken>,
+        cleartext: String,
         qs: &QueryServerWriteTransaction,
-        msg: IdmAccountSetPasswordMessage,
     ) -> Result<Self, OperationError> {
-        let e = Event::from_rw_uat(audit, qs, msg.uat.as_ref())?;
+        let e = Event::from_rw_uat(audit, qs, uat)?;
         let u = e.get_uuid().ok_or(OperationError::InvalidState)?;
 
         Ok(PasswordChangeEvent {
             event: e,
             target: u,
-            cleartext: msg.cleartext,
+            cleartext,
             appid: None,
         })
     }

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -429,7 +429,7 @@ fn ldap_domain_to_dc(input: &str) -> String {
     input.split('.').for_each(|dc| {
         output.push_str("dc=");
         output.push_str(dc);
-        #[allow(clippy::single_char_add_str)]
+        #[allow(clippy::single_char_pattern)]
         output.push_str(",");
     });
     // Remove the last ','

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -122,6 +122,7 @@ pub trait QueryServerTransaction<'a> {
     type AccessControlsTransactionType: AccessControlsTransaction<'a>;
     fn get_accesscontrols(&self) -> &Self::AccessControlsTransactionType;
 
+    #[allow(clippy::mut_from_ref)]
     fn get_resolve_filter_cache(
         &self,
     ) -> &mut ARCacheReadTxn<'a, (EventOriginId, Filter<FilterValid>), Filter<FilterValidResolved>>;

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -138,23 +138,23 @@ pub trait QueryServerTransaction<'a> {
     /// [`fn search`]: trait.QueryServerTransaction.html#method.search
     fn search_ext(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         se: &SearchEvent,
     ) -> Result<Vec<Entry<EntryReduced, EntryCommitted>>, OperationError> {
-        lperf_segment!(au, "server::search_ext", || {
+        lperf_segment!(audit, "server::search_ext", || {
             /*
              * This just wraps search, but it's for the external interface
              * so as a result it also reduces the entry set's attributes at
              * the end.
              */
-            let entries = self.search(au, se)?;
+            let entries = self.search(audit, se)?;
 
             let access = self.get_accesscontrols();
             access
-                .search_filter_entry_attributes(au, se, entries)
+                .search_filter_entry_attributes(audit, se, entries)
                 .map_err(|e| {
                     // Log and fail if something went wrong.
-                    ladmin_error!(au, "Failed to filter entry attributes {:?}", e);
+                    ladmin_error!(audit, "Failed to filter entry attributes {:?}", e);
                     e
                 })
             // This now returns the reduced vec.
@@ -163,15 +163,15 @@ pub trait QueryServerTransaction<'a> {
 
     fn search(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         se: &SearchEvent,
     ) -> Result<Vec<Entry<EntrySealed, EntryCommitted>>, OperationError> {
-        lperf_segment!(au, "server::search", || {
+        lperf_segment!(audit, "server::search", || {
             if se.event.is_internal() {
-                ltrace!(au, "search: internal filter -> {:?}", se.filter);
+                ltrace!(audit, "search: internal filter -> {:?}", se.filter);
             } else {
-                lsecurity!(au, "search initiator: -> {}", se.event);
-                ladmin_info!(au, "search: external filter -> {:?}", se.filter);
+                lsecurity!(audit, "search initiator: -> {}", se.event);
+                ladmin_info!(audit, "search: external filter -> {:?}", se.filter);
             }
 
             // This is an important security step because it prevents us from
@@ -188,12 +188,12 @@ pub trait QueryServerTransaction<'a> {
             let be_txn = self.get_be_txn();
             let idxmeta = be_txn.get_idxmeta_ref();
             // Now resolve all references and indexes.
-            let vfr = lperf_trace_segment!(au, "server::search<filter_resolve>", || {
+            let vfr = lperf_trace_segment!(audit, "server::search<filter_resolve>", || {
                 se.filter
                     .resolve(&se.event, Some(idxmeta), Some(resolve_filter_cache))
             })
             .map_err(|e| {
-                ladmin_error!(au, "search filter resolve failure {:?}", e);
+                ladmin_error!(audit, "search filter resolve failure {:?}", e);
                 e
             })?;
 
@@ -203,8 +203,8 @@ pub trait QueryServerTransaction<'a> {
             // the QS wr/ro to the plugin trait. However, there shouldn't be a need for search
             // plugis, because all data transforms should be in the write path.
 
-            let res = self.get_be_txn().search(au, lims, &vfr).map_err(|e| {
-                ladmin_error!(au, "backend failure -> {:?}", e);
+            let res = self.get_be_txn().search(audit, lims, &vfr).map_err(|e| {
+                ladmin_error!(audit, "backend failure -> {:?}", e);
                 OperationError::Backend
             })?;
 
@@ -214,15 +214,15 @@ pub trait QueryServerTransaction<'a> {
             // attribute set on the entries!
             //
             let access = self.get_accesscontrols();
-            access.search_filter_entries(au, se, res).map_err(|e| {
-                ladmin_error!(au, "Unable to access filter entries {:?}", e);
+            access.search_filter_entries(audit, se, res).map_err(|e| {
+                ladmin_error!(audit, "Unable to access filter entries {:?}", e);
                 e
             })
         })
     }
 
-    fn exists(&self, au: &mut AuditScope, ee: &ExistsEvent) -> Result<bool, OperationError> {
-        lperf_segment!(au, "server::exists", || {
+    fn exists(&self, audit: &mut AuditScope, ee: &ExistsEvent) -> Result<bool, OperationError> {
+        lperf_segment!(audit, "server::exists", || {
             let be_txn = self.get_be_txn();
             let idxmeta = be_txn.get_idxmeta_ref();
 
@@ -232,14 +232,14 @@ pub trait QueryServerTransaction<'a> {
                 .filter
                 .resolve(&ee.event, Some(idxmeta), Some(resolve_filter_cache))
                 .map_err(|e| {
-                    ladmin_error!(au, "Failed to resolve filter {:?}", e);
+                    ladmin_error!(audit, "Failed to resolve filter {:?}", e);
                     e
                 })?;
 
             let lims = ee.get_limits();
 
-            self.get_be_txn().exists(au, &lims, &vfr).map_err(|e| {
-                ladmin_error!(au, "backend failure -> {:?}", e);
+            self.get_be_txn().exists(audit, &lims, &vfr).map_err(|e| {
+                ladmin_error!(audit, "backend failure -> {:?}", e);
                 OperationError::Backend
             })
         })
@@ -297,10 +297,10 @@ pub trait QueryServerTransaction<'a> {
     // From internal, generate an exists event and dispatch
     fn internal_exists(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         filter: Filter<FilterInvalid>,
     ) -> Result<bool, OperationError> {
-        lperf_segment!(au, "server::internal_exists", || {
+        lperf_segment!(audit, "server::internal_exists", || {
             // Check the filter
             let f_valid = filter
                 .validate(self.get_schema())
@@ -308,7 +308,7 @@ pub trait QueryServerTransaction<'a> {
             // Build an exists event
             let ee = ExistsEvent::new_internal(f_valid);
             // Submit it
-            self.exists(au, &ee)
+            self.exists(audit, &ee)
         })
     }
 
@@ -761,25 +761,25 @@ impl<'a> QueryServerReadTransaction<'a> {
     // Verify the data content of the server is as expected. This will probably
     // call various functions for validation, including possibly plugin
     // verifications.
-    fn verify(&self, au: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
+    fn verify(&self, audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
         // If we fail after backend, we need to return NOW because we can't
         // assert any other faith in the DB states.
         //  * backend
-        let be_errs = self.get_be_txn().verify(au);
+        let be_errs = self.get_be_txn().verify(audit);
 
         if !be_errs.is_empty() {
             return be_errs;
         }
 
         //  * in memory schema consistency.
-        let sc_errs = self.get_schema().validate(au);
+        let sc_errs = self.get_schema().validate(audit);
 
         if !sc_errs.is_empty() {
             return sc_errs;
         }
 
         //  * Indexing (req be + sch )
-        let idx_errs = self.get_be_txn().verify_indexes(au);
+        let idx_errs = self.get_be_txn().verify_indexes(audit);
 
         if !idx_errs.is_empty() {
             return idx_errs;
@@ -790,7 +790,7 @@ impl<'a> QueryServerReadTransaction<'a> {
         // do their job.
 
         // Now, call the plugins verification system.
-        Plugins::run_verify(au, self)
+        Plugins::run_verify(audit, self)
         // Finished
     }
 }
@@ -1019,20 +1019,20 @@ impl QueryServer {
         Ok(())
     }
 
-    pub fn verify(&self, au: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
+    pub fn verify(&self, audit: &mut AuditScope) -> Vec<Result<(), ConsistencyError>> {
         let r_txn = task::block_on(self.read_async());
-        r_txn.verify(au)
+        r_txn.verify(audit)
     }
 }
 
 impl<'a> QueryServerWriteTransaction<'a> {
-    pub fn create(&self, au: &mut AuditScope, ce: &CreateEvent) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::create", || {
+    pub fn create(&self, audit: &mut AuditScope, ce: &CreateEvent) -> Result<(), OperationError> {
+        lperf_segment!(audit, "server::create", || {
             // The create event is a raw, read only representation of the request
             // that was made to us, including information about the identity
             // performing the request.
             if !ce.event.is_internal() {
-                lsecurity!(au, "create initiator: -> {}", ce.event);
+                lsecurity!(audit, "create initiator: -> {}", ce.event);
             }
 
             // Log the request
@@ -1048,9 +1048,9 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // create_allow_operation
             let access = self.get_accesscontrols();
             let op_allow = access
-                .create_allow_operation(au, ce, &candidates)
+                .create_allow_operation(audit, ce, &candidates)
                 .map_err(|e| {
-                    ladmin_error!(au, "Failed to check create access {:?}", e);
+                    ladmin_error!(audit, "Failed to check create access {:?}", e);
                     e
                 })?;
             if !op_allow {
@@ -1067,9 +1067,9 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // pre-plugins are defined here in their correct order of calling!
             // I have no intent to make these dynamic or configurable.
 
-            Plugins::run_pre_create_transform(au, self, &mut candidates, ce).map_err(|e| {
+            Plugins::run_pre_create_transform(audit, self, &mut candidates, ce).map_err(|e| {
                 ladmin_error!(
-                    au,
+                    audit,
                     "Create operation failed (pre_transform plugin), {:?}",
                     e
                 );
@@ -1086,7 +1086,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .map(|e| {
                     e.validate(&self.schema)
                         .map_err(|e| {
-                            ladmin_error!(au, "Schema Violation -> {:?}", e);
+                            ladmin_error!(audit, "Schema Violation -> {:?}", e);
                             OperationError::SchemaViolation(e)
                         })
                         .map(|e| {
@@ -1101,20 +1101,20 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // Run any pre-create plugins now with schema validated entries.
             // This is important for normalisation of certain types IE class
             // or attributes for these checks.
-            Plugins::run_pre_create(au, self, &norm_cand, ce).map_err(|e| {
-                ladmin_error!(au, "Create operation failed (plugin), {:?}", e);
+            Plugins::run_pre_create(audit, self, &norm_cand, ce).map_err(|e| {
+                ladmin_error!(audit, "Create operation failed (plugin), {:?}", e);
                 e
             })?;
 
             // We may change from ce.entries later to something else?
-            let commit_cand = self.be_txn.create(au, norm_cand).map_err(|e| {
-                ladmin_error!(au, "betxn create failure {:?}", e);
+            let commit_cand = self.be_txn.create(audit, norm_cand).map_err(|e| {
+                ladmin_error!(audit, "betxn create failure {:?}", e);
                 e
             })?;
             // Run any post plugins
 
-            Plugins::run_post_create(au, self, &commit_cand, ce).map_err(|e| {
-                ladmin_error!(au, "Create operation failed (post plugin), {:?}", e);
+            Plugins::run_post_create(audit, self, &commit_cand, ce).map_err(|e| {
+                ladmin_error!(audit, "Create operation failed (post plugin), {:?}", e);
                 e
             })?;
 
@@ -1139,7 +1139,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 (*cu).extend(commit_cand.iter().map(|e| e.get_uuid()));
             }
             ltrace!(
-                au,
+                audit,
                 "Schema reload: {:?}, ACP reload: {:?}",
                 self.changed_schema,
                 self.changed_acp
@@ -1148,17 +1148,17 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // We are complete, finalise logging and return
 
             if ce.event.is_internal() {
-                ltrace!(au, "Create operation success");
+                ltrace!(audit, "Create operation success");
             } else {
-                ladmin_info!(au, "Create operation success");
+                ladmin_info!(audit, "Create operation success");
             }
             Ok(())
         })
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub fn delete(&self, au: &mut AuditScope, de: &DeleteEvent) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::delete", || {
+    pub fn delete(&self, audit: &mut AuditScope, de: &DeleteEvent) -> Result<(), OperationError> {
+        lperf_segment!(audit, "server::delete", || {
             // Do you have access to view all the set members? Reduce based on your
             // read permissions and attrs
             // THIS IS PRETTY COMPLEX SEE THE DESIGN DOC
@@ -1166,19 +1166,19 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // associated credentials.
             // We only need to retrieve uuid though ...
             if !de.event.is_internal() {
-                lsecurity!(au, "delete initiator: -> {}", de.event);
+                lsecurity!(audit, "delete initiator: -> {}", de.event);
             }
 
             // Now, delete only what you can see
             let pre_candidates = match self.impersonate_search_valid(
-                au,
+                audit,
                 de.filter.clone(),
                 de.filter_orig.clone(),
                 &de.event,
             ) {
                 Ok(results) => results,
                 Err(e) => {
-                    ladmin_error!(au, "delete: error in pre-candidate selection {:?}", e);
+                    ladmin_error!(audit, "delete: error in pre-candidate selection {:?}", e);
                     return Err(e);
                 }
             };
@@ -1187,9 +1187,9 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // delete_allow_operation
             let access = self.get_accesscontrols();
             let op_allow = access
-                .delete_allow_operation(au, de, &pre_candidates)
+                .delete_allow_operation(audit, de, &pre_candidates)
                 .map_err(|e| {
-                    ladmin_error!(au, "Failed to check delete access {:?}", e);
+                    ladmin_error!(audit, "Failed to check delete access {:?}", e);
                     e
                 })?;
             if !op_allow {
@@ -1198,7 +1198,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // Is the candidate set empty?
             if pre_candidates.is_empty() {
-                lrequest_error!(au, "delete: no candidates match filter {:?}", de.filter);
+                lrequest_error!(audit, "delete: no candidates match filter {:?}", de.filter);
                 return Err(OperationError::NoMatchingEntries);
             };
 
@@ -1208,16 +1208,16 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .map(|er| er.clone().invalidate(self.cid.clone()))
                 .collect();
 
-            ltrace!(au, "delete: candidates -> {:?}", candidates);
+            ltrace!(audit, "delete: candidates -> {:?}", candidates);
 
             // Pre delete plugs
-            Plugins::run_pre_delete(au, self, &mut candidates, de).map_err(|e| {
-                ladmin_error!(au, "Delete operation failed (plugin), {:?}", e);
+            Plugins::run_pre_delete(audit, self, &mut candidates, de).map_err(|e| {
+                ladmin_error!(audit, "Delete operation failed (plugin), {:?}", e);
                 e
             })?;
 
             ltrace!(
-                au,
+                audit,
                 "delete: now marking candidates as recycled -> {:?}",
                 candidates
             );
@@ -1228,7 +1228,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                     e.into_recycled()
                         .validate(&self.schema)
                         .map_err(|e| {
-                            ladmin_error!(au, "Schema Violation -> {:?}", e);
+                            ladmin_error!(audit, "Schema Violation -> {:?}", e);
                             OperationError::SchemaViolation(e)
                         })
                         // seal if it worked.
@@ -1239,16 +1239,16 @@ impl<'a> QueryServerWriteTransaction<'a> {
             let del_cand: Vec<Entry<_, _>> = res?;
 
             self.be_txn
-                .modify(au, &pre_candidates, &del_cand)
+                .modify(audit, &pre_candidates, &del_cand)
                 .map_err(|e| {
                     // be_txn is dropped, ie aborted here.
-                    ladmin_error!(au, "Delete operation failed (backend), {:?}", e);
+                    ladmin_error!(audit, "Delete operation failed (backend), {:?}", e);
                     e
                 })?;
 
             // Post delete plugs
-            Plugins::run_post_delete(au, self, &del_cand, de).map_err(|e| {
-                ladmin_error!(au, "Delete operation failed (plugin), {:?}", e);
+            Plugins::run_post_delete(audit, self, &del_cand, de).map_err(|e| {
+                ladmin_error!(audit, "Delete operation failed (plugin), {:?}", e);
                 e
             })?;
 
@@ -1274,7 +1274,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             }
 
             ltrace!(
-                au,
+                audit,
                 "Schema reload: {:?}, ACP reload: {:?}",
                 self.changed_schema,
                 self.changed_acp
@@ -1282,23 +1282,23 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // Send result
             if de.event.is_internal() {
-                ltrace!(au, "Delete operation success");
+                ltrace!(audit, "Delete operation success");
             } else {
-                ladmin_info!(au, "Delete operation success");
+                ladmin_info!(audit, "Delete operation success");
             }
             Ok(())
         })
     }
 
-    pub fn purge_tombstones(&self, au: &mut AuditScope) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::purge_tombstones", || {
+    pub fn purge_tombstones(&self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        lperf_segment!(audit, "server::purge_tombstones", || {
             // delete everything that is a tombstone.
             let cid = self.cid.sub_secs(CHANGELOG_MAX_AGE).map_err(|e| {
-                ladmin_error!(au, "Unable to generate search cid {:?}", e);
+                ladmin_error!(audit, "Unable to generate search cid {:?}", e);
                 e
             })?;
             let ts = match self.internal_search(
-                au,
+                audit,
                 filter_all!(f_and!([
                     f_eq("class", PVCLASS_TOMBSTONE.clone()),
                     f_lt("last_modified_cid", PartialValue::new_cid(cid)),
@@ -1309,33 +1309,33 @@ impl<'a> QueryServerWriteTransaction<'a> {
             };
 
             if ts.is_empty() {
-                ladmin_info!(au, "No Tombstones present - purge operation success");
+                ladmin_info!(audit, "No Tombstones present - purge operation success");
                 return Ok(());
             }
 
             // Delete them - this is a TRUE delete, no going back now!
             self.be_txn
-                .delete(au, &ts)
+                .delete(audit, &ts)
                 .map_err(|e| {
-                    ladmin_error!(au, "Tombstone purge operation failed (backend), {:?}", e);
+                    ladmin_error!(audit, "Tombstone purge operation failed (backend), {:?}", e);
                     e
                 })
                 .map(|_| {
-                    ladmin_info!(au, "Tombstone purge operation success");
+                    ladmin_info!(audit, "Tombstone purge operation success");
                 })
         })
     }
 
-    pub fn purge_recycled(&self, au: &mut AuditScope) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::purge_recycled", || {
+    pub fn purge_recycled(&self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        lperf_segment!(audit, "server::purge_recycled", || {
             // Send everything that is recycled to tombstone
             // Search all recycled
             let cid = self.cid.sub_secs(RECYCLEBIN_MAX_AGE).map_err(|e| {
-                ladmin_error!(au, "Unable to generate search cid {:?}", e);
+                ladmin_error!(audit, "Unable to generate search cid {:?}", e);
                 e
             })?;
             let rc = match self.internal_search(
-                au,
+                audit,
                 filter_all!(f_and!([
                     f_eq("class", PVCLASS_RECYCLED.clone()),
                     f_lt("last_modified_cid", PartialValue::new_cid(cid)),
@@ -1346,7 +1346,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             };
 
             if rc.is_empty() {
-                ladmin_info!(au, "No recycled present - purge operation success");
+                ladmin_info!(audit, "No recycled present - purge operation success");
                 return Ok(());
             }
 
@@ -1357,7 +1357,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                     e.to_tombstone(self.cid.clone())
                         .validate(&self.schema)
                         .map_err(|e| {
-                            ladmin_error!(au, "Schema Violationi {:?}", e);
+                            ladmin_error!(audit, "Schema Violationi {:?}", e);
                             OperationError::SchemaViolation(e)
                         })
                         // seal if it worked.
@@ -1369,13 +1369,13 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // Backend Modify
             self.be_txn
-                .modify(au, &rc, &tombstone_cand)
+                .modify(audit, &rc, &tombstone_cand)
                 .map_err(|e| {
-                    ladmin_error!(au, "Purge recycled operation failed (backend), {:?}", e);
+                    ladmin_error!(audit, "Purge recycled operation failed (backend), {:?}", e);
                     e
                 })
                 .map(|_| {
-                    ladmin_info!(au, "Purge recycled operation success");
+                    ladmin_info!(audit, "Purge recycled operation success");
                 })
         })
     }
@@ -1383,10 +1383,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
     // Should this take a revive event?
     pub fn revive_recycled(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         re: &ReviveRecycledEvent,
     ) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::revive_recycled", || {
+        lperf_segment!(audit, "server::revive_recycled", || {
             // Revive an entry to live. This is a specialised (limited)
             // modify proxy.
             //
@@ -1401,14 +1401,18 @@ impl<'a> QueryServerWriteTransaction<'a> {
             )]);
 
             let m_valid = modlist.validate(self.get_schema()).map_err(|e| {
-                ladmin_error!(au, "revive recycled modlist Schema Violation {:?}", e);
+                ladmin_error!(audit, "revive recycled modlist Schema Violation {:?}", e);
                 OperationError::SchemaViolation(e)
             })?;
 
             // Get the entries we are about to revive.
             //    we make a set of per-entry mod lists. A list of lists even ...
-            let revive_cands =
-                self.impersonate_search_valid(au, re.filter.clone(), re.filter.clone(), &re.event)?;
+            let revive_cands = self.impersonate_search_valid(
+                audit,
+                re.filter.clone(),
+                re.filter.clone(),
+                &re.event,
+            )?;
 
             let mut dm_mods: HashMap<Uuid, ModifyList<ModifyInvalid>> =
                 HashMap::with_capacity(revive_cands.len());
@@ -1441,7 +1445,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // Now impersonate the modify
             self.impersonate_modify_valid(
-                au,
+                audit,
                 re.filter.clone(),
                 re.filter.clone(),
                 m_valid,
@@ -1453,7 +1457,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 // I think the filter/filter_all shouldn't matter here because the only
                 // valid direct memberships should be still valid/live references.
                 let f = filter_all!(f_eq("uuid", PartialValue::new_uuid(g)));
-                self.internal_modify(au, &f, &mods)
+                self.internal_modify(audit, &f, &mods)
             });
             r
         })
@@ -1464,22 +1468,22 @@ impl<'a> QueryServerWriteTransaction<'a> {
     /// and call multiple pre-applies at the same time, else you can cause DB corruption.
     pub(crate) unsafe fn modify_pre_apply<'x>(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         me: &'x ModifyEvent,
     ) -> Result<Option<ModifyPartial<'x>>, OperationError> {
-        lperf_segment!(au, "server::modify_pre_apply", || {
+        lperf_segment!(audit, "server::modify_pre_apply", || {
             // Get the candidates.
             // Modify applies a modlist to a filter, so we need to internal search
             // then apply.
             if !me.event.is_internal() {
-                lsecurity!(au, "modify initiator: -> {}", me.event);
+                lsecurity!(audit, "modify initiator: -> {}", me.event);
             }
 
             // Validate input.
 
             // Is the modlist non zero?
             if me.modlist.len() == 0 {
-                lrequest_error!(au, "modify: empty modify request");
+                lrequest_error!(audit, "modify: empty modify request");
                 return Err(OperationError::EmptyRequest);
             }
 
@@ -1491,14 +1495,14 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // This also checks access controls due to use of the impersonation.
             let pre_candidates = match self.impersonate_search_valid(
-                au,
+                audit,
                 me.filter.clone(),
                 me.filter_orig.clone(),
                 &me.event,
             ) {
                 Ok(results) => results,
                 Err(e) => {
-                    ladmin_error!(au, "modify: error in pre-candidate selection {:?}", e);
+                    ladmin_error!(audit, "modify: error in pre-candidate selection {:?}", e);
                     return Err(e);
                 }
             };
@@ -1507,7 +1511,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 match me.event.origin {
                     EventOrigin::Internal => {
                         ltrace!(
-                            au,
+                            audit,
                             "modify: no candidates match filter ... continuing {:?}",
                             me.filter
                         );
@@ -1515,7 +1519,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                     }
                     _ => {
                         lrequest_error!(
-                            au,
+                            audit,
                             "modify: no candidates match filter, failure {:?}",
                             me.filter
                         );
@@ -1528,9 +1532,9 @@ impl<'a> QueryServerWriteTransaction<'a> {
             // modify_allow_operation
             let access = self.get_accesscontrols();
             let op_allow = access
-                .modify_allow_operation(au, me, &pre_candidates)
+                .modify_allow_operation(audit, me, &pre_candidates)
                 .map_err(|e| {
-                    ladmin_error!(au, "Unable to check modify access {:?}", e);
+                    ladmin_error!(audit, "Unable to check modify access {:?}", e);
                     e
                 })?;
             if !op_allow {
@@ -1549,12 +1553,12 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .iter_mut()
                 .for_each(|er| er.apply_modlist(&me.modlist));
 
-            ltrace!(au, "modify: candidates -> {:?}", candidates);
+            ltrace!(audit, "modify: candidates -> {:?}", candidates);
 
             // Pre mod plugins
             // We should probably supply the pre-post cands here.
-            Plugins::run_pre_modify(au, self, &mut candidates, me).map_err(|e| {
-                ladmin_error!(au, "Modify operation failed (plugin), {:?}", e);
+            Plugins::run_pre_modify(audit, self, &mut candidates, me).map_err(|e| {
+                ladmin_error!(audit, "Modify operation failed (plugin), {:?}", e);
                 e
             })?;
 
@@ -1570,7 +1574,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .map(|e| {
                     e.validate(&self.schema)
                         .map_err(|e| {
-                            ladmin_error!(au, "Schema Violation {:?}", e);
+                            ladmin_error!(audit, "Schema Violation {:?}", e);
                             OperationError::SchemaViolation(e)
                         })
                         .map(|e| e.seal())
@@ -1589,10 +1593,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
     pub(crate) fn modify_apply(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         mp: ModifyPartial<'_>,
     ) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::modify_apply", || {
+        lperf_segment!(audit, "server::modify_apply", || {
             let ModifyPartial {
                 norm_cand,
                 pre_candidates,
@@ -1601,9 +1605,9 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // Backend Modify
             self.be_txn
-                .modify(au, &pre_candidates, &norm_cand)
+                .modify(audit, &pre_candidates, &norm_cand)
                 .map_err(|e| {
-                    ladmin_error!(au, "Modify operation failed (backend), {:?}", e);
+                    ladmin_error!(audit, "Modify operation failed (backend), {:?}", e);
                     e
                 })?;
 
@@ -1611,10 +1615,12 @@ impl<'a> QueryServerWriteTransaction<'a> {
             //
             // memberOf actually wants the pre cand list and the norm_cand list to see what
             // changed. Could be optimised, but this is correct still ...
-            Plugins::run_post_modify(au, self, &pre_candidates, &norm_cand, me).map_err(|e| {
-                ladmin_error!(au, "Modify operation failed (plugin), {:?}", e);
-                e
-            })?;
+            Plugins::run_post_modify(audit, self, &pre_candidates, &norm_cand, me).map_err(
+                |e| {
+                    ladmin_error!(audit, "Modify operation failed (plugin), {:?}", e);
+                    e
+                },
+            )?;
 
             // We have finished all plugs and now have a successful operation - flag if
             // schema or acp requires reload. Remember, this is a modify, so we need to check
@@ -1645,7 +1651,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             }
 
             ltrace!(
-                au,
+                audit,
                 "Schema reload: {:?}, ACP reload: {:?}",
                 self.changed_schema,
                 self.changed_acp
@@ -1653,20 +1659,20 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // return
             if me.event.is_internal() {
-                ltrace!(au, "Modify operation success");
+                ltrace!(audit, "Modify operation success");
             } else {
-                ladmin_info!(au, "Modify operation success");
+                ladmin_info!(audit, "Modify operation success");
             }
             Ok(())
         })
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub fn modify(&self, au: &mut AuditScope, me: &ModifyEvent) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::modify", || {
-            let mp = unsafe { self.modify_pre_apply(au, me)? };
+    pub fn modify(&self, audit: &mut AuditScope, me: &ModifyEvent) -> Result<(), OperationError> {
+        lperf_segment!(audit, "server::modify", || {
+            let mp = unsafe { self.modify_pre_apply(audit, me)? };
             if let Some(mp) = mp {
-                self.modify_apply(au, mp)
+                self.modify_apply(audit, mp)
             } else {
                 // No action to apply, the pre-apply said nothing to be done.
                 Ok(())
@@ -1706,18 +1712,18 @@ impl<'a> QueryServerWriteTransaction<'a> {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn internal_batch_modify(
         &self,
-        au: &mut AuditScope,
+        audit: &mut AuditScope,
         pre_candidates: Vec<Entry<EntrySealed, EntryCommitted>>,
         candidates: Vec<Entry<EntryInvalid, EntryCommitted>>,
     ) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::internal_batch_modify", || {
+        lperf_segment!(audit, "server::internal_batch_modify", || {
             if pre_candidates.is_empty() && candidates.is_empty() {
                 // No action needed.
                 return Ok(());
             }
 
             if pre_candidates.len() != candidates.len() {
-                ladmin_error!(au, "internal_batch_modify - cand lengths differ");
+                ladmin_error!(audit, "internal_batch_modify - cand lengths differ");
                 return Err(OperationError::InvalidRequestState);
             }
 
@@ -1726,7 +1732,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .map(|e| {
                     e.validate(&self.schema)
                         .map_err(|e| {
-                            ladmin_error!(au, "Schema Violation {:?}", e);
+                            ladmin_error!(audit, "Schema Violation {:?}", e);
                             OperationError::SchemaViolation(e)
                         })
                         .map(|e| e.seal())
@@ -1743,7 +1749,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                         if pre.get_uuid() == post.get_uuid() {
                             Ok(())
                         } else {
-                            ladmin_error!(au, "modify - cand sets not correctly aligned");
+                            ladmin_error!(audit, "modify - cand sets not correctly aligned");
                             Err(OperationError::InvalidRequestState)
                         }
                     })?;
@@ -1751,9 +1757,9 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
             // Backend Modify
             self.be_txn
-                .modify(au, &pre_candidates, &norm_cand)
+                .modify(audit, &pre_candidates, &norm_cand)
                 .map_err(|e| {
-                    ladmin_error!(au, "Modify operation failed (backend), {:?}", e);
+                    ladmin_error!(audit, "Modify operation failed (backend), {:?}", e);
                     e
                 })?;
 
@@ -1782,33 +1788,36 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 );
             }
             ltrace!(
-                au,
+                audit,
                 "Schema reload: {:?}, ACP reload: {:?}",
                 self.changed_schema,
                 self.changed_acp
             );
 
-            ltrace!(au, "Modify operation success");
+            ltrace!(audit, "Modify operation success");
             Ok(())
         })
     }
 
     /// Migrate 2 to 3 changes the name, domain_name types from iutf8 to iname.
-    pub fn migrate_2_to_3(&self, au: &mut AuditScope) -> Result<(), OperationError> {
-        lperf_segment!(au, "server::migrate_2_to_3", || {
-            ladmin_warning!(au, "starting 2 to 3 migration. THIS MAY TAKE A LONG TIME!");
+    pub fn migrate_2_to_3(&self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        lperf_segment!(audit, "server::migrate_2_to_3", || {
+            ladmin_warning!(
+                audit,
+                "starting 2 to 3 migration. THIS MAY TAKE A LONG TIME!"
+            );
             // Get all entries where pres name or domain_name. INCLUDE TS + RECYCLE.
 
             let filt = filter_all!(f_or!([f_pres("name"), f_pres("domain_name"),]));
 
-            let pre_candidates = self.internal_search(au, filt).map_err(|e| {
-                ladmin_error!(au, "migrate_2_to_3 internal search failure -> {:?}", e);
+            let pre_candidates = self.internal_search(audit, filt).map_err(|e| {
+                ladmin_error!(audit, "migrate_2_to_3 internal search failure -> {:?}", e);
                 e
             })?;
 
             // If there is nothing, we donn't need to do anything.
             if pre_candidates.is_empty() {
-                ladmin_info!(au, "migrate_2_to_3 no entries to migrate, complete");
+                ladmin_info!(audit, "migrate_2_to_3 no entries to migrate, complete");
                 return Ok(());
             }
 
@@ -1830,8 +1839,8 @@ impl<'a> QueryServerWriteTransaction<'a> {
                         .collect()
                 });
 
-                ltrace!(au, "{:?}", opt_names);
-                ltrace!(au, "{:?}", opt_dnames);
+                ltrace!(audit, "{:?}", opt_names);
+                ltrace!(audit, "{:?}", opt_dnames);
                 if let Some(v) = opt_names {
                     er.set_ava("name", v)
                 };
@@ -1849,16 +1858,16 @@ impl<'a> QueryServerWriteTransaction<'a> {
             let norm_cand: Vec<Entry<_, _>> = match res {
                 Ok(v) => v,
                 Err(e) => {
-                    ladmin_error!(au, "migrate_2_to_3 schema error -> {:?}", e);
+                    ladmin_error!(audit, "migrate_2_to_3 schema error -> {:?}", e);
                     return Err(OperationError::SchemaViolation(e));
                 }
             };
 
             // Write them back.
             self.be_txn
-                .modify(au, &pre_candidates, &norm_cand)
+                .modify(audit, &pre_candidates, &norm_cand)
                 .map_err(|e| {
-                    ladmin_error!(au, "migrate_2_to_3 modification failure -> {:?}", e);
+                    ladmin_error!(audit, "migrate_2_to_3 modification failure -> {:?}", e);
                     e
                 })
 


### PR DESCRIPTION
This cleans up some un-needed structures, starts to replace au with audit as a variable name, and resolves all clippy errors from 1.47.

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
