### PR TITLE
Arc cachesize warning fixes

### DIFF
--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -901,7 +901,8 @@ impl IdlArcSqlite {
             None => {
                 // For now I've noticed about 20% of the number of entries
                 // works well, but it may not be perfect ...
-                db.get_allids_count(audit)
+                let tmpsize = db
+                    .get_allids_count(audit)
                     .map(|c| {
                         (if c > 0 {
                             // We want one fifth of this.
@@ -910,7 +911,13 @@ impl IdlArcSqlite {
                             c
                         }) as usize
                     })
-                    .unwrap_or(DEFAULT_CACHE_TARGET)
+                    .unwrap_or(DEFAULT_CACHE_TARGET);
+                // if our calculation's too small anyway, just set it to the minimum target
+                if tmpsize < DEFAULT_CACHE_TARGET {
+                    DEFAULT_CACHE_TARGET
+                } else {
+                    tmpsize
+                }
             }
         };
 
@@ -918,7 +925,8 @@ impl IdlArcSqlite {
             cache_size = DEFAULT_CACHE_TARGET;
             ladmin_warning!(
                 audit,
-                "Arc Cache size too low - setting to {} ...",
+                "Configured Arc Cache size too low {} - setting to {} ...",
+                &cache_size,
                 DEFAULT_CACHE_TARGET
             );
         }

--- a/kanidmd/src/lib/ldap.rs
+++ b/kanidmd/src/lib/ldap.rs
@@ -474,7 +474,7 @@ fn ldap_domain_to_dc(input: &str) -> String {
     input.split('.').for_each(|dc| {
         output.push_str("dc=");
         output.push_str(dc);
-        #[allow(clippy::single_char_pattern)]
+        #[allow(clippy::single_char_pattern, clippy::single_char_add_str)]
         output.push_str(",");
     });
     // Remove the last ','


### PR DESCRIPTION
This sets the Arc cache size to the default if it's not configured and the auto-calculation says it's too small anyway. Saves an admin warning on startup that is confusing. 😄 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
