### PR TITLE
Fixing kanidm windows client build

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -14,7 +14,6 @@ extern crate log;
 use serde_derive::Deserialize;
 use serde_json::error::Error as SerdeJsonError;
 use std::collections::BTreeSet as Set;
-use std::env::consts::FAMILY;
 use std::fs::{metadata, File, Metadata};
 use std::io::ErrorKind;
 use std::io::Read;
@@ -104,9 +103,11 @@ impl KanidmClientBuilder {
     fn parse_certificate(ca_path: &str) -> Result<reqwest::Certificate, ()> {
         let mut buf = Vec::new();
         // Is the CA secure?
-        if FAMILY == "windows" {
-            warn!("File metadata checks on Windows aren't supported right now...");
-        } else {
+        #[cfg(target_family = "windows")]
+        warn!("File metadata checks on Windows aren't supported right now, this could be a security risk.");
+
+        #[cfg(target_family = "unix")]
+        {
             let path = Path::new(ca_path);
             let ca_meta = read_file_metadata(&path)?;
 

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -23,8 +23,8 @@ use std::io::Read;
 use std::os::unix::fs::MetadataExt;
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::MetadataExt;
-#[cfg(target_os = "windows")]
-use std::os::windows::fs::MetadataExt;
+// #[cfg(target_os = "windows")]
+// use std::os::windows::fs::MetadataExt;
 
 use std::path::Path;
 use std::time::Duration;
@@ -118,6 +118,7 @@ impl KanidmClientBuilder {
                 warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...", ca_path);
             }
 
+            #[cfg(target_family = "unix")]
             if ca_meta.uid() != 0 || ca_meta.gid() != 0 {
                 warn!(
                     "{} should be owned be root:root to prevent tampering",

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -14,10 +14,18 @@ extern crate log;
 use serde_derive::Deserialize;
 use serde_json::error::Error as SerdeJsonError;
 use std::collections::BTreeSet as Set;
+use std::env::consts::FAMILY;
 use std::fs::{metadata, File, Metadata};
 use std::io::ErrorKind;
 use std::io::Read;
+
+#[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
+#[cfg(target_os = "macos")]
+use std::os::unix::fs::MetadataExt;
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::MetadataExt;
+
 use std::path::Path;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -100,18 +108,22 @@ impl KanidmClientBuilder {
     fn parse_certificate(ca_path: &str) -> Result<reqwest::Certificate, ()> {
         let mut buf = Vec::new();
         // Is the CA secure?
-        let path = Path::new(ca_path);
-        let ca_meta = read_file_metadata(&path)?;
+        if FAMILY == "windows" {
+            warn!("File metadata checks on Windows aren't supported right now...");
+        } else {
+            let path = Path::new(ca_path);
+            let ca_meta = read_file_metadata(&path)?;
 
-        if !ca_meta.permissions().readonly() {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...", ca_path);
-        }
+            if !ca_meta.permissions().readonly() {
+                warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...", ca_path);
+            }
 
-        if ca_meta.uid() != 0 || ca_meta.gid() != 0 {
-            warn!(
-                "{} should be owned be root:root to prevent tampering",
-                ca_path
-            );
+            if ca_meta.uid() != 0 || ca_meta.gid() != 0 {
+                warn!(
+                    "{} should be owned be root:root to prevent tampering",
+                    ca_path
+                );
+            }
         }
 
         // TODO #253: Handle these errors better, or at least provide diagnostics?

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -19,12 +19,8 @@ use std::fs::{metadata, File, Metadata};
 use std::io::ErrorKind;
 use std::io::Read;
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::MetadataExt;
-#[cfg(target_os = "macos")]
-use std::os::unix::fs::MetadataExt;
-// #[cfg(target_os = "windows")]
-// use std::os::windows::fs::MetadataExt;
 
 use std::path::Path;
 use std::time::Duration;

--- a/kanidmd/src/lib/utils.rs
+++ b/kanidmd/src/lib/utils.rs
@@ -10,6 +10,8 @@ use std::fs::Metadata;
 use std::os::linux::fs::MetadataExt;
 #[cfg(target_os = "macos")]
 use std::os::macos::fs::MetadataExt;
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::MetadataExt;
 
 use users::{get_current_gid, get_current_uid};
 


### PR DESCRIPTION
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

This removes some of the umask/uid specific checks to yeet this into prod as windows rust libs can't handle such checks.