### PR TITLE
fixing the favicon

### DIFF
--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -161,6 +161,8 @@ async fn index_view(_req: tide::Request<AppState>) -> tide::Result {
         <meta charset="utf-8">
         <title>Kanidm</title>
         <script src="/pkg/bundle.js" defer></script>
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦀</text></svg>">
+
     </head>
 
     <body>

--- a/kanidmd_web_ui/src/manager.rs
+++ b/kanidmd_web_ui/src/manager.rs
@@ -104,6 +104,8 @@ impl Component for ManagerApp {
                 <link rel="stylesheet" href="/pkg/style.css"/>
                 <script src="/pkg/external/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"></script>
                 <script src="/pkg/external/confetti.js"></script>
+                <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦀</text></svg>" />
+
             </head>
 
             {


### PR DESCRIPTION
Adds an SVG/emoji favicon of a crab.

... I couldn't get WASM to build on my m1, so this definitely needs testing 😄 

```
[INFO]: ⬇️  Installing wasm-bindgen...
Error: no prebuilt wasm-opt binaries are available for this platform: Unrecognized target!
To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
```

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

