### PR TITLE
`kanidm_tools` cleanup

### DIFF
--- a/kanidm_tools/src/badlist_preprocess.rs
+++ b/kanidm_tools/src/badlist_preprocess.rs
@@ -70,14 +70,11 @@ fn main() {
             }
         };
         let mut contents = String::new();
-        match file.read_to_string(&mut contents) {
-            Ok(_) => {}
-            Err(e) => {
-                error!("{:?} -> {:?}", f, e);
-                continue;
-            }
+        if let Err(e) = file.read_to_string(&mut contents) {
+            error!("{:?} -> {:?}", f, e);
+            continue;
         }
-        let mut inner_pw: Vec<_> = contents.as_str().lines().map(|s| s.to_string()).collect();
+        let mut inner_pw: Vec<_> = contents.as_str().lines().map(str::to_string).collect();
         pwset.append(&mut inner_pw);
     }
 

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -423,14 +423,13 @@ impl AccountOpt {
                 }
                 AccountValidity::ExpireAt(ano) => {
                     let client = ano.copt.to_client();
-                    if ano.datetime == "never" || ano.datetime == "clear" {
+                    if matches!(ano.datetime.as_str(), "never" | "clear") {
                         // Unset the value
-                        if let Err(e) = client
+                        match client
                             .idm_account_purge_attr(ano.aopts.account_id.as_str(), "account_expire")
                         {
-                            eprintln!("Error -> {:?}", e)
-                        } else {
-                            println!("Success")
+                            Err(e) => eprintln!("Error -> {:?}", e),
+                            _ => println!("Success"),
                         }
                     } else {
                         if let Err(e) =
@@ -440,31 +439,26 @@ impl AccountOpt {
                             return;
                         }
 
-                        if let Err(e) = client.idm_account_set_attr(
+                        match client.idm_account_set_attr(
                             ano.aopts.account_id.as_str(),
                             "account_expire",
                             &[ano.datetime.as_str()],
                         ) {
-                            eprintln!("Error -> {:?}", e);
-                        } else {
-                            println!("Success")
+                            Err(e) => eprintln!("Error -> {:?}", e),
+                            _ => println!("Success"),
                         }
                     }
                 }
                 AccountValidity::BeginFrom(ano) => {
                     let client = ano.copt.to_client();
-                    if ano.datetime == "any"
-                        || ano.datetime == "clear"
-                        || ano.datetime == "whenever"
-                    {
+                    if matches!(ano.datetime.as_str(), "any" | "clear" | "whenever") {
                         // Unset the value
-                        if let Err(e) = client.idm_account_purge_attr(
+                        match client.idm_account_purge_attr(
                             ano.aopts.account_id.as_str(),
                             "account_valid_from",
                         ) {
-                            eprintln!("Error -> {:?}", e)
-                        } else {
-                            println!("Success")
+                            Err(e) => eprintln!("Error -> {:?}", e),
+                            _ => println!("Success"),
                         }
                     } else {
                         // Attempt to parse and set
@@ -475,14 +469,13 @@ impl AccountOpt {
                             return;
                         }
 
-                        if let Err(e) = client.idm_account_set_attr(
+                        match client.idm_account_set_attr(
                             ano.aopts.account_id.as_str(),
                             "account_valid_from",
                             &[ano.datetime.as_str()],
                         ) {
-                            eprintln!("Error -> {:?}", e);
-                        } else {
-                            println!("Success")
+                            Err(e) => eprintln!("Error -> {:?}", e),
+                            _ => println!("Success"),
                         }
                     }
                 }

--- a/kanidm_tools/src/cli/group.rs
+++ b/kanidm_tools/src/cli/group.rs
@@ -25,9 +25,7 @@ impl GroupOpt {
                 let client = copt.to_client();
                 match client.idm_group_list() {
                     Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
-                    Err(e) => {
-                        eprintln!("Error -> {:?}", e);
-                    }
+                    Err(e) => eprintln!("Error -> {:?}", e),
                 }
             }
             GroupOpt::Get(gcopt) => {
@@ -62,14 +60,12 @@ impl GroupOpt {
                 match client.idm_group_get_members(gcopt.name.as_str()) {
                     Ok(Some(groups)) => groups.iter().for_each(|m| println!("{:?}", m)),
                     Ok(None) => {}
-                    Err(e) => {
-                        eprintln!("Error -> {:?}", e);
-                    }
+                    Err(e) => eprintln!("Error -> {:?}", e),
                 }
             }
             GroupOpt::AddMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
-                let new_members: Vec<&str> = gcopt.members.iter().map(|s| s.as_str()).collect();
+                let new_members: Vec<&str> = gcopt.members.iter().map(String::as_str).collect();
 
                 if let Err(e) = client.idm_group_add_members(gcopt.name.as_str(), &new_members) {
                     eprintln!("Error -> {:?}", e);
@@ -78,7 +74,7 @@ impl GroupOpt {
 
             GroupOpt::RemoveMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
-                let remove_members: Vec<&str> = gcopt.members.iter().map(|s| s.as_str()).collect();
+                let remove_members: Vec<&str> = gcopt.members.iter().map(String::as_str).collect();
 
                 if let Err(e) =
                     client.idm_group_remove_members(gcopt.name.as_str(), &remove_members)
@@ -89,7 +85,7 @@ impl GroupOpt {
 
             GroupOpt::SetMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
-                let new_members: Vec<&str> = gcopt.members.iter().map(|s| s.as_str()).collect();
+                let new_members: Vec<&str> = gcopt.members.iter().map(String::as_str).collect();
 
                 if let Err(e) = client.idm_group_set_members(gcopt.name.as_str(), &new_members) {
                     eprintln!("Error -> {:?}", e);

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -101,16 +101,10 @@ impl KanidmClientOpt {
 
 pub(crate) fn password_prompt(prompt: &str) -> Option<String> {
     for _ in 0..3 {
-        let password = match rpassword::prompt_password_stderr(prompt) {
-            Ok(p) => p,
-            Err(_e) => return None,
-        };
+        let password = rpassword::prompt_password_stderr(prompt).ok()?;
 
         let password_confirm =
-            match rpassword::prompt_password_stderr("Retype the new password to confirm: ") {
-                Ok(p) => p,
-                Err(_e) => return None,
-            };
+            rpassword::prompt_password_stderr("Retype the new password to confirm: ").ok()?;
 
         if password == password_confirm {
             return Some(password);

--- a/kanidm_tools/src/cli/raw.rs
+++ b/kanidm_tools/src/cli/raw.rs
@@ -13,8 +13,7 @@ fn read_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T, Box<dyn 
     let f = File::open(path)?;
     let r = BufReader::new(f);
 
-    let t: T = serde_json::from_reader(r)?;
-    Ok(t)
+    Ok(serde_json::from_reader(r)?)
 }
 
 impl RawOpt {
@@ -42,9 +41,7 @@ impl RawOpt {
 
                 match client.search(filter) {
                     Ok(rset) => rset.iter().for_each(|e| println!("{}", e)),
-                    Err(e) => {
-                        eprintln!("Error -> {:?}", e);
-                    }
+                    Err(e) => eprintln!("Error -> {:?}", e),
                 }
             }
             RawOpt::Create(copt) => {


### PR DESCRIPTION
Fixes #my desire to have clean code

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

I realize this is not a very fun PR to review, but I wanted an excuse to dig through the code and clean up things. 

90% of the changes are:
* Changing basic closures in `map`s like `|s: &str| s.to_string()` to `str::to_string`.
* Adding in `unwrap_or_else` statements where appropriate.
* Removing type hints that were guaranteed unnecessary.

This passes all tests and clippy, and I also made sure to not wrap any `return`, `continue`, or `break` statements in closures.