### PR TITLE
508 token introspect

### DIFF
--- a/kanidm_client/tests/oauth2_test.rs
+++ b/kanidm_client/tests/oauth2_test.rs
@@ -2,7 +2,10 @@ mod common;
 use crate::common::{run_test, ADMIN_TEST_PASSWORD};
 use kanidm_client::KanidmClient;
 
-use kanidm_proto::oauth2::{AccessTokenRequest, AccessTokenResponse, ConsentRequest};
+use kanidm_proto::oauth2::{
+    AccessTokenRequest, AccessTokenResponse, ConsentRequest, IntrospectionRequest,
+    IntrospectionResponse,
+};
 use oauth2_ext::PkceCodeChallenge;
 use std::collections::HashMap;
 use url::Url;
@@ -153,7 +156,7 @@ fn test_oauth2_basic_flow() {
 
             let response = client
                 .post(format!("{}/oauth2/token", url))
-                .basic_auth("test_integration", Some(client_secret))
+                .basic_auth("test_integration", Some(client_secret.clone()))
                 .form(&form_req)
                 .send()
                 .await
@@ -164,12 +167,34 @@ fn test_oauth2_basic_flow() {
 
             // The body is a json AccessTokenResponse
 
-            let _atr = response
+            let atr = response
                 .json::<AccessTokenResponse>()
                 .await
                 .expect("Unable to decode AccessTokenResponse");
 
             // Step 4 - inspect the granted token.
+
+            let inspect_req = IntrospectionRequest {
+                token: atr.access_token.clone(),
+                token_type_hint: Some("access_token".to_string()),
+            };
+
+            let response = client
+                .post(format!("{}/oauth2/token/introspect", url))
+                .basic_auth("test_integration", Some(client_secret))
+                .form(&inspect_req)
+                .send()
+                .await
+                .expect("Failed to send token introspection request.");
+
+            assert!(response.status() == reqwest::StatusCode::OK);
+
+            let tir = response
+                .json::<IntrospectionResponse>()
+                .await
+                .expect("Unable to decode IntrospectionResponse");
+
+            eprintln!("{:?}", tir);
         })
     })
 }

--- a/kanidm_proto/src/oauth2.rs
+++ b/kanidm_proto/src/oauth2.rs
@@ -131,11 +131,11 @@ pub struct OpenIDConnectToken {
     #[serde(rename = "iss")]
     pub issuer: String,
     #[serde(rename = "exp")]
-    pub expiryf: i64,
+    pub expiry: i64,
     #[serde(rename = "iat")]
-    pub time_issued: i64,
+    pub issued_at: i64,
     #[serde(rename = "aud")]
-    pub intended_audience: Vec<String>,
+    pub audience: Vec<String>,
     pub auth_time: i64,
     //
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,6 +165,6 @@ pub struct Oauth2Rfc7662 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jti: Option<String>,
     // not before
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub nbf: Option<i64>,
+    #[serde(rename = "nbf", skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<i64>,
 }

--- a/kanidm_proto/src/oauth2.rs
+++ b/kanidm_proto/src/oauth2.rs
@@ -126,16 +126,16 @@ pub struct Oauth2UserToken {
 // https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OpenIDConnectToken {
-    // Subject (uuid)
-    pub sub: Uuid,
-    // issuer
-    pub iss: String,
-    // expiryf
-    pub exp: i64,
-    // time issued
-    pub iat: i64,
-    // "intended audience"
-    pub aud: Vec<String>,
+    #[serde(rename = "sub")]
+    pub subject: Uuid,
+    #[serde(rename = "iss")]
+    pub issuer: String,
+    #[serde(rename = "exp")]
+    pub expiryf: i64,
+    #[serde(rename = "iat")]
+    pub time_issued: i64,
+    #[serde(rename = "aud")]
+    pub intended_audience: Vec<String>,
     pub auth_time: i64,
     //
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/kanidm_proto/src/oauth2.rs
+++ b/kanidm_proto/src/oauth2.rs
@@ -1,4 +1,6 @@
+use crate::v1::AuthType;
 use url::Url;
+use uuid::Uuid;
 use webauthn_rs::base64_data::Base64UrlSafeData;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -68,7 +70,7 @@ pub struct AccessTokenResponse {
     // Enum?
     pub token_type: String,
     // seconds.
-    pub expires_in: u32,
+    pub expires_in: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refresh_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -84,4 +86,85 @@ pub struct ErrorResponse {
     pub error_description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_uri: Option<Url>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct IntrospectionRequest {
+    pub token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_type_hint: Option<String>,
+}
+
+// Revoked is just active-false.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum IntrospectionResponse {
+    Active {
+        active: bool,
+        #[serde(flatten)]
+        token: Oauth2UserToken,
+    },
+    Invalid {
+        active: bool,
+    },
+}
+
+// Kani extensions + oidc + rfc7662 introspect
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Oauth2UserToken {
+    // Kani extensions
+    pub spn: String,
+    pub session_id: Uuid,
+    pub auth_type: AuthType,
+    #[serde(flatten)]
+    pub oidc_token: OpenIDConnectToken,
+    #[serde(flatten)]
+    pub rfc7662: Oauth2Rfc7662,
+}
+
+// oidc id token
+// https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OpenIDConnectToken {
+    // Subject (uuid)
+    pub sub: Uuid,
+    // issuer
+    pub iss: String,
+    // expiryf
+    pub exp: i64,
+    // time issued
+    pub iat: i64,
+    // "intended audience"
+    pub aud: Vec<String>,
+    pub auth_time: i64,
+    //
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+    // auth context?
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acr: Option<String>,
+    // how it was auth / could come from authtype instead?
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amr: Option<String>,
+    // not needed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub azp: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Oauth2Rfc7662 {
+    // rfc 7662 - most of this come from openidconnect token, these
+    // are just the missing values.
+
+    // space seperated scopes.
+    pub token_type: String,
+    pub username: String,
+    pub scope: String,
+    pub client_id: String,
+    // string identifier of the token
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jti: Option<String>,
+    // not before
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nbf: Option<i64>,
 }

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -182,12 +182,15 @@ pub enum AuthType {
 pub struct UserAuthToken {
     pub session_id: Uuid,
     pub auth_type: AuthType,
+    // What time we issued this authentication token.
+    pub issued_at: time::OffsetDateTime,
     // When this token should be considered expired. Interpretation
     // may depend on the client application.
     pub expiry: time::OffsetDateTime,
     pub uuid: Uuid,
     // pub name: String,
     pub spn: String,
+    pub displayname: String,
     // pub groups: Vec<Group>,
     // pub claims: Vec<Claim>,
     // Should we just retrieve these inside the server instead of in the uat?

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -551,7 +551,7 @@ pub trait AccessControlsTransaction<'a> {
                                 .iter()
                                 .filter_map(|(acs, f_res)| {
                                     // if it applies
-                                    if e.entry_match_no_index(&f_res) {
+                                    if e.entry_match_no_index(f_res) {
                                         lsecurity_access!(
                                             audit,
                                             "entry {:?} matches acs {}",
@@ -700,7 +700,7 @@ pub trait AccessControlsTransaction<'a> {
                             let allowed_attrs: BTreeSet<&str> = related_acp
                                 .iter()
                                 .filter_map(|(acs, f_res)| {
-                                    if e.entry_match_no_index(&f_res) {
+                                    if e.entry_match_no_index(f_res) {
                                         lsecurity_access!(
                                             audit,
                                             "target entry {:?} matches acs {}",
@@ -909,7 +909,7 @@ pub trait AccessControlsTransaction<'a> {
                     let scoped_acp: Vec<&AccessControlModify> = related_acp
                         .iter()
                         .filter_map(|(acm, f_res)| {
-                            if e.entry_match_no_index(&f_res) {
+                            if e.entry_match_no_index(f_res) {
                                 Some(*acm)
                             } else {
                                 None
@@ -1064,7 +1064,7 @@ pub trait AccessControlsTransaction<'a> {
                             r_acc
                         } else {
                             // Check to see if allowed.
-                            if e.entry_match_no_index(&f_res) {
+                            if e.entry_match_no_index(f_res) {
                                 lsecurity_access!(audit, "entry {:?} matches acs {:?}", e, accr);
                                 // It matches, so now we have to check attrs and classes.
                                 // Remember, we have to match ALL requested attrs
@@ -1209,7 +1209,7 @@ pub trait AccessControlsTransaction<'a> {
                         if r_acc {
                             // If something allowed us to delete, skip doing silly work.
                             r_acc
-                        } else if e.entry_match_no_index(&f_res) {
+                        } else if e.entry_match_no_index(f_res) {
                             lsecurity_access!(
                                 audit,
                                 "entry {:?} matches acs {}",

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -1001,7 +1001,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
         let slopes: HashMap<_, _> = data
             .into_iter()
             .filter_map(|(k, lens)| {
-                let slope_factor = Self::calculate_sd_slope(lens);
+                let slope_factor = Self::calculate_sd_slope(&lens);
                 if slope_factor == 0 || slope_factor == IdxSlope::MAX {
                     None
                 } else {
@@ -1014,7 +1014,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
         self.db.store_idx_slope_analysis(audit, &slopes)
     }
 
-    fn calculate_sd_slope(data: Vec<f64>) -> IdxSlope {
+    fn calculate_sd_slope(data: &[f64]) -> IdxSlope {
         let (n_keys, sd_1) = if data.len() >= 2 {
             // We can only do SD on sets greater than 2
             let l: u32 = data.len().try_into().unwrap_or(u32::MAX);

--- a/kanidmd/src/lib/be/idxkey.rs
+++ b/kanidmd/src/lib/be/idxkey.rs
@@ -122,7 +122,7 @@ impl IdlCacheKeyToRef for IdlCacheKey {
         IdlCacheKeyRef {
             a: self.a.as_str(),
             i: &self.i,
-            k: &self.k.as_str(),
+            k: self.k.as_str(),
         }
     }
 }

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -590,14 +590,14 @@ pub trait BackendTransaction {
                 IdList::AllIds => lperf_segment!(au, "be::search<entry::ftest::allids>", || {
                     entries
                         .into_iter()
-                        .filter(|e| e.entry_match_no_index(&filt))
+                        .filter(|e| e.entry_match_no_index(filt))
                         .collect()
                 }),
                 IdList::Partial(_) => {
                     lperf_segment!(au, "be::search<entry::ftest::partial>", || {
                         entries
                             .into_iter()
-                            .filter(|e| e.entry_match_no_index(&filt))
+                            .filter(|e| e.entry_match_no_index(filt))
                             .collect()
                     })
                 }
@@ -605,7 +605,7 @@ pub trait BackendTransaction {
                     lperf_trace_segment!(au, "be::search<entry::ftest::thresh>", || {
                         entries
                             .into_iter()
-                            .filter(|e| e.entry_match_no_index(&filt))
+                            .filter(|e| e.entry_match_no_index(filt))
                             .collect()
                     })
                 }
@@ -690,7 +690,7 @@ pub trait BackendTransaction {
                         lperf_trace_segment!(au, "be::exists -> entry_match_no_index", || {
                             entries
                                 .into_iter()
-                                .filter(|e| e.entry_match_no_index(&filt))
+                                .filter(|e| e.entry_match_no_index(filt))
                                 .collect()
                         });
 
@@ -713,7 +713,7 @@ pub trait BackendTransaction {
         if e.mask_recycled_ts().is_some() {
             let e_uuid = e.get_uuid();
             // We only check these on live entries.
-            let (n2u_add, n2u_rem) = Entry::idx_name2uuid_diff(None, Some(&e));
+            let (n2u_add, n2u_rem) = Entry::idx_name2uuid_diff(None, Some(e));
 
             let n2u_set = match (n2u_add, n2u_rem) {
                 (Some(set), None) => set,
@@ -745,7 +745,7 @@ pub trait BackendTransaction {
             })?;
 
             let spn = e.get_uuid2spn();
-            match self.get_idlayer().uuid2spn(audit, &e_uuid) {
+            match self.get_idlayer().uuid2spn(audit, e_uuid) {
                 Ok(Some(idx_spn)) => {
                     if spn != idx_spn {
                         ladmin_error!(audit, "Invalid uuid2spn state -> incorrect idx spn value");
@@ -759,7 +759,7 @@ pub trait BackendTransaction {
             };
 
             let rdn = e.get_uuid2rdn();
-            match self.get_idlayer().uuid2rdn(audit, &e_uuid) {
+            match self.get_idlayer().uuid2rdn(audit, e_uuid) {
                 Ok(Some(idx_rdn)) => {
                     if rdn != idx_rdn {
                         ladmin_error!(audit, "Invalid uuid2rdn state -> incorrect idx rdn value");

--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -394,11 +394,9 @@ pub fn create_https_server(
         .post(oauth2_authorise_permit_post)
         .get(oauth2_authorise_permit_get);
     oauth2_process.at("/token").post(oauth2_token_post);
-    /*
     oauth2_process
         .at("/token/introspect")
-        .get(oauth2_token_introspect_get);
-    */
+        .post(oauth2_token_introspect_post);
 
     let mut raw_route = appserver.at("/v1/raw");
     raw_route.at("/create").post(create);

--- a/kanidmd/src/lib/core/https/oauth2.rs
+++ b/kanidmd/src/lib/core/https/oauth2.rs
@@ -1,7 +1,8 @@
 use super::v1::{json_rest_event_get, json_rest_event_post};
 use super::{to_tide_response, AppState, RequestExtensions};
 use crate::idm::oauth2::{
-    AccessTokenRequest, AuthorisationRequest, AuthorisePermitSuccess, ErrorResponse, Oauth2Error,
+    AccessTokenRequest, AuthorisationRequest, AuthorisePermitSuccess, ErrorResponse,
+    IntrospectionRequest, Oauth2Error,
 };
 use crate::prelude::*;
 use kanidm_proto::v1::Entry as ProtoEntry;
@@ -367,7 +368,68 @@ pub async fn get_openid_configuration(_req: tide::Request<AppState>) -> tide::Re
     Ok(res)
 }
 
-/*
-pub async fn oauth2_token_introspect_get(req: tide::Request<AppState>) -> tide::Result {
+pub async fn oauth2_token_introspect_post(mut req: tide::Request<AppState>) -> tide::Result {
+    // This is issued directly by the resource server, which is why we authenticate
+    // it with the client_id and client_pw.
+    let (eventid, hvalue) = req.new_eventid();
+
+    // Get the authz header (if present).
+    let client_authz = req
+        .header("authorization")
+        .and_then(|hv| hv.get(0))
+        .and_then(|h| h.as_str().strip_prefix("Basic "))
+        .map(str::to_string)
+        .ok_or_else(|| {
+            error!("Basic Authentication Not Provided");
+            tide::Error::from_str(
+                tide::StatusCode::Unauthorized,
+                "Invalid Basic Authorisation",
+            )
+        })?;
+
+    let tok_req: IntrospectionRequest = req.body_form().await.map_err(|e| {
+        error!("atr parse error - {:?}", e);
+        tide::Error::from_str(
+            tide::StatusCode::BadRequest,
+            "Invalid Oauth2 IntrospectionRequest",
+        )
+    })?;
+
+    let res = req
+        .state()
+        .qe_r_ref
+        .handle_oauth2_token_introspect(client_authz, tok_req, eventid)
+        .await;
+
+    match res {
+        Ok(atr) => {
+            let mut res = tide::Response::new(200);
+            tide::Body::from_json(&atr).map(|b| {
+                res.set_body(b);
+                res
+            })
+        }
+        Err(Oauth2Error::AuthenticationRequired) => {
+            // This will trigger our ui to auth and retry.
+            Ok(tide::Response::new(tide::StatusCode::Unauthorized))
+        }
+        Err(e) => {
+            // https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+            let err = ErrorResponse {
+                error: e.to_string(),
+                error_description: None,
+                error_uri: None,
+            };
+
+            let mut res = tide::Response::new(400);
+            tide::Body::from_json(&err).map(|b| {
+                res.set_body(b);
+                res
+            })
+        }
+    }
+    .map(|mut res| {
+        res.insert_header("X-KANIDM-OPID", hvalue);
+        res
+    })
 }
-*/

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -192,7 +192,7 @@ impl Password {
             Kdf::SSHA512(salt, key) => {
                 let mut hasher = Sha512::new();
                 hasher.update(cleartext.as_bytes());
-                hasher.update(&salt);
+                hasher.update(salt);
                 let r = hasher.finish();
                 Ok(key == &(r.to_vec()))
             }
@@ -341,25 +341,22 @@ impl TryFrom<DbCredV1> for Credential {
             None => None,
         };
 
-        let v_webauthn = match webauthn {
-            Some(dbw) => Some(
-                dbw.into_iter()
-                    .map(|wc| {
-                        (
-                            wc.label,
-                            WebauthnCredential {
-                                cred_id: wc.id,
-                                cred: wc.cred,
-                                counter: wc.counter,
-                                verified: wc.verified,
-                                registration_policy: wc.registration_policy,
-                            },
-                        )
-                    })
-                    .collect(),
-            ),
-            None => None,
-        };
+        let v_webauthn = webauthn.map(|dbw| {
+            dbw.into_iter()
+                .map(|wc| {
+                    (
+                        wc.label,
+                        WebauthnCredential {
+                            cred_id: wc.id,
+                            cred: wc.cred,
+                            counter: wc.counter,
+                            verified: wc.verified,
+                            registration_policy: wc.registration_policy,
+                        },
+                    )
+                })
+                .collect()
+        });
 
         let v_backup_code = match backup_code {
             Some(dbb) => Some(BackupCodes::try_from(dbb)?),
@@ -806,7 +803,7 @@ impl Credential {
             CredentialType::PasswordMfa(pw, totp, wan, opt_backup_codes) => {
                 match opt_backup_codes {
                     Some(mut backup_codes) => {
-                        backup_codes.remove(&code_to_remove);
+                        backup_codes.remove(code_to_remove);
                         Ok(Credential {
                             type_: CredentialType::PasswordMfa(pw, totp, wan, Some(backup_codes)),
                             claims: self.claims.clone(),
@@ -841,13 +838,13 @@ impl Credential {
         match &self.type_ {
             CredentialType::PasswordMfa(_, _, _, opt_bc) => opt_bc
                 .as_ref()
-                .ok_or(OperationError::InvalidAccountState(String::from(
-                    "No backup codes are available for this account",
-                )))
-                .and_then(|bc| {
-                    Ok(BackupCodesView {
-                        backup_codes: bc.code_set.clone().into_iter().collect(),
-                    })
+                .ok_or_else(|| {
+                    OperationError::InvalidAccountState(String::from(
+                        "No backup codes are available for this account",
+                    ))
+                })
+                .map(|bc| BackupCodesView {
+                    backup_codes: bc.code_set.clone().into_iter().collect(),
                 }),
             _ => Err(OperationError::InvalidAccountState(
                 "Non-MFA credential type".to_string(),

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -605,7 +605,7 @@ impl<STATE> Entry<EntryInvalid, STATE> {
                 .map(|s| {
                     // This should NOT fail - if it does, it means our schema is
                     // in an invalid state!
-                    Ok(schema_attributes.get(s).ok_or(SchemaError::Corrupted)?)
+                    schema_attributes.get(s).ok_or(SchemaError::Corrupted)
                 })
                 .collect();
 
@@ -1241,7 +1241,7 @@ impl Entry<EntrySealed, EntryCommitted> {
                             (Some(pre_vs), Some(post_vs)) => {
                                 // it exists in both, we need to work out the differents within the attr.
                                 pre_vs
-                                    .difference(&post_vs)
+                                    .difference(post_vs)
                                     .map(|pre_v| {
                                         // Was in pre, now not in post
                                         match ikey.itype {
@@ -1262,7 +1262,7 @@ impl Entry<EntrySealed, EntryCommitted> {
                                             IndexType::SubString => Vec::new(),
                                         }
                                     })
-                                    .chain(post_vs.difference(&pre_vs).map(|post_v| {
+                                    .chain(post_vs.difference(pre_vs).map(|post_v| {
                                         // is in post, but not in pre (add)
                                         match ikey.itype {
                                             IndexType::Equality => {
@@ -1389,7 +1389,7 @@ impl Entry<EntrySealed, EntryCommitted> {
 
         attrs_new.insert(
             AttrString::from("uuid"),
-            valueset![Value::new_uuidr(&self.get_uuid())],
+            valueset![Value::new_uuidr(self.get_uuid())],
         );
         attrs_new.insert(AttrString::from("class"), class_ava);
         attrs_new.insert(AttrString::from("last_modified_cid"), last_mod_ava);

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -284,7 +284,7 @@ impl SearchEvent {
         attrs: Option<BTreeSet<AttrString>>,
     ) -> Result<Self, OperationError> {
         // Kanidm Filter from LdapFilter
-        let f = Filter::from_ldap_ro(audit, &ident, &lf, qs)?;
+        let f = Filter::from_ldap_ro(audit, &ident, lf, qs)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
@@ -538,7 +538,7 @@ impl ModifyEvent {
         // Add any supplemental conditions we have.
         let f = Filter::join_parts_and(f_uuid, filter);
 
-        let m = ModifyList::from(audit, &proto_ml, qs)?;
+        let m = ModifyList::from(audit, proto_ml, qs)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -622,7 +622,7 @@ impl FilterComp {
                 match schema_attributes.get(&attr_norm) {
                     Some(schema_a) => {
                         schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             // Okay, it worked, transform to a filter component
                             .map(|_| FilterComp::Eq(attr_norm, value.clone()))
                         // On error, pass the error back out.
@@ -637,7 +637,7 @@ impl FilterComp {
                 match schema_attributes.get(&attr_norm) {
                     Some(schema_a) => {
                         schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             // Okay, it worked, transform to a filter component
                             .map(|_| FilterComp::Sub(attr_norm, value.clone()))
                         // On error, pass the error back out.
@@ -663,7 +663,7 @@ impl FilterComp {
                 match schema_attributes.get(&attr_norm) {
                     Some(schema_a) => {
                         schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             // Okay, it worked, transform to a filter component
                             .map(|_| FilterComp::LessThan(attr_norm, value.clone()))
                         // On error, pass the error back out.

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -172,11 +172,10 @@ impl Account {
 
         // TODO: Apply policy to this expiry time.
         let expiry = OffsetDateTime::unix_epoch() + ct + Duration::from_secs(AUTH_SESSION_EXPIRY);
-        let issued_at = OffsetDateTime::unix_epoch() + ct;
 
         Some(UserAuthToken {
             session_id,
-            issued_at,
+            issued_at: OffsetDateTime::unix_epoch() + ct,
             expiry,
             // name: self.name.clone(),
             spn: self.spn.clone(),

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -172,13 +172,15 @@ impl Account {
 
         // TODO: Apply policy to this expiry time.
         let expiry = OffsetDateTime::unix_epoch() + ct + Duration::from_secs(AUTH_SESSION_EXPIRY);
+        let issued_at = OffsetDateTime::unix_epoch() + ct;
 
         Some(UserAuthToken {
             session_id,
+            issued_at,
             expiry,
             // name: self.name.clone(),
             spn: self.spn.clone(),
-            // displayname: self.displayname.clone(),
+            displayname: self.displayname.clone(),
             uuid: self.uuid,
             // application: None,
             // groups: self.groups.iter().map(|g| g.to_proto()).collect(),
@@ -193,7 +195,7 @@ impl Account {
         })
     }
 
-    pub fn check_within_valid_time(
+    fn check_within_valid_time(
         ct: Duration,
         valid_from: Option<&OffsetDateTime>,
         expire: Option<&OffsetDateTime>,
@@ -216,6 +218,14 @@ impl Account {
         };
         // Mix the results
         vmin && vmax
+    }
+
+    pub fn entry_within_valid_time(ct: Duration, entry: &EntrySealedCommitted) -> bool {
+        Self::check_within_valid_time(
+            ct,
+            entry.get_ava_single_datetime("account_valid_from").as_ref(),
+            entry.get_ava_single_datetime("account_expire").as_ref(),
+        )
     }
 
     pub fn is_within_valid_time(&self, ct: Duration) -> bool {

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -269,7 +269,7 @@ impl CredHandler {
                     pw_mfa.backup_code.as_ref(),
                 ) {
                     (AuthCredential::Webauthn(resp), _, Some((_, wan_state)), _) => {
-                        match webauthn.authenticate_credential(&resp, &wan_state) {
+                        match webauthn.authenticate_credential(resp, wan_state) {
                             Ok((cid, auth_data)) => {
                                 pw_mfa.mfa_state = CredVerifyState::Success;
                                 // Success. Determine if we need to update the counter
@@ -320,7 +320,7 @@ impl CredHandler {
                         }
                     }
                     (AuthCredential::BackupCode(code_chal), _, _, Some(backup_codes)) => {
-                        if backup_codes.verify(&code_chal) {
+                        if backup_codes.verify(code_chal) {
                             if let Err(_e) =
                                 async_tx.send(DelayedAction::BackupCodeRemoval(BackupCodeRemoval {
                                     target_uuid: who,
@@ -434,7 +434,7 @@ impl CredHandler {
         match cred {
             AuthCredential::Webauthn(resp) => {
                 // lets see how we go.
-                match webauthn.authenticate_credential(&resp, &wan_cred.wan_state) {
+                match webauthn.authenticate_credential(resp, &wan_cred.wan_state) {
                     Ok((cid, auth_data)) => {
                         wan_cred.state = CredVerifyState::Success;
                         // Success. Determine if we need to update the counter

--- a/kanidmd/src/lib/idm/oauth2.rs
+++ b/kanidmd/src/lib/idm/oauth2.rs
@@ -6,6 +6,8 @@
 //!
 
 use crate::identity::IdentityId;
+use crate::idm::account::Account;
+use crate::idm::server::{IdmServerProxyReadTransaction, IdmServerTransaction};
 use crate::prelude::*;
 use concread::cowcell::*;
 use fernet::Fernet;
@@ -18,10 +20,10 @@ use webauthn_rs::base64_data::Base64UrlSafeData;
 
 pub use kanidm_proto::oauth2::{
     AccessTokenRequest, AccessTokenResponse, AuthorisationRequest, CodeChallengeMethod,
-    ConsentRequest, ErrorResponse,
+    ConsentRequest, ErrorResponse, IntrospectionRequest, IntrospectionResponse, Oauth2Rfc7662,
+    Oauth2UserToken, OpenIDConnectToken,
 };
 
-use std::convert::TryFrom;
 use std::time::Duration;
 
 lazy_static! {
@@ -130,6 +132,7 @@ pub enum Oauth2RS {
 
 #[derive(Clone)]
 struct Oauth2RSInner {
+    origin: String,
     fernet: Fernet,
     rs_set: HashMap<String, Oauth2RS>,
 }
@@ -146,14 +149,16 @@ pub struct Oauth2ResourceServersWriteTransaction<'a> {
     inner: CowCellWriteTxn<'a, Oauth2RSInner>,
 }
 
-impl TryFrom<Vec<EntrySealedCommitted>> for Oauth2ResourceServers {
-    type Error = OperationError;
-
-    fn try_from(value: Vec<EntrySealedCommitted>) -> Result<Self, Self::Error> {
+impl Oauth2ResourceServers {
+    pub fn try_new(
+        value: Vec<EntrySealedCommitted>,
+        origin: String,
+    ) -> Result<Self, OperationError> {
         let fernet =
             Fernet::new(&Fernet::generate_key()).ok_or(OperationError::CryptographyError)?;
         let oauth2rs = Oauth2ResourceServers {
             inner: CowCell::new(Oauth2RSInner {
+                origin,
                 fernet,
                 rs_set: HashMap::new(),
             }),
@@ -164,9 +169,7 @@ impl TryFrom<Vec<EntrySealedCommitted>> for Oauth2ResourceServers {
         oauth2rs_wr.commit();
         Ok(oauth2rs)
     }
-}
 
-impl Oauth2ResourceServers {
     pub fn read(&self) -> Oauth2ResourceServersReadTransaction {
         Oauth2ResourceServersReadTransaction {
             inner: self.inner.read(),
@@ -209,7 +212,7 @@ impl<'a> Oauth2ResourceServersWriteTransaction<'a> {
                         .get_ava_single_secret("oauth2_rs_basic_token_key")
                         .ok_or(OperationError::InvalidValueState)
                         .and_then(|key| {
-                            Fernet::new(&key).ok_or(OperationError::CryptographyError)
+                            Fernet::new(key).ok_or(OperationError::CryptographyError)
                         })?;
 
                     // Currently unsure if this is how I want to handle this.
@@ -402,21 +405,11 @@ impl Oauth2ResourceServersReadTransaction {
         })
     }
 
-    pub fn check_oauth2_token_exchange(
+    fn oauth2_authz_basic(
         &self,
         audit: &mut AuditScope,
         client_authz: &str,
-        token_req: &AccessTokenRequest,
-        ct: Duration,
-    ) -> Result<AccessTokenResponse, Oauth2Error> {
-        if token_req.grant_type != "authorization_code" {
-            ladmin_warning!(
-                audit,
-                "Invalid oauth2 grant_type (should be 'authorization_code')"
-            );
-            return Err(Oauth2Error::InvalidRequest);
-        }
-
+    ) -> Result<&Oauth2RSBasic, Oauth2Error> {
         // Check the client_authz
         let authz = base64::decode(&client_authz)
             .map_err(|_| {
@@ -450,16 +443,35 @@ impl Oauth2ResourceServersReadTransaction {
         })?;
 
         // check the secret.
-        let o2rs_fernet = match o2rs {
+        match o2rs {
             Oauth2RS::Basic(rsbasic) => {
                 if rsbasic.authz_secret != secret {
                     lsecurity!(audit, "Invalid oauth2 client_id secret");
                     return Err(Oauth2Error::AuthenticationRequired);
                 }
                 // We are authenticated! Yay! Now we can actually check things ...
-                &rsbasic.token_fernet
+                Ok(rsbasic)
             }
-        };
+        }
+    }
+
+    pub fn check_oauth2_token_exchange(
+        &self,
+        audit: &mut AuditScope,
+        client_authz: &str,
+        token_req: &AccessTokenRequest,
+        ct: Duration,
+    ) -> Result<AccessTokenResponse, Oauth2Error> {
+        if token_req.grant_type != "authorization_code" {
+            ladmin_warning!(
+                audit,
+                "Invalid oauth2 grant_type (should be 'authorization_code')"
+            );
+            return Err(Oauth2Error::InvalidRequest);
+        }
+
+        let rsbasic = self.oauth2_authz_basic(audit, client_authz)?;
+        let o2rs_fernet = &rsbasic.token_fernet;
 
         // Check the token_req is within the valid time, and correctly signed for
         // this client.
@@ -499,13 +511,16 @@ impl Oauth2ResourceServersReadTransaction {
             return Err(Oauth2Error::InvalidRequest);
         }
 
-        // We are now GOOD TO GO!
-        // Use this to grant the access token response.
-        let odt_ct = OffsetDateTime::unix_epoch() + ct;
+        // =====================================================
+        // We are now GOOD TO GO! 🥳
 
-        let expires_in = if code_xchg.uat.expiry > odt_ct {
-            // Becomes a duration.
-            (code_xchg.uat.expiry - odt_ct).whole_seconds() as u32
+        // Later we need to limit this and use refresh tokens.
+        let iat = (OffsetDateTime::unix_epoch() + ct).unix_timestamp();
+        let exp = code_xchg.uat.expiry.unix_timestamp();
+
+        // Used in the access token response.
+        let expires_in = if exp > iat {
+            exp - iat
         } else {
             lsecurity!(
                 audit,
@@ -513,10 +528,39 @@ impl Oauth2ResourceServersReadTransaction {
             );
             return Err(Oauth2Error::AccessDenied);
         };
+        debug_assert!(expires_in.is_positive());
 
-        let access_token = serde_json::to_vec(&code_xchg.uat)
+        // Convert the uat into an oauth2 token from the code_xchg.uat
+        let ouat = Oauth2UserToken {
+            spn: code_xchg.uat.spn.clone(),
+            session_id: code_xchg.uat.session_id,
+            auth_type: code_xchg.uat.auth_type.clone(),
+            oidc_token: OpenIDConnectToken {
+                sub: code_xchg.uat.uuid,
+                iss: self.inner.origin.clone(),
+                exp: code_xchg.uat.expiry.unix_timestamp(),
+                iat,
+                aud: vec![rsbasic.name.clone(), rsbasic.origin.ascii_serialization()],
+                auth_time: code_xchg.uat.issued_at.unix_timestamp(),
+                nonce: None,
+                acr: None,
+                amr: None,
+                azp: None,
+            },
+            rfc7662: Oauth2Rfc7662 {
+                token_type: "access_token".to_string(),
+                username: code_xchg.uat.displayname,
+                scope: "".to_string(),
+                client_id: rsbasic.name.clone(),
+                jti: None,
+                // Can't be used before now!
+                nbf: Some(iat),
+            },
+        };
+
+        let access_token = serde_json::to_vec(&ouat)
             .map_err(|e| {
-                ladmin_error!(audit, "Unable to encode uat data {:?}", e);
+                ladmin_error!(audit, "Unable to encode oauth uat data {:?}", e);
                 Oauth2Error::ServerError(OperationError::SerdeJsonError)
             })
             .map(|data| o2rs_fernet.encrypt_at_time(&data, ct.as_secs()))?;
@@ -529,13 +573,87 @@ impl Oauth2ResourceServersReadTransaction {
             scope: None,
         })
     }
+
+    pub fn check_oauth2_token_introspect(
+        &self,
+        audit: &mut AuditScope,
+        client_authz: &str,
+        token_req: &IntrospectionRequest,
+        ct: Duration,
+        idm_read: &IdmServerProxyReadTransaction<'_>,
+    ) -> Result<IntrospectionResponse, Oauth2Error> {
+        // Check the client_authz
+        // Get our client handle
+
+        let rsbasic = self.oauth2_authz_basic(audit, client_authz)?;
+        let o2rs_fernet = &rsbasic.token_fernet;
+
+        // Check the token_req / type
+        if let Some(token_type_hint) = token_req.token_type_hint.as_ref() {
+            if token_type_hint != "access_token" {
+                ladmin_warning!(
+                    audit,
+                    "Invalid oauth2 token_type_hint (should be 'access_token' or not set)"
+                );
+                return Err(Oauth2Error::InvalidRequest);
+            }
+        }
+
+        // Can we decrypt the uat with our client handle?
+        // token_req.token
+
+        let ouat: Oauth2UserToken = o2rs_fernet
+            .decrypt(&token_req.token)
+            .map_err(|e| {
+                lsecurity!(audit, "Failed to decrypt token - {:?}", e);
+                Oauth2Error::InvalidRequest
+            })
+            .and_then(|data| {
+                serde_json::from_slice(&data).map_err(|e| {
+                    ladmin_error!(audit, "Failed to deserialise token - {:?}", e);
+                    Oauth2Error::ServerError(OperationError::SerdeJsonError)
+                })
+            })?;
+
+        // Is it still valid? This applies to both the token AND the account
+        // that the token references.
+
+        if (time::OffsetDateTime::unix_epoch() + ct).unix_timestamp() >= ouat.oidc_token.exp {
+            lsecurity!(audit, "Token expired");
+            // We return an inactive response here.
+            return Ok(IntrospectionResponse::Invalid { active: false });
+        }
+
+        let entry = idm_read
+            .get_qs_txn()
+            .internal_search_uuid(audit, &ouat.oidc_token.sub)
+            .map_err(|e| {
+                ladmin_error!(audit, "from_ro_uat failed {:?}", e);
+                Oauth2Error::InvalidRequest
+            })?;
+
+        if !Account::entry_within_valid_time(ct, &entry) {
+            lsecurity!(audit, "Account expired");
+            // We return an inactive response here.
+            return Ok(IntrospectionResponse::Invalid { active: false });
+        }
+
+        lsecurity!(audit, "Token active");
+        // Generate the response structure.
+        Ok(IntrospectionResponse::Active {
+            active: true,
+            token: ouat,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::event::CreateEvent;
+    use crate::event::ModifyEvent;
     use crate::idm::oauth2::Oauth2Error;
     use crate::idm::server::{IdmServer, IdmServerTransaction};
+    use crate::modify::{Modify, ModifyList};
     use crate::prelude::*;
 
     use kanidm_proto::oauth2::*;
@@ -1016,6 +1134,143 @@ mod tests {
                     .unwrap_err()
                     == Oauth2Error::InvalidRequest
             );
+        })
+    }
+
+    #[test]
+    fn test_idm_oauth2_token_introspection_requests() {
+        run_idm_test!(|_qs: &QueryServer,
+                       idms: &IdmServer,
+                       _idms_delayed: &mut IdmServerDelayed,
+                       audit: &mut AuditScope| {
+            let ct = Duration::from_secs(TEST_CURRENT_TIME);
+            let (secret, uat, ident) = setup_oauth2_resource_server(audit, idms, ct);
+
+            let idms_prox_read = idms.proxy_read();
+            // First we need a valid session.
+
+            let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+
+            let consent_request = good_authorisation_request!(
+                audit,
+                idms_prox_read,
+                &ident,
+                &uat,
+                ct,
+                code_challenge
+            );
+
+            let permit_success = idms_prox_read
+                .check_oauth2_authorise_permit(
+                    audit,
+                    &ident,
+                    &uat,
+                    &consent_request.consent_token,
+                    ct,
+                )
+                .expect("Failed to perform oauth2 permit");
+
+            let client_authz = base64::encode(format!("test_resource_server:{}", secret));
+            let token_req = AccessTokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: permit_success.code,
+                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+                client_id: None,
+                // From the first step.
+                code_verifier,
+            };
+
+            let token_response = idms_prox_read
+                .check_oauth2_token_exchange(audit, &client_authz, &token_req, ct)
+                .expect("Failed to perform oauth2 token exchange");
+
+            assert!(token_response.token_type == "bearer");
+
+            // Check a good req
+            let good_req = IntrospectionRequest {
+                token: token_response.access_token.clone(),
+                token_type_hint: None,
+            };
+            let r1 =
+                idms_prox_read.check_oauth2_token_introspect(audit, &client_authz, &good_req, ct);
+
+            let token = if let Ok(IntrospectionResponse::Active { active, token }) = r1 {
+                assert!(active);
+                token
+            } else {
+                panic!();
+            };
+
+            assert!(token.spn == uat.spn);
+
+            // Check some invalid requests
+            assert!(idms_prox_read
+                .check_oauth2_token_introspect(
+                    audit,
+                    &client_authz,
+                    &IntrospectionRequest {
+                        token: token_response.access_token.clone(),
+                        token_type_hint: Some("cheese".to_string()),
+                    },
+                    ct
+                )
+                .is_err());
+
+            assert!(idms_prox_read
+                .check_oauth2_token_introspect(
+                    audit,
+                    &client_authz,
+                    &IntrospectionRequest {
+                        token: "".to_string(),
+                        token_type_hint: None,
+                    },
+                    ct
+                )
+                .is_err());
+
+            // Now check if the time has passed to session exp
+            let exp = Duration::from_secs(token.oidc_token.exp as u64 + 1);
+
+            let r2 =
+                idms_prox_read.check_oauth2_token_introspect(audit, &client_authz, &good_req, exp);
+
+            if let Ok(IntrospectionResponse::Invalid { active }) = r2 {
+                assert!(!active);
+            } else {
+                panic!();
+            };
+
+            // expire the account, check it's enforced.
+            std::mem::drop(idms_prox_read);
+
+            let idms_prox_write = idms.proxy_write(ct);
+
+            let v_expire = Value::new_datetime_epoch(Duration::from_secs(TEST_CURRENT_TIME - 1));
+
+            let me_inv_m = unsafe {
+                ModifyEvent::new_internal_invalid(
+                    filter!(f_eq("name", PartialValue::new_iname("admin"))),
+                    ModifyList::new_list(vec![Modify::Present(
+                        AttrString::from("account_expire"),
+                        v_expire,
+                    )]),
+                )
+            };
+            // go!
+            assert!(idms_prox_write.qs_write.modify(audit, &me_inv_m).is_ok());
+
+            idms_prox_write.commit(audit).expect("Must not fail");
+
+            let idms_prox_read = idms.proxy_read();
+
+            let r2 =
+                idms_prox_read.check_oauth2_token_introspect(audit, &client_authz, &good_req, ct);
+
+            if let Ok(IntrospectionResponse::Invalid { active }) = r2 {
+                assert!(!active);
+            } else {
+                panic!();
+            };
         })
     }
 }

--- a/kanidmd/src/lib/idm/oauth2.rs
+++ b/kanidmd/src/lib/idm/oauth2.rs
@@ -1238,7 +1238,7 @@ mod tests {
             };
 
             // expire the account, check it's enforced.
-            std::mem::drop(idms_prox_read);
+            drop(idms_prox_read);
 
             let idms_prox_write = idms.proxy_write(ct);
 

--- a/kanidmd/src/lib/idm/radius.rs
+++ b/kanidmd/src/lib/idm/radius.rs
@@ -60,7 +60,7 @@ impl RadiusAccount {
                 OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
             })?;
 
-        let groups = Group::try_from_account_entry_red_ro(au, &value, qs)?;
+        let groups = Group::try_from_account_entry_red_ro(au, value, qs)?;
 
         let valid_from = value.get_ava_single_datetime("account_valid_from");
 

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -143,11 +143,11 @@ impl ModifyList<ModifyInvalid> {
 
         pe.attrs.iter().try_for_each(|(attr, vals)| {
             // Issue a purge to the attr.
-            mods.push(m_purge(&attr));
+            mods.push(m_purge(attr));
             // Now if there are vals, push those too.
             // For each value we want to now be present.
             vals.iter().try_for_each(|val| {
-                qs.clone_value(audit, &attr, &val).map(|resolved_v| {
+                qs.clone_value(audit, attr, val).map(|resolved_v| {
                     mods.push(Modify::Present(attr.as_str().into(), resolved_v));
                 })
             })
@@ -176,7 +176,7 @@ impl ModifyList<ModifyInvalid> {
                     let attr_norm = schema.normalise_attr_name(attr);
                     match schema_attributes.get(&attr_norm) {
                         Some(schema_a) => schema_a
-                            .validate_value(attr_norm.as_str(), &value)
+                            .validate_value(attr_norm.as_str(), value)
                             .map(|_| Modify::Present(attr_norm, value.clone())),
                         None => Err(SchemaError::InvalidAttribute(attr_norm.to_string())),
                     }
@@ -185,7 +185,7 @@ impl ModifyList<ModifyInvalid> {
                     let attr_norm = schema.normalise_attr_name(attr);
                     match schema_attributes.get(&attr_norm) {
                         Some(schema_a) => schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             .map(|_| Modify::Removed(attr_norm, value.clone())),
                         None => Err(SchemaError::InvalidAttribute(attr_norm.to_string())),
                     }

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -240,7 +240,7 @@ pub trait QueryServerTransaction<'a> {
 
             let lims = ee.get_limits();
 
-            self.get_be_txn().exists(audit, &lims, &vfr).map_err(|e| {
+            self.get_be_txn().exists(audit, lims, &vfr).map_err(|e| {
                 ladmin_error!(audit, "backend failure -> {:?}", e);
                 OperationError::Backend
             })

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -553,7 +553,7 @@ impl PartialValue {
 
     pub fn to_url(&self) -> Option<&Url> {
         match self {
-            PartialValue::Url(u) => Some(&u),
+            PartialValue::Url(u) => Some(u),
             _ => None,
         }
     }
@@ -909,7 +909,7 @@ impl Value {
         match &self.pv {
             PartialValue::Cred(_) => match &self.data {
                 Some(dv) => match dv.as_ref() {
-                    DataValue::Cred(c) => Some(&c),
+                    DataValue::Cred(c) => Some(c),
                     _ => None,
                 },
                 None => None,
@@ -1264,7 +1264,7 @@ impl Value {
 
     pub fn to_url(&self) -> Option<&Url> {
         match &self.pv {
-            PartialValue::Url(u) => Some(&u),
+            PartialValue::Url(u) => Some(u),
             _ => None,
         }
     }
@@ -1282,28 +1282,28 @@ impl Value {
     // in refint plugin.
     pub fn to_ref_uuid(&self) -> Option<&Uuid> {
         match &self.pv {
-            PartialValue::Refer(u) => Some(&u),
+            PartialValue::Refer(u) => Some(u),
             _ => None,
         }
     }
 
     pub fn to_uuid(&self) -> Option<&Uuid> {
         match &self.pv {
-            PartialValue::Uuid(u) => Some(&u),
+            PartialValue::Uuid(u) => Some(u),
             _ => None,
         }
     }
 
     pub fn to_indextype(&self) -> Option<&IndexType> {
         match &self.pv {
-            PartialValue::Index(i) => Some(&i),
+            PartialValue::Index(i) => Some(i),
             _ => None,
         }
     }
 
     pub fn to_syntaxtype(&self) -> Option<&SyntaxType> {
         match &self.pv {
-            PartialValue::Syntax(s) => Some(&s),
+            PartialValue::Syntax(s) => Some(s),
             _ => None,
         }
     }

--- a/kanidmd/src/lib/valueset.rs
+++ b/kanidmd/src/lib/valueset.rs
@@ -77,7 +77,7 @@ impl ValueSet {
     // We'll need to be able to do partialeq/intersect etc later.
 
     pub fn iter(&self) -> Iter {
-        (&self).into_iter()
+        self.into_iter()
     }
 
     pub fn difference<'a>(&'a self, other: &'a ValueSet) -> Difference<'a> {

--- a/kanidmd_web_ui/src/login.rs
+++ b/kanidmd_web_ui/src/login.rs
@@ -257,7 +257,7 @@ impl LoginApp {
                     let promise = win
                         .navigator()
                         .credentials()
-                        .get_with_options(&challenge)
+                        .get_with_options(challenge)
                         .expect("Unable to create promise");
                     let fut = JsFuture::from(promise);
                     let linkc = self.link.clone();

--- a/kanidmd_web_ui/src/oauth2.rs
+++ b/kanidmd_web_ui/src/oauth2.rs
@@ -239,7 +239,7 @@ impl Component for Oauth2App {
 
                 self.state = match (&self.state, ar) {
                     (State::TokenCheck(token, _), Some(ar)) => {
-                        match Self::fetch_authreq(&token, &ar, &self.link) {
+                        match Self::fetch_authreq(token, &ar, &self.link) {
                             Ok(ft) => State::SubmitAuthReq(token.clone(), ft),
                             Err(e_msg) => {
                                 ConsoleService::log(e_msg.as_str());
@@ -268,7 +268,7 @@ impl Component for Oauth2App {
                 self.state = match &self.state {
                     State::Consent(token, consent_req) => {
                         match Self::fetch_consent_token(
-                            &token,
+                            token,
                             consent_req.consent_token.clone(),
                             &self.link,
                         ) {

--- a/orca/src/preprocess.rs
+++ b/orca/src/preprocess.rs
@@ -113,8 +113,7 @@ impl Record {
                             Some(Entity::Group(_g)) => {
                                 // This could be better! It's quite an evil method at the moment...
                                 let m = rng.gen_range(0..max_m);
-                                let ngrp =
-                                    (&exists).choose_multiple(&mut rng, m).cloned().collect();
+                                let ngrp = (exists).choose_multiple(&mut rng, m).cloned().collect();
                                 (*id, Change::Group(ngrp))
                             }
                             None => {


### PR DESCRIPTION
Fixes #508 - adds rfc7662 oauth2 token introspection. This changes the internal formats of some of our auth tokens to better support this behaviour.

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
