### PR TITLE
Fix proxy usage in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ kanidm_rlm_python/test_data/ca.pem
 loc.sh
 todo.sh
 vendor.tar.*
+*.patch
 

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -92,6 +92,7 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
     let addr = format!("http://127.0.0.1:{}", port);
     let rsclient = KanidmClientBuilder::new()
         .address(addr)
+        .no_proxy()
         .build()
         .expect("Failed to build client");
 

--- a/kanidm_unix_int/tests/cache_layer_test.rs
+++ b/kanidm_unix_int/tests/cache_layer_test.rs
@@ -97,17 +97,20 @@ fn run_test(fix_fn: fn(&KanidmClient) -> (), test_fn: fn(CacheLayer, KanidmAsync
     // Run fixtures
     let adminclient = KanidmClientBuilder::new()
         .address(addr.clone())
+        .no_proxy()
         .build()
         .expect("Failed to build sync client");
     fix_fn(&adminclient);
 
     let client = KanidmClientBuilder::new()
         .address(addr.clone())
+        .no_proxy()
         .build_async()
         .expect("Failed to build async admin client");
 
     let rsclient = KanidmClientBuilder::new()
         .address(addr)
+        .no_proxy()
         .build_async()
         .expect("Failed to build client");
 


### PR DESCRIPTION
Fixes #416 - this sets that system proxies should not be used in tests which run exclusively on localhost. 

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
