### PR TITLE
fixes #503 - TOTP prompt no longer drops a newline

### DIFF
--- a/kanidm_tools/src/cli/session.rs
+++ b/kanidm_tools/src/cli/session.rs
@@ -145,6 +145,7 @@ impl LoginOpt {
     fn do_totp(&self, client: &mut KanidmClient) -> Result<AuthResponse, ClientError> {
         let totp = loop {
             print!("Enter TOTP: ");
+            // We flush stdout so it'll write the buffer to screen, continuing operation. Without it, the application halts.
             io::stdout().flush().unwrap();
             let mut buffer = String::new();
             if let Err(e) = io::stdin().read_line(&mut buffer) {

--- a/kanidm_tools/src/cli/session.rs
+++ b/kanidm_tools/src/cli/session.rs
@@ -6,7 +6,7 @@ use libc::umask;
 use std::collections::BTreeMap;
 use std::fs::{create_dir, File};
 use std::io::ErrorKind;
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use webauthn_authenticator_rs::{u2fhid::U2FHid, RequestChallengeResponse, WebauthnAuthenticator};
 
@@ -144,7 +144,8 @@ impl LoginOpt {
 
     fn do_totp(&self, client: &mut KanidmClient) -> Result<AuthResponse, ClientError> {
         let totp = loop {
-            println!("Enter TOTP: ");
+            print!("Enter TOTP: ");
+            io::stdout().flush().unwrap();
             let mut buffer = String::new();
             if let Err(e) = io::stdin().read_line(&mut buffer) {
                 eprintln!("Failed to read from stdin -> {:?}", e);


### PR DESCRIPTION
Fixes #503 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
