### PR TITLE
Add statistical analysis to indexes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,5 @@
 ## Acknowledgements
 
 * M. Gerstner
+* Perri Boulton
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
 name = "kanidm"
 version = "1.1.0-alpha.4"
 dependencies = [
+ "ahash 0.7.4",
  "async-h1",
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,6 @@ dependencies = [
 name = "kanidm"
 version = "1.1.0-alpha.4"
 dependencies = [
- "ahash 0.7.4",
  "async-h1",
  "async-std",
  "async-trait",

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -1022,7 +1022,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
             let mean = data
                 .iter()
                 .take(u32::MAX as usize)
-                .fold(0.0, |acc, x| x + acc)
+                .sum::<f64>()
                 / c;
             let varience: f64 = data.iter().take(u32::MAX as usize).fold(0.0, |acc, i| {
                 let diff = mean - i;

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -2,16 +2,22 @@ use crate::audit::AuditScope;
 use crate::be::idl_sqlite::{
     IdlSqlite, IdlSqliteReadTransaction, IdlSqliteTransaction, IdlSqliteWriteTransaction,
 };
-use crate::be::idxkey::{IdlCacheKey, IdlCacheKeyRef, IdlCacheKeyToRef};
+use crate::be::idxkey::{
+    IdlCacheKey, IdlCacheKeyRef, IdlCacheKeyToRef, IdxKey, IdxKeyRef, IdxKeyToRef, IdxSlope,
+};
 use crate::be::{BackendConfig, IdList, IdRawEntry};
 use crate::entry::{Entry, EntryCommitted, EntrySealed};
 use crate::value::IndexType;
 use crate::value::Value;
+
 use concread::arcache::{ARCache, ARCacheReadTxn, ARCacheWriteTxn};
 use concread::cowcell::*;
 use idlset::{v2::IDLBitRange, AndNot};
 use kanidm_proto::v1::{ConsistencyError, OperationError};
+
+use hashbrown::HashMap;
 use std::collections::BTreeSet;
+use std::convert::TryInto;
 use std::ops::DerefMut;
 use std::time::Duration;
 use uuid::Uuid;
@@ -798,6 +804,256 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
                 }
             }
         })
+    }
+
+    pub fn is_idx_slopeyness_generated(
+        &self,
+        audit: &mut AuditScope,
+    ) -> Result<bool, OperationError> {
+        self.db.is_idx_slopeyness_generated(audit)
+    }
+
+    pub fn get_idx_slope(
+        &self,
+        audit: &mut AuditScope,
+        ikey: &IdxKey,
+    ) -> Result<Option<IdxSlope>, OperationError> {
+        self.db.get_idx_slope(audit, ikey)
+    }
+
+    /// Index Slope Analysis. For the purpose of external modules you can consider this as a
+    /// module that generates "weights" for each index that we have. Smaller values are faster
+    /// indexes - larger values are more costly ones. This is not intended to yield perfect
+    /// weights. The intent is to seperate over obviously more effective indexes rather than
+    /// to min-max the fine tuning of these. Consider name=foo vs class=*. name=foo will always
+    /// be better than class=*, but comparing name=foo to spn=foo is "much over muchness" since
+    /// both are really fast.
+    pub fn analyse_idx_slopes(&mut self, audit: &mut AuditScope) -> Result<(), OperationError> {
+        /*
+         * Inside of this analysis there are two major factors we need to understand
+         *
+         * * What is the variation of idl lengths within an index?
+         * * How man keys are stored in this index?
+         *
+         * Since we have the filter2idl threshold, we want to find "what is the smallest
+         * and most unique index asap so we can exit faster". This allows us to avoid
+         * loading larger most costly indexs that either have large idls, high variation
+         * or few keys and are likely to miss and have to go out to disk.
+         *
+         * A few methods were proposed, but thanks to advice from a Psychology researcher
+         * and statistics enthustiast, we were able to device a reasonable approach.
+         *
+         * These are commented in line to help understand the process.
+         */
+
+        /*
+         * Step 1 - we have an index like "idx_eq_member". It has data that looks somewhat
+         * like:
+         *
+         *  key    | idl
+         *  -------+------------
+         *  uuid_a | [1, 2, 3, ...]
+         *  -------+------------
+         *  uuid_b | [4, 5, 6, ...]
+         *
+         * We need to collect this into a single vec of "how long is each idl". Since we have
+         * each idl in the vec, the length of the vec is also the number of keys in the set.
+         * This yields for us:
+         *
+         *   idx_eq_member: [4.0, 5.0, ...]
+         * where each f64 value is the float representation of the length of idl.
+         *
+         * We then assemble these to a map so we have each idxkey and it's associated list
+         * of idl lens.
+         */
+
+        let mut data: HashMap<IdxKey, Vec<f64>> = HashMap::new();
+        self.idl_cache.iter_dirty().for_each(|(k, maybe_idl)| {
+            if let Some(idl) = maybe_idl {
+                let idl_len: u32 = idl.len().try_into().unwrap_or(u32::MAX);
+                // Convert to something we can use.
+                let idl_len = f64::from(idl_len);
+
+                let kref = IdxKeyRef::new(&k.a, &k.i);
+                if idl_len > 0.0 {
+                    // It's worth looking at. Anything len 0 will be removed.
+                    if let Some(lens) = data.get_mut(&kref as &dyn IdxKeyToRef) {
+                        lens.push(idl_len)
+                    } else {
+                        data.insert(kref.to_key(), vec![idl_len]);
+                    }
+                }
+            }
+        });
+
+        /*
+        * So now for each of our sets:
+        *
+        *   idx_eq_member: [4.0, 5.0, ...]
+        *   idx_eq_name  : [1.0, 1.0, 1.0, ...]
+        *
+        * To get the variability, we calculate the normal distribution of the set of values
+        * and then using this variance we use the 1st deviation (~85%) value to assert that
+        * 85% or more of the values in this set will be "equal or less" than this length.*
+        *
+        * So given say:
+        *  [1.0, 1.0, 1.0, 1.0]
+        * We know that the sd_1 will be 1.0. Given:
+        *  [1.0, 1.0, 2.0, 3.0]
+        * We know that it will be ~2.57 (mean 1.75 + sd of 0.82).
+        *
+        * The other factor is number of keys. This is thankfully easy! We have that from
+        * vec.len().
+        *
+        * We can now calculate the index slope. Why is it a slope you ask? Because we
+        * plot the data out on a graph, with "variability" on the y axis, and number of
+        * keys on the x.
+        *
+        * Lets plot our data we just added.
+        *
+        *    |
+        *  4 +
+        *    |
+        *  3 +
+        *    |
+        *  2 +           *  eq_member
+        *    |
+        *  1 +           *  eq_name
+        *    |
+        *    +--+--+--+--+--
+        *       1  2  3  4
+        *
+        * Now, if we were to connect a line from (0,0) to each point we get a line with an angle.
+        *
+        *    |
+        *  4 +
+        *    |
+        *  3 +
+        *    |
+        *  2 +           *  eq_member
+        *    |
+        *  1 +           *  eq_name
+        *    |/---------/
+        *    +--+--+--+--+--
+        *       1  2  3  4
+
+        *    |
+        *  4 +
+        *    |
+        *  3 +
+        *    |
+        *  2 +           *  eq_member
+        *    |        /--/
+        *  1 +    /--/   *  eq_name
+        *    |/--/
+        *    +--+--+--+--+--
+        *       1  2  3  4
+        *
+        * (Look it's ascii art, don't judge.).
+        *
+        * Point is that eq_member is "steeper" and eq_name is "shallower". This is what we call
+        * the "slopeyness" aka the jank of the line, or more precisely, the angle.
+        *
+        * Now we need a way to numerically compare these lines. Since the points could be
+        * anywere on our graph:
+        *
+        *    |
+        *  4 +  *
+        *    |
+        *  3 +         *
+        *    |
+        *  2 +     *
+        *    |
+        *  1 +           *
+        *    |
+        *    +--+--+--+--+--
+        *       1  2  3  4
+        *
+        * While we can see what's obvious or best here, a computer has to know it. So we now
+        * assume that these points construct a triangle, going through (0,0), (x, 0) and (x, y).
+        *
+        *
+        *                Λ│
+        *               ╱ │
+        *              ╱  │
+        *             ╱   │
+        *            ╱    │
+        *           ╱     │
+        *          ╱      │
+        *         ╱       │ sd_1
+        *        ╱        │
+        *       ╱         │
+        *      ───────────┼
+        *         nkeys
+        *
+        * Since this is right angled we can use arctan to work out the degress of the line. This
+        * gives us a value from 1.0 to 90.0 (We clamp to a minimum of 1.0, but really 0.0 would
+        * be okay).
+        *
+        * The problem is that we have to go from float to u8 - this means we lose decimal precision
+        * in the conversion. To lessen this, we multiply by 2 to give some extra weight to each angle
+        * to minimise this loss and then we convert.
+        *
+        * And there we have it! A slope factor of the index! A way to compare these sets quickly
+        * at query optimisation time to minimse index access.
+        */
+        let slopes: HashMap<_, _> = data
+            .into_iter()
+            .filter_map(|(k, lens)| {
+                let slope_factor = Self::calculate_sd_slope(lens);
+                if slope_factor == 0 {
+                    None
+                } else {
+                    Some((k, slope_factor))
+                }
+            })
+            .collect();
+        ltrace!(audit, "Generated slopes -> {:?}", slopes);
+        // Write the data down
+        self.db.store_idx_slope_analysis(audit, &slopes)
+    }
+
+    fn calculate_sd_slope(data: Vec<f64>) -> IdxSlope {
+        let (n_keys, sd_1) = if data.len() >= 2 {
+            // We can only do SD on sets greater than 2
+            let l: u32 = data.len().try_into().unwrap_or(u32::MAX);
+            let c = f64::from(l);
+            let mean = data
+                .iter()
+                .take(u32::MAX as usize)
+                .fold(0.0, |acc, x| x + acc)
+                / c;
+            let varience: f64 = data.iter().take(u32::MAX as usize).fold(0.0, |acc, i| {
+                let diff = mean - i;
+                acc + (diff * diff)
+            }) / (c - 1.0);
+            let sd = varience.sqrt();
+
+            // This is saying ~85% of values will be at least this len or less.
+            let sd_1 = mean + sd;
+            (c, sd_1)
+        } else if data.len() == 1 {
+            (1.0, data[0])
+        } else {
+            // Cant resolve.
+            return IdxSlope::MAX;
+        };
+
+        // Now we know sd_1 and number of keys. We can use this as a triangle to work out
+        // the angle along the hypotenuse. We use this angle - or slope - to show which
+        // elements have the smallest sd_1 and most keys available. Then because this
+        // is bound between 0.0 -> 90.0, we "unfurl" this around a half circle by multipling
+        // by 2. This gives us a little more precision when we drop the decimal point.
+        let sf = (sd_1 / n_keys).atan().to_degrees() * 2.0;
+
+        // Now these are fractions, and we can't use those in u8, so we resolve where this
+        // point would be at 100.
+        let sf = sf.clamp(1.0, 180.0);
+        if !sf.is_finite() {
+            IdxSlope::MAX
+        } else {
+            unsafe { sf.to_int_unchecked::<IdxSlope>() }
+        }
     }
 
     pub fn create_name2uuid(&self, audit: &mut AuditScope) -> Result<(), OperationError> {

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -840,8 +840,9 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
          * loading larger most costly indexs that either have large idls, high variation
          * or few keys and are likely to miss and have to go out to disk.
          *
-         * A few methods were proposed, but thanks to advice from a Psychology researcher
-         * and statistics enthustiast, we were able to device a reasonable approach.
+         * A few methods were proposed, but thanks to advice from Perri Boulton (psychology
+         * researcher with a background in statistics), we were able to device a reasonable
+         * approach.
          *
          * These are commented in line to help understand the process.
          */

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -1054,6 +1054,9 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
         if !sf.is_finite() {
             IdxSlope::MAX
         } else {
+            // SAFETY
+            // `sf` is clamped between 1.0 and 180.0 above, ensuring it is
+            // always in range.
             unsafe { sf.to_int_unchecked::<IdxSlope>() }
         }
     }

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -1024,10 +1024,11 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
                 .take(u32::MAX as usize)
                 .sum::<f64>()
                 / c;
-            let varience: f64 = data.iter().take(u32::MAX as usize).fold(0.0, |acc, i| {
-                let diff = mean - i;
-                acc + (diff * diff)
-            }) / (c - 1.0);
+            let varience: f64 = data.iter().take(u32::MAX as usize).map(|len| {
+                let delta = mean - len;
+                delta * delta
+            }).sum::<f64>() / (c - 1.0);
+
             let sd = varience.sqrt();
 
             // This is saying ~85% of values will be at least this len or less.

--- a/kanidmd/src/lib/be/idxkey.rs
+++ b/kanidmd/src/lib/be/idxkey.rs
@@ -4,12 +4,23 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
+pub type IdxSlope = u8;
+
 // Huge props to https://github.com/sunshowers/borrow-complex-key-example/blob/master/src/lib.rs
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IdxKey {
     pub attr: AttrString,
     pub itype: IndexType,
+}
+
+impl IdxKey {
+    pub fn new(attr: &str, itype: IndexType) -> Self {
+        IdxKey {
+            attr: attr.into(),
+            itype,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -21,6 +32,13 @@ pub struct IdxKeyRef<'a> {
 impl<'a> IdxKeyRef<'a> {
     pub fn new(attr: &'a str, itype: &'a IndexType) -> Self {
         IdxKeyRef { attr, itype }
+    }
+
+    pub fn to_key(&self) -> IdxKey {
+        IdxKey {
+            attr: self.attr.into(),
+            itype: self.itype.clone(),
+        }
     }
 }
 

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -2872,30 +2872,30 @@ mod tests {
             let ta_eq_slope = be
                 .get_idx_slope(audit, &IdxKey::new("ta", IndexType::Equality))
                 .unwrap();
-            assert_eq!(ta_eq_slope, 143);
+            assert_eq!(ta_eq_slope, 200);
 
             let tb_eq_slope = be
                 .get_idx_slope(audit, &IdxKey::new("tb", IndexType::Equality))
                 .unwrap();
-            assert_eq!(tb_eq_slope, 95);
+            assert_eq!(tb_eq_slope, 133);
 
             let name_eq_slope = be
                 .get_idx_slope(audit, &IdxKey::new("name", IndexType::Equality))
                 .unwrap();
-            assert_eq!(name_eq_slope, 36);
+            assert_eq!(name_eq_slope, 51);
             let uuid_eq_slope = be
                 .get_idx_slope(audit, &IdxKey::new("uuid", IndexType::Equality))
                 .unwrap();
-            assert_eq!(uuid_eq_slope, 36);
+            assert_eq!(uuid_eq_slope, 51);
 
             let name_pres_slope = be
                 .get_idx_slope(audit, &IdxKey::new("name", IndexType::Presence))
                 .unwrap();
-            assert_eq!(name_pres_slope, 143);
+            assert_eq!(name_pres_slope, 200);
             let uuid_pres_slope = be
                 .get_idx_slope(audit, &IdxKey::new("uuid", IndexType::Presence))
                 .unwrap();
-            assert_eq!(uuid_pres_slope, 143);
+            assert_eq!(uuid_pres_slope, 200);
         })
     }
 

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -1145,7 +1145,7 @@ impl FilterResolved {
                 // Since we have no index data, we manually configure a reasonable
                 // slope and indicate the presence of some expected basic
                 // indexes.
-                let idx = a == "name" || a == "uuid";
+                let idx = matches!(a, "name" | "uuid");
                 let idx = NonZeroU8::new(idx as u8);
                 Some(FilterResolved::Eq(a, v, idx))
             }

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -147,7 +147,7 @@ enum FilterComp {
 ///
 /// Each filter that has been resolved also has been enriched with metadata about its
 /// index, and index slope. For the purpose of this module, consider slope as a "weight"
-/// where small value - faster index, larger value - slower index. This metadat is extremely
+/// where small value - faster index, larger value - slower index. This metadata is extremely
 /// important for the query optimiser to make decisions about how to re-arrange queries
 /// correctly.
 #[derive(Debug, Clone, Eq)]

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -1145,7 +1145,7 @@ impl FilterResolved {
                 // Since we have no index data, we manually configure a reasonable
                 // slope and indicate the presence of some expected basic
                 // indexes.
-                let idx = matches!(a, "name" | "uuid");
+                let idx = matches!(a.as_str(), "name" | "uuid");
                 let idx = NonZeroU8::new(idx as u8);
                 Some(FilterResolved::Eq(a, v, idx))
             }

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -8,26 +8,29 @@
 //! [`Filter`]: struct.Filter.html
 //! [`Entry`]: ../entry/struct.Entry.html
 
-use crate::be::{IdxKey, IdxKeyRef, IdxKeyToRef, IdxMeta};
+use crate::be::{IdxKey, IdxKeyRef, IdxKeyToRef, IdxMeta, IdxSlope};
 use crate::identity::IdentityId;
 use crate::ldap::ldap_attr_filter_map;
 use crate::prelude::*;
 use crate::schema::SchemaTransaction;
 use crate::value::{IndexType, PartialValue};
-use hashbrown::HashSet;
+use concread::arcache::ARCacheReadTxn;
 use kanidm_proto::v1::Filter as ProtoFilter;
 use kanidm_proto::v1::{OperationError, SchemaError};
 use ldap3_server::proto::{LdapFilter, LdapSubstringFilter};
-// use smartstring::alias::String;
-use concread::arcache::ARCacheReadTxn;
-use smartstring::alias::String as AttrString;
+// use smartstring::alias::String as AttrString;
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::BTreeSet;
 use std::hash::Hash;
 use std::iter;
 use uuid::Uuid;
 
+use hashbrown::HashMap;
+#[cfg(test)]
+use hashbrown::HashSet;
+
 const FILTER_DEPTH_MAX: usize = 16;
+const NO_INDEX_SLOPE: IdxSlope = 50;
 
 // Default filter is safe, ignores all hidden types!
 
@@ -104,8 +107,8 @@ pub fn f_spn_name(id: &str) -> FC<'static> {
     FC::Or(f)
 }
 
-// This is the short-form for tests and internal filters that can then
-// be transformed into a filter for the server to use.
+/// This is the short-form for tests and internal filters that can then
+/// be transformed into a filter for the server to use.
 #[derive(Debug, Deserialize)]
 pub enum FC<'a> {
     Eq(&'a str, PartialValue),
@@ -120,7 +123,7 @@ pub enum FC<'a> {
     // Not(Box<FC>),
 }
 
-// This is the filters internal representation.
+/// This is the filters internal representation
 #[derive(Debug, Clone, Hash, PartialEq, PartialOrd, Ord, Eq)]
 enum FilterComp {
     // This is attr - value
@@ -137,22 +140,28 @@ enum FilterComp {
     // Not(Box<FilterComp>),
 }
 
-// This is the fully resolved internal representation. Note the lack of Not and selfUUID
-// because these are resolved into And(Pres(class), AndNot(term)) and Eq(uuid, ...).
-// Importantly, we make this accessible to Entry so that it can then match on filters
-// properly.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// This is the fully resolved internal representation. Note the lack of Not and selfUUID
+/// because these are resolved into And(Pres(class), AndNot(term)) and Eq(uuid, ...).
+/// Importantly, we make this accessible to Entry so that it can then match on filters
+/// internally.
+///
+/// Each filter that has been resolved also has been enriched with metadata about its
+/// index, and index slope. For the purpose of this module, consider slope as a "weight"
+/// where small value - faster index, larger value - slower index. This metadat is extremely
+/// important for the query optimiser to make decisions about how to re-arrange queries
+/// correctly.
+#[derive(Debug, Clone, Eq)]
 pub enum FilterResolved {
-    // This is attr - value - indexed
-    Eq(AttrString, PartialValue, bool),
-    Sub(AttrString, PartialValue, bool),
-    Pres(AttrString, bool),
-    LessThan(AttrString, PartialValue, bool),
-    Or(Vec<FilterResolved>),
-    And(Vec<FilterResolved>),
+    // This is attr - value - indexed slope factor
+    Eq(AttrString, PartialValue, Option<IdxSlope>),
+    Sub(AttrString, PartialValue, Option<IdxSlope>),
+    Pres(AttrString, Option<IdxSlope>),
+    LessThan(AttrString, PartialValue, Option<IdxSlope>),
+    Or(Vec<FilterResolved>, Option<IdxSlope>),
+    And(Vec<FilterResolved>, Option<IdxSlope>),
     // All terms must have 1 or more items, or the inclusion is false!
-    Inclusion(Vec<FilterResolved>),
-    AndNot(Box<FilterResolved>),
+    Inclusion(Vec<FilterResolved>, Option<IdxSlope>),
+    AndNot(Box<FilterResolved>, Option<IdxSlope>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -904,26 +913,6 @@ impl PartialEq for Filter<FilterValidResolved> {
 */
 
 /*
-impl PartialEq for FilterResolved {
-    fn eq(&self, rhs: &FilterResolved) -> bool {
-        match (self, rhs) {
-            (FilterResolved::Eq(a1, v1, i1), FilterResolved::Eq(a2, v2, i2)) => {
-                a1 == a2 && v1 == v2 && i1 == i2
-            }
-            (FilterResolved::Sub(a1, v1, i1), FilterResolved::Sub(a2, v2, i2)) => {
-                a1 == a2 && v1 == v2 && i1 == i2
-            }
-            (FilterResolved::Pres(a1, i1), FilterResolved::Pres(a2, i2)) => a1 == a2 && i1 == i2,
-            (FilterResolved::And(vs1), FilterResolved::And(vs2)) => vs1 == vs2,
-            (FilterResolved::Or(vs1), FilterResolved::Or(vs2)) => vs1 == vs2,
-            (FilterResolved::AndNot(f1), FilterResolved::AndNot(f2)) => f1 == f2,
-            (_, _) => false,
-        }
-    }
-}
-*/
-
-/*
  * Only needed in tests, in run time order only matters on the inner for
  * optimisation.
  */
@@ -934,8 +923,26 @@ impl PartialOrd for Filter<FilterValidResolved> {
     }
 }
 
-// remember, this isn't ordering by alphanumeric, this is ordering of
-// optimisation preference!
+impl PartialEq for FilterResolved {
+    fn eq(&self, rhs: &FilterResolved) -> bool {
+        match (self, rhs) {
+            (FilterResolved::Eq(a1, v1, _), FilterResolved::Eq(a2, v2, _)) => a1 == a2 && v1 == v2,
+            (FilterResolved::Sub(a1, v1, _), FilterResolved::Sub(a2, v2, _)) => {
+                a1 == a2 && v1 == v2
+            }
+            (FilterResolved::Pres(a1, _), FilterResolved::Pres(a2, _)) => a1 == a2,
+            (FilterResolved::LessThan(a1, v1, _), FilterResolved::LessThan(a2, v2, _)) => {
+                a1 == a2 && v1 == v2
+            }
+            (FilterResolved::And(vs1, _), FilterResolved::And(vs2, _)) => vs1 == vs2,
+            (FilterResolved::Or(vs1, _), FilterResolved::Or(vs2, _)) => vs1 == vs2,
+            (FilterResolved::Inclusion(vs1, _), FilterResolved::Inclusion(vs2, _)) => vs1 == vs2,
+            (FilterResolved::AndNot(f1, _), FilterResolved::AndNot(f2, _)) => f1 == f2,
+            (_, _) => false,
+        }
+    }
+}
+
 impl PartialOrd for FilterResolved {
     fn partial_cmp(&self, rhs: &FilterResolved) -> Option<Ordering> {
         Some(self.cmp(rhs))
@@ -943,41 +950,50 @@ impl PartialOrd for FilterResolved {
 }
 
 impl Ord for FilterResolved {
+    /// Ordering of filters for optimisation and subsequent dead term elimination.
+    ///
     fn cmp(&self, rhs: &FilterResolved) -> Ordering {
-        match (self, rhs) {
-            (FilterResolved::Eq(a1, v1, true), FilterResolved::Eq(a2, v2, true)) => {
-                match a1.cmp(a2) {
-                    Ordering::Equal => v1.cmp(v2),
-                    o => o,
+        let left_slopey = self.get_slopeyness_factor();
+        let right_slopey = rhs.get_slopeyness_factor();
+
+        let r = match (left_slopey, right_slopey) {
+            (Some(sfl), Some(sfr)) => sfl.cmp(&sfr),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        };
+
+        // If they are equal, compare other elements for determining the order. This is what
+        // allows dead term elimination to occur.
+        //
+        // In almost all cases, we'll miss this step though as slopes will vary distinctly.
+        //
+        // We do NOT need to check for indexed vs unindexed here, we already did it in the slope check!
+        if r == Ordering::Equal {
+            match (self, rhs) {
+                (FilterResolved::Eq(a1, v1, _), FilterResolved::Eq(a2, v2, _))
+                | (FilterResolved::Sub(a1, v1, _), FilterResolved::Sub(a2, v2, _))
+                | (FilterResolved::LessThan(a1, v1, _), FilterResolved::LessThan(a2, v2, _)) => {
+                    match a1.cmp(a2) {
+                        Ordering::Equal => v1.cmp(v2),
+                        o => o,
+                    }
                 }
+                (FilterResolved::Pres(a1, _), FilterResolved::Pres(a2, _)) => a1.cmp(a2),
+                // Now sort these into the generally "best" order.
+                (FilterResolved::Eq(_, _, _), _) => Ordering::Less,
+                (_, FilterResolved::Eq(_, _, _)) => Ordering::Greater,
+                (FilterResolved::Pres(_, _), _) => Ordering::Less,
+                (_, FilterResolved::Pres(_, _)) => Ordering::Greater,
+                (FilterResolved::LessThan(_, _, _), _) => Ordering::Less,
+                (_, FilterResolved::LessThan(_, _, _)) => Ordering::Greater,
+                (FilterResolved::Sub(_, _, _), _) => Ordering::Less,
+                (_, FilterResolved::Sub(_, _, _)) => Ordering::Greater,
+                // They can't be re-arranged, they don't move!
+                (_, _) => Ordering::Equal,
             }
-            (FilterResolved::Sub(a1, v1, true), FilterResolved::Sub(a2, v2, true)) => {
-                match a1.cmp(a2) {
-                    Ordering::Equal => v1.cmp(v2),
-                    o => o,
-                }
-            }
-            (FilterResolved::Pres(a1, true), FilterResolved::Pres(a2, true)) => a1.cmp(a2),
-            // Always higher prefer indexed Eq over all else, as these will have
-            // the best indexes and return smallest candidates.
-            (FilterResolved::Eq(_, _, true), _) => Ordering::Less,
-            (_, FilterResolved::Eq(_, _, true)) => Ordering::Greater,
-            (FilterResolved::Pres(_, true), _) => Ordering::Less,
-            (_, FilterResolved::Pres(_, true)) => Ordering::Greater,
-            (FilterResolved::Sub(_, _, true), _) => Ordering::Greater,
-            (_, FilterResolved::Sub(_, _, true)) => Ordering::Less,
-            // Now prefer the unindexed types by performance order.
-            (FilterResolved::Pres(_, false), FilterResolved::Pres(_, false)) => Ordering::Equal,
-            (FilterResolved::Pres(_, false), _) => Ordering::Less,
-            (_, FilterResolved::Pres(_, false)) => Ordering::Greater,
-            (FilterResolved::Eq(_, _, false), FilterResolved::Eq(_, _, false)) => Ordering::Equal,
-            (FilterResolved::Eq(_, _, false), _) => Ordering::Less,
-            (_, FilterResolved::Eq(_, _, false)) => Ordering::Greater,
-            (FilterResolved::Sub(_, _, false), FilterResolved::Sub(_, _, false)) => Ordering::Equal,
-            (FilterResolved::Sub(_, _, false), _) => Ordering::Greater,
-            (_, FilterResolved::Sub(_, _, false)) => Ordering::Less,
-            // They can't be compared, they don't move!
-            (_, _) => Ordering::Equal,
+        } else {
+            r
         }
     }
 }
@@ -987,39 +1003,50 @@ impl FilterResolved {
     unsafe fn from_invalid(fc: FilterComp, idxmeta: &HashSet<(&AttrString, &IndexType)>) -> Self {
         match fc {
             FilterComp::Eq(a, v) => {
-                let idx = idxmeta.contains(&(&a, &IndexType::Equality));
+                let idx = if idxmeta.contains(&(&a, &IndexType::Equality)) {
+                    Some(IdxSlope::MAX)
+                } else {
+                    None
+                };
                 FilterResolved::Eq(a, v, idx)
             }
             FilterComp::Sub(a, v) => {
                 // let idx = idxmeta.contains(&(&a, &IndexType::SubString));
                 // TODO: For now, don't emit substring indexes.
-                let idx = false;
+                let idx = None;
                 FilterResolved::Sub(a, v, idx)
             }
             FilterComp::Pres(a) => {
-                let idx = idxmeta.contains(&(&a, &IndexType::Presence));
+                let idx = if idxmeta.contains(&(&a, &IndexType::Presence)) {
+                    Some(IdxSlope::MAX)
+                } else {
+                    None
+                };
                 FilterResolved::Pres(a, idx)
             }
             FilterComp::LessThan(a, v) => {
                 // let idx = idxmeta.contains(&(&a, &IndexType::ORDERING));
                 // TODO: For now, don't emit ordering indexes.
-                let idx = false;
+                let idx = None;
                 FilterResolved::LessThan(a, v, idx)
             }
             FilterComp::Or(vs) => FilterResolved::Or(
                 vs.into_iter()
                     .map(|v| FilterResolved::from_invalid(v, idxmeta))
                     .collect(),
+                None,
             ),
             FilterComp::And(vs) => FilterResolved::And(
                 vs.into_iter()
                     .map(|v| FilterResolved::from_invalid(v, idxmeta))
                     .collect(),
+                None,
             ),
             FilterComp::Inclusion(vs) => FilterResolved::Inclusion(
                 vs.into_iter()
                     .map(|v| FilterResolved::from_invalid(v, idxmeta))
                     .collect(),
+                None,
             ),
             FilterComp::AndNot(f) => {
                 // TODO: pattern match box here. (AndNot(box f)).
@@ -1027,57 +1054,70 @@ impl FilterResolved {
                 // not today remove the box, and we need f in our ownership. Since
                 // AndNot currently is a rare request, cloning is not the worst thing
                 // here ...
-                FilterResolved::AndNot(Box::new(FilterResolved::from_invalid(
-                    (*f).clone(),
-                    idxmeta,
-                )))
+                FilterResolved::AndNot(
+                    Box::new(FilterResolved::from_invalid((*f).clone(), idxmeta)),
+                    None,
+                )
             }
             FilterComp::SelfUuid => panic!("Not possible to resolve SelfUuid in from_invalid!"),
         }
     }
 
-    fn resolve_idx(fc: FilterComp, ev: &Identity, idxmeta: &HashSet<IdxKey>) -> Option<Self> {
+    fn resolve_idx(
+        fc: FilterComp,
+        ev: &Identity,
+        idxmeta: &HashMap<IdxKey, IdxSlope>,
+    ) -> Option<Self> {
         match fc {
             FilterComp::Eq(a, v) => {
                 let idxkref = IdxKeyRef::new(&a, &IndexType::Equality);
-                let idx = idxmeta.contains(&idxkref as &dyn IdxKeyToRef);
+                let idx = idxmeta.get(&idxkref as &dyn IdxKeyToRef).copied();
                 Some(FilterResolved::Eq(a, v, idx))
             }
+            FilterComp::SelfUuid => ev.get_uuid().map(|uuid| {
+                let uuid_s = AttrString::from("uuid");
+                let idxkref = IdxKeyRef::new(&uuid_s, &IndexType::Equality);
+                let idx = idxmeta.get(&idxkref as &dyn IdxKeyToRef).copied();
+                FilterResolved::Eq(uuid_s, PartialValue::new_uuid(uuid), idx)
+            }),
             FilterComp::Sub(a, v) => {
                 let idxkref = IdxKeyRef::new(&a, &IndexType::SubString);
-                let idx = idxmeta.contains(&idxkref as &dyn IdxKeyToRef);
+                let idx = idxmeta.get(&idxkref as &dyn IdxKeyToRef).copied();
                 Some(FilterResolved::Sub(a, v, idx))
             }
             FilterComp::Pres(a) => {
                 let idxkref = IdxKeyRef::new(&a, &IndexType::Presence);
-                let idx = idxmeta.contains(&idxkref as &dyn IdxKeyToRef);
+                let idx = idxmeta.get(&idxkref as &dyn IdxKeyToRef).copied();
                 Some(FilterResolved::Pres(a, idx))
             }
             FilterComp::LessThan(a, v) => {
                 // let idx = idxmeta.contains(&(&a, &IndexType::SubString));
-                let idx = false;
+                let idx = None;
                 Some(FilterResolved::LessThan(a, v, idx))
             }
+            // We set the compound filters slope factor to "None" here, because when we do
+            // optimise we'll actually fill in the correct slope factors after we sort those
+            // inner terms in a more optimial way.
             FilterComp::Or(vs) => {
                 let fi: Option<Vec<_>> = vs
                     .into_iter()
                     .map(|f| FilterResolved::resolve_idx(f, ev, idxmeta))
                     .collect();
-                fi.map(FilterResolved::Or)
+                fi.map(|fi| FilterResolved::Or(fi, None))
             }
             FilterComp::And(vs) => {
                 let fi: Option<Vec<_>> = vs
                     .into_iter()
                     .map(|f| FilterResolved::resolve_idx(f, ev, idxmeta))
                     .collect();
-                fi.map(FilterResolved::And)
+                fi.map(|fi| FilterResolved::And(fi, None))
             }
             FilterComp::Inclusion(vs) => {
                 let fi: Option<Vec<_>> = vs
                     .into_iter()
                     .map(|f| FilterResolved::resolve_idx(f, ev, idxmeta))
                     .collect();
-                fi.map(FilterResolved::Inclusion)
+                fi.map(|fi| FilterResolved::Inclusion(fi, None))
             }
             FilterComp::AndNot(f) => {
                 // TODO: pattern match box here. (AndNot(box f)).
@@ -1086,43 +1126,53 @@ impl FilterResolved {
                 // AndNot currently is a rare request, cloning is not the worst thing
                 // here ...
                 FilterResolved::resolve_idx((*f).clone(), ev, idxmeta)
-                    .map(|fi| FilterResolved::AndNot(Box::new(fi)))
+                    .map(|fi| FilterResolved::AndNot(Box::new(fi), None))
             }
-            FilterComp::SelfUuid => ev.get_uuid().map(|uuid| {
-                let uuid_s = AttrString::from("uuid");
-                let idxkref = IdxKeyRef::new(&uuid_s, &IndexType::Equality);
-                let idx = idxmeta.contains(&idxkref as &dyn IdxKeyToRef);
-                FilterResolved::Eq(uuid_s, PartialValue::new_uuid(uuid), idx)
-            }),
         }
     }
 
     fn resolve_no_idx(fc: FilterComp, ev: &Identity) -> Option<Self> {
         match fc {
-            FilterComp::Eq(a, v) => Some(FilterResolved::Eq(a, v, false)),
-            FilterComp::Sub(a, v) => Some(FilterResolved::Sub(a, v, false)),
-            FilterComp::Pres(a) => Some(FilterResolved::Pres(a, false)),
-            FilterComp::LessThan(a, v) => Some(FilterResolved::LessThan(a, v, false)),
+            FilterComp::Eq(a, v) => {
+                let idx = if a == "name" || a == "uuid" {
+                    // Since we have no index data, we manually configure a reasonable
+                    // slope for the index here.
+                    Some(NO_INDEX_SLOPE)
+                } else {
+                    None
+                };
+                Some(FilterResolved::Eq(a, v, idx))
+            }
+            FilterComp::SelfUuid => ev.get_uuid().map(|uuid| {
+                FilterResolved::Eq(
+                    AttrString::from("uuid"),
+                    PartialValue::new_uuid(uuid),
+                    Some(NO_INDEX_SLOPE),
+                )
+            }),
+            FilterComp::Sub(a, v) => Some(FilterResolved::Sub(a, v, None)),
+            FilterComp::Pres(a) => Some(FilterResolved::Pres(a, None)),
+            FilterComp::LessThan(a, v) => Some(FilterResolved::LessThan(a, v, None)),
             FilterComp::Or(vs) => {
                 let fi: Option<Vec<_>> = vs
                     .into_iter()
                     .map(|f| FilterResolved::resolve_no_idx(f, ev))
                     .collect();
-                fi.map(FilterResolved::Or)
+                fi.map(|fi| FilterResolved::Or(fi, None))
             }
             FilterComp::And(vs) => {
                 let fi: Option<Vec<_>> = vs
                     .into_iter()
                     .map(|f| FilterResolved::resolve_no_idx(f, ev))
                     .collect();
-                fi.map(FilterResolved::And)
+                fi.map(|fi| FilterResolved::And(fi, None))
             }
             FilterComp::Inclusion(vs) => {
                 let fi: Option<Vec<_>> = vs
                     .into_iter()
                     .map(|f| FilterResolved::resolve_no_idx(f, ev))
                     .collect();
-                fi.map(FilterResolved::Inclusion)
+                fi.map(|fi| FilterResolved::Inclusion(fi, None))
             }
             FilterComp::AndNot(f) => {
                 // TODO: pattern match box here. (AndNot(box f)).
@@ -1131,31 +1181,25 @@ impl FilterResolved {
                 // AndNot currently is a rare request, cloning is not the worst thing
                 // here ...
                 FilterResolved::resolve_no_idx((*f).clone(), ev)
-                    .map(|fi| FilterResolved::AndNot(Box::new(fi)))
+                    .map(|fi| FilterResolved::AndNot(Box::new(fi), None))
             }
-
-            FilterComp::SelfUuid => ev.get_uuid().map(|uuid| {
-                FilterResolved::Eq(
-                    AttrString::from("uuid"),
-                    PartialValue::new_uuid(uuid),
-                    false,
-                )
-            }),
         }
     }
 
     // This is an optimise that only attempts to optimise the outer terms.
     fn fast_optimise(self) -> Self {
         match self {
-            FilterResolved::Inclusion(mut f_list) => {
+            FilterResolved::Inclusion(mut f_list, _) => {
                 f_list.sort_unstable();
                 f_list.dedup();
-                FilterResolved::Inclusion(f_list)
+                let sf = f_list.last().and_then(|f| f.get_slopeyness_factor());
+                FilterResolved::Inclusion(f_list, sf)
             }
-            FilterResolved::And(mut f_list) => {
+            FilterResolved::And(mut f_list, _) => {
                 f_list.sort_unstable();
                 f_list.dedup();
-                FilterResolved::And(f_list)
+                let sf = f_list.first().and_then(|f| f.get_slopeyness_factor());
+                FilterResolved::And(f_list, sf)
             }
             v => v,
         }
@@ -1164,29 +1208,31 @@ impl FilterResolved {
     fn optimise(&self) -> Self {
         // Most optimisations only matter around or/and terms.
         match self {
-            FilterResolved::Inclusion(f_list) => {
+            FilterResolved::Inclusion(f_list, _) => {
                 // first, optimise all our inner elements
                 let (f_list_inc, mut f_list_new): (Vec<_>, Vec<_>) = f_list
                     .iter()
                     .map(|f_ref| f_ref.optimise())
-                    .partition(|f| matches!(f, FilterResolved::Inclusion(_)));
+                    .partition(|f| matches!(f, FilterResolved::Inclusion(_, _)));
 
                 f_list_inc.into_iter().for_each(|fc| {
-                    if let FilterResolved::Inclusion(mut l) = fc {
+                    if let FilterResolved::Inclusion(mut l, _) = fc {
                         f_list_new.append(&mut l)
                     }
                 });
                 // finally, optimise this list by sorting.
                 f_list_new.sort_unstable();
                 f_list_new.dedup();
-                FilterResolved::Inclusion(f_list_new)
+                // Inclusions are similar to or, so what's our worst case?
+                let sf = f_list_new.last().and_then(|f| f.get_slopeyness_factor());
+                FilterResolved::Inclusion(f_list_new, sf)
             }
-            FilterResolved::And(f_list) => {
+            FilterResolved::And(f_list, _) => {
                 // first, optimise all our inner elements
                 let (f_list_and, mut f_list_new): (Vec<_>, Vec<_>) = f_list
                     .iter()
                     .map(|f_ref| f_ref.optimise())
-                    .partition(|f| matches!(f, FilterResolved::And(_)));
+                    .partition(|f| matches!(f, FilterResolved::And(_, _)));
 
                 // now, iterate over this list - for each "and" term, fold
                 // it's elements to this level.
@@ -1201,12 +1247,12 @@ impl FilterResolved {
                 // shortcutting
 
                 f_list_and.into_iter().for_each(|fc| {
-                    if let FilterResolved::And(mut l) = fc {
+                    if let FilterResolved::And(mut l, _) = fc {
                         f_list_new.append(&mut l)
                     }
                 });
 
-                // If the f_list_or only has one element, pop it and return.
+                // If the f_list_and only has one element, pop it and return.
                 if f_list_new.len() == 1 {
                     #[allow(clippy::expect_used)]
                     f_list_new.pop().expect("corrupt?")
@@ -1214,21 +1260,25 @@ impl FilterResolved {
                     // finally, optimise this list by sorting.
                     f_list_new.sort_unstable();
                     f_list_new.dedup();
+                    // Which ever element as the head is first must be the min SF
+                    // so we use this in our And to represent us.
+                    let sf = f_list_new.first().and_then(|f| f.get_slopeyness_factor());
+                    //
                     // return!
-                    FilterResolved::And(f_list_new)
+                    FilterResolved::And(f_list_new, sf)
                 }
             }
-            FilterResolved::Or(f_list) => {
+            FilterResolved::Or(f_list, _) => {
                 let (f_list_or, mut f_list_new): (Vec<_>, Vec<_>) = f_list
                     .iter()
                     // Optimise all inner items.
                     .map(|f_ref| f_ref.optimise())
                     // Split out inner-or terms to fold into this term.
-                    .partition(|f| matches!(f, FilterResolved::Or(_)));
+                    .partition(|f| matches!(f, FilterResolved::Or(_, _)));
 
                 // Append the inner terms.
                 f_list_or.into_iter().for_each(|fc| {
-                    if let FilterResolved::Or(mut l) = fc {
+                    if let FilterResolved::Or(mut l, _) = fc {
                         f_list_new.append(&mut l)
                     }
                 });
@@ -1247,8 +1297,9 @@ impl FilterResolved {
                     #[allow(clippy::unnecessary_sort_by)]
                     f_list_new.sort_unstable_by(|a, b| b.cmp(a));
                     f_list_new.dedup();
-
-                    FilterResolved::Or(f_list_new)
+                    // The *last* element is the most here, and our worst case factor.
+                    let sf = f_list_new.last().and_then(|f| f.get_slopeyness_factor());
+                    FilterResolved::Or(f_list_new, sf)
                 }
             }
             f => f.clone(),
@@ -1256,7 +1307,21 @@ impl FilterResolved {
     }
 
     pub fn is_andnot(&self) -> bool {
-        matches!(self, FilterResolved::AndNot(_))
+        matches!(self, FilterResolved::AndNot(_, _))
+    }
+
+    #[inline(always)]
+    fn get_slopeyness_factor(&self) -> Option<IdxSlope> {
+        match self {
+            FilterResolved::Eq(_, _, sf)
+            | FilterResolved::Sub(_, _, sf)
+            | FilterResolved::Pres(_, sf)
+            | FilterResolved::LessThan(_, _, sf)
+            | FilterResolved::Or(_, sf)
+            | FilterResolved::And(_, sf)
+            | FilterResolved::Inclusion(_, sf)
+            | FilterResolved::AndNot(_, sf) => *sf,
+        }
     }
 }
 
@@ -1452,8 +1517,8 @@ mod tests {
         // antisymmetry: if a < b then !(a > b), as well as a > b implying !(a < b); and
         // These are unindexed so we have to check them this way.
         let f_t3b = unsafe { filter_resolved!(f_eq("userid", PartialValue::new_iutf8(""))) };
-        assert_eq!(f_t1a.partial_cmp(&f_t3b), Some(Ordering::Less));
-        assert_eq!(f_t3b.partial_cmp(&f_t1a), Some(Ordering::Greater));
+        assert_eq!(f_t1a.partial_cmp(&f_t3b), Some(Ordering::Greater));
+        assert_eq!(f_t3b.partial_cmp(&f_t1a), Some(Ordering::Less));
 
         // transitivity: a < b and b < c implies a < c. The same must hold for both == and >.
         let f_t4b = unsafe { filter_resolved!(f_sub("userid", PartialValue::new_iutf8(""))) };

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -512,7 +512,7 @@ impl<'a> SchemaWriteTransaction<'a> {
         r
     }
 
-    pub(crate) fn reload_idxmeta(&self) -> HashSet<IdxKey> {
+    pub(crate) fn reload_idxmeta(&self) -> Vec<IdxKey> {
         self.get_attributes()
             .values()
             .flat_map(|a| {


### PR DESCRIPTION
Fixes #238 - this adds statistical analysis capabilities to indexes allow the optimiser to make better decisions about queries and how to run them. It has some benefits in reducing the time to perform a query optimisation as well. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
