### PR TITLE
Change default totp to sha256

### DIFF
--- a/kanidmd/src/lib/credential/totp.rs
+++ b/kanidmd/src/lib/credential/totp.rs
@@ -105,7 +105,7 @@ impl Totp {
     pub fn generate_secure(step: u64) -> Self {
         let mut rng = rand::thread_rng();
         let secret: Vec<u8> = (0..SECRET_SIZE_BYTES).map(|_| rng.gen()).collect();
-        let algo = TotpAlgo::Sha512;
+        let algo = TotpAlgo::Sha256;
         Totp { secret, step, algo }
     }
 


### PR DESCRIPTION
Fixes #501 - change default totp algo to sha256 which is as secure and has broad compatability. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
