### PR TITLE
Adding an example config file

### DIFF
--- a/examples/config
+++ b/examples/config
@@ -1,0 +1,4 @@
+# this should be at /etc/kanidm/config, and configures the kanidm command line tool
+uri = "https://idm.example.com"
+verify_ca = true
+verify_hostnames = true

--- a/examples/config
+++ b/examples/config
@@ -1,4 +1,4 @@
-# this should be at /etc/kanidm/config, and configures the kanidm command line tool
+# This should be at /etc/kanidm/config or ~/.config/kanidm, and configures the kanidm command line tool
 uri = "https://idm.example.com"
 verify_ca = true
 verify_hostnames = true

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -1,0 +1,50 @@
+#   The webserver bind address. Will use HTTPS if tls_* is provided.
+#   Defaults to "127.0.0.1:8443"
+bindaddress = "[::]:443"
+#
+#   The read-only ldap server bind address. The server will use LDAPS if tls_* is provided.
+#   Defaults to "" (disabled)
+# ldapbindaddress = "[::]:636"
+#
+#   The path to the kanidm database.
+db_path = "/var/lib/kanidm/kanidm.db"
+#
+#   If you have a known filesystem, kanidm can tune sqlite to match. Valid choices are:
+#   [zfs, other]
+#   If you are unsure about this leave it as the default (other). After changing this
+#   value you must run a vacuum task.
+#   - zfs:
+#     * sets sqlite pagesize to 64k. You must set recordsize=64k on the zfs filesystem.
+#   - other:
+#     * sets sqlite pagesize to 4k, matching most filesystems block sizes.
+# db_fs_type = "zfs"
+#
+#   The number of entries to store in the in-memory cache. Minimum value is 256. If unset
+#   an automatic heuristic is used to scale this.
+# db_arc_size = 2048
+#
+#   TLS chain and key in pem format. Both must be commented, or both must be present
+# tls_chain = "/data/chain.pem"
+# tls_key = "/data/key.pem"
+#
+#   The log level of the server. May be default, verbose, perfbasic, perffull
+#   Defaults to "default"
+# log_level = "default"
+#
+#   The origin for webauthn. This is the url to the server, with the port included if
+#   it is non-standard (any port except 443)
+# origin = "https://idm.example.com"
+origin = "https://idm.example.com:8443"
+#
+#   The role of this server. This affects features available and how replication may interact.
+#   Valid roles are:
+#   - write_replica
+#     This server provides all functionality of Kanidm. It allows authentication, writes, and
+#     the web user interface to be served.
+#   - write_replica_no_ui
+#     This server is the same as a write_replica, but does NOT offer the web user interface.
+#   - read_only_replica
+#     This server will not writes initiated by clients. It supports authentication and reads,
+#     and must have a replication agreement as a source of it's data.
+#   Defaults to "write_replica".
+# role = "write_replica"

--- a/examples/unixd
+++ b/examples/unixd
@@ -1,0 +1,4 @@
+# this should be at /etc/kanidm/unixd, and configures kanidm-unixd
+uri = "https://idm.example.com"
+verify_ca = true
+verify_hostnames = true

--- a/kanidm_book/src/installing_the_server.md
+++ b/kanidm_book/src/installing_the_server.md
@@ -108,13 +108,14 @@ If these verifications pass you can now use these certificates with Kanidm. To p
 in place you can use a shell container that mounts the volume such as:
 
     docker run --rm -i -t -v kanidmd:/data -v /my/host/path/work:/work opensuse/leap:latest cp /work/* /data/
-    OR for a shell into the volume:
+
+OR for a shell into the volume:
+
     docker run --rm -i -t -v kanidmd:/data opensuse/leap:latest /bin/sh
 
 ## Configuration
 
-You will also need a config file in the volume named `server.toml` (Within the container it should be
-`/data/server.toml`). Its contents should be as follows:
+You will also need a config file in the volume named `server.toml` (Within the container it should be `/data/server.toml`). Its contents should be as follows:
 
     #   The webserver bind address. Will use HTTPS if tls_* is provided.
     #   Defaults to "127.0.0.1:8443"
@@ -166,6 +167,8 @@ You will also need a config file in the volume named `server.toml` (Within the c
     #     and must have a replication agreement as a source of it's data.
     #   Defaults to "write_replica".
     # role = "write_replica"
+
+An example is located in [examples/server.toml](../../examples/server.toml).
 
 Then you can setup the initial admin account and initialise the database into your volume.
 


### PR DESCRIPTION
Adds an example config file, mainly because when I'm packaging kani I want a default one ^_^

- [x] book chapter updated

