### PR TITLE
Fixes #528 - DynamicUser was set to kanidmd

### DIFF
--- a/platform/opensuse/kanidmd.service
+++ b/platform/opensuse/kanidmd.service
@@ -11,7 +11,7 @@ Before=radiusd.service
 Type=simple
 DynamicUser=yes
 UMask=0027
-StateDirectory=kanidmd
+StateDirectory=kanidm
 ExecStart=/usr/sbin/kanidmd server -c /etc/kanidm/server.toml
 
 NoNewPrivileges=true


### PR DESCRIPTION
Resolves DynamicUser issue in #528 for opensuse builds