### PR TITLE
20210607 orca ldap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,11 +62,11 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "once_cell",
  "version_check 0.9.3",
 ]
@@ -257,7 +257,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "sha2 0.9.4",
+ "sha2 0.9.5",
 ]
 
 [[package]]
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bundy"
@@ -564,18 +564,18 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cast"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
+checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -639,11 +639,11 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a695f8f543f6c58f519d0006c069d244c269ef64291b9eead6ebe30ffc294f4"
+checksum = "07528232eb364b5096c93e0a39553dd22ed373befc7882f773fbffb2159c1fd2"
 dependencies = [
- "ahash 0.7.2",
+ "ahash 0.7.4",
  "crossbeam",
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402da840495de3f976eaefc3485b7f5eb5b0bf9761f9a47be27fe975b3b8c2ec"
+checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
 name = "constant_time_eq"
@@ -697,7 +697,7 @@ dependencies = [
  "hmac 0.10.1",
  "percent-encoding",
  "rand 0.8.3",
- "sha2 0.9.4",
+ "sha2 0.9.5",
  "time 0.2.26",
  "version_check 0.9.3",
 ]
@@ -736,9 +736,12 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpuid-bool"
@@ -784,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-channel",
@@ -819,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -832,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -842,11 +845,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -1138,7 +1140,7 @@ checksum = "93804560e638370a8be6d59ce71ed803e55e230abdbf42598e666b41adda9b1f"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "openssl",
  "zeroize",
 ]
@@ -1188,9 +1190,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1203,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1213,15 +1215,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1230,15 +1232,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1251,10 +1253,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1263,22 +1266,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1325,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1442,23 +1446,23 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.2",
+ "ahash 0.7.4",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1515,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -1526,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "6.3.5"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5566ecc26bc6b04e773e680d66141fced78e091ad818e420d726c152b05a64ff"
+checksum = "ce318d86a47d18d1db645c979214f809a6cd625202ad334ef75ca813b30dac80"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -1561,15 +1565,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -1579,9 +1583,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1593,7 +1597,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite 0.2.6",
  "socket2",
  "tokio",
  "tower-service",
@@ -1720,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1912,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "ldap3_server"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54525e92774f10788c708dd5cb4905ba0e71cce5dab90ea718f45cf1f8d80dfd"
+checksum = "3beb05c22d6cb1792389efb3e71ed90af6148b6f26d283db67322d356ab2556d"
 dependencies = [
  "bytes",
  "lber",
@@ -1936,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
 
 [[package]]
 name = "libm"
@@ -1959,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cb1effde5f834799ac5e5ef0e40d45027cd74f271b1de786ba8abb30e2164d"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -2023,9 +2027,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mathru"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c215ebdf47c84492edae3ecf33951a95d786201132d1521b3809df18bec293e1"
+checksum = "c4c11f3fbdfe75b7ae7dedf62c583a5fd3b2ead296f6d26982dd7eee782281dc"
 dependencies = [
  "rand 0.8.3",
 ]
@@ -2038,9 +2042,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -2219,15 +2223,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.62"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
@@ -2266,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
+checksum = "0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7"
 dependencies = [
  "cfg-if 0.1.10",
  "libm",
@@ -2345,6 +2349,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,9 +2403,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2484,9 +2497,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -2512,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2612,7 +2625,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -2635,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2647,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2673,15 +2686,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2690,12 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -2789,9 +2799,9 @@ checksum = "5d79b4b604167921892e84afbbaad9d5ad74e091bf6c511d9dbfb0593f09fabd"
 
 [[package]]
 name = "rusqlite"
-version = "0.25.1"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc783b7ddae608338003bac1fa00b6786a75a9675fbd8e87243ecfdea3f6ed2"
+checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2808,7 +2818,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -2876,9 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2889,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2903,7 +2922,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2913,10 +2941,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.125"
+name = "semver-parser"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
@@ -2942,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3006,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -3028,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3038,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -3134,7 +3171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -3281,18 +3318,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3412,9 +3449,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3432,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3465,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3525,6 +3562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -3578,9 +3621,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3605,25 +3648,26 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "serde",
 ]
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
 dependencies = [
  "ctor",
  "sval",
+ "version_check 0.9.3",
 ]
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "version_check"
@@ -3678,9 +3722,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3690,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3705,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3717,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3727,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3740,15 +3784,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/kanidm_client/Cargo.toml
+++ b/kanidm_client/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kanidm/kanidm/"
 [dependencies]
 log = "0.4"
 env_logger = "0.8"
-reqwest = { version = "0.11", features=["blocking", "cookies", "json", "native-tls"] }
+reqwest = { version = "0.11", features=["cookies", "json", "native-tls"] }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha" }
 serde = "1.0"
 serde_json = "1.0"

--- a/kanidmd/src/lib/core/https.rs
+++ b/kanidmd/src/lib/core/https.rs
@@ -1204,7 +1204,9 @@ pub fn create_https_server(
     tserver.at("/status").get(self::status);
 
     let mut well_known = tserver.at("/well-known");
-    well_known.at("/openid-configuration").get(get_openid_configuration);
+    well_known
+        .at("/openid-configuration")
+        .get(get_openid_configuration);
 
     let mut raw_route = tserver.at("/v1/raw");
     raw_route.at("/create").post(create);

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -435,7 +435,7 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
         Ok(new_pw) => match idms_prox_write.commit(&mut audit) {
             Ok(()) => {
                 audit.write_log();
-                info!("Password reset to -> {}", new_pw);
+                eprintln!("Password reset to -> {}", new_pw);
             }
             Err(e) => {
                 error!("A critical error during commit occured {:?}", e);

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -73,7 +73,7 @@ struct CredWebauthn {
 
 /// The current active handler for this authentication session. This is determined from what credentials
 /// are possible from the account, and what the user selected as the preferred authentication
-/// mechanism. 
+/// mechanism.
 #[derive(Clone, Debug)]
 enum CredHandler {
     Anonymous,

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -39,6 +39,7 @@ futures-util = "0.3"
 openssl = "0.10"
 
 ldap3_server = "0.1"
+# ldap3_server = { version = "0.1", path = "../../ldap3_server" }
 
 crossbeam = "0.8"
 async-std = "1.6"

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -38,7 +38,7 @@ tokio-openssl = "0.6"
 futures-util = "0.3"
 openssl = "0.10"
 
-ldap3_server = "0.1"
+ldap3_server = "^0.1.7"
 # ldap3_server = { version = "0.1", path = "../../ldap3_server" }
 
 crossbeam = "0.8"

--- a/orca/example_profiles/small/orca.toml
+++ b/orca/example_profiles/small/orca.toml
@@ -3,7 +3,7 @@ data = "data.json"
 results = "/tmp/small_results"
 
 [ds_config]
-uri = "ldaps://172.24.20.4:636"
+uri = "ldaps://localhost:636"
 base_dn = "dc=example,dc=com"
 dm_pw = "password"
 

--- a/orca/example_profiles/small/orca.toml
+++ b/orca/example_profiles/small/orca.toml
@@ -3,7 +3,8 @@ data = "data.json"
 results = "/tmp/small_results"
 
 [ds_config]
-uri = "ldaps://localhost:3636"
+uri = "ldaps://172.24.20.4:636"
+base_dn = "dc=example,dc=com"
 dm_pw = "password"
 
 [kani_http_config]

--- a/orca/src/data.rs
+++ b/orca/src/data.rs
@@ -41,6 +41,10 @@ pub struct Account {
 }
 
 impl Account {
+    pub fn get_ds_ldap_dn(&self, basedn: &str) -> String {
+        format!("uid={},ou=people,{}", self.name.as_str(), basedn)
+    }
+
     pub fn generate(uuid: Uuid) -> Self {
         let mut rng = rand::thread_rng();
         let id: u64 = rng.gen();
@@ -64,6 +68,10 @@ pub struct Group {
 }
 
 impl Group {
+    pub fn get_ds_ldap_dn(&self, basedn: &str) -> String {
+        format!("cn={},ou=groups,{}", self.name.as_str(), basedn)
+    }
+
     pub fn generate(uuid: Uuid, members: Vec<Uuid>) -> Self {
         let mut rng = rand::thread_rng();
 
@@ -96,6 +104,13 @@ impl Entity {
         match self {
             Entity::Account(a) => a.name.as_str(),
             Entity::Group(g) => g.name.as_str(),
+        }
+    }
+
+    pub fn get_ds_ldap_dn(&self, basedn: &str) -> String {
+        match self {
+            Entity::Account(a) => a.get_ds_ldap_dn(basedn),
+            Entity::Group(g) => g.get_ds_ldap_dn(basedn),
         }
     }
 

--- a/orca/src/ds.rs
+++ b/orca/src/ds.rs
@@ -1,0 +1,125 @@
+use crate::data::*;
+use crate::ldap::{LdapClient, LdapSchema};
+use crate::profile::DsConfig;
+use crate::{TargetServer, TargetServerBuilder};
+use ldap3_server::proto::*;
+use std::time::{Duration, Instant};
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct DirectoryServer {
+    ldap: LdapClient,
+    dm_pw: String,
+}
+
+impl DirectoryServer {
+    fn construct(uri: String, dm_pw: String,
+        basedn: String,
+    ) -> Result<Self, ()> {
+        let ldap = LdapClient::new(uri, basedn, LdapSchema::Rfc2307bis)?;
+
+        Ok(DirectoryServer { ldap, dm_pw })
+    }
+
+    pub fn build(uri: String, dm_pw: String,
+        basedn: String,
+    ) -> Result<TargetServer, ()> {
+        Self::construct(uri, dm_pw, basedn).map(TargetServer::DirSrv)
+    }
+
+    pub fn new(lconfig: &DsConfig) -> Result<TargetServer, ()> {
+        Self::construct(lconfig.uri.clone(), lconfig.dm_pw.clone(), lconfig.base_dn.clone()).map(TargetServer::DirSrv)
+    }
+
+    pub fn info(&self) -> String {
+        format!("Directory Server Connection: {}", self.ldap.uri)
+    }
+
+    pub fn builder(&self) -> TargetServerBuilder {
+        TargetServerBuilder::DirSrv(
+            self.ldap.uri.clone(),
+            self.dm_pw.clone(),
+            self.ldap.basedn.clone(),
+     )
+    }
+
+    pub async fn open_admin_connection(&self) -> Result<(), ()> {
+        self.ldap.open_dm_connection(&self.dm_pw).await
+    }
+
+    pub async fn setup_admin_delete_uuids(&self, targets: &[Uuid]) -> Result<(), ()> {
+        // We might hit admin limits depending on the dataset size, so we probably
+        // need to do this iteratively eventually. Or just change the limits ...
+
+        let filter = LdapFilter::Or(
+                targets.iter()
+                    .map(|u| LdapFilter::Equality("uid".to_string(), u.to_string()))
+                    .collect());
+
+        let res = self.ldap.search(filter).await?;
+
+        for ent in res.iter() {
+            self.ldap.delete(ent.dn.clone()).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn setup_admin_precreate_entities(
+        &self,
+        targets: &HashSet<Uuid>,
+        all_entities: &HashMap<Uuid, Entity>,
+    ) -> Result<(), ()> {
+        // Check if ou=people and ou=group exist
+        let res = self.ldap.search(
+            LdapFilter::Equality("ou".to_string(), "people".to_string())).await?;
+
+        if res.is_empty() {
+            // Doesn't exist
+            info!("Creating ou=people");
+        }
+
+        let res = self.ldap.search(
+            LdapFilter::Equality("ou".to_string(), "groups".to_string())).await?;
+
+        if res.is_empty() {
+            // Doesn't exist
+            info!("Creating ou=groups");
+        }
+
+        // Now go and create the rest.
+
+        // We stick ACI's on the rootdse, so we can clear them and reset them easier.
+
+        unimplemented!();
+    }
+
+    pub async fn setup_access_controls(
+        &self,
+        access: &HashMap<Uuid, Vec<EntityType>>,
+        all_entities: &HashMap<Uuid, Entity>,
+    ) -> Result<(), ()> {
+        unimplemented!();
+    }
+
+    pub async fn open_user_connection(
+        &self,
+        test_start: Instant,
+        name: &str,
+        pw: &str,
+    ) -> Result<(Duration, Duration), ()> {
+        self.ldap.open_user_connection(test_start, name, pw).await
+    }
+
+    pub async fn close_connection(&self) {
+        self.ldap.close_connection().await;
+    }
+
+    pub async fn search(
+        &self,
+        test_start: Instant,
+        ids: &[String],
+    ) -> Result<(Duration, Duration, usize), ()> {
+        self.ldap.search_name(test_start, ids).await
+    }
+}

--- a/orca/src/ds.rs
+++ b/orca/src/ds.rs
@@ -3,8 +3,8 @@ use crate::ldap::{LdapClient, LdapSchema};
 use crate::profile::DsConfig;
 use crate::{TargetServer, TargetServerBuilder};
 use ldap3_server::proto::*;
-use std::time::{Duration, Instant};
 use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -14,22 +14,24 @@ pub struct DirectoryServer {
 }
 
 impl DirectoryServer {
-    fn construct(uri: String, dm_pw: String,
-        basedn: String,
-    ) -> Result<Self, ()> {
+    fn construct(uri: String, dm_pw: String, basedn: String) -> Result<Self, ()> {
         let ldap = LdapClient::new(uri, basedn, LdapSchema::Rfc2307bis)?;
 
         Ok(DirectoryServer { ldap, dm_pw })
     }
 
-    pub fn build(uri: String, dm_pw: String,
-        basedn: String,
-    ) -> Result<TargetServer, ()> {
+    pub fn build(uri: String, dm_pw: String, basedn: String) -> Result<TargetServer, ()> {
         Self::construct(uri, dm_pw, basedn).map(TargetServer::DirSrv)
     }
 
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(lconfig: &DsConfig) -> Result<TargetServer, ()> {
-        Self::construct(lconfig.uri.clone(), lconfig.dm_pw.clone(), lconfig.base_dn.clone()).map(TargetServer::DirSrv)
+        Self::construct(
+            lconfig.uri.clone(),
+            lconfig.dm_pw.clone(),
+            lconfig.base_dn.clone(),
+        )
+        .map(TargetServer::DirSrv)
     }
 
     pub fn info(&self) -> String {
@@ -41,7 +43,7 @@ impl DirectoryServer {
             self.ldap.uri.clone(),
             self.dm_pw.clone(),
             self.ldap.basedn.clone(),
-     )
+        )
     }
 
     pub async fn open_admin_connection(&self) -> Result<(), ()> {
@@ -53,13 +55,22 @@ impl DirectoryServer {
         // need to do this iteratively eventually. Or just change the limits ...
 
         let filter = LdapFilter::Or(
-                targets.iter()
-                    .map(|u| LdapFilter::Equality("uid".to_string(), u.to_string()))
-                    .collect());
+            targets
+                .iter()
+                .map(|u| LdapFilter::Equality("cn".to_string(), u.to_string()))
+                .collect(),
+        );
+
+        print!("(|");
+        for u in targets.iter() {
+            print!("(cn={})", u);
+        }
+        println!(")");
 
         let res = self.ldap.search(filter).await?;
 
         for ent in res.iter() {
+            debug!("Deleting ... {}", ent.dn);
             self.ldap.delete(ent.dn.clone()).await?;
         }
         Ok(())
@@ -71,27 +82,168 @@ impl DirectoryServer {
         all_entities: &HashMap<Uuid, Entity>,
     ) -> Result<(), ()> {
         // Check if ou=people and ou=group exist
-        let res = self.ldap.search(
-            LdapFilter::Equality("ou".to_string(), "people".to_string())).await?;
+        let res = self
+            .ldap
+            .search(LdapFilter::Equality("ou".to_string(), "people".to_string()))
+            .await?;
 
         if res.is_empty() {
             // Doesn't exist
             info!("Creating ou=people");
+            let ou_people = LdapAddRequest {
+                dn: format!("ou=people,{}", self.ldap.basedn),
+                attributes: vec![
+                    LdapAttribute {
+                        atype: "objectClass".to_string(),
+                        vals: vec!["top".to_string(), "organizationalUnit".to_string()],
+                    },
+                    LdapAttribute {
+                        atype: "ou".to_string(),
+                        vals: vec!["people".to_string()],
+                    },
+                ],
+            };
+            self.ldap.add(ou_people).await?;
         }
 
-        let res = self.ldap.search(
-            LdapFilter::Equality("ou".to_string(), "groups".to_string())).await?;
+        let res = self
+            .ldap
+            .search(LdapFilter::Equality("ou".to_string(), "groups".to_string()))
+            .await?;
 
         if res.is_empty() {
             // Doesn't exist
             info!("Creating ou=groups");
+            let ou_groups = LdapAddRequest {
+                dn: format!("ou=groups,{}", self.ldap.basedn),
+                attributes: vec![
+                    LdapAttribute {
+                        atype: "objectClass".to_string(),
+                        vals: vec!["top".to_string(), "organizationalUnit".to_string()],
+                    },
+                    LdapAttribute {
+                        atype: "ou".to_string(),
+                        vals: vec!["groups".to_string()],
+                    },
+                ],
+            };
+            self.ldap.add(ou_groups).await?;
         }
 
         // Now go and create the rest.
-
         // We stick ACI's on the rootdse, so we can clear them and reset them easier.
+        for u in targets {
+            // does it already exist?
+            let res = self
+                .ldap
+                .search(LdapFilter::Equality("cn".to_string(), u.to_string()))
+                .await?;
 
-        unimplemented!();
+            if !res.is_empty() {
+                continue;
+            }
+
+            let e = all_entities.get(u).unwrap();
+            let dn = e.get_ds_ldap_dn(&self.ldap.basedn);
+            match e {
+                Entity::Account(a) => {
+                    let account = LdapAddRequest {
+                        dn,
+                        attributes: vec![
+                            LdapAttribute {
+                                atype: "objectClass".to_string(),
+                                vals: vec![
+                                    "top".to_string(),
+                                    "nsPerson".to_string(),
+                                    "nsAccount".to_string(),
+                                    "nsOrgPerson".to_string(),
+                                    "posixAccount".to_string(),
+                                ],
+                            },
+                            LdapAttribute {
+                                atype: "cn".to_string(),
+                                vals: vec![a.uuid.to_string()],
+                            },
+                            LdapAttribute {
+                                atype: "uid".to_string(),
+                                vals: vec![a.name.clone()],
+                            },
+                            LdapAttribute {
+                                atype: "displayName".to_string(),
+                                vals: vec![a.display_name.clone()],
+                            },
+                            LdapAttribute {
+                                atype: "userPassword".to_string(),
+                                vals: vec![a.password.clone()],
+                            },
+                            LdapAttribute {
+                                atype: "homeDirectory".to_string(),
+                                vals: vec![format!("/home/{}", a.uuid)],
+                            },
+                            LdapAttribute {
+                                atype: "uidNumber".to_string(),
+                                vals: vec!["1000".to_string()],
+                            },
+                            LdapAttribute {
+                                atype: "gidNumber".to_string(),
+                                vals: vec!["1000".to_string()],
+                            },
+                        ],
+                    };
+                    self.ldap.add(account).await?;
+                }
+                Entity::Group(g) => {
+                    let group = LdapAddRequest {
+                        dn,
+                        attributes: vec![
+                            LdapAttribute {
+                                atype: "objectClass".to_string(),
+                                vals: vec!["top".to_string(), "groupOfNames".to_string()],
+                            },
+                            LdapAttribute {
+                                atype: "cn".to_string(),
+                                vals: vec![g.uuid.to_string(), g.name.clone()],
+                            },
+                        ],
+                    };
+                    self.ldap.add(group).await?;
+                }
+            }
+        }
+
+        // Add all the members.
+        for g in targets.iter().filter_map(|u| {
+            let e = all_entities.get(u).unwrap();
+            match e {
+                Entity::Group(g) => Some(g),
+                _ => None,
+            }
+        }) {
+            // List of dns
+            let vals: Vec<_> = g
+                .members
+                .iter()
+                .map(|id| {
+                    all_entities
+                        .get(id)
+                        .unwrap()
+                        .get_ds_ldap_dn(&self.ldap.basedn)
+                })
+                .collect();
+
+            let req = LdapModifyRequest {
+                dn: g.get_ds_ldap_dn(&self.ldap.basedn),
+                changes: vec![LdapModify {
+                    operation: LdapModifyType::Replace,
+                    modification: LdapPartialAttribute {
+                        atype: "member".to_string(),
+                        vals,
+                    },
+                }],
+            };
+            self.ldap.modify(req).await?;
+        }
+        Ok(())
     }
 
     pub async fn setup_access_controls(
@@ -99,7 +251,144 @@ impl DirectoryServer {
         access: &HashMap<Uuid, Vec<EntityType>>,
         all_entities: &HashMap<Uuid, Entity>,
     ) -> Result<(), ()> {
-        unimplemented!();
+        // Create top level priv groups
+        let res = self
+            .ldap
+            .search(LdapFilter::Equality(
+                "cn".to_string(),
+                "priv_account_manage".to_string(),
+            ))
+            .await?;
+
+        if res.is_empty() {
+            // Doesn't exist
+            info!("Creating cn=priv_account_manage");
+            let group = LdapAddRequest {
+                dn: format!("cn=priv_account_manage,{}", self.ldap.basedn),
+                attributes: vec![
+                    LdapAttribute {
+                        atype: "objectClass".to_string(),
+                        vals: vec!["top".to_string(), "groupOfNames".to_string()],
+                    },
+                    LdapAttribute {
+                        atype: "cn".to_string(),
+                        vals: vec!["priv_account_manage".to_string()],
+                    },
+                ],
+            };
+            self.ldap.add(group).await?;
+        }
+
+        let res = self
+            .ldap
+            .search(LdapFilter::Equality(
+                "cn".to_string(),
+                "priv_group_manage".to_string(),
+            ))
+            .await?;
+
+        if res.is_empty() {
+            // Doesn't exist
+            info!("Creating cn=priv_group_manage");
+            let group = LdapAddRequest {
+                dn: format!("cn=priv_group_manage,{}", self.ldap.basedn),
+                attributes: vec![
+                    LdapAttribute {
+                        atype: "objectClass".to_string(),
+                        vals: vec!["top".to_string(), "groupOfNames".to_string()],
+                    },
+                    LdapAttribute {
+                        atype: "cn".to_string(),
+                        vals: vec!["priv_group_manage".to_string()],
+                    },
+                ],
+            };
+            self.ldap.add(group).await?;
+        }
+
+        // Add the acis with mod replace.
+        let acimod = LdapModifyRequest {
+                dn: self.ldap.basedn.clone(),
+                changes: vec![
+                    LdapModify {
+                        operation: LdapModifyType::Replace,
+                        modification: LdapPartialAttribute {
+                            atype: "aci".to_string(),
+                            vals: vec![
+                                r#"(targetattr="dc || description || objectClass")(targetfilter="(objectClass=domain)")(version 3.0; acl "Enable anyone domain read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
+
+                                r#"(targetattr="ou || objectClass")(targetfilter="(objectClass=organizationalUnit)")(version 3.0; acl "Enable anyone ou read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
+                                r#"(targetattr="cn || member || gidNumber || nsUniqueId || description || objectClass")(targetfilter="(objectClass=groupOfNames)")(version 3.0; acl "Enable anyone group read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
+                                format!(r#"(targetattr="cn || member || gidNumber || description || objectClass")(targetfilter="(objectClass=groupOfNames)")(version 3.0; acl "Enable group_admin to manage groups"; allow (write,add, delete)(groupdn="ldap:///cn=priv_group_manage,{}");)"#, self.ldap.basedn),
+                                r#"(targetattr="objectClass || description || nsUniqueId || uid || displayName || loginShell || uidNumber || gidNumber || gecos || homeDirectory || cn || memberOf || mail || nsSshPublicKey || nsAccountLock || userCertificate")(targetfilter="(objectClass=posixaccount)")(version 3.0; acl "Enable anyone user read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
+                                r#"(targetattr="displayName || legalName || userPassword || nsSshPublicKey")(version 3.0; acl "Enable self partial modify"; allow (write)(userdn="ldap:///self");)"#.to_string(),
+                                format!(r#"(targetattr="uid || description || displayName || loginShell || uidNumber || gidNumber || gecos || homeDirectory || cn || memberOf || mail || legalName || telephoneNumber || mobile")(targetfilter="(&(objectClass=nsPerson)(objectClass=nsAccount))")(version 3.0; acl "Enable user admin create"; allow (write, add, delete, read)(groupdn="ldap:///cn=priv_account_manage,{}");)"#, self.ldap.basedn),
+                            ]
+                        }
+                    }
+                ]
+            };
+        self.ldap.modify(acimod).await?;
+
+        // Add members as needed.
+        let mut priv_account = Vec::new();
+        let mut priv_group = Vec::new();
+
+        for (id, list) in access.iter() {
+            // get the users name.
+            let account = all_entities.get(id).unwrap();
+
+            let need_account = list
+                .iter()
+                .filter(|v| matches!(v, EntityType::Account(_)))
+                .count()
+                == 0;
+            let need_group = list
+                .iter()
+                .filter(|v| matches!(v, EntityType::Group(_)))
+                .count()
+                == 0;
+
+            if need_account {
+                priv_account.push(account.get_ds_ldap_dn(&self.ldap.basedn))
+            }
+            if need_group {
+                priv_group.push(account.get_ds_ldap_dn(&self.ldap.basedn))
+            }
+        }
+
+        // Sort and dedup
+        priv_account.sort_unstable();
+        priv_group.sort_unstable();
+        priv_account.dedup();
+        priv_group.dedup();
+        // Do the mod in one pass.
+        info!("Setting up cn=priv_group_manage");
+        let req = LdapModifyRequest {
+            dn: format!("cn=priv_group_manage,{}", self.ldap.basedn),
+            changes: vec![LdapModify {
+                operation: LdapModifyType::Delete,
+                modification: LdapPartialAttribute {
+                    atype: "member".to_string(),
+                    vals: priv_group,
+                },
+            }],
+        };
+        let _ = self.ldap.modify(req).await;
+
+        info!("Setting up cn=priv_account_manage");
+        let req = LdapModifyRequest {
+            dn: format!("cn=priv_account_manage,{}", self.ldap.basedn),
+            changes: vec![LdapModify {
+                operation: LdapModifyType::Delete,
+                modification: LdapPartialAttribute {
+                    atype: "member".to_string(),
+                    vals: priv_account,
+                },
+            }],
+        };
+        let _ = self.ldap.modify(req).await;
+        Ok(())
     }
 
     pub async fn open_user_connection(

--- a/orca/src/kani.rs
+++ b/orca/src/kani.rs
@@ -45,9 +45,9 @@ impl KaniHttpServer {
         Self::construct(uri, admin_pw).map(TargetServer::Kanidm)
     }
 
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(khconfig: &KaniHttpConfig) -> Result<TargetServer, ()> {
-        Self::construct(khconfig.uri.clone(), khconfig.admin_pw.clone())
-            .map(|s| TargetServer::Kanidm(s))
+        Self::construct(khconfig.uri.clone(), khconfig.admin_pw.clone()).map(TargetServer::Kanidm)
     }
 
     pub fn info(&self) -> String {
@@ -330,11 +330,11 @@ impl KaniLdapServer {
         admin_pw: String,
         ldap_uri: String,
         basedn: String,
-    ) -> Result<Self, ()> {
+    ) -> Result<Box<Self>, ()> {
         let http = KaniHttpServer::construct(uri, admin_pw)?;
         let ldap = LdapClient::new(ldap_uri, basedn, LdapSchema::Kanidm)?;
 
-        Ok(KaniLdapServer { http, ldap })
+        Ok(Box::new(KaniLdapServer { http, ldap }))
     }
 
     pub fn build(
@@ -346,6 +346,7 @@ impl KaniLdapServer {
         Self::construct(uri, admin_pw, ldap_uri, basedn).map(TargetServer::KanidmLdap)
     }
 
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(klconfig: &KaniLdapConfig) -> Result<TargetServer, ()> {
         Self::construct(
             klconfig.uri.clone(),

--- a/orca/src/kani.rs
+++ b/orca/src/kani.rs
@@ -416,6 +416,6 @@ impl KaniLdapServer {
         test_start: Instant,
         ids: &[String],
     ) -> Result<(Duration, Duration, usize), ()> {
-        self.ldap.search(test_start, ids).await
+        self.ldap.search_name(test_start, ids).await
     }
 }

--- a/orca/src/ldap.rs
+++ b/orca/src/ldap.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use openssl::ssl::{Ssl, SslConnector, SslMethod, SslVerifyMode};
-use std::sync::atomic::{AtomicUsize, Ordering};
+// use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio_openssl::SslStream;
@@ -78,27 +78,20 @@ impl LdapClient {
         })
     }
 
-    pub async fn open_user_connection(
+    async fn bind(
         &self,
-        test_start: Instant,
-        name: &str,
-        pw: &str,
-    ) -> Result<(Duration, Duration), ()> {
-        let dn = match self.schema {
-            LdapSchema::Kanidm => name.to_string(),
-            LdapSchema::Rfc2307bis => format!("cn={},ou=People,{}", name, self.basedn),
-        };
+        dn: String,
+        pw: String,
+    ) -> Result<(), ()> {
 
         let msg = LdapMsg {
             msgid: 1,
             op: LdapOp::BindRequest(LdapBindRequest {
                 dn,
-                cred: LdapBindCred::Simple(pw.to_string()),
+                cred: LdapBindCred::Simple(pw),
             }),
             ctrl: vec![],
         };
-
-        let start = Instant::now();
 
         let tcpstream = TcpStream::connect(self.addr)
             .await
@@ -135,11 +128,7 @@ impl LdapClient {
                     let mut mguard = self.conn.lock().await;
                     *mguard = Some(LdapInner { framed, msgid: 1 });
 
-                    let end = Instant::now();
-                    let diff = end.duration_since(start);
-                    let rel_diff = start.duration_since(test_start);
-
-                    return Ok((rel_diff, diff));
+                    return Ok(());
                 }
             }
         }
@@ -147,12 +136,41 @@ impl LdapClient {
         Err(())
     }
 
+    pub async fn open_dm_connection(
+        &self,
+        pw: &str,
+    ) -> Result<(), ()> {
+        self.bind("cn=Directory Manager".to_string(), pw.to_string()).await
+    }
+
+    pub async fn open_user_connection(
+        &self,
+        test_start: Instant,
+        name: &str,
+        pw: &str,
+    ) -> Result<(Duration, Duration), ()> {
+        let dn = match self.schema {
+            LdapSchema::Kanidm => name.to_string(),
+            LdapSchema::Rfc2307bis => format!("cn={},ou=People,{}", name, self.basedn),
+        };
+
+        let start = Instant::now();
+
+        self.bind(dn, pw.to_string()).await?;
+
+        let end = Instant::now();
+        let diff = end.duration_since(start);
+        let rel_diff = start.duration_since(test_start);
+
+        return Ok((rel_diff, diff));
+    }
+
     pub async fn close_connection(&self) {
         let mut mguard = self.conn.lock().await;
         *mguard = None;
     }
 
-    pub async fn search(
+    pub async fn search_name(
         &self,
         test_start: Instant,
         ids: &[String],
@@ -162,6 +180,27 @@ impl LdapClient {
             LdapSchema::Rfc2307bis => "cn",
         };
 
+        let filter = LdapFilter::Or(
+                ids.iter()
+                    .map(|n| LdapFilter::Equality(name_attr.to_string(), n.to_string()))
+                    .collect());
+
+        let start = Instant::now();
+
+        let res = self.search(filter).await?;
+
+        let end = Instant::now();
+        let diff = end.duration_since(start);
+        let rel_diff = start.duration_since(test_start);
+
+        Ok((rel_diff, diff, res.len()))
+    }
+
+    pub async fn search(
+        &self,
+        filter: LdapFilter,
+    ) -> Result<Vec<LdapSearchResultEntry>, ()> {
+
         // Create the search filter
         let req = LdapSearchRequest {
             base: self.basedn.clone(),
@@ -170,11 +209,7 @@ impl LdapClient {
             sizelimit: 0,
             timelimit: 0,
             typesonly: false,
-            filter: LdapFilter::Or(
-                ids.iter()
-                    .map(|n| LdapFilter::Equality(name_attr.to_string(), n.to_string()))
-                    .collect(),
-            ),
+            filter,
             attrs: vec![],
         };
 
@@ -197,20 +232,17 @@ impl LdapClient {
             op: LdapOp::SearchRequest(req),
         };
 
-        let start = Instant::now();
-
-        let count = AtomicUsize::new(0);
-
         // Send it
         let _ = inner.framed.send(msg).await.map_err(|e| {
             error!("Unable to search -> {:?}", e);
         })?;
 
+        let mut results = Vec::new();
         // It takes a lot more work to process a response from ldap :(
         while let Some(Ok(msg)) = inner.framed.next().await {
             match msg.op {
-                LdapOp::SearchResultEntry(_) => {
-                    count.fetch_add(1, Ordering::Relaxed);
+                LdapOp::SearchResultEntry(ent) => {
+                    results.push(ent)
                 }
                 LdapOp::SearchResultDone(res) => {
                     if res.code == LdapResultCode::Success {
@@ -226,12 +258,51 @@ impl LdapClient {
                 }
             }
         }
-        // Wait on the response
+        Ok(results)
+    }
 
-        let end = Instant::now();
-        let diff = end.duration_since(start);
-        let rel_diff = start.duration_since(test_start);
+    pub async fn delete(
+        &self,
+        dn: String,
+    ) -> Result<(), ()> {
+        let mut mguard = self.conn.lock().await;
+        let inner = match (*mguard).as_mut() {
+            Some(i) => i,
+            None => {
+                error!("No connection available");
+                return Err(());
+            }
+        };
 
-        Ok((rel_diff, diff, count.into_inner()))
+        inner.msgid += 1;
+        let msgid = inner.msgid;
+
+        let msg = LdapMsg {
+            msgid,
+            ctrl: vec![],
+            op: LdapOp::DelRequest(dn),
+        };
+
+        // Send it
+        let _ = inner.framed.send(msg).await.map_err(|e| {
+            error!("Unable to search -> {:?}", e);
+        })?;
+        while let Some(Ok(msg)) = inner.framed.next().await {
+            match msg.op {
+                LdapOp::DelResponse(res) => {
+                    if res.code == LdapResultCode::Success {
+                        break;
+                    } else {
+                        error!("Delete Failed");
+                        return Err(());
+                    }
+                }
+                _ => {
+                    error!("Invalid ldap response state");
+                    return Err(());
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/orca/src/main.rs
+++ b/orca/src/main.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings)]
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
@@ -18,8 +18,8 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
-use crate::kani::{KaniHttpServer, KaniLdapServer};
 use crate::ds::DirectoryServer;
+use crate::kani::{KaniHttpServer, KaniLdapServer};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -65,7 +65,7 @@ impl TargetServerBuilder {
 
 pub enum TargetServer {
     Kanidm(KaniHttpServer),
-    KanidmLdap(KaniLdapServer),
+    KanidmLdap(Box<KaniLdapServer>),
     DirSrv(DirectoryServer),
 }
 

--- a/orca/src/main.rs
+++ b/orca/src/main.rs
@@ -1,8 +1,8 @@
 // #![deny(warnings)]
 #![warn(unused_extern_crates)]
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
-#![deny(clippy::panic)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
 #![deny(clippy::unreachable)]
 #![deny(clippy::await_holding_lock)]
 #![deny(clippy::needless_pass_by_value)]
@@ -19,6 +19,7 @@ extern crate log;
 extern crate serde_derive;
 
 use crate::kani::{KaniHttpServer, KaniLdapServer};
+use crate::ds::DirectoryServer;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -26,6 +27,7 @@ use structopt::StructOpt;
 use uuid::Uuid;
 
 mod data;
+mod ds;
 mod kani;
 mod ldap;
 mod preprocess;
@@ -48,6 +50,7 @@ impl OrcaOpt {
 pub enum TargetServerBuilder {
     Kanidm(String, String),
     KanidmLdap(String, String, String, String),
+    DirSrv(String, String, String),
 }
 
 impl TargetServerBuilder {
@@ -55,6 +58,7 @@ impl TargetServerBuilder {
         match self {
             TargetServerBuilder::Kanidm(a, b) => KaniHttpServer::build(a, b),
             TargetServerBuilder::KanidmLdap(a, b, c, d) => KaniLdapServer::build(a, b, c, d),
+            TargetServerBuilder::DirSrv(a, b, c) => DirectoryServer::build(a, b, c),
         }
     }
 }
@@ -62,6 +66,7 @@ impl TargetServerBuilder {
 pub enum TargetServer {
     Kanidm(KaniHttpServer),
     KanidmLdap(KaniLdapServer),
+    DirSrv(DirectoryServer),
 }
 
 impl TargetServer {
@@ -69,6 +74,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.info(),
             TargetServer::KanidmLdap(k) => k.info(),
+            TargetServer::DirSrv(k) => k.info(),
         }
     }
 
@@ -76,6 +82,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(_) => "kanidm_http",
             TargetServer::KanidmLdap(_) => "kanidm_ldap",
+            TargetServer::DirSrv(_) => "directory_server",
         }
     }
 
@@ -83,6 +90,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.builder(),
             TargetServer::KanidmLdap(k) => k.builder(),
+            TargetServer::DirSrv(k) => k.builder(),
         }
     }
 
@@ -90,6 +98,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.open_admin_connection().await,
             TargetServer::KanidmLdap(k) => k.open_admin_connection().await,
+            TargetServer::DirSrv(k) => k.open_admin_connection().await,
         }
     }
 
@@ -97,6 +106,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.setup_admin_delete_uuids(targets).await,
             TargetServer::KanidmLdap(k) => k.setup_admin_delete_uuids(targets).await,
+            TargetServer::DirSrv(k) => k.setup_admin_delete_uuids(targets).await,
         }
     }
 
@@ -114,6 +124,10 @@ impl TargetServer {
                 k.setup_admin_precreate_entities(targets, all_entities)
                     .await
             }
+            TargetServer::DirSrv(k) => {
+                k.setup_admin_precreate_entities(targets, all_entities)
+                    .await
+            }
         }
     }
 
@@ -125,6 +139,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.setup_access_controls(access, all_entities).await,
             TargetServer::KanidmLdap(k) => k.setup_access_controls(access, all_entities).await,
+            TargetServer::DirSrv(k) => k.setup_access_controls(access, all_entities).await,
         }
     }
 
@@ -137,6 +152,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.open_user_connection(test_start, name, pw).await,
             TargetServer::KanidmLdap(k) => k.open_user_connection(test_start, name, pw).await,
+            TargetServer::DirSrv(k) => k.open_user_connection(test_start, name, pw).await,
         }
     }
 
@@ -144,6 +160,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.close_connection().await,
             TargetServer::KanidmLdap(k) => k.close_connection().await,
+            TargetServer::DirSrv(k) => k.close_connection().await,
         }
     }
 
@@ -155,6 +172,7 @@ impl TargetServer {
         match self {
             TargetServer::Kanidm(k) => k.search(test_start, ids).await,
             TargetServer::KanidmLdap(k) => k.search(test_start, ids).await,
+            TargetServer::DirSrv(k) => k.search(test_start, ids).await,
         }
     }
 }

--- a/orca/src/preprocess.rs
+++ b/orca/src/preprocess.rs
@@ -79,6 +79,7 @@ fn parse_rtime(s: &str) -> Result<Duration, ()> {
 }
 
 impl Record {
+    #[allow(clippy::wrong_self_convention)]
     fn into_op(&self, all_entities: &HashMap<Uuid, Entity>, exists: &mut Vec<Uuid>) -> Op {
         let op_type = match self.op_type {
             RawOpType::Add => {
@@ -140,7 +141,7 @@ impl Record {
             _ => panic!(),
         };
         Op {
-            orig_etime: self.etime.clone(),
+            orig_etime: self.etime,
             rtime: self.rtime,
             op_type,
         }
@@ -216,7 +217,7 @@ pub fn doit(input: &Path, output: &Path) {
         }
     };
 
-    let data: Result<Vec<_>, _> = u.into_iter().map(|v| Record::try_from(v)).collect();
+    let data: Result<Vec<_>, _> = u.into_iter().map(Record::try_from).collect();
 
     let data = match data {
         Ok(d) => d,

--- a/orca/src/profile.rs
+++ b/orca/src/profile.rs
@@ -2,6 +2,7 @@
 pub struct DsConfig {
     pub uri: String,
     pub dm_pw: String,
+    pub base_dn: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/orca/src/setup.rs
+++ b/orca/src/setup.rs
@@ -1,5 +1,6 @@
 use crate::data::TestData;
 use crate::kani::{KaniHttpServer, KaniLdapServer};
+use crate::ds::DirectoryServer;
 use crate::profile::Profile;
 use crate::TargetOpt;
 use crate::TargetServer;
@@ -48,7 +49,12 @@ pub(crate) fn config(
     // Does our target section exist?
     let server: TargetServer = match target {
         TargetOpt::Ds => {
-            unimplemented!();
+            if let Some(dsconfig) = profile.ds_config.as_ref() {
+                DirectoryServer::new(dsconfig)?
+            } else {
+                error!("To use ds, you must have the ds_config section in your profile");
+                return Err(());
+            }
         }
         TargetOpt::KanidmLdap => {
             if let Some(klconfig) = profile.kani_ldap_config.as_ref() {

--- a/orca/src/setup.rs
+++ b/orca/src/setup.rs
@@ -1,6 +1,6 @@
 use crate::data::TestData;
-use crate::kani::{KaniHttpServer, KaniLdapServer};
 use crate::ds::DirectoryServer;
+use crate::kani::{KaniHttpServer, KaniLdapServer};
 use crate::profile::Profile;
 use crate::TargetOpt;
 use crate::TargetServer;
@@ -32,16 +32,14 @@ pub(crate) fn config(
 
     let data_path = if Path::new(&profile.data).is_absolute() {
         PathBuf::from(&profile.data)
+    } else if let Some(p) = profile_path.parent() {
+        p.join(&profile.data)
     } else {
-        if let Some(p) = profile_path.parent() {
-            p.join(&profile.data)
-        } else {
-            error!(
-                "Unable to find parent directory of {}",
-                profile_path.to_str().unwrap()
-            );
-            return Err(());
-        }
+        error!(
+            "Unable to find parent directory of {}",
+            profile_path.to_str().unwrap()
+        );
+        return Err(());
     };
 
     debug!("Data Path -> {}", data_path.to_str().unwrap());


### PR DESCRIPTION
This adds support for Orca to conduct load tests against 389-ds. This also resolves a few warnings and clippy lints. In the future this will allow us to perform performance comparisons between 389-ds and kanidm, and potentially even freeipa or similar. 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ - ] book chapter included (if relevant)
- [ - ] design document included (if relevant)
