### PR TITLE
Fix docu for generate password

### DIFF
--- a/kanidm_book/src/accounts_and_groups.md
+++ b/kanidm_book/src/accounts_and_groups.md
@@ -25,10 +25,10 @@ and sensitive data), group management, and more.
 ## Recovering the Initial idm_admin Account
 
 By default the idm_admin has no password, and can not be accessed. You should recover it with the
-admin (system admin) account. We recommend the use of "generate_password" as it provides a high
+admin (system admin) account. We recommend the use of "reset_credential" as it provides a high
 strength, random, machine only password.
 
-    kanidm account credential generate_password  --name admin idm_admin
+    kanidm account credential reset_credential  --name admin idm_admin
     Generated password for idm_admin: tqoReZfz....
 
 ## Creating Accounts

--- a/kanidm_book/src/radius.md
+++ b/kanidm_book/src/radius.md
@@ -81,7 +81,7 @@ correct privileges. This can be created and assigned through the group
 
     kanidm account create --name admin radius_service_account "Radius Service Account"
     kanidm group add_members --name admin idm_radius_servers radius_service_account
-    kanidm account credential generate_password --name admin radius_service_account
+    kanidm account credential reset_credential --name admin radius_service_account
 
 ## Deploying a RADIUS Container
 


### PR DESCRIPTION
This updates the docs to reflect the latest kanidm-tools cli commands.

* old
`kanidm account credential generate_password [OPTIONS] <account-id>`

* new 
`kanidm account credential reset_credential [OPTIONS] <account-id>
`