### PR TITLE
444 - client's config URI missing and more file open handling

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -292,7 +292,7 @@ impl KanidmClientBuilder {
         let address = match &self.address {
             Some(a) => a.clone(),
             None => {
-                eprintln!("uri (-H) missing, can not proceed");
+                eprintln!("Configuration option 'uri' missing, cannot continue client startup.");
                 unimplemented!();
             }
         };

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -158,7 +158,10 @@ impl KanidmClientBuilder {
         debug!("Attempting to load configuration from {:#?}", &config_path);
         // If the file does not exist, we skip this function.
         let mut f = match File::open(&config_path) {
-            Ok(f) => f,
+            Ok(f) => {
+                debug!("Successfully opened configuration file {:#?}", &config_path);
+                f
+            }
             Err(e) => {
                 match e.kind() {
                     ErrorKind::NotFound => {

--- a/kanidm_unix_int/src/unix_config.rs
+++ b/kanidm_unix_int/src/unix_config.rs
@@ -5,7 +5,7 @@ use crate::constants::{
 };
 use serde_derive::Deserialize;
 use std::fs::File;
-use std::io::Read;
+use std::io::{ErrorKind, Read};
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]

--- a/kanidm_unix_int/src/unix_config.rs
+++ b/kanidm_unix_int/src/unix_config.rs
@@ -83,7 +83,10 @@ impl KanidmUnixdConfig {
     ) -> Result<Self, ()> {
         debug!("Attempting to load configuration from {:#?}", &config_path);
         let mut f = match File::open(&config_path) {
-            Ok(f) => f,
+            Ok(f) => {
+                debug!("Successfully opened configuration file {:#?}", &config_path);
+                f
+            }
             Err(e) => {
                 match e.kind() {
                     ErrorKind::NotFound => {

--- a/kanidm_unix_int/src/unix_config.rs
+++ b/kanidm_unix_int/src/unix_config.rs
@@ -81,13 +81,30 @@ impl KanidmUnixdConfig {
         self,
         config_path: P,
     ) -> Result<Self, ()> {
+        debug!("Attempting to load configuration from {:#?}", &config_path);
         let mut f = match File::open(&config_path) {
             Ok(f) => f,
             Err(e) => {
-                debug!(
-                    "Unable to open config file {:#?} [{:?}], skipping ...",
-                    &config_path, e
-                );
+                match e.kind() {
+                    ErrorKind::NotFound => {
+                        debug!(
+                            "Configuration file {:#?} not found, skipping.",
+                            &config_path
+                        );
+                    }
+                    ErrorKind::PermissionDenied => {
+                        warn!(
+                            "Permission denied loading configuration file {:#?}, skipping.",
+                            &config_path
+                        );
+                    }
+                    _ => {
+                        debug!(
+                            "Unable to open config file {:#?} [{:?}], skipping ...",
+                            &config_path, e
+                        );
+                    }
+                };
                 return Ok(self);
             }
         };


### PR DESCRIPTION
Starts on #444, adds some more messages

- [x] cargo fmt has been run
- [x] cargo clippy has been run and it is very upset
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
