### PR TITLE
Implement driftwood HTTP request logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "concread"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1090,18 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "driftwood"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b3023a4726001fac50751213c596901a1f3b2edd9d071012f01b92eba0c995"
+dependencies = [
+ "chrono",
+ "colored",
+ "size",
+ "tide",
+]
 
 [[package]]
 name = "either"
@@ -1797,6 +1820,7 @@ dependencies = [
  "chrono",
  "concread",
  "criterion",
+ "driftwood",
  "env_logger",
  "fernet",
  "filetime",
@@ -3157,6 +3181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "size"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5021178e8e70579d009fb545932e274ec2dde4c917791c6063d1002bee2a56"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -91,6 +91,8 @@ validator = { version = "0.14" }
 touch = "0.0.1"
 filetime = "0.2.14"
 
+driftwood = "0.0.6"
+
 [features]
 simd_support = [ "concread/simd_support" ]
 # default = [ "libsqlite3-sys/bundled", "openssl/vendored" ]

--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -1188,6 +1188,8 @@ pub fn create_https_server(
         bundy_handle,
     });
 
+    tserver.with(driftwood::ApacheCombinedLogger);
+
     // tide::log::with_level(tide::log::LevelFilter::Debug);
 
     // Add middleware?


### PR DESCRIPTION
This is separate to the existing tracing work, adds an initial function to log HTTP requests to the server.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes


# Example output 

This is running locally with local queries (filtered for just the logs)... it'll log the remote IP address when queries happen.

Me running random cURL requests:
```
[::ffff:127.0.0.1]:52846 - - [31/Jul/2021:12:02:25 +1000] "GET /HELLO HTTP/1.1" 404 0 "" "curl/7.64.1"
```
Me `kanidm login`:
```
[::ffff:127.0.0.1]:52868 - - [31/Jul/2021:12:03:51 +1000] "POST /v1/auth HTTP/1.1" 200 87 "" ""
[::ffff:127.0.0.1]:52869 - - [31/Jul/2021:12:03:51 +1000] "POST /v1/auth HTTP/1.1" 200 410 "" ""
[::ffff:127.0.0.1]:52870 - - [31/Jul/2021:12:03:58 +1000] "POST /v1/auth HTTP/1.1" 200 86 "" ""
[::ffff:127.0.0.1]:52871 - - [31/Jul/2021:12:04:01 +1000] "POST /v1/auth HTTP/1.1" 200 715 "" ""
```

Future ideas I have include a proper UserAgent (with version) for `kanidmd` client requests and `userid`s being in these logs.