### PR TITLE
Fixing #520, moving cert loading into server mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .DS_Store
+.backup*_test.json
 .backup_test.db
 /target
 /insecure


### PR DESCRIPTION
Fixes #520 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
