### PR TITLE
Improved LDAP client address logging, move AuditScope out a layer

### DIFF
--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -43,7 +43,7 @@ use std::convert::TryFrom;
 
 pub struct QueryServerReadV1 {
     log: Sender<AuditScope>,
-    log_level: Option<u32>,
+    pub log_level: Option<u32>,
     idms: Arc<IdmServer>,
     ldap: Arc<LdapServer>,
 }
@@ -1172,11 +1172,10 @@ impl QueryServerReadV1 {
     pub async fn handle_ldaprequest(
         &self,
         eventid: Uuid,
+        mut audit: AuditScope,
         protomsg: LdapMsg,
         uat: Option<LdapBoundToken>,
     ) -> Option<LdapResponseState> {
-        let mut audit = AuditScope::new("ldap_request_message", eventid, self.log_level);
-
         /*
         let res = lperf_op_segment!(
             &mut audit,

--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -388,9 +388,7 @@ impl PerfProcessed {
     }
 }
 
-// This structure tracks and event lifecycle, and is eventually
-// sent to the logging system where it's structured and written
-// out to the current logging BE.
+/// This structure tracks and event lifecycle, and is eventually sent to the logging system where it's structured and written out to the current logging BE.
 #[derive(Serialize)]
 pub struct AuditScope {
     // vec of start/end points of various parts of the event?

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -81,32 +81,29 @@ pub struct IdmServer {
     // Do we need a softlock ticket?
     softlock_ticket: Semaphore,
     softlocks: HashMap<Uuid, CredSoftLock>,
-    // Keep a set of inprogress mfa registrations
+    /// A set of inprogress mfa registrations
     mfareg_sessions: BptreeMap<Uuid, MfaRegSession>,
-    // Need a reference to the query server.
+    /// Reference to the query server.
     qs: QueryServer,
-    // The configured crypto policy for the IDM server. Later this could be transactional
-    // and loaded from the db similar to access. But today it's just to allow dynamic pbkdf2rounds
+    /// The configured crypto policy for the IDM server. Later this could be transactional and loaded from the db similar to access. But today it's just to allow dynamic pbkdf2rounds
     crypto_policy: CryptoPolicy,
     async_tx: Sender<DelayedAction>,
-    // Our webauthn verifier/config
+    /// [WebAuthn] verifier/config
     webauthn: Webauthn<WebauthnDomainConfig>,
     pw_badlist_cache: Arc<CowCell<HashSet<String>>>,
     oauth2rs: Arc<Oauth2ResourceServers>,
     uat_bundy_hmac: Arc<CowCell<HS512>>,
 }
 
+/// Contains methods that require writes, but in the context of writing to the idm in memory structures (maybe the query server too). This is things like authentication
 pub struct IdmServerAuthTransaction<'a> {
-    // Contains methods that require writes, but in the context of writing to
-    // the idm in memory structures (maybe the query server too). This is
-    // things like authentication
     session_ticket: &'a Semaphore,
     sessions: &'a BptreeMap<Uuid, AuthSession>,
 
     softlock_ticket: &'a Semaphore,
     softlocks: &'a HashMap<Uuid, CredSoftLock>,
     pub qs_read: QueryServerReadTransaction<'a>,
-    // thread/server id
+    /// Thread/Server ID
     sid: Sid,
     // For flagging eventual actions.
     async_tx: Sender<DelayedAction>,
@@ -115,9 +112,8 @@ pub struct IdmServerAuthTransaction<'a> {
     uat_bundy_hmac: CowCellReadTxn<HS512>,
 }
 
+/// This contains read-only methods, like getting users, groups and other structured content.
 pub struct IdmServerProxyReadTransaction<'a> {
-    // This contains read-only methods, like getting users, groups
-    // and other structured content.
     pub qs_read: QueryServerReadTransaction<'a>,
     uat_bundy_hmac: CowCellReadTxn<HS512>,
     oauth2rs: Oauth2ResourceServersReadTransaction,
@@ -127,7 +123,7 @@ pub struct IdmServerProxyWriteTransaction<'a> {
     // This does NOT take any read to the memory content, allowing safe
     // qs operations to occur through this interface.
     pub qs_write: QueryServerWriteTransaction<'a>,
-    // Associate to an event origin ID, which has a TS and a UUID instead
+    /// Associate to an event origin ID, which has a TS and a UUID instead
     mfareg_sessions: BptreeMapWriteTxn<'a, Uuid, MfaRegSession>,
     sid: Sid,
     crypto_policy: &'a CryptoPolicy,

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -81,7 +81,7 @@ pub struct IdmServer {
     // Do we need a softlock ticket?
     softlock_ticket: Semaphore,
     softlocks: HashMap<Uuid, CredSoftLock>,
-    /// A set of inprogress mfa registrations
+    /// A set of in progress MFA registrations
     mfareg_sessions: BptreeMap<Uuid, MfaRegSession>,
     /// Reference to the query server.
     qs: QueryServer,
@@ -95,7 +95,7 @@ pub struct IdmServer {
     uat_bundy_hmac: Arc<CowCell<HS512>>,
 }
 
-/// Contains methods that require writes, but in the context of writing to the idm in memory structures (maybe the query server too). This is things like authentication
+/// Contains methods that require writes, but in the context of writing to the idm in memory structures (maybe the query server too). This is things like authentication.
 pub struct IdmServerAuthTransaction<'a> {
     session_ticket: &'a Semaphore,
     sessions: &'a BptreeMap<Uuid, AuthSession>,
@@ -3812,8 +3812,7 @@ mod tests {
                 .target_to_account(audit, &UUID_ADMIN)
                 .expect("account must exist");
 
-            // create some fake uats
-            // process them and see what claims fall out :D
+            // Create some fake UATs, then process them and see what claims fall out 🥳
             let session_id = uuid::Uuid::new_v4();
 
             // For the different auth types, check that we get the correct claims:

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -88,7 +88,7 @@ pub struct IdmServer {
     /// The configured crypto policy for the IDM server. Later this could be transactional and loaded from the db similar to access. But today it's just to allow dynamic pbkdf2rounds
     crypto_policy: CryptoPolicy,
     async_tx: Sender<DelayedAction>,
-    /// [WebAuthn] verifier/config
+    /// [Webauthn] verifier/config
     webauthn: Webauthn<WebauthnDomainConfig>,
     pw_badlist_cache: Arc<CowCell<HashSet<String>>>,
     oauth2rs: Arc<Oauth2ResourceServers>,


### PR DESCRIPTION
fixes #450, previous logging from #454 wasn't actually working because I was using `info!()` which got eaten by `tokio` and async things.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

