### PR TITLE
Renamed fields in `dbvalue`

### DIFF
--- a/kanidmd/src/lib/be/dbvalue.rs
+++ b/kanidmd/src/lib/be/dbvalue.rs
@@ -4,13 +4,12 @@ use webauthn_rs::proto::COSEKey;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbCidV1 {
-    //? what do `d`, `s`, and `t` stand for? I wasn't able to infer it.
     #[serde(rename = "d")]
-    pub d: Uuid,
+    pub domain_id: Uuid,
     #[serde(rename = "s")]
-    pub s: Uuid,
+    pub server_id: Uuid,
     #[serde(rename = "t")]
-    pub t: Duration,
+    pub timestamp: Duration,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -19,10 +18,6 @@ pub enum DbPasswordV1 {
     SSHA512(Vec<u8>, Vec<u8>),
 }
 
-//? This type is basically an alias for `TotpAlgo`.
-//? Why don't we do
-//? `type DbTotpAlgoV1 = TotpAlgo` and then
-//? derive `Serialize`/`Deserialize` on `TotpAlgo`?
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DbTotpAlgoV1 {
     S1,
@@ -33,9 +28,9 @@ pub enum DbTotpAlgoV1 {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbTotpV1 {
     #[serde(rename = "l")]
-    pub l: String, //? is this short for "label"?
+    pub label: String,
     #[serde(rename = "k")]
-    pub k: Vec<u8>, //? is this short for "secret"?
+    pub key: Vec<u8>,
     #[serde(rename = "s")]
     pub step: u64,
     #[serde(rename = "a")]
@@ -45,15 +40,15 @@ pub struct DbTotpV1 {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbWebauthnV1 {
     #[serde(rename = "l")]
-    pub l: String, //? is this short for "label"?
+    pub label: String,
     #[serde(rename = "i")]
-    pub cred_id: Vec<u8>,
+    pub id: Vec<u8>,
     #[serde(rename = "c")]
     pub cred: COSEKey,
     #[serde(rename = "t")]
     pub counter: u32,
     #[serde(rename = "v")]
-    pub is_verified: bool,
+    pub verified: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -103,8 +98,7 @@ pub struct DbValueTaggedStringV1 {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbValueEmailAddressV1 {
-    #[serde(rename = "d")]
-    pub email_addr: String,
+    pub d: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -120,17 +114,17 @@ pub enum DbValueV1 {
     #[serde(rename = "BO")]
     Bool(bool),
     #[serde(rename = "SY")]
-    SynType(usize),
+    SyntaxType(usize),
     #[serde(rename = "IN")]
-    IdxType(usize),
+    IndexType(usize),
     #[serde(rename = "RF")]
-    Refer(Uuid),
+    Reference(Uuid),
     #[serde(rename = "JF")]
     JsonFilter(String),
     #[serde(rename = "CR")]
-    Cred(DbValueCredV1),
+    Credential(DbValueCredV1),
     #[serde(rename = "RU")]
-    RadiusCred(String),
+    SecretValue(String),
     #[serde(rename = "SK")]
     SshKey(DbValueTaggedStringV1),
     #[serde(rename = "SP")]

--- a/kanidmd/src/lib/be/dbvalue.rs
+++ b/kanidmd/src/lib/be/dbvalue.rs
@@ -4,8 +4,12 @@ use webauthn_rs::proto::COSEKey;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbCidV1 {
+    //? what do `d`, `s`, and `t` stand for? I wasn't able to infer it.
+    #[serde(rename = "d")]
     pub d: Uuid,
+    #[serde(rename = "s")]
     pub s: Uuid,
+    #[serde(rename = "t")]
     pub t: Duration,
 }
 
@@ -15,6 +19,10 @@ pub enum DbPasswordV1 {
     SSHA512(Vec<u8>, Vec<u8>),
 }
 
+//? This type is basically an alias for `TotpAlgo`.
+//? Why don't we do
+//? `type DbTotpAlgoV1 = TotpAlgo` and then
+//? derive `Serialize`/`Deserialize` on `TotpAlgo`?
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DbTotpAlgoV1 {
     S1,
@@ -24,19 +32,28 @@ pub enum DbTotpAlgoV1 {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbTotpV1 {
-    pub l: String,
-    pub k: Vec<u8>,
-    pub s: u64,
-    pub a: DbTotpAlgoV1,
+    #[serde(rename = "l")]
+    pub l: String, //? is this short for "label"?
+    #[serde(rename = "k")]
+    pub k: Vec<u8>, //? is this short for "secret"?
+    #[serde(rename = "s")]
+    pub step: u64,
+    #[serde(rename = "a")]
+    pub algo: DbTotpAlgoV1,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbWebauthnV1 {
-    pub l: String,
-    pub i: Vec<u8>,
-    pub c: COSEKey,
-    pub t: u32,
-    pub v: bool,
+    #[serde(rename = "l")]
+    pub l: String, //? is this short for "label"?
+    #[serde(rename = "i")]
+    pub cred_id: Vec<u8>,
+    #[serde(rename = "c")]
+    pub cred: COSEKey,
+    #[serde(rename = "t")]
+    pub counter: u32,
+    #[serde(rename = "v")]
+    pub is_verified: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -70,41 +87,64 @@ pub struct DbCredV1 {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbValueCredV1 {
-    pub t: String,
-    pub d: DbCredV1,
+    #[serde(rename = "t")]
+    pub tag: String,
+    #[serde(rename = "d")]
+    pub data: DbCredV1,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbValueTaggedStringV1 {
-    pub t: String,
-    pub d: String,
+    #[serde(rename = "t")]
+    pub tag: String,
+    #[serde(rename = "d")]
+    pub data: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DbValueEmailAddressV1 {
-    pub d: String,
+    #[serde(rename = "d")]
+    pub email_addr: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DbValueV1 {
-    U8(String),
-    I8(String),
-    N8(String),
-    UU(Uuid),
-    BO(bool),
-    SY(usize),
-    IN(usize),
-    RF(Uuid),
-    JF(String),
-    CR(DbValueCredV1),
-    RU(String),
-    SK(DbValueTaggedStringV1),
-    SP(String, String),
-    UI(u32),
-    CI(DbCidV1),
-    NU(String),
-    DT(String),
-    EM(DbValueEmailAddressV1),
+    #[serde(rename = "U8")]
+    Utf8(String),
+    #[serde(rename = "I8")]
+    Iutf8(String),
+    #[serde(rename = "N8")]
+    Iname(String),
+    #[serde(rename = "UU")]
+    Uuid(Uuid),
+    #[serde(rename = "BO")]
+    Bool(bool),
+    #[serde(rename = "SY")]
+    SynType(usize),
+    #[serde(rename = "IN")]
+    IdxType(usize),
+    #[serde(rename = "RF")]
+    Refer(Uuid),
+    #[serde(rename = "JF")]
+    JsonFilter(String),
+    #[serde(rename = "CR")]
+    Cred(DbValueCredV1),
+    #[serde(rename = "RU")]
+    RadiusCred(String),
+    #[serde(rename = "SK")]
+    SshKey(DbValueTaggedStringV1),
+    #[serde(rename = "SP")]
+    Spn(String, String),
+    #[serde(rename = "UI")]
+    Uint32(u32),
+    #[serde(rename = "CI")]
+    Cid(DbCidV1),
+    #[serde(rename = "NU")]
+    NsUniqueId(String),
+    #[serde(rename = "DT")]
+    DateTime(String),
+    #[serde(rename = "EM")]
+    EmailAddress(DbValueEmailAddressV1),
 }
 
 #[cfg(test)]

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -304,10 +304,10 @@ impl TryFrom<DbCredV1> for Credential {
                         (
                             wc.l,
                             WebauthnCredential {
-                                cred_id: wc.i,
-                                cred: wc.c,
-                                counter: wc.t,
-                                verified: wc.v,
+                                cred_id: wc.cred_id,
+                                cred: wc.cred,
+                                counter: wc.counter,
+                                verified: wc.is_verified,
                             },
                         )
                     })
@@ -584,10 +584,10 @@ impl Credential {
                     map.iter()
                         .map(|(k, v)| DbWebauthnV1 {
                             l: k.clone(),
-                            i: v.cred_id.clone(),
-                            c: v.cred.clone(),
-                            t: v.counter,
-                            v: v.verified,
+                            cred_id: v.cred_id.clone(),
+                            cred: v.cred.clone(),
+                            counter: v.counter,
+                            is_verified: v.verified,
                         })
                         .collect(),
                 ),
@@ -602,10 +602,10 @@ impl Credential {
                     map.iter()
                         .map(|(k, v)| DbWebauthnV1 {
                             l: k.clone(),
-                            i: v.cred_id.clone(),
-                            c: v.cred.clone(),
-                            t: v.counter,
-                            v: v.verified,
+                            cred_id: v.cred_id.clone(),
+                            cred: v.cred.clone(),
+                            counter: v.counter,
+                            is_verified: v.verified,
                         })
                         .collect(),
                 ),

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -302,12 +302,12 @@ impl TryFrom<DbCredV1> for Credential {
                 dbw.into_iter()
                     .map(|wc| {
                         (
-                            wc.l,
+                            wc.label,
                             WebauthnCredential {
-                                cred_id: wc.cred_id,
+                                cred_id: wc.id,
                                 cred: wc.cred,
                                 counter: wc.counter,
-                                verified: wc.is_verified,
+                                verified: wc.verified,
                             },
                         )
                     })
@@ -583,11 +583,11 @@ impl Credential {
                 webauthn: Some(
                     map.iter()
                         .map(|(k, v)| DbWebauthnV1 {
-                            l: k.clone(),
-                            cred_id: v.cred_id.clone(),
+                            label: k.clone(),
+                            id: v.cred_id.clone(),
                             cred: v.cred.clone(),
                             counter: v.counter,
-                            is_verified: v.verified,
+                            verified: v.verified,
                         })
                         .collect(),
                 ),
@@ -601,11 +601,11 @@ impl Credential {
                 webauthn: Some(
                     map.iter()
                         .map(|(k, v)| DbWebauthnV1 {
-                            l: k.clone(),
-                            cred_id: v.cred_id.clone(),
+                            label: k.clone(),
+                            id: v.cred_id.clone(),
                             cred: v.cred.clone(),
                             counter: v.counter,
-                            is_verified: v.verified,
+                            verified: v.verified,
                         })
                         .collect(),
                 ),

--- a/kanidmd/src/lib/credential/totp.rs
+++ b/kanidmd/src/lib/credential/totp.rs
@@ -69,14 +69,14 @@ impl TryFrom<DbTotpV1> for Totp {
     type Error = ();
 
     fn try_from(value: DbTotpV1) -> Result<Self, Self::Error> {
-        let algo = match value.a {
+        let algo = match value.algo {
             DbTotpAlgoV1::S1 => TotpAlgo::Sha1,
             DbTotpAlgoV1::S256 => TotpAlgo::Sha256,
             DbTotpAlgoV1::S512 => TotpAlgo::Sha512,
         };
         Ok(Totp {
             secret: value.k,
-            step: value.s,
+            step: value.step,
             algo,
         })
     }
@@ -113,8 +113,8 @@ impl Totp {
         DbTotpV1 {
             l: "totp".to_string(),
             k: self.secret.clone(),
-            s: self.step,
-            a: match self.algo {
+            step: self.step,
+            algo: match self.algo {
                 TotpAlgo::Sha1 => DbTotpAlgoV1::S1,
                 TotpAlgo::Sha256 => DbTotpAlgoV1::S256,
                 TotpAlgo::Sha512 => DbTotpAlgoV1::S512,

--- a/kanidmd/src/lib/credential/totp.rs
+++ b/kanidmd/src/lib/credential/totp.rs
@@ -75,7 +75,7 @@ impl TryFrom<DbTotpV1> for Totp {
             DbTotpAlgoV1::S512 => TotpAlgo::Sha512,
         };
         Ok(Totp {
-            secret: value.k,
+            secret: value.key,
             step: value.step,
             algo,
         })
@@ -111,8 +111,8 @@ impl Totp {
 
     pub(crate) fn to_dbtotpv1(&self) -> DbTotpV1 {
         DbTotpV1 {
-            l: "totp".to_string(),
-            k: self.secret.clone(),
+            label: "totp".to_string(),
+            key: self.secret.clone(),
             step: self.step,
             algo: match self.algo {
                 TotpAlgo::Sha1 => DbTotpAlgoV1::S1,

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -1056,11 +1056,11 @@ impl Value {
     // Keep this updated with DbValueV1 in be::dbvalue.
     pub(crate) fn from_db_valuev1(v: DbValueV1) -> Result<Self, ()> {
         match v {
-            DbValueV1::U8(s) => Ok(Value {
+            DbValueV1::Utf8(s) => Ok(Value {
                 pv: PartialValue::Utf8(s),
                 data: None,
             }),
-            DbValueV1::I8(s) => {
+            DbValueV1::Iutf8(s) => {
                 Ok(Value {
                     // TODO: Should we be lowercasing here? The dbv should be normalised
                     // already, but is there a risk of corruption/tampering if we don't touch this?
@@ -1068,61 +1068,61 @@ impl Value {
                     data: None,
                 })
             }
-            DbValueV1::N8(s) => Ok(Value {
+            DbValueV1::Iname(s) => Ok(Value {
                 pv: PartialValue::Iname(s.to_lowercase()),
                 data: None,
             }),
-            DbValueV1::UU(u) => Ok(Value {
+            DbValueV1::Uuid(u) => Ok(Value {
                 pv: PartialValue::Uuid(u),
                 data: None,
             }),
-            DbValueV1::BO(b) => Ok(Value {
+            DbValueV1::Bool(b) => Ok(Value {
                 pv: PartialValue::Bool(b),
                 data: None,
             }),
-            DbValueV1::SY(us) => Ok(Value {
+            DbValueV1::SynType(us) => Ok(Value {
                 pv: PartialValue::Syntax(SyntaxType::try_from(us)?),
                 data: None,
             }),
-            DbValueV1::IN(us) => Ok(Value {
+            DbValueV1::IdxType(us) => Ok(Value {
                 pv: PartialValue::Index(IndexType::try_from(us)?),
                 data: None,
             }),
-            DbValueV1::RF(u) => Ok(Value {
+            DbValueV1::Refer(u) => Ok(Value {
                 pv: PartialValue::Refer(u),
                 data: None,
             }),
-            DbValueV1::JF(s) => Ok(Value {
+            DbValueV1::JsonFilter(s) => Ok(Value {
                 pv: match PartialValue::new_json_filter(s.as_str()) {
                     Some(pv) => pv,
                     None => return Err(()),
                 },
                 data: None,
             }),
-            DbValueV1::CR(dvc) => {
+            DbValueV1::Cred(dvc) => {
                 // Deserialise the db cred here.
                 Ok(Value {
-                    pv: PartialValue::Cred(dvc.t.to_lowercase()),
-                    data: Some(Box::new(DataValue::Cred(Credential::try_from(dvc.d)?))),
+                    pv: PartialValue::Cred(dvc.tag.to_lowercase()),
+                    data: Some(Box::new(DataValue::Cred(Credential::try_from(dvc.data)?))),
                 })
             }
-            DbValueV1::RU(d) => Ok(Value {
+            DbValueV1::RadiusCred(d) => Ok(Value {
                 pv: PartialValue::RadiusCred,
                 data: Some(Box::new(DataValue::RadiusCred(d))),
             }),
-            DbValueV1::SK(ts) => Ok(Value {
-                pv: PartialValue::SshKey(ts.t),
-                data: Some(Box::new(DataValue::SshKey(ts.d))),
+            DbValueV1::SshKey(ts) => Ok(Value {
+                pv: PartialValue::SshKey(ts.tag),
+                data: Some(Box::new(DataValue::SshKey(ts.data))),
             }),
-            DbValueV1::SP(n, r) => Ok(Value {
+            DbValueV1::Spn(n, r) => Ok(Value {
                 pv: PartialValue::Spn(n, r),
                 data: None,
             }),
-            DbValueV1::UI(u) => Ok(Value {
+            DbValueV1::Uint32(u) => Ok(Value {
                 pv: PartialValue::Uint32(u),
                 data: None,
             }),
-            DbValueV1::CI(dc) => Ok(Value {
+            DbValueV1::Cid(dc) => Ok(Value {
                 pv: PartialValue::Cid(Cid {
                     ts: dc.t,
                     d_uuid: dc.d,
@@ -1130,15 +1130,15 @@ impl Value {
                 }),
                 data: None,
             }),
-            DbValueV1::NU(s) => Ok(Value {
+            DbValueV1::NsUniqueId(s) => Ok(Value {
                 pv: PartialValue::Nsuniqueid(s),
                 data: None,
             }),
-            DbValueV1::DT(s) => PartialValue::new_datetime_s(&s)
+            DbValueV1::DateTime(s) => PartialValue::new_datetime_s(&s)
                 .ok_or(())
                 .map(|pv| Value { pv, data: None }),
-            DbValueV1::EM(DbValueEmailAddressV1 { d }) => Ok(Value {
-                pv: PartialValue::EmailAddress(d),
+            DbValueV1::EmailAddress(DbValueEmailAddressV1 { email_addr }) => Ok(Value {
+                pv: PartialValue::EmailAddress(email_addr),
                 data: None,
             }),
         }
@@ -1149,15 +1149,15 @@ impl Value {
     pub(crate) fn to_db_valuev1(&self) -> DbValueV1 {
         // This has to clone due to how the backend works.
         match &self.pv {
-            PartialValue::Utf8(s) => DbValueV1::U8(s.clone()),
-            PartialValue::Iutf8(s) => DbValueV1::I8(s.clone()),
-            PartialValue::Iname(s) => DbValueV1::N8(s.clone()),
-            PartialValue::Uuid(u) => DbValueV1::UU(*u),
-            PartialValue::Bool(b) => DbValueV1::BO(*b),
-            PartialValue::Syntax(syn) => DbValueV1::SY(syn.to_usize()),
-            PartialValue::Index(it) => DbValueV1::IN(it.to_usize()),
-            PartialValue::Refer(u) => DbValueV1::RF(*u),
-            PartialValue::JsonFilt(s) => DbValueV1::JF(
+            PartialValue::Utf8(s) => DbValueV1::Utf8(s.clone()),
+            PartialValue::Iutf8(s) => DbValueV1::Iutf8(s.clone()),
+            PartialValue::Iname(s) => DbValueV1::Iname(s.clone()),
+            PartialValue::Uuid(u) => DbValueV1::Uuid(*u),
+            PartialValue::Bool(b) => DbValueV1::Bool(*b),
+            PartialValue::Syntax(syn) => DbValueV1::SynType(syn.to_usize()),
+            PartialValue::Index(it) => DbValueV1::IdxType(it.to_usize()),
+            PartialValue::Refer(u) => DbValueV1::Refer(*u),
+            PartialValue::JsonFilt(s) => DbValueV1::JsonFilter(
                 serde_json::to_string(s)
                     .expect("A json filter value was corrupted during run-time"),
             ),
@@ -1172,9 +1172,9 @@ impl Value {
                 };
 
                 // Save the tag AND the dataValue here!
-                DbValueV1::CR(DbValueCredV1 {
-                    t: tag.clone(),
-                    d: c.to_db_valuev1(),
+                DbValueV1::Cred(DbValueCredV1 {
+                    tag: tag.clone(),
+                    data: c.to_db_valuev1(),
                 })
             }
             PartialValue::RadiusCred => {
@@ -1185,7 +1185,7 @@ impl Value {
                     },
                     None => unreachable!(),
                 };
-                DbValueV1::RU(ru)
+                DbValueV1::RadiusCred(ru)
             }
             PartialValue::SshKey(t) => {
                 let sk = match &self.data {
@@ -1195,26 +1195,26 @@ impl Value {
                     },
                     None => unreachable!(),
                 };
-                DbValueV1::SK(DbValueTaggedStringV1 {
-                    t: t.clone(),
-                    d: sk,
+                DbValueV1::SshKey(DbValueTaggedStringV1 {
+                    tag: t.clone(),
+                    data: sk,
                 })
             }
-            PartialValue::Spn(n, r) => DbValueV1::SP(n.clone(), r.clone()),
-            PartialValue::Uint32(u) => DbValueV1::UI(*u),
-            PartialValue::Cid(c) => DbValueV1::CI(DbCidV1 {
+            PartialValue::Spn(n, r) => DbValueV1::Spn(n.clone(), r.clone()),
+            PartialValue::Uint32(u) => DbValueV1::Uint32(*u),
+            PartialValue::Cid(c) => DbValueV1::Cid(DbCidV1 {
                 d: c.d_uuid,
                 s: c.s_uuid,
                 t: c.ts,
             }),
-            PartialValue::Nsuniqueid(s) => DbValueV1::NU(s.clone()),
+            PartialValue::Nsuniqueid(s) => DbValueV1::NsUniqueId(s.clone()),
             PartialValue::DateTime(odt) => {
                 debug_assert!(odt.offset() == time::UtcOffset::UTC);
-                DbValueV1::DT(odt.format(time::Format::Rfc3339))
+                DbValueV1::DateTime(odt.format(time::Format::Rfc3339))
             }
-            PartialValue::EmailAddress(mail) => {
-                DbValueV1::EM(DbValueEmailAddressV1 { d: mail.clone() })
-            }
+            PartialValue::EmailAddress(mail) => DbValueV1::EmailAddress(DbValueEmailAddressV1 {
+                email_addr: mail.clone(),
+            }),
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/kanidm/kanidm/issues/473

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

How do I check that the shortened names are actually what's getting serialized, and not the variant names directly? Also, There are some fields that I still can't infer the meaning of, help appreciated :)