### PR TITLE
unixd will now bail if startup tests fail

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -132,7 +132,10 @@ impl KanidmClientBuilder {
         // Process and apply all our options if they exist.
         let address = match kcc.uri {
             Some(uri) => Some(uri),
-            None => address,
+            None => {
+                debug!("No URI in supplied config");
+                address
+            }
         };
         let verify_ca = kcc.verify_ca.unwrap_or(verify_ca);
         let verify_hostnames = kcc.verify_hostnames.unwrap_or(verify_hostnames);

--- a/kanidm_unix_int/build.rs
+++ b/kanidm_unix_int/build.rs
@@ -61,7 +61,7 @@ fn main() {
     println!("cargo:rerun-if-changed={}", profile_path.to_str().unwrap());
 
     let mut f =
-        File::open(&profile_path).expect(format!("Failed to open {:?}", profile_path).as_str());
+        File::open(&profile_path).unwrap_or_else(|_| panic!("Failed to open {:?}", profile_path));
 
     let mut contents = String::new();
     f.read_to_string(&mut contents)

--- a/kanidm_unix_int/build.rs
+++ b/kanidm_unix_int/build.rs
@@ -61,7 +61,7 @@ fn main() {
     println!("cargo:rerun-if-changed={}", profile_path.to_str().unwrap());
 
     let mut f =
-        File::open(&profile_path).unwrap_or_else(|_| panic!("Failed to open {:?}", profile_path));
+        File::open(&profile_path).expect(format!("Failed to open {:?}", profile_path).as_str());
 
     let mut contents = String::new();
     f.read_to_string(&mut contents)


### PR DESCRIPTION
Relates to #456

Checks to see if `kanidm_unixd` can actually start and run and write to the DB path

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
