### PR TITLE
`tracing` for `kanidmd/src/lib/plugins/memberof.rs`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@
 * Samuel Cabrero (scabrero)
 * Victor Wai (vcwai)
 * James Hodgkinson (yaleman)
+* Quinn Okabayashi (QnnOkabayashi)
 
 ## Acknowledgements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1788,8 @@ dependencies = [
  "tokio-openssl",
  "tokio-util",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "users",
  "uuid",
@@ -2018,6 +2029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 dependencies = [
  "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2707,6 +2727,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -3056,6 +3079,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shellexpand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tide"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,7 +3579,19 @@ checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.6",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3548,6 +3601,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -89,7 +89,7 @@ smartstring = { version = "0.2", features = ["serde"] }
 validator = { version = "0.13" }
 
 tracing = "0.1.26"
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.2.19"
 
 [features]
 simd_support = [ "concread/simd_support" ]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -88,6 +88,9 @@ smartstring = { version = "0.2", features = ["serde"] }
 
 validator = { version = "0.13" }
 
+tracing = "0.1.26"
+tracing-subscriber = "0.2.18"
+
 [features]
 simd_support = [ "concread/simd_support" ]
 # default = [ "libsqlite3-sys/bundled", "openssl/vendored" ]

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -81,3 +81,4 @@ pub mod prelude {
     pub use crate::value::{IndexType, PartialValue, SyntaxType, Value};
 }
 pub mod logbuffer;
+pub mod subscriber;

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -59,7 +59,7 @@ mod status;
 pub mod config;
 pub mod core;
 
-/// A prelude of imports that should be imported by all other Kanid modules to
+/// A prelude of imports that should be imported by all other Kanidm modules to
 /// help make imports cleaner.
 pub mod prelude {
     pub use crate::utils::duration_from_epoch_now;
@@ -80,3 +80,4 @@ pub mod prelude {
     };
     pub use crate::value::{IndexType, PartialValue, SyntaxType, Value};
 }
+pub mod logbuffer;

--- a/kanidmd/src/lib/logbuffer.rs
+++ b/kanidmd/src/lib/logbuffer.rs
@@ -1,0 +1,68 @@
+use std::{io, ops};
+use tracing_subscriber::fmt::MakeWriter;
+
+// This type may be moved out of `kanidmd` later
+#[derive(Default)]
+pub struct LogBuffer {
+    buf: Vec<u8>,
+}
+
+// An "owned" type pointing to a buffer in a
+// `LogBuffer`. This type exists to satisfy the
+// `MakeWriter` trait restriction on `make_writer`,
+// which must return an owned `io::Write` object.
+// The benefit of using a raw ptr is that creating this
+// object of very cheap and fast, and unless `Subscriber`s
+// are opening a new thread of each log (I don't think they are),
+// this will never cross a thread boundry.
+pub struct LogBufferWriter(*mut Vec<u8>);
+
+impl ops::Drop for LogBuffer {
+    fn drop(&mut self) {
+        // logs are written to stderr when dropped
+        use io::Write;
+        #[allow(clippy::expect_used)]
+        io::stderr()
+            .write_all(&self.buf)
+            .expect("Failed to write logs")
+    }
+}
+
+impl MakeWriter for LogBuffer {
+    type Writer = LogBufferWriter;
+
+    fn make_writer(&self) -> Self::Writer {
+        LogBufferWriter(&self.buf as *const _ as *mut _)
+    }
+}
+
+impl LogBufferWriter {
+    fn get_buffer(&mut self) -> &mut Vec<u8> {
+        // SAFETY:
+        //
+        // `LogBufferWriter`s are logical references to a
+        // `LogBuffer`, which is held for the entire duration
+        // of a `Subscriber`. A `LogBufferWriter` is only held
+        // for the duration of a `write` call, which is shorter
+        // than the lifetime of the `Subscriber` that created it.
+        // Therefore, the data behind the ptr will always be safe.
+        //
+        // I think this is concurrency safe, because I'm pretty sure
+        // `Subscriber`s aren't sending each log to a new thread.
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl io::Write for LogBufferWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.get_buffer().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.get_buffer().flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.get_buffer().write_all(buf)
+    }
+}

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -241,6 +241,7 @@ macro_rules! run_create_test {
         use crate::schema::Schema;
         use crate::utils::duration_from_epoch_now;
         use crate::logbuffer::LogBuffer;
+        use crate::subscriber::KaniSubscriber;
 
         use tracing::{self, Level};
         use tracing_subscriber::FmtSubscriber;
@@ -270,6 +271,9 @@ macro_rules! run_create_test {
             })
 
             .finish();
+
+        let _ = subscriber;
+        let subscriber = KaniSubscriber::new();
 
         tracing::subscriber::with_default(subscriber, || {
             let mut au = AuditScope::new("run_create_test", uuid::Uuid::new_v4(), None);

--- a/kanidmd/src/lib/subscriber.rs
+++ b/kanidmd/src/lib/subscriber.rs
@@ -1,0 +1,154 @@
+use tracing::{
+    span::{Attributes, Record},
+    Event, Id, Metadata, Subscriber,
+};
+use tracing_subscriber::{
+    layer::{Context, Layered, SubscriberExt as _},
+    registry::Registry,
+    Layer,
+};
+
+pub struct KaniSubscriber {
+    inner: Layered<KaniLayer, Registry>,
+}
+
+pub struct KaniLayer;
+
+// This could be a DST since it gets boxed internally.
+// Feel like that might be overengineering things a bit though.
+// Also everything about this type is very temporary.
+pub struct KaniLogBuffer {
+    path: String, // the string containing the spans it's wrapped in?
+    // this is poorly designed but hopefully works
+    buf: Vec<String>,
+}
+
+impl Layer<Registry> for KaniLayer {
+    fn new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<Registry>) {
+        ctx.span(id)
+            .expect("the span doesn't exist even though we just made it??")
+            .extensions_mut()
+            .insert(KaniLogBuffer::new(/* ctx stuff here */));
+
+        let _ = attrs;
+    }
+
+    fn on_event(&self, event: &Event, ctx: Context<Registry>) {
+        // How can I make it so that this wraps one of `tracing_subscriber`s
+        // preexisting formatting utilities?
+        // I don't want to do the formatting by myself ;(
+        let span = match ctx.lookup_current() {
+            Some(span) => span,
+            _ => {
+                // We're not in any spans, do we still care about the log?
+                // Let's just ignore it for now and short-circuit.
+                return;
+            }
+        };
+
+        // `extensions_mut` returns an `ExtensionsMut`, which is essentially a
+        // wrapping for the `AnyMap` type offered in https://docs.rs/anymap/0.12.1/anymap/
+        let mut ext_mut = span.extensions_mut();
+
+        let logbuf = ext_mut
+            .get_mut::<KaniLogBuffer>()
+            .expect("doesn't have a logbuf even though we initialized one?");
+
+        // TODO: use some formatter to transform this event into a nice string
+        let event_string = format!("{:?}", event);
+
+        logbuf.log(event_string);
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<Registry>) {
+        let span = ctx.span(id).expect("how is the span not in ctx?");
+
+        let mut ext_mut = span.extensions_mut();
+
+        let logs = ext_mut
+            // We can take the `KaniLogBuffer` here because we're done with it
+            .remove::<KaniLogBuffer>()
+            .expect("doesn't have a logbuf even though we initialized one?")
+            .dump();
+
+        match span.parent() {
+            Some(parent) => {
+                // There exists a parent span
+                // Write to parent
+                let mut ext_mut = parent.extensions_mut();
+
+                ext_mut
+                    .get_mut::<KaniLogBuffer>()
+                    .expect("has to be here")
+                    .log(logs);
+            }
+            None => {
+                // There is no parent span
+                // Write to `stderr`
+                eprintln!("{}", logs);
+            }
+        }
+    }
+}
+
+impl KaniLogBuffer {
+    pub fn new() -> Self {
+        let mut logbuf = KaniLogBuffer {
+            // TODO: use ctx to get information about what this should be
+            path: "a path".to_string(),
+            buf: vec![],
+        };
+        // TODO: update this to use the ctx to get span information
+        logbuf.log(format!("INFO: {}: OPENED", logbuf.path));
+        logbuf
+    }
+
+    pub fn log(&mut self, event: String) {
+        self.buf.push(event)
+    }
+
+    pub fn dump(mut self) -> String {
+        // TODO: update this to use the ctx to get span information
+        self.log(format!("INFO: {}: CLOSED", self.path));
+        self.buf.join("\n")
+    }
+}
+
+impl KaniSubscriber {
+    pub fn new() -> Self {
+        println!("OOGA NEW SUBSCRIBER");
+        KaniSubscriber {
+            inner: Registry::default().with(KaniLayer),
+        }
+    }
+}
+
+impl Subscriber for KaniSubscriber {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn new_span(&self, span: &Attributes) -> Id {
+        self.inner.new_span(span)
+    }
+
+    fn record(&self, span: &Id, values: &Record) {
+        self.inner.record(span, values)
+    }
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        self.inner.record_follows_from(span, follows)
+    }
+
+    fn event(&self, event: &Event) {
+        self.inner.event(event)
+    }
+
+    fn enter(&self, span: &Id) {
+        self.inner.enter(span)
+    }
+
+    fn exit(&self, span: &Id) {
+        self.inner.exit(span)
+    }
+}


### PR DESCRIPTION
Fixes #453

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

An implementation sample for the [`tracing`](https://docs.rs/tracing/0.1.26/tracing) crate in `memberof.rs`. This PR is intended to illustrate two key points:
* `tracing`s first-class logging capabilities. It has a ton of features that we can use universally in Kanidm, allowing us to remove boilerplate code that we currently use to handle logging like `AuditScope`.
* The `LogBuffer` type, which is compatible with `tracing` and allows us to capture logs in memory to avoid `stderr` locking, and write them all at once.

Notes:
My initial changes only have an effect on the first test in `memberof.rs`. It can be tested with:
```
cargo test --package kanidm --lib -- plugins::memberof::tests::test_create_mo_single --exact --nocapture > out.log 2> err.log
```
Additionally, the `tracing` logs have been added in parallel to the existing `AuditScope` logs. I hope to eventually have it completely replace them before this gets merged.