### PR TITLE
updating well-known URI to meed OIDC spec

### DIFF
--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -1230,7 +1230,7 @@ pub fn create_https_server(
 
     tserver.at("/status").get(self::status);
 
-    let mut well_known = tserver.at("/well-known");
+    let mut well_known = tserver.at("/.well-known");
     well_known
         .at("/openid-configuration")
         .get(get_openid_configuration);


### PR DESCRIPTION
Per https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig the URI should be `/.well-known/openid-configuration`

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

