### PR TITLE
Removed `OperationResponse`

### DIFF
--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -659,20 +659,17 @@ impl KanidmAsyncClient {
 
     pub async fn create(&self, entries: Vec<Entry>) -> Result<(), ClientError> {
         let c = CreateRequest { entries };
-        let r: Result<OperationResponse, _> = self.perform_post_request("/v1/raw/create", c).await;
-        r.map(|_| ())
+        self.perform_post_request("/v1/raw/create", c).await
     }
 
     pub async fn modify(&self, filter: Filter, modlist: ModifyList) -> Result<(), ClientError> {
         let mr = ModifyRequest { filter, modlist };
-        let r: Result<OperationResponse, _> = self.perform_post_request("/v1/raw/modify", mr).await;
-        r.map(|_| ())
+        self.perform_post_request("/v1/raw/modify", mr).await
     }
 
     pub async fn delete(&self, filter: Filter) -> Result<(), ClientError> {
         let dr = DeleteRequest { filter };
-        let r: Result<OperationResponse, _> = self.perform_post_request("/v1/raw/delete", dr).await;
-        r.map(|_| ())
+        self.perform_post_request("/v1/raw/delete", dr).await
     }
 
     // === idm actions here ==
@@ -702,9 +699,7 @@ impl KanidmAsyncClient {
         new_group
             .attrs
             .insert("name".to_string(), vec![name.to_string()]);
-        self.perform_post_request("/v1/group", new_group)
-            .await
-            .map(|_: OperationResponse| ())
+        self.perform_post_request("/v1/group", new_group).await
     }
 
     pub async fn idm_group_set_members(
@@ -791,18 +786,14 @@ impl KanidmAsyncClient {
         new_acct
             .attrs
             .insert("displayname".to_string(), vec![dn.to_string()]);
-        self.perform_post_request("/v1/account", new_acct)
-            .await
-            .map(|_: OperationResponse| ())
+        self.perform_post_request("/v1/account", new_acct).await
     }
 
     pub async fn idm_account_set_password(&self, cleartext: String) -> Result<(), ClientError> {
         let s = SingleStringRequest { value: cleartext };
 
-        let r: Result<OperationResponse, _> = self
-            .perform_post_request("/v1/self/_credential/primary/set_password", s)
-            .await;
-        r.map(|_| ())
+        self.perform_post_request("/v1/self/_credential/primary/set_password", s)
+            .await
     }
 
     pub async fn idm_account_set_displayname(&self, id: &str, dn: &str) -> Result<(), ClientError> {

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -438,15 +438,6 @@ impl ModifyList {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct OperationResponse {}
-
-impl OperationResponse {
-    pub fn new(_: ()) -> Self {
-        OperationResponse {}
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct SearchRequest {
     pub filter: Filter,
 }


### PR DESCRIPTION
Fixes #484 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

This is going to have some minor conflicts with https://github.com/kanidm/kanidm/pull/485, just a heads up.