### PR TITLE
Makes kanidmd bail on startup if it can't find the webpkg dir

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -140,3 +140,5 @@ Then you are able to build the UI.
     ./build_wasm.sh
 
 The "developer" profile for kanidmd will automatically use the pkg output in this folder.
+
+Setting different developer profiles while building is done by setting the environment variable KANIDM_BUILD_PROFILE to one of the bare filename of the TOML files in `/profiles`. For example: `KANIDM_BUILD_PROFILE=release_suse_generic cargo build --release --bin kanidmd`

--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -19,6 +19,7 @@ use kanidm_proto::v1::{
 };
 
 use serde::Serialize;
+use std::path::PathBuf;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -1199,6 +1200,15 @@ pub fn create_https_server(
 
     // If we are no-ui, we remove this.
     if !matches!(role, ServerRole::WriteReplicaNoUI) {
+        let pkg_path = PathBuf::from(env!("KANIDM_WEB_UI_PKG_PATH"));
+        if !pkg_path.exists() {
+            eprintln!(
+                "Couldn't find Web UI package path: ({}), quitting.",
+                env!("KANIDM_WEB_UI_PKG_PATH")
+            );
+            std::process::exit(1);
+        }
+
         tserver.at("/").get(index_view);
         tserver
             .at("/pkg")

--- a/platform/opensuse/kanidmd.service
+++ b/platform/opensuse/kanidmd.service
@@ -11,7 +11,7 @@ Before=radiusd.service
 Type=simple
 DynamicUser=yes
 UMask=0027
-StateDirectory=kanidmd
+StateDirectory=kanidm
 ExecStart=/usr/sbin/kanidmd server -c /etc/kanidm/server.toml
 
 NoNewPrivileges=true


### PR DESCRIPTION
Previously it wouldn't fail until someone tried to access it, which is a bit janky 😳

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
