### PR TITLE
Swap to tide-openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,17 +240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-rustls"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c86f33abd5a4f3e2d6d9251a9e0c6a7e52eb1113caf893dae8429bf4a53f378"
-dependencies = [
- "futures-lite",
- "rustls",
- "webpki",
-]
-
-[[package]]
 name = "async-session"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +300,19 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-std-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408a76b00fc49b11fe78f1f7a90557a3c887af1d4570fb33e15a70eb7e6b95ee"
+dependencies = [
+ "async-dup",
+ "async-std",
+ "futures-util",
+ "openssl",
+ "openssl-sys",
 ]
 
 [[package]]
@@ -1839,7 +1841,7 @@ dependencies = [
  "sshkeys",
  "structopt",
  "tide",
- "tide-rustls",
+ "tide-openssl",
  "time 0.2.27",
  "tokio",
  "tokio-openssl",
@@ -2862,21 +2864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "route-recognizer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,19 +2925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.0",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,16 +2973,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -3248,12 +3212,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sshkeys"
@@ -3511,16 +3469,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "tide-rustls"
-version = "0.3.0"
+name = "tide-openssl"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a85b568b611840ba794ae749d4fa8b345b9f71a9c02b82cf0c28ff076fde6b7"
+checksum = "5ca37203863763d3faf05b22d32a0c2da7a2d429b8fb22345e19e45ec2ad1071"
 dependencies = [
  "async-dup",
  "async-h1",
- "async-rustls",
  "async-std",
- "rustls",
+ "async-std-openssl",
+ "futures-util",
+ "openssl",
+ "openssl-sys",
  "tide",
 ]
 
@@ -3823,12 +3783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,16 +4045,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -24,7 +24,7 @@ jemallocator = { version = "0.3.0", optional = true }
 
 url = { version = "2", features = ["serde"] }
 tide = "0.16"
-tide-rustls = "0.3"
+tide-openssl = "^0.1.1"
 async-trait = "0.1"
 async-h1 = "2.0"
 fernet = { version = "^0.1.4", features = ["fernet_danger_timestamps"] }

--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use uuid::Uuid;
 
-use tide_rustls::TlsListener;
+use tide_openssl::TlsListener;
 
 use crate::tracing_tree::TreeMiddleware;
 use tracing::{error, info};


### PR DESCRIPTION
Fixes #341 - this merges @victorcwai (excellent) tide-openssl project and allows us to standardise on openssl again. 🎉

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
