### PR TITLE
Fix io capture in tests

### DIFF
--- a/kanidmd/src/lib/audit.rs
+++ b/kanidmd/src/lib/audit.rs
@@ -64,9 +64,11 @@ impl fmt::Display for LogTag {
 macro_rules! lqueue {
     ($audit:expr, $tag:expr, $($arg:tt)*) => ({
         use crate::audit::{LogTag, AUDIT_LINE_SIZE};
+        /*
         if cfg!(test) {
             println!($($arg)*)
         }
+        */
         if ($audit.level & $tag as u32) == $tag as u32 {
             use std::fmt;
             // We have to buffer the string to over-alloc it.

--- a/kanidmd/src/lib/tracing_tree/subscriber.rs
+++ b/kanidmd/src/lib/tracing_tree/subscriber.rs
@@ -482,14 +482,20 @@ impl TreePreProcessed {
                 // BUG - we can't write to stdout/err directly because this breaks
                 // cargo test capturing of io.
                 // io::stdout().write_all(buf)
-                let s = unsafe { std::str::from_utf8_unchecked(buf) };
-                print!("{}", s);
+
+                match std::str::from_utf8(buf) {
+                    Ok(s) => print!("{}", s),
+                    Err(e) => eprintln!("CRITICAL - UNABLE TO PRINT BUFFER -> {:?}", e),
+                }
                 Ok(())
             }
             TreeIo::Stderr => {
                 // io::stderr().write_all(buf)
-                let s = unsafe { std::str::from_utf8_unchecked(buf) };
-                eprint!("{}", s);
+
+                match std::str::from_utf8(buf) {
+                    Ok(s) => eprint!("{}", s),
+                    Err(e) => eprintln!("CRITICAL - UNABLE TO PRINT BUFFER -> {:?}", e),
+                }
                 Ok(())
             }
             TreeIo::File(ref path) => OpenOptions::new()


### PR DESCRIPTION
This fixes tracing such that IO is properly captured during tests.


- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
