### PR TITLE
Correct multivalue description

### DIFF
--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -2790,10 +2790,10 @@ mod tests {
             let me_sin = unsafe {
                 ModifyEvent::new_internal_invalid(
                     filter!(f_eq("name", PartialValue::new_iname("testperson2"))),
-                    ModifyList::new_list(vec![Modify::Present(
-                        AttrString::from("description"),
-                        Value::from("anusaosu"),
-                    )]),
+                    ModifyList::new_list(vec![
+                        Modify::Purged(AttrString::from("description")),
+                        Modify::Present(AttrString::from("description"), Value::from("anusaosu")),
+                    ]),
                 )
             };
             assert!(server_txn.modify(audit, &me_sin).is_ok());
@@ -2805,10 +2805,10 @@ mod tests {
                         f_eq("name", PartialValue::new_iname("testperson1")),
                         f_eq("name", PartialValue::new_iname("testperson2")),
                     ])),
-                    ModifyList::new_list(vec![Modify::Present(
-                        AttrString::from("description"),
-                        Value::from("anusaosu"),
-                    )]),
+                    ModifyList::new_list(vec![
+                        Modify::Purged(AttrString::from("description")),
+                        Modify::Present(AttrString::from("description"), Value::from("anusaosu")),
+                    ]),
                 )
             };
             assert!(server_txn.modify(audit, &me_mult).is_ok());


### PR DESCRIPTION
Fixes #455 - description was incorrect marked multivalue which meant that a change to the schema in memory caused a second value to be created. This resulted in the schema loading process failing as it was not considered consistent. 

This corrects the description definition to be single value, improves the logging of schema consistency, and corrects a single test case that relied on multivalue description.

- [ x ] cargo fmt has been run
- [ - ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
