### PR TITLE
471 add service files

### DIFF
--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -1,0 +1,34 @@
+# Source: https://build.opensuse.org/package/view_file/home:firstyear:kanidm/kanidm/kanidm-unixd-tasks.service
+# You should not need to edit this file. Instead, use a drop-in file:
+#   systemctl edit kanidm-unixd-tasks.service
+
+
+[Unit]
+Description=Kanidm Local Tasks
+After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
+
+[Service]
+User=root
+Type=simple
+ExecStart=/usr/sbin/kanidm_unixd_tasks
+
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
+# SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
+ProtectSystem=strict
+ReadWritePaths=/home /var/run/kanidm-unixd
+RestrictAddressFamilies=AF_UNIX
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target
+

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -1,0 +1,36 @@
+# Source: https://build.opensuse.org/package/view_file/home:firstyear:kanidm/kanidm/kanidm-unixd.service
+# You should not need to edit this file. Instead, use a drop-in file:
+#   systemctl edit kanidm-unixd.service
+
+[Unit]
+Description=Kanidm Local Client Resolver
+After=chronyd.service ntpd.service network-online.target
+
+[Service]
+DynamicUser=yes
+UMask=0027
+CacheDirectory=kanidm-unixd
+RuntimeDirectory=kanidm-unixd
+
+Type=simple
+ExecStart=/usr/sbin/kanidm_unixd
+
+# Implied by dynamic user.
+# ProtectHome=
+# ProtectSystem=strict
+# ReadWritePaths=/var/run/kanidm-unixd /var/cache/kanidm-unixd
+
+# SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/opensuse/kanidmd.service
+++ b/platform/opensuse/kanidmd.service
@@ -1,0 +1,29 @@
+# Source: https://build.opensuse.org/package/view_file/home:firstyear:kanidm/kanidm/kanidmd.service
+# You should not need to edit this file. Instead, use a drop-in file as described in:
+#   /usr/lib/systemd/system/kanidmd.service.d/custom.conf
+
+[Unit]
+Description=Kanidm Identity Server
+After=chronyd.service ntpd.service network-online.target
+Before=radiusd.service
+
+[Service]
+Type=simple
+DynamicUser=yes
+UMask=0027
+StateDirectory=kanidmd
+ExecStart=/usr/sbin/kanidmd server -c /etc/kanidm/server.toml
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #471 

Here is a proposal to include the current `.service` files from https://build.opensuse.org/package/show/home:firstyear:kanidm/kanidm into this repo. 

As the files come from openSUSE, I have put the files into `platform/opensuse/<*.service>` as proposed.

Looking forward to comments and suggestions.

- [-] cargo fmt has been run
- [-] cargo clippy has been run
- [-] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
