### PR TITLE
Add some openid stubs

### DIFF
--- a/kanidmd/src/lib/core/https.rs
+++ b/kanidmd/src/lib/core/https.rs
@@ -1040,6 +1040,14 @@ pub async fn status(req: tide::Request<AppState>) -> tide::Result {
     Ok(res)
 }
 
+// For future openid integration
+pub async fn get_openid_configuration(_req: tide::Request<AppState>) -> tide::Result {
+    let mut res = tide::Response::new(200);
+    res.set_content_type("text/html;charset=utf-8");
+    res.set_body("");
+    Ok(res)
+}
+
 /*
 // For openssl
 struct TlsListener {
@@ -1166,6 +1174,8 @@ pub fn create_https_server(
         bundy_handle,
     });
 
+    // tide::log::with_level(tide::log::LevelFilter::Debug);
+
     // Add middleware?
     tserver.with(tide::log::LogMiddleware::new()).with(
         // We do not force a session ttl, because we validate this elsewhere in usage.
@@ -1192,6 +1202,9 @@ pub fn create_https_server(
     };
 
     tserver.at("/status").get(self::status);
+
+    let mut well_known = tserver.at("/well-known");
+    well_known.at("/openid-configuration").get(get_openid_configuration);
 
     let mut raw_route = tserver.at("/v1/raw");
     raw_route.at("/create").post(create);


### PR DESCRIPTION
This adds a stub for openid connect discovery

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
