### PR TITLE
Improve cbor errors - fix accidental decode issue that prevents startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,8 +3932,6 @@ dependencies = [
 [[package]]
 name = "webauthn-rs"
 version = "0.3.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbb2b77105c3b25ef0187146d80824648da0645f650c4d2080e3815d6cbbb87"
 dependencies = [
  "base64 0.13.0",
  "js-sys",

--- a/kanidmd/src/lib/be/idl_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_sqlite.rs
@@ -271,7 +271,10 @@ pub trait IdlSqliteTransaction {
 
             let idl = match idl_raw {
                 Some(d) => serde_cbor::from_slice(d.as_slice())
-                    .map_err(|_| OperationError::SerdeCborError)?,
+                    .map_err(|e| {
+                        ladmin_error!(audit, "Serde CBOR Error -> {:?}", e);
+                        OperationError::SerdeCborError
+                    })?,
                 // We don't have this value, it must be empty (or we
                 // have a corrupted index .....
                 None => IDLBitRange::new(),
@@ -339,7 +342,10 @@ pub trait IdlSqliteTransaction {
             let spn: Option<Value> = match spn_raw {
                 Some(d) => {
                     let dbv = serde_cbor::from_slice(d.as_slice())
-                        .map_err(|_| OperationError::SerdeCborError)?;
+                        .map_err(|e| {
+                            ladmin_error!(audit, "Serde CBOR Error -> {:?}", e);
+                            OperationError::SerdeCborError
+                        })?;
                     let spn = Value::from_db_valuev1(dbv)
                         .map_err(|_| OperationError::CorruptedIndex("uuid2spn".to_string()))?;
                     Some(spn)
@@ -401,7 +407,10 @@ pub trait IdlSqliteTransaction {
 
         Ok(match data {
             Some(d) => Some(
-                serde_cbor::from_slice(d.as_slice()).map_err(|_| OperationError::SerdeCborError)?,
+                serde_cbor::from_slice(d.as_slice()).map_err(|e| {
+                    eprintln!("CRITICAL: Serde CBOR Error -> {:?}", e);
+                    OperationError::SerdeCborError
+                })?,
             ),
             None => None,
         })
@@ -425,7 +434,10 @@ pub trait IdlSqliteTransaction {
 
         Ok(match data {
             Some(d) => Some(
-                serde_cbor::from_slice(d.as_slice()).map_err(|_| OperationError::SerdeCborError)?,
+                serde_cbor::from_slice(d.as_slice()).map_err(|e| {
+                    eprintln!("CRITICAL: Serde CBOR Error -> {:?}", e);
+                    OperationError::SerdeCborError
+                })?,
             ),
             None => None,
         })
@@ -494,7 +506,7 @@ pub trait IdlSqliteTransaction {
         let allids = self.get_identry_raw(audit, &IdList::AllIds)?;
         allids
             .into_iter()
-            .map(|data| data.into_dbentry().map(|(id, db_e)| (id, db_e.to_string())))
+            .map(|data| data.into_dbentry(audit).map(|(id, db_e)| (id, db_e.to_string())))
             .collect()
     }
 
@@ -509,7 +521,7 @@ pub trait IdlSqliteTransaction {
             .pop()
             .ok_or(OperationError::InvalidEntryId)
             .and_then(|data| {
-                data.into_dbentry()
+                data.into_dbentry(audit)
                     .map(|(id, db_e)| (id, format!("{:?}", db_e)))
             })
     }
@@ -547,7 +559,10 @@ pub trait IdlSqliteTransaction {
                 })
                 .and_then(|KeyIdl { key, data }| {
                     serde_cbor::from_slice(data.as_slice())
-                        .map_err(|_| OperationError::SerdeCborError)
+                        .map_err(|e| {
+                            ladmin_error!(audit, "Serde CBOR Error -> {:?}", e);
+                            OperationError::SerdeCborError
+                        })
                         .map(|idl| (key, idl))
                 })
             })
@@ -728,7 +743,11 @@ impl IdlSqliteWriteTransaction {
         entry: &Entry<EntrySealed, EntryCommitted>,
     ) -> Result<(), OperationError> {
         let dbe = entry.to_dbentry();
-        let data = serde_cbor::to_vec(&dbe).map_err(|_| OperationError::SerdeCborError)?;
+        let data = serde_cbor::to_vec(&dbe).map_err(|e|
+            {
+                ladmin_error!(au, "Serde CBOR Error -> {:?}", e);
+                OperationError::SerdeCborError
+            })?;
 
         let raw_entries = std::iter::once(IdRawEntry {
             id: entry.get_id(),
@@ -971,7 +990,10 @@ impl IdlSqliteWriteTransaction {
             Some(k) => {
                 let dbv1 = k.to_db_valuev1();
                 let data =
-                    serde_cbor::to_vec(&dbv1).map_err(|_e| OperationError::SerdeCborError)?;
+                    serde_cbor::to_vec(&dbv1).map_err(|e| {
+                        ladmin_error!(audit, "Serde CBOR Error -> {:?}", e);
+                        OperationError::SerdeCborError
+                    })?;
                 self.conn
                     .prepare("INSERT OR REPLACE INTO idx_uuid2spn (uuid, spn) VALUES(:uuid, :spn)")
                     .and_then(|mut stmt| {
@@ -1181,7 +1203,10 @@ impl IdlSqliteWriteTransaction {
     }
 
     pub fn write_db_s_uuid(&self, nsid: Uuid) -> Result<(), OperationError> {
-        let data = serde_cbor::to_vec(&nsid).map_err(|_e| OperationError::SerdeCborError)?;
+        let data = serde_cbor::to_vec(&nsid).map_err(|e| {
+            eprintln!("CRITICAL: Serde CBOR Error -> {:?}", e);
+            OperationError::SerdeCborError
+        })?;
 
         self.conn
             .execute(
@@ -1199,7 +1224,10 @@ impl IdlSqliteWriteTransaction {
     }
 
     pub fn write_db_d_uuid(&self, nsid: Uuid) -> Result<(), OperationError> {
-        let data = serde_cbor::to_vec(&nsid).map_err(|_e| OperationError::SerdeCborError)?;
+        let data = serde_cbor::to_vec(&nsid).map_err(|e| {
+            eprintln!("CRITICAL: Serde CBOR Error -> {:?}", e);
+            OperationError::SerdeCborError
+        })?;
 
         self.conn
             .execute(
@@ -1217,7 +1245,10 @@ impl IdlSqliteWriteTransaction {
     }
 
     pub fn set_db_ts_max(&self, ts: &Duration) -> Result<(), OperationError> {
-        let data = serde_cbor::to_vec(ts).map_err(|_e| OperationError::SerdeCborError)?;
+        let data = serde_cbor::to_vec(ts).map_err(|e| {
+            eprintln!("CRITICAL: Serde CBOR Error -> {:?}", e);
+            OperationError::SerdeCborError
+        })?;
 
         self.conn
             .execute(
@@ -1254,7 +1285,10 @@ impl IdlSqliteWriteTransaction {
 
         Ok(match data {
             Some(d) => Some(
-                serde_cbor::from_slice(d.as_slice()).map_err(|_| OperationError::SerdeCborError)?,
+                serde_cbor::from_slice(d.as_slice()).map_err(|e| {
+                    eprintln!("CRITICAL: Serde CBOR Error -> {:?}", e);
+                    OperationError::SerdeCborError
+                })?,
             ),
             None => None,
         })

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -122,9 +122,12 @@ pub struct BackendWriteTransaction<'a> {
 }
 
 impl IdRawEntry {
-    fn into_dbentry(self) -> Result<(u64, DbEntry), OperationError> {
+    fn into_dbentry(self, audit: &mut AuditScope) -> Result<(u64, DbEntry), OperationError> {
         serde_cbor::from_slice(self.data.as_slice())
-            .map_err(|_| OperationError::SerdeCborError)
+            .map_err(|e| {
+                ladmin_error!(audit, "Serde CBOR Error -> {:?}", e);
+                OperationError::SerdeCborError
+            })
             .map(|dbe| (self.id, dbe))
     }
 
@@ -133,7 +136,10 @@ impl IdRawEntry {
         audit: &mut AuditScope,
     ) -> Result<Entry<EntrySealed, EntryCommitted>, OperationError> {
         let db_e = serde_cbor::from_slice(self.data.as_slice())
-            .map_err(|_| OperationError::SerdeCborError)?;
+            .map_err(|e| {
+                ladmin_error!(audit, "Serde CBOR Error -> {:?}", e);
+                OperationError::SerdeCborError
+            })?;
         // let id = u64::try_from(self.id).map_err(|_| OperationError::InvalidEntryId)?;
         Entry::from_dbentry(audit, db_e, self.id)
             .map_err(|_| OperationError::CorruptedEntry(self.id))


### PR DESCRIPTION
A change in webauthn broke startup but only for ecdsa keys which had a serialised field renamed. .10 adds an alias to allow successful deserialisation. 

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
