### PR TITLE
Implement Online Backups (#25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "rpassword",
  "rusqlite",
  "rustc_version 0.4.0",
+ "saffron",
  "serde",
  "serde_cbor",
  "serde_derive",
@@ -2174,6 +2175,16 @@ checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
  "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -2919,6 +2930,16 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "saffron"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fb9a628596fc7590eb7edbf7b0613287be78df107f5f97b118aad59fb2eea9"
+dependencies = [
+ "chrono",
+ "nom 5.1.2",
+]
 
 [[package]]
 name = "same-file"

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -40,9 +40,11 @@ origin = "https://idm.example.com:8443"
 # [online_backup]
 #   The path to the output folder for online backups
 # path = "/var/lib/kanidm/backups/"
-#   How often the online_backup should run
-#   every day at 22:00 - see https://crontab.guru/ 
-# schedule = "0 22 * * *" 
+#   How often the online_backup should run - see https://crontab.guru/
+#   every day at 22:00
+# schedule = "00 22 * * *"
+#    four times a day at 3 minutes past the hour, every 6th hours
+# schedule = "03 */6 * * *"
 #   Number of backups to keep
 # versions = 3
 #

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -36,17 +36,16 @@ db_path = "/var/lib/kanidm/kanidm.db"
 # origin = "https://idm.example.com"
 origin = "https://idm.example.com:8443"
 #
-#   TODO
-#   The path to the output folder for online backups
-#   Uncommenting this will enable the online backup.
-# online_backup_path = "/var/lib/kanidm/"
-online_backup_path = "/tmp/kanidm/"
 #
+# [online_backup]
+#   The path to the output folder for online backups
+# path = "/var/lib/kanidm/backups/"
 #   How often the online_backup should run
-#   might be switched to something cron like
-online_backup_interval = 5
+#   every day at 22:00 - see https://crontab.guru/ 
+# schedule = "0 22 * * *" 
 #   Number of backups to keep
-# online_backup_versions = 10
+# versions = 3
+#
 #
 #   The role of this server. This affects features available and how replication may interact.
 #   Valid roles are:

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -51,13 +51,13 @@ origin = "https://idm.example.com:8443"
 #
 #   The role of this server. This affects features available and how replication may interact.
 #   Valid roles are:
-#   - write_replica
+#   - WriteReplica
 #     This server provides all functionality of Kanidm. It allows authentication, writes, and
 #     the web user interface to be served.
-#   - write_replica_no_ui
+#   - WriteReplicaNoUI
 #     This server is the same as a write_replica, but does NOT offer the web user interface.
-#   - read_only_replica
+#   - ReadOnlyReplica
 #     This server will not writes initiated by clients. It supports authentication and reads,
 #     and must have a replication agreement as a source of it's data.
-#   Defaults to "write_replica".
-# role = "write_replica"
+#   Defaults to "WriteReplica".
+# role = "WriteReplica"

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -36,6 +36,18 @@ db_path = "/var/lib/kanidm/kanidm.db"
 # origin = "https://idm.example.com"
 origin = "https://idm.example.com:8443"
 #
+#   TODO
+#   The path to the output folder for online backups
+#   Uncommenting this will enable the online backup.
+# online_backup_path = "/var/lib/kanidm/"
+online_backup_path = "/tmp/kanidm/"
+#
+#   How often the online_backup should run
+#   might be switched to something cron like
+online_backup_interval = 5
+#   Number of backups to keep
+# online_backup_versions = 10
+#
 #   The role of this server. This affects features available and how replication may interact.
 #   Valid roles are:
 #   - write_replica

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -41,12 +41,12 @@ origin = "https://idm.example.com:8443"
 #   The path to the output folder for online backups
 # path = "/var/lib/kanidm/backups/"
 #   How often the online_backup should run - see https://crontab.guru/
-#   every day at 22:00
+#   every day at 22:00 UTC (default)
 # schedule = "00 22 * * *"
 #    four times a day at 3 minutes past the hour, every 6th hours
 # schedule = "03 */6 * * *"
 #   Number of backups to keep
-# versions = 3
+# versions = 7
 #
 #
 #   The role of this server. This affects features available and how replication may interact.

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -40,12 +40,12 @@ origin = "https://idm.example.com:8443"
 # [online_backup]
 #   The path to the output folder for online backups
 # path = "/var/lib/kanidm/backups/"
-#   How often the online_backup should run - see https://crontab.guru/
+#   The schedule to run online backups - see https://crontab.guru/
 #   every day at 22:00 UTC (default)
 # schedule = "00 22 * * *"
 #    four times a day at 3 minutes past the hour, every 6th hours
 # schedule = "03 */6 * * *"
-#   Number of backups to keep
+#   Number of backups to keep (default 7)
 # versions = 7
 #
 #

--- a/kanidm_book/src/administrivia.md
+++ b/kanidm_book/src/administrivia.md
@@ -41,6 +41,13 @@ This is a simple backup of the data volume.
     # Backup your docker's volume folder
     docker start <container name>
 
+## Method 3
+
+Automatic backups can be generated online by a `kanidmd server` instance
+by including the `[online_backup]` section in the `server.toml`.
+This allows you to run regular backups, defined by a cron schedule, and maintain
+the number of backup versions to keep. An example is located in [examples/server.toml](../../examples/server.toml).
+
 # Rename the domain
 
 There are some cases where you may need to rename the domain. You should have configured
@@ -65,7 +72,6 @@ you can then rename the domain with the commands as follows:
         kanidm/server:latest /sbin/kanidmd domain_name_change -c /data/server.toml \
         -n idm.new.domain.name
     docker start <container name>
-
 
 # Reindexing after schema extension
 
@@ -96,12 +102,12 @@ Generally, reindexing is a rare action and should not normally be required.
 
 # Vacuum
 
-[Vacuuming](https://www.sqlite.org/lang_vacuum.html) is the process of reclaiming un-used pages 
-from the sqlite freelists, as well as performing some data reordering tasks that may make some 
-queries more efficient . It is recommended that you vacuum after a reindex is performed or 
+[Vacuuming](https://www.sqlite.org/lang_vacuum.html) is the process of reclaiming un-used pages
+from the sqlite freelists, as well as performing some data reordering tasks that may make some
+queries more efficient . It is recommended that you vacuum after a reindex is performed or
 when you wish to reclaim space in the database file.
 
-Vacuum is also able to change the pagesize of the database. After changing db\_fs\_type (which affects 
+Vacuum is also able to change the pagesize of the database. After changing `db_fs_type` (which affects
 pagesize) in server.toml, you must run a vacuum for this to take effect.
 
     docker stop <container name>
@@ -114,7 +120,7 @@ pagesize) in server.toml, you must run a vacuum for this to take effect.
 The server ships with a number of verification utilities to ensure that data is consistent such
 as referential integrity or memberof.
 
-Note that verification really is a last resort - the server does *a lot* to prevent and self-heal
+Note that verification really is a last resort - the server does _a lot_ to prevent and self-heal
 from errors at run time, so you should rarely if ever require this utility. This utility was
 developed to guarantee consistency during development!
 

--- a/kanidm_book/src/server_configuration.md
+++ b/kanidm_book/src/server_configuration.md
@@ -4,11 +4,11 @@ You will also need a config file in the volume named `server.toml` (Within the c
 
     #   The webserver bind address. Will use HTTPS if tls_* is provided.
     #   Defaults to "127.0.0.1:8443"
-    bindaddress = "127.0.0.1:8443"
+    bindaddress = "[::]:8443"
     #
     #   The read-only ldap server bind address. The server will use LDAPS if tls_* is provided.
     #   Defaults to "" (disabled)
-    # ldapbindaddress = "127.0.0.1:3636"
+    # ldapbindaddress = "[::]:3636"
     #
     #   The path to the kanidm database.
     db_path = "/data/kanidm.db"

--- a/kanidm_book/src/server_configuration.md
+++ b/kanidm_book/src/server_configuration.md
@@ -40,6 +40,19 @@ You will also need a config file in the volume named `server.toml` (Within the c
     # origin = "https://idm.example.com"
     origin = "https://idm.example.com:8443"
     #
+    #
+    # [online_backup]
+    #   The path to the output folder for online backups
+    # path = "/var/lib/kanidm/backups/"
+    #   The schedule to run online backups - see https://crontab.guru/
+    #   every day at 22:00 UTC (default)
+    # schedule = "00 22 * * *"
+    #    four times a day at 3 minutes past the hour, every 6th hours
+    # schedule = "03 */6 * * *"
+    #   Number of backups to keep (default 7)
+    # versions = 7
+    #
+    #
     #   The role of this server. This affects features available and how replication may interact.
     #   Valid roles are:
     #   - WriteReplica
@@ -60,7 +73,7 @@ Then you can setup the initial admin account and initialise the database into yo
     docker run --rm -i -t -v kanidmd:/data kanidm/server:latest /sbin/kanidmd recover_account -c /data/server.toml -n admin
 
 You then want to set your domain name so that security principal names (spn's) are generated correctly.
-This domain name *must* match the url/origin of the server that you plan to use to interact with
+This domain name _must_ match the url/origin of the server that you plan to use to interact with
 so that other features work correctly. It is possible to change this domain name later.
 
     docker run --rm -i -t -v kanidmd:/data kanidm/server:latest /sbin/kanidmd domain_name_change -c /data/server.toml -n idm.example.com

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.8"
 toml = "0.5"
 
 chrono = "0.4"
+saffron = "0.1.0"
 regex = "1"
 lazy_static = "1.2.0"
 

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -1,5 +1,6 @@
 use tokio::sync::mpsc::UnboundedSender as Sender;
 
+use chrono::{DateTime, SecondsFormat, Utc};
 use std::sync::Arc;
 
 use crate::prelude::*;
@@ -177,7 +178,9 @@ impl QueryServerReadV1 {
         ltrace!(audit, "Begin online backup event {:?}", msg.eventid);
 
         // TODO: might be something like "backup-timestamp.json"
-        let dest_file = format!("{}/{}", outpath, "backup.json");
+        let now: DateTime<Utc> = Utc::now();
+        let timestamp = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let dest_file = format!("{}/backup-{}.json", outpath, timestamp);
 
         // TODO: handle the max versions to keep here?
         let idms_prox_read = self.idms.proxy_read_async().await;

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -171,11 +171,15 @@ impl QueryServerReadV1 {
         res
     }
 
-    pub async fn handle_online_backup(&self, msg: LiveBackupEvent) {
+    pub async fn handle_online_backup(&self, msg: LiveBackupEvent, outpath: &str) {
         let mut audit = AuditScope::new("online backup", msg.eventid, self.log_level);
 
         ltrace!(audit, "Begin online backup event {:?}", msg.eventid);
 
+        // TODO: might be something like "backup-timestamp.json"
+        let dest_file = format!("{}/{}", outpath, "backup.json");
+
+        // TODO: handle the max versions to keep here?
         let idms_prox_read = self.idms.proxy_read_async().await;
         lperf_op_segment!(
             &mut audit,
@@ -184,7 +188,7 @@ impl QueryServerReadV1 {
                 let res = idms_prox_read
                     .qs_read
                     .get_be_txn()
-                    .backup(&mut audit, "/tmp/backup.json");
+                    .backup(&mut audit, &dest_file);
 
                 ladmin_info!(audit, "online backup result: {:?}", res);
                 #[allow(clippy::expect_used)]

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -172,7 +172,12 @@ impl QueryServerReadV1 {
         res
     }
 
-    pub async fn handle_online_backup(&self, msg: OnlineBackupEvent, outpath: &str, versions: u64) {
+    pub async fn handle_online_backup(
+        &self,
+        msg: OnlineBackupEvent,
+        outpath: &str,
+        versions: usize,
+    ) {
         let mut audit = AuditScope::new("online backup", msg.eventid, self.log_level);
 
         ltrace!(audit, "Begin online backup event {:?}", msg.eventid);

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -171,24 +171,24 @@ impl QueryServerReadV1 {
         res
     }
 
-    pub async fn handle_live_backup(&self, msg: LiveBackupEvent) {
-        let mut audit = AuditScope::new("live backup", msg.eventid, self.log_level);
+    pub async fn handle_online_backup(&self, msg: LiveBackupEvent) {
+        let mut audit = AuditScope::new("online backup", msg.eventid, self.log_level);
 
-        ltrace!(audit, "Begin live-backup event {:?}", msg.eventid);
+        ltrace!(audit, "Begin online backup event {:?}", msg.eventid);
 
         let idms_prox_read = self.idms.proxy_read_async().await;
         lperf_op_segment!(
             &mut audit,
-            "actors::v1_read::handle<LiveBackupEvent>",
+            "actors::v1_read::handle<OnlineBackupEvent>",
             || {
                 let res = idms_prox_read
                     .qs_read
                     .get_be_txn()
                     .backup(&mut audit, "/tmp/backup.json");
 
-                ladmin_info!(audit, "live backup result: {:?}", res);
+                ladmin_info!(audit, "online backup result: {:?}", res);
                 #[allow(clippy::expect_used)]
-                res.expect("Live backup failed");
+                res.expect("Online backup failed");
             }
         );
         // At the end of the event we send it for logging.

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -15,6 +15,13 @@ pub struct IntegrationTestConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct OnlineBackup {
+    pub path: String,
+    pub schedule: String,
+    pub versions: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TlsConfiguration {
     pub chain: String,
     pub key: String,
@@ -71,11 +78,7 @@ pub struct Configuration {
     pub cookie_key: [u8; 32],
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
     pub log_level: Option<u32>,
-    // TODO: online backup settings
-    pub online_backup_path: Option<String>,
-    // TOOD: maybe a cron pattern?
-    pub online_backup_interval: Option<u32>,
-    pub online_backup_versions: Option<u32>,
+    pub online_backup: Option<OnlineBackup>,
     pub origin: String,
     pub role: ServerRole,
 }
@@ -100,15 +103,12 @@ impl fmt::Display for Configuration {
                 Some(u) => write!(f, "with log_level: {:x}, ", u),
                 None => write!(f, "with log_level: default, "),
             })
+            .and_then(|_| match &self.online_backup {
+                // TODO improve output
+                Some(_) => write!(f, "with online_backup: {}, ", "ok"),
+                None => write!(f, "with online_backup: None, "),
+            })
             .and_then(|_| write!(f, "role: {}, ", self.role.to_string()))
-            .and_then(|_| match &self.online_backup_path {
-                Some(p) => write!(f, "with online_backup_path: {}, ", p),
-                None => write!(f, "with online_backup_path: None, "),
-            })
-            .and_then(|_| match self.online_backup_interval {
-                Some(i) => write!(f, "with online_backup_interval: {}, ", i),
-                None => write!(f, "with online_backup_interval: None, "),
-            })
             .and_then(|_| {
                 write!(
                     f,
@@ -137,9 +137,7 @@ impl Configuration {
             cookie_key: [0; 32],
             integration_test_config: None,
             log_level: None,
-            online_backup_path: None,
-            online_backup_interval: None,
-            online_backup_versions: None,
+            online_backup: None,
             origin: "https://idm.example.com".to_string(),
             role: ServerRole::WriteReplica,
         };
@@ -152,17 +150,22 @@ impl Configuration {
         self.log_level = log_level;
     }
 
-    pub fn update_online_backup_path(&mut self, online_backup_path: &Option<String>) {
-        self.online_backup_path = online_backup_path.clone();
+    pub fn update_online_backup(&mut self, cfg: &Option<OnlineBackup>) {
+        match cfg {
+            None => {}
+            Some(cfg) => {
+                let path = cfg.path.to_string();
+                let schedule = cfg.schedule.to_string();
+                let versions = cfg.versions;
+                self.online_backup = Some(OnlineBackup {
+                    path,
+                    schedule,
+                    versions,
+                })
+            }
+        }
     }
 
-    pub fn update_online_backup_interval(&mut self, online_backup_interval: Option<u32>) {
-        self.online_backup_interval = online_backup_interval;
-    }
-
-    pub fn update_online_backup_versions(&mut self, online_backup_versions: Option<u32>) {
-        self.online_backup_versions = online_backup_versions;
-    }
     pub fn update_db_path(&mut self, p: &str) {
         self.db_path = p.to_string();
     }

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -16,9 +16,24 @@ pub struct IntegrationTestConfig {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OnlineBackup {
+    #[serde(default = "default_online_backup_path")]
     pub path: String,
+    #[serde(default = "default_online_backup_schedule")]
     pub schedule: String,
-    pub versions: u64,
+    #[serde(default = "default_online_backup_versions")]
+    pub versions: usize,
+}
+
+fn default_online_backup_path() -> String {
+    "/var/lib/kanidm/backups/".to_string()
+}
+
+fn default_online_backup_schedule() -> String {
+    "00 22 * * *".to_string()
+}
+
+fn default_online_backup_versions() -> usize {
+    7
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -120,8 +120,8 @@ impl fmt::Display for Configuration {
             })
             .and_then(|_| match &self.online_backup {
                 // TODO improve output
-                Some(_) => write!(f, "with online_backup: {}, ", "ok"),
-                None => write!(f, "with online_backup: None, "),
+                Some(_) => write!(f, "with online_backup: enabled, "),
+                None => write!(f, "with online_backup: disabled, "),
             })
             .and_then(|_| write!(f, "role: {}, ", self.role.to_string()))
             .and_then(|_| {

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -71,6 +71,11 @@ pub struct Configuration {
     pub cookie_key: [u8; 32],
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
     pub log_level: Option<u32>,
+    // TODO: online backup settings
+    pub online_backup_path: Option<String>,
+    // TOOD: maybe a cron pattern?
+    pub online_backup_interval: Option<u32>,
+    pub online_backup_versions: Option<u32>,
     pub origin: String,
     pub role: ServerRole,
 }
@@ -96,6 +101,14 @@ impl fmt::Display for Configuration {
                 None => write!(f, "with log_level: default, "),
             })
             .and_then(|_| write!(f, "role: {}, ", self.role.to_string()))
+            .and_then(|_| match &self.online_backup_path {
+                Some(p) => write!(f, "with online_backup_path: {}, ", p),
+                None => write!(f, "with online_backup_path: None, "),
+            })
+            .and_then(|_| match self.online_backup_interval {
+                Some(i) => write!(f, "with online_backup_interval: {}, ", i),
+                None => write!(f, "with online_backup_interval: None, "),
+            })
             .and_then(|_| {
                 write!(
                     f,
@@ -124,6 +137,9 @@ impl Configuration {
             cookie_key: [0; 32],
             integration_test_config: None,
             log_level: None,
+            online_backup_path: None,
+            online_backup_interval: None,
+            online_backup_versions: None,
             origin: "https://idm.example.com".to_string(),
             role: ServerRole::WriteReplica,
         };
@@ -136,6 +152,17 @@ impl Configuration {
         self.log_level = log_level;
     }
 
+    pub fn update_online_backup_path(&mut self, online_backup_path: &Option<String>) {
+        self.online_backup_path = online_backup_path.clone();
+    }
+
+    pub fn update_online_backup_interval(&mut self, online_backup_interval: Option<u32>) {
+        self.online_backup_interval = online_backup_interval;
+    }
+
+    pub fn update_online_backup_versions(&mut self, online_backup_versions: Option<u32>) {
+        self.online_backup_versions = online_backup_versions;
+    }
     pub fn update_db_path(&mut self, p: &str) {
         self.db_path = p.to_string();
     }

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -114,7 +114,6 @@ impl fmt::Display for Configuration {
                 None => write!(f, "with log_level: default, "),
             })
             .and_then(|_| match &self.online_backup {
-                // TODO improve output
                 Some(_) => write!(f, "with online_backup: enabled, "),
                 None => write!(f, "with online_backup: disabled, "),
             })

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -16,16 +16,11 @@ pub struct IntegrationTestConfig {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OnlineBackup {
-    #[serde(default = "default_online_backup_path")]
     pub path: String,
     #[serde(default = "default_online_backup_schedule")]
     pub schedule: String,
     #[serde(default = "default_online_backup_versions")]
     pub versions: usize,
-}
-
-fn default_online_backup_path() -> String {
-    "/var/lib/kanidm/backups/".to_string()
 }
 
 fn default_online_backup_schedule() -> String {

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -703,17 +703,9 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
     // Setup timed events associated to the write thread
     IntervalActor::start(server_write_ref);
     // Setup timed events associated to the read thread
-    // TODO: only start this if enable in config.
-    // TODO: maybe we should have better option processing here
-    // and pass it on to `start_online_backup()`
-    match &config.online_backup_path {
-        Some(p) => {
-            // TODO check path exists?
-            let outpath = p;
-            // TODO improve this as well.
-            let itime = config.online_backup_interval.unwrap_or(15);
-            // pass all necessary online backup options
-            IntervalActor::start_online_backup(server_read_ref, outpath, itime.into());
+    match &config.online_backup {
+        Some(cfg) => {
+            IntervalActor::start_online_backup(server_read_ref, &cfg);
         }
         None => {
             debug!("Online backup not requested, skipping");

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -705,7 +705,7 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
     // Setup timed events associated to the read thread
     match &config.online_backup {
         Some(cfg) => {
-            IntervalActor::start_online_backup(server_read_ref, &cfg);
+            IntervalActor::start_online_backup(server_read_ref, &cfg)?;
         }
         None => {
             debug!("Online backup not requested, skipping");

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -703,7 +703,7 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
     // Setup timed events associated to the write thread
     IntervalActor::start(server_write_ref);
     // Setup timed events associated to the read thread
-    IntervalActor::start_live_backup(server_read_ref);
+    IntervalActor::start_online_backup(server_read_ref);
 
     // If we have been requested to init LDAP, configure it now.
     match &config.ldapaddress {

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -702,6 +702,8 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
 
     // Setup timed events associated to the write thread
     IntervalActor::start(server_write_ref);
+    // Setup timed events associated to the read thread
+    IntervalActor::start_live_backup(server_read_ref);
 
     // If we have been requested to init LDAP, configure it now.
     match &config.ldapaddress {

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -703,7 +703,22 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
     // Setup timed events associated to the write thread
     IntervalActor::start(server_write_ref);
     // Setup timed events associated to the read thread
-    IntervalActor::start_online_backup(server_read_ref);
+    // TODO: only start this if enable in config.
+    // TODO: maybe we should have better option processing here
+    // and pass it on to `start_online_backup()`
+    match &config.online_backup_path {
+        Some(p) => {
+            // TODO check path exists?
+            let outpath = p;
+            // TODO improve this as well.
+            let itime = config.online_backup_interval.unwrap_or(15);
+            // pass all necessary online backup options
+            IntervalActor::start_online_backup(server_read_ref, outpath, itime.into());
+        }
+        None => {
+            debug!("Online backup not requested, skipping");
+        }
+    };
 
     // If we have been requested to init LDAP, configure it now.
     match &config.ldapaddress {

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -911,6 +911,27 @@ impl PurgeRecycledEvent {
 }
 
 #[derive(Debug)]
+pub struct LiveBackupEvent {
+    pub ident: Identity,
+    pub eventid: Uuid,
+}
+
+impl Default for LiveBackupEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveBackupEvent {
+    pub fn new() -> Self {
+        LiveBackupEvent {
+            ident: Identity::from_internal(),
+            eventid: Uuid::new_v4(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct ReviveRecycledEvent {
     pub ident: Identity,
     // This is the filter, as it will be processed.

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -911,20 +911,20 @@ impl PurgeRecycledEvent {
 }
 
 #[derive(Debug)]
-pub struct LiveBackupEvent {
+pub struct OnlineBackupEvent {
     pub ident: Identity,
     pub eventid: Uuid,
 }
 
-impl Default for LiveBackupEvent {
+impl Default for OnlineBackupEvent {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl LiveBackupEvent {
+impl OnlineBackupEvent {
     pub fn new() -> Self {
-        LiveBackupEvent {
+        OnlineBackupEvent {
             ident: Identity::from_internal(),
             eventid: Uuid::new_v4(),
         }

--- a/kanidmd/src/lib/interval.rs
+++ b/kanidmd/src/lib/interval.rs
@@ -70,7 +70,8 @@ impl IntervalActor {
 
             let cron_iter = cron.clone().iter_after(ct);
             for next_time in cron_iter {
-                // +1 to have even times, but we might anyway cut away the seconds from the timestamp.
+                // We add 1 second to the `wait_time` in order to get "even" timestampes
+                // for example: 1 + 17:05:59Z --> 17:06:00Z
                 let wait_seconds = 1 + (next_time - Utc::now()).num_seconds() as u64;
                 info!(
                     "Online backup next run on {}, wait_time = {}s",

--- a/kanidmd/src/lib/interval.rs
+++ b/kanidmd/src/lib/interval.rs
@@ -27,12 +27,12 @@ impl IntervalActor {
         });
     }
 
-    pub fn start_live_backup(server: &'static QueryServerReadV1) {
+    pub fn start_online_backup(server: &'static QueryServerReadV1) {
         tokio::spawn(async move {
             let mut inter = interval(Duration::from_secs(5));
             loop {
                 inter.tick().await;
-                server.handle_live_backup(LiveBackupEvent::new()).await;
+                server.handle_online_backup(LiveBackupEvent::new()).await;
             }
         });
     }

--- a/kanidmd/src/lib/interval.rs
+++ b/kanidmd/src/lib/interval.rs
@@ -27,12 +27,16 @@ impl IntervalActor {
         });
     }
 
-    pub fn start_online_backup(server: &'static QueryServerReadV1) {
+    pub fn start_online_backup(server: &'static QueryServerReadV1, outpath: &String, itime: u64) {
+        let outpath = outpath.to_owned();
+
         tokio::spawn(async move {
-            let mut inter = interval(Duration::from_secs(5));
+            let mut inter = interval(Duration::from_secs(itime));
             loop {
                 inter.tick().await;
-                server.handle_online_backup(LiveBackupEvent::new()).await;
+                server
+                    .handle_online_backup(LiveBackupEvent::new(), outpath.clone().as_str())
+                    .await;
             }
         });
     }

--- a/kanidmd/src/lib/interval.rs
+++ b/kanidmd/src/lib/interval.rs
@@ -7,7 +7,6 @@ use crate::actors::v1_write::QueryServerWriteV1;
 use crate::config::OnlineBackup;
 use crate::constants::PURGE_FREQUENCY;
 use crate::event::{OnlineBackupEvent, PurgeRecycledEvent, PurgeTombstoneEvent};
-use crate::utils::file_permissions_readonly;
 
 use chrono::Utc;
 use saffron::parse::{CronExpr, English};
@@ -81,13 +80,6 @@ impl IntervalActor {
         if !op.is_dir() {
             error!("Online backup output '{}' is not a directory or we are missing permissions to access it.", outpath);
             return Err(());
-        }
-
-        // checking permissions (not sure about this)
-        // TODO: we still might have a folder that we can read but not write in it.
-        let meta = op.metadata().unwrap();
-        if !file_permissions_readonly(&meta) {
-            eprintln!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...", outpath);
         }
 
         tokio::spawn(async move {

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -26,7 +26,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use kanidm::audit::LogLevel;
-use kanidm::config::{Configuration, ServerRole};
+use kanidm::config::{Configuration, OnlineBackup, ServerRole};
 use kanidm::core::{
     backup_server_core, create_server_core, dbscan_get_id2entry_core, dbscan_list_id2entry_core,
     dbscan_list_index_analysis_core, dbscan_list_index_core, dbscan_list_indexes_core,
@@ -50,11 +50,7 @@ struct ServerConfig {
     pub tls_chain: Option<String>,
     pub tls_key: Option<String>,
     pub log_level: Option<String>,
-    // TODO online backup settings
-    pub online_backup_path: Option<String>,
-    // TOOD: maybe a cron pattern?
-    pub online_backup_interval: Option<u32>,
-    pub online_backup_versions: Option<u32>,
+    pub online_backup: Option<OnlineBackup>,
     pub origin: String,
     #[serde(default)]
     pub role: ServerRole,
@@ -228,10 +224,7 @@ async fn main() {
             config.update_tls(&sconfig.tls_chain, &sconfig.tls_key);
             config.update_bind(&sconfig.bindaddress);
             config.update_ldapbind(&sconfig.ldapbindaddress);
-            // TODO: update some online_backup stuff here?
-            config.update_online_backup_path(&sconfig.online_backup_path);
-            config.update_online_backup_interval(sconfig.online_backup_interval);
-            config.update_online_backup_versions(sconfig.online_backup_versions);
+            config.update_online_backup(&sconfig.online_backup);
 
             if let Some(i_str) = &(sconfig.tls_chain) {
                 let i_path = PathBuf::from(i_str.as_str());

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -50,6 +50,11 @@ struct ServerConfig {
     pub tls_chain: Option<String>,
     pub tls_key: Option<String>,
     pub log_level: Option<String>,
+    // TODO online backup settings
+    pub online_backup_path: Option<String>,
+    // TOOD: maybe a cron pattern?
+    pub online_backup_interval: Option<u32>,
+    pub online_backup_versions: Option<u32>,
     pub origin: String,
     #[serde(default)]
     pub role: ServerRole,
@@ -223,6 +228,10 @@ async fn main() {
             config.update_tls(&sconfig.tls_chain, &sconfig.tls_key);
             config.update_bind(&sconfig.bindaddress);
             config.update_ldapbind(&sconfig.ldapbindaddress);
+            // TODO: update some online_backup stuff here?
+            config.update_online_backup_path(&sconfig.online_backup_path);
+            config.update_online_backup_interval(sconfig.online_backup_interval);
+            config.update_online_backup_versions(sconfig.online_backup_versions);
 
             if let Some(i_str) = &(sconfig.tls_chain) {
                 let i_path = PathBuf::from(i_str.as_str());


### PR DESCRIPTION
This adds automatic online backups to a running kanidmd server.

Fixes #25 

- [X] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [X] book chapter included (if relevant)
- [-] design document included (if relevant)
