### PR TITLE
Env vars and cleaner messaging

### DIFF
--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -60,7 +60,7 @@ impl KanidmAsyncClient {
         // format doesn't work in async ?!
         // let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
 
         let response = self
             .client
@@ -120,7 +120,7 @@ impl KanidmAsyncClient {
         response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))
+            .map_err(|e| ClientError::JsonDecode(e, opid))
     }
 
     async fn perform_post_request<R: Serialize, T: DeserializeOwned>(
@@ -133,7 +133,7 @@ impl KanidmAsyncClient {
         // format doesn't work in async ?!
         // let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
         let response = self
             .client
             .post(dest.as_str())
@@ -172,7 +172,7 @@ impl KanidmAsyncClient {
         response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))
+            .map_err(|e| ClientError::JsonDecode(e, opid))
     }
 
     async fn perform_put_request<R: Serialize, T: DeserializeOwned>(
@@ -185,7 +185,7 @@ impl KanidmAsyncClient {
         // format doesn't work in async ?!
         // let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
 
         let response = self
             .client
@@ -228,7 +228,7 @@ impl KanidmAsyncClient {
         response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))
+            .map_err(|e| ClientError::JsonDecode(e, opid))
     }
 
     async fn perform_get_request<T: DeserializeOwned>(&self, dest: &str) -> Result<T, ClientError> {
@@ -270,7 +270,7 @@ impl KanidmAsyncClient {
         response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))
+            .map_err(|e| ClientError::JsonDecode(e, opid))
     }
 
     async fn perform_delete_request(&self, dest: &str) -> Result<bool, ClientError> {
@@ -313,7 +313,7 @@ impl KanidmAsyncClient {
         response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))
+            .map_err(|e| ClientError::JsonDecode(e, opid))
     }
     async fn perform_delete_request_with_body<R: Serialize>(
         &self,
@@ -322,7 +322,7 @@ impl KanidmAsyncClient {
     ) -> Result<bool, ClientError> {
         let dest = format!("{}{}", self.addr, dest);
 
-        let req_string = serde_json::to_string(&request).map_err(ClientError::JSONEncode)?;
+        let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
         let response = self
             .client
             .delete(dest.as_str())
@@ -361,7 +361,7 @@ impl KanidmAsyncClient {
         response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))
+            .map_err(|e| ClientError::JsonDecode(e, opid))
     }
 
     pub async fn auth_step_init(&self, ident: &str) -> Result<Set<AuthMech>, ClientError> {
@@ -644,7 +644,7 @@ impl KanidmAsyncClient {
         let r: WhoamiResponse = response
             .json()
             .await
-            .map_err(|e| ClientError::JSONDecode(e, opid))?;
+            .map_err(|e| ClientError::JsonDecode(e, opid))?;
 
         Ok(Some((r.youare, r.uat)))
     }

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -50,8 +50,8 @@ pub enum ClientError {
     AuthenticationFailed,
     EmptyResponse,
     TotpVerifyFailed(Uuid, TotpSecret),
-    JSONDecode(reqwest::Error, String),
-    JSONEncode(SerdeJsonError),
+    JsonDecode(reqwest::Error, String),
+    JsonEncode(SerdeJsonError),
     SystemError,
 }
 
@@ -151,6 +151,7 @@ impl KanidmClientBuilder {
         self,
         config_path: P,
     ) -> Result<Self, ()> {
+        debug!("Attempting to load configuration from {:#?}", &config_path);
         // If the file does not exist, we skip this function.
         let mut f = match File::open(&config_path) {
             Ok(f) => f,
@@ -158,13 +159,13 @@ impl KanidmClientBuilder {
                 match e.kind() {
                     ErrorKind::NotFound => {
                         debug!(
-                            "Configuration file {:#?} not found, skipping ...",
+                            "Configuration file {:#?} not found, skipping.",
                             &config_path
                         );
                     }
                     ErrorKind::PermissionDenied => {
                         warn!(
-                            "Permission denied loading configuration file {:#?}, skipping ...",
+                            "Permission denied loading configuration file {:#?}, skipping.",
                             &config_path
                         );
                     }

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -79,7 +79,7 @@ pub enum OperationError {
     InvalidState,
     InvalidEntryState,
     InvalidUuid,
-    InvalidReplCID,
+    InvalidReplChangeId,
     InvalidAcpState(String),
     InvalidSchemaState(String),
     InvalidAccountState(String),

--- a/kanidm_tools/src/cli/common.rs
+++ b/kanidm_tools/src/cli/common.rs
@@ -6,14 +6,14 @@ impl CommonOpt {
     pub fn to_unauth_client(&self) -> KanidmClient {
         let config_path: String = shellexpand::tilde("~/.config/kanidm").into_owned();
 
-        debug!("Attempting to use config {}", "/etc/kanidm/config");
         let client_builder = match KanidmClientBuilder::new()
             .read_options_from_optional_config("/etc/kanidm/config")
-            .and_then(|cb| {
-                debug!("Attempting to use config {}", config_path);
-                cb.read_options_from_optional_config(config_path)
-            }) {
-            Ok(c) => c,
+            .and_then(|cb| cb.read_options_from_optional_config(&config_path))
+        {
+            Ok(c) => {
+                debug!("Successfully read configuration from {}", &config_path);
+                c
+            }
             Err(e) => {
                 error!("Failed to parse config (if present) -- {:?}", e);
                 std::process::exit(1);

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -8,13 +8,13 @@ pub struct Named {
 
 #[derive(Debug, StructOpt)]
 pub struct CommonOpt {
-    #[structopt(short = "d", long = "debug")]
+    #[structopt(short = "d", long = "debug", env = "KANIDM_DEBUG")]
     pub debug: bool,
-    #[structopt(short = "H", long = "url")]
+    #[structopt(short = "H", long = "url", env = "KANIDM_URL")]
     pub addr: Option<String>,
-    #[structopt(short = "D", long = "name")]
+    #[structopt(short = "D", long = "name", env = "KANIDM_NAME")]
     pub username: Option<String>,
-    #[structopt(parse(from_os_str), short = "C", long = "ca")]
+    #[structopt(parse(from_os_str), short = "C", long = "ca", env = "KANIDM_CA_PATH")]
     pub ca_path: Option<PathBuf>,
 }
 

--- a/kanidmd/src/lib/audit_loglevel.rs
+++ b/kanidmd/src/lib/audit_loglevel.rs
@@ -29,7 +29,7 @@ impl FromStr for LogLevel {
             "perfbasic" => Ok(LogLevel::PerfBasic),
             "perffull" => Ok(LogLevel::PerfFull),
             "fulltrace" => Ok(LogLevel::FullTrace),
-            _ => Err("Could not parse loglevel"),
+            _ => Err("Could not parse loglevel, should be one of (default|quiet|filter|verbose|perfbasic|perffull|fulltrace)"),
         }
     }
 }

--- a/kanidmd/src/lib/repl/cid.rs
+++ b/kanidmd/src/lib/repl/cid.rs
@@ -45,7 +45,7 @@ impl Cid {
                     .expect("Invalid compiled s_uuid"),
                 ts: r,
             })
-            .ok_or(OperationError::InvalidReplCID)
+            .ok_or(OperationError::InvalidReplChangeId)
     }
 }
 

--- a/kanidmd/src/server/opt.rs
+++ b/kanidmd/src/server/opt.rs
@@ -1,9 +1,9 @@
 #[derive(Debug, StructOpt)]
 struct CommonOpt {
-    #[structopt(short = "d", long = "debug")]
+    #[structopt(short = "d", long = "debug", env = "KANIDM_DEBUG")]
     /// Logging level. quiet, default, filter, verbose, perffull
     debug: Option<LogLevel>,
-    #[structopt(parse(from_os_str), short = "c", long = "config")]
+    #[structopt(parse(from_os_str), short = "c", long = "config", env = "KANIDM_CONFIG")]
     /// Path to the server's configuration file. If it does not exist, it will be created.
     config_path: PathBuf,
 }
@@ -20,7 +20,7 @@ struct BackupOpt {
 #[derive(Debug, StructOpt)]
 struct RestoreOpt {
     #[structopt(parse(from_os_str))]
-    /// Restore from this path. Should be created with "backupu".
+    /// Restore from this path. Should be created with "backup".
     path: PathBuf,
     #[structopt(flatten)]
     commonopts: CommonOpt,


### PR DESCRIPTION
* Using structopt's env vars handling to match some command-line config things to start looking at #290.
* Moved some duplicate debug messages from `CommonOpt:: to_unauth_client` into `KanidmClientBuilder ::read_options_from_optional_config`.
* Made the debug levels discoverable to users because previously you'd have to read the source.
* While I was there, clippy yelled at me so I made some small changes to calm it.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
