### PR TITLE
Start to remove audit scope :)

### DIFF
--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -142,7 +142,7 @@ pub fn dbscan_list_indexes_core(config: &Configuration) {
     let be = dbscan_setup_be!(audit, &config);
     let be_rotxn = be.read();
 
-    match be_rotxn.list_indexes(&mut audit) {
+    match be_rotxn.list_indexes() {
         Ok(mut idx_list) => {
             idx_list.sort_unstable();
             idx_list.iter().for_each(|idx_name| {
@@ -165,7 +165,7 @@ pub fn dbscan_list_id2entry_core(config: &Configuration) {
     let be = dbscan_setup_be!(audit, &config);
     let be_rotxn = be.read();
 
-    match be_rotxn.list_id2entry(&mut audit) {
+    match be_rotxn.list_id2entry() {
         Ok(mut id_list) => {
             id_list.sort_unstable_by_key(|k| k.0);
             id_list.iter().for_each(|(id, value)| {
@@ -195,7 +195,7 @@ pub fn dbscan_list_index_core(config: &Configuration, index_name: &str) {
     let be = dbscan_setup_be!(audit, &config);
     let be_rotxn = be.read();
 
-    match be_rotxn.list_index_content(&mut audit, index_name) {
+    match be_rotxn.list_index_content(index_name) {
         Ok(mut idx_list) => {
             idx_list.sort_unstable_by(|a, b| a.0.cmp(&b.0));
             idx_list.iter().for_each(|(key, value)| {
@@ -218,7 +218,7 @@ pub fn dbscan_get_id2entry_core(config: &Configuration, id: u64) {
     let be = dbscan_setup_be!(audit, &config);
     let be_rotxn = be.read();
 
-    match be_rotxn.get_id2entry(&mut audit, id) {
+    match be_rotxn.get_id2entry(id) {
         Ok((id, value)) => println!("{:>8}: {}", id, value),
         Err(e) => {
             audit.write_log();

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -286,12 +286,12 @@ pub trait QueryServerTransaction<'a> {
     // Remember, we don't care if the name is invalid, because search
     // will validate/normalise the filter we construct for us. COOL!
     // ! TRACING INTEGRATED
-    fn name_to_uuid(&self, audit: &mut AuditScope, name: &str) -> Result<Uuid, OperationError> {
+    fn name_to_uuid(&self, _audit: &mut AuditScope, name: &str) -> Result<Uuid, OperationError> {
         // Is it just a uuid?
         Uuid::parse_str(name).or_else(|_| {
             let lname = name.to_lowercase();
             self.get_be_txn()
-                .name2uuid(audit, lname.as_str())?
+                .name2uuid(lname.as_str())?
                 .ok_or(OperationError::NoMatchingEntries) // should we log this?
         })
     }
@@ -299,10 +299,10 @@ pub trait QueryServerTransaction<'a> {
     // ! TRACING INTEGRATED
     fn uuid_to_spn(
         &self,
-        audit: &mut AuditScope,
+        _audit: &mut AuditScope,
         uuid: &Uuid,
     ) -> Result<Option<Value>, OperationError> {
-        let r = self.get_be_txn().uuid2spn(audit, uuid)?;
+        let r = self.get_be_txn().uuid2spn(uuid)?;
 
         if let Some(ref n) = r {
             // Shouldn't we be doing more graceful error handling here?
@@ -314,10 +314,10 @@ pub trait QueryServerTransaction<'a> {
     }
 
     // ! TRACING INTEGRATED
-    fn uuid_to_rdn(&self, audit: &mut AuditScope, uuid: &Uuid) -> Result<String, OperationError> {
+    fn uuid_to_rdn(&self, _audit: &mut AuditScope, uuid: &Uuid) -> Result<String, OperationError> {
         // If we have a some, pass it on, else unwrap into a default.
         self.get_be_txn()
-            .uuid2rdn(audit, uuid)
+            .uuid2rdn(uuid)
             .map(|v| v.unwrap_or_else(|| format!("uuid={}", uuid.to_hyphenated_ref())))
     }
 
@@ -844,7 +844,7 @@ impl<'a> QueryServerReadTransaction<'a> {
         // If we fail after backend, we need to return NOW because we can't
         // assert any other faith in the DB states.
         //  * backend
-        let be_errs = self.get_be_txn().verify(audit);
+        let be_errs = self.get_be_txn().verify();
 
         if !be_errs.is_empty() {
             return be_errs;


### PR DESCRIPTION
You know what this means - I'm starting to remove auditscope from the backend. From here, we should remove as many auditscope log types to tracing as we can, to start to prep to fully remove auditscopes. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
