### PR TITLE
Fix totp registration workflow with broken authenticators

### DIFF
--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -982,6 +982,27 @@ impl KanidmAsyncClient {
         match res {
             Ok(SetCredentialResponse::Success) => Ok(()),
             Ok(SetCredentialResponse::TotpCheck(u, s)) => Err(ClientError::TotpVerifyFailed(u, s)),
+            Ok(SetCredentialResponse::TotpInvalidSha1(u)) => Err(ClientError::TotpInvalidSha1(u)),
+            Ok(_) => Err(ClientError::EmptyResponse),
+            Err(e) => Err(e),
+        }
+    }
+
+    // Accept a sha1 totp
+    pub async fn idm_account_primary_credential_accept_sha1_totp(
+        &self,
+        id: &str,
+        session: Uuid,
+    ) -> Result<(), ClientError> {
+        let r = SetCredentialRequest::TotpAcceptSha1(session);
+        let res: Result<SetCredentialResponse, ClientError> = self
+            .perform_put_request(
+                format!("/v1/account/{}/_credential/primary", id).as_str(),
+                r,
+            )
+            .await;
+        match res {
+            Ok(SetCredentialResponse::Success) => Ok(()),
             Ok(_) => Err(ClientError::EmptyResponse),
             Err(e) => Err(e),
         }

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -53,6 +53,7 @@ pub enum ClientError {
     AuthenticationFailed,
     EmptyResponse,
     TotpVerifyFailed(Uuid, TotpSecret),
+    TotpInvalidSha1(Uuid),
     JsonDecode(reqwest::Error, String),
     JsonEncode(SerdeJsonError),
     SystemError,
@@ -648,6 +649,17 @@ impl KanidmClient {
         tokio_block_on(
             self.asclient
                 .idm_account_primary_credential_verify_totp(id, otp, session),
+        )
+    }
+
+    pub fn idm_account_primary_credential_accept_sha1_totp(
+        &self,
+        id: &str,
+        session: Uuid,
+    ) -> Result<(), ClientError> {
+        tokio_block_on(
+            self.asclient
+                .idm_account_primary_credential_accept_sha1_totp(id, session),
         )
     }
 

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -673,6 +673,7 @@ pub enum SetCredentialRequest {
     GeneratePassword,
     TotpGenerate,
     TotpVerify(Uuid, u32),
+    TotpAcceptSha1(Uuid),
     TotpRemove,
     // Start the rego.
     WebauthnBegin(String),
@@ -747,6 +748,7 @@ pub enum SetCredentialResponse {
     Success,
     Token(String),
     TotpCheck(Uuid, TotpSecret),
+    TotpInvalidSha1(Uuid),
     WebauthnCreateChallenge(Uuid, CreationChallengeResponse),
     BackupCodes(Vec<String>),
 }

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -192,7 +192,8 @@ impl AccountOpt {
                     eprintln!("--------------------------------------------------------------");
                     eprintln!("Enter a TOTP from your authenticator to complete registration:");
 
-                    loop {
+                    let mut attempts = 3;
+                    while attempts > 0 {
                         eprint!("TOTP: ");
                         let mut totp_input = String::new();
                         let input_result = io::stdin().read_line(&mut totp_input);
@@ -237,7 +238,7 @@ impl AccountOpt {
                                     break;
                                 };
 
-                                if confirm_input.trim() == "I am sure" {
+                                if confirm_input.to_lowercase().trim() == "i am sure" {
                                     match client.idm_account_primary_credential_accept_sha1_totp(
                                         acsopt.aopts.account_id.as_str(),
                                         session,
@@ -257,6 +258,7 @@ impl AccountOpt {
                             }
                             Err(ClientError::TotpVerifyFailed(_, _)) => {
                                 eprintln!("Incorrect TOTP code - try again");
+                                attempts -= 1;
                                 continue;
                             }
                             Err(e) => {

--- a/kanidmd/src/lib/credential/totp.rs
+++ b/kanidmd/src/lib/credential/totp.rs
@@ -182,6 +182,18 @@ impl Totp {
             },
         }
     }
+
+    pub fn is_legacy_algo(&self) -> bool {
+        matches!(&self.algo, TotpAlgo::Sha1)
+    }
+
+    pub fn downgrade_to_legacy(self) -> Self {
+        Totp {
+            secret: self.secret,
+            step: self.step,
+            algo: TotpAlgo::Sha1,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -343,6 +343,40 @@ impl VerifyTotpEvent {
 }
 
 #[derive(Debug)]
+pub struct AcceptSha1TotpEvent {
+    pub ident: Identity,
+    pub target: Uuid,
+    pub session: Uuid,
+}
+
+impl AcceptSha1TotpEvent {
+    pub fn from_parts(
+        _audit: &mut AuditScope,
+        // qs: &QueryServerWriteTransaction,
+        ident: Identity,
+        target: Uuid,
+        session: Uuid,
+    ) -> Result<Self, OperationError> {
+        Ok(AcceptSha1TotpEvent {
+            ident,
+            target,
+            session,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_internal(target: Uuid, session: Uuid) -> Self {
+        let ident = Identity::from_internal();
+
+        AcceptSha1TotpEvent {
+            ident,
+            target,
+            session,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct RemoveTotpEvent {
     pub ident: Identity,
     pub target: Uuid,


### PR DESCRIPTION
Fixes #501 #506 - This changes the workflow in totp registration, so that we can detect broken authenticators. When we detect these, we request consent from the user to proceed in allowing this registration to proceed for the account. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
