### PR TITLE
Rewrite how we store the internals of valuesets in entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,6 +1809,7 @@ dependencies = [
  "chrono",
  "concread",
  "criterion",
+ "either",
  "env_logger",
  "fernet",
  "filetime",
@@ -1838,6 +1839,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smartstring",
+ "smolset",
  "sshkeys",
  "structopt",
  "tide",
@@ -3201,6 +3203,15 @@ checksum = "baaf55266b953d41d45fc7c4d3ff756490c5666a2af64f77aeb95d0ffadb91de"
 dependencies = [
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "smolset"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d372e8fe15dc5229e7d6c65f5810849385e79e24f9d9d64263e132879c7be0"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/server/main.rs"
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha" }
 
 jemallocator = { version = "0.3.0", optional = true }
+either = "1.6"
 
 url = { version = "2", features = ["serde"] }
 tide = "0.16"
@@ -65,6 +66,7 @@ time = { version = "0.2", features = ["serde", "std"] }
 
 hashbrown = "0.11"
 concread = "^0.2.16"
+smolset = "1.3"
 # concread = { version = "^0.2.9", path = "../../concread" }
 # concread = { version = "^0.2.9", features = ["simd_support"] }
 

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -571,7 +571,7 @@ pub trait AccessControlsTransaction<'a> {
                                             .iter()
                                             .filter_map(|(acs, f_res)| {
                                                 // if it applies
-                                                if e.entry_match_no_index(&f_res) {
+                                                if e.entry_match_no_index(f_res) {
                                                     security_access!(entry = ?e.get_uuid(), acs = %acs.acp.name, "entry matches acs");
                                                     lsecurity_access!(
                                                         audit,
@@ -748,7 +748,7 @@ pub trait AccessControlsTransaction<'a> {
                                         let allowed_attrs: BTreeSet<&str> = related_acp
                                             .iter()
                                             .filter_map(|(acs, f_res)| {
-                                                if e.entry_match_no_index(&f_res) {
+                                                if e.entry_match_no_index(f_res) {
                                                     security_access!(
                                                         target = ?e.get_uuid(),
                                                         acs = %acs.acp.name,
@@ -967,7 +967,7 @@ pub trait AccessControlsTransaction<'a> {
                 let scoped_acp: Vec<&AccessControlModify> = related_acp
                     .iter()
                     .filter_map(|(acm, f_res)| {
-                        if e.entry_match_no_index(&f_res) {
+                        if e.entry_match_no_index(f_res) {
                             Some(*acm)
                         } else {
                             None
@@ -1107,7 +1107,7 @@ pub trait AccessControlsTransaction<'a> {
 
                 related_acp.iter().any(|(accr, f_res)| {
                     // Check to see if allowed.
-                    if e.entry_match_no_index(&f_res) {
+                    if e.entry_match_no_index(f_res) {
                         lsecurity_access!(audit, "entry {:?} matches acs {:?}", e, accr);
                         // It matches, so now we have to check attrs and classes.
                         // Remember, we have to match ALL requested attrs
@@ -1227,7 +1227,7 @@ pub trait AccessControlsTransaction<'a> {
             // For each entry
             let r = entries.iter().all(|e| {
                 related_acp.iter().any(|(acd, f_res)| {
-                    if e.entry_match_no_index(&f_res) {
+                    if e.entry_match_no_index(f_res) {
                         lsecurity_access!(
                             audit,
                             "entry {:?} matches acs {}",

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -15,7 +15,6 @@ use crate::idm::event::{
     CredentialStatusEvent, RadiusAuthTokenEvent, ReadBackupCodeEvent, UnixGroupTokenEvent,
     UnixUserAuthEvent, UnixUserTokenEvent,
 };
-use crate::value::PartialValue;
 use kanidm_proto::v1::{BackupCodesView, OperationError, RadiusAuthToken};
 
 use crate::filter::{Filter, FilterInvalid};
@@ -894,11 +893,7 @@ impl QueryServerReadV1 {
                                 // From the entry, turn it into the value
                                 e.get_ava_set("ssh_publickey").and_then(|vs| {
                                     // Get the one tagged value
-                                    let pv = PartialValue::new_sshkey_tag(tag);
-                                    vs.get(&pv)
-                                        // Now turn that value to a pub key.
-                                        .and_then(|v| v.get_sshkey())
-                                        .map(|s| s.to_string())
+                                    vs.get_ssh_tag(&tag).map(str::to_string)
                                 })
                             })
                             .unwrap_or_else(|| {

--- a/kanidmd/src/lib/be/idl_arc_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_arc_sqlite.rs
@@ -939,7 +939,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
         let slopes: HashMap<_, _> = data
             .into_iter()
             .filter_map(|(k, lens)| {
-                let slope_factor = Self::calculate_sd_slope(lens);
+                let slope_factor = Self::calculate_sd_slope(&lens);
                 if slope_factor == 0 || slope_factor == IdxSlope::MAX {
                     None
                 } else {
@@ -952,7 +952,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
         self.db.store_idx_slope_analysis(&slopes)
     }
 
-    fn calculate_sd_slope(data: Vec<f64>) -> IdxSlope {
+    fn calculate_sd_slope(data: &[f64]) -> IdxSlope {
         let (n_keys, sd_1) = if data.len() >= 2 {
             // We can only do SD on sets greater than 2
             let l: u32 = data.len().try_into().unwrap_or(u32::MAX);

--- a/kanidmd/src/lib/be/idl_sqlite.rs
+++ b/kanidmd/src/lib/be/idl_sqlite.rs
@@ -880,7 +880,7 @@ impl IdlSqliteWriteTransaction {
             Some(k) => self
                 .conn
                 .prepare("INSERT OR REPLACE INTO idx_uuid2rdn (uuid, rdn) VALUES(:uuid, :rdn)")
-                .and_then(|mut stmt| stmt.execute(&[(":uuid", &uuids), (":rdn", &k)]))
+                .and_then(|mut stmt| stmt.execute(&[(":uuid", &uuids), (":rdn", k)]))
                 .map(|_| ())
                 .map_err(sqlite_error),
             None => self

--- a/kanidmd/src/lib/be/idxkey.rs
+++ b/kanidmd/src/lib/be/idxkey.rs
@@ -122,7 +122,7 @@ impl IdlCacheKeyToRef for IdlCacheKey {
         IdlCacheKeyRef {
             a: self.a.as_str(),
             i: &self.i,
-            k: &self.k.as_str(),
+            k: self.k.as_str(),
         }
     }
 }

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -141,7 +141,7 @@ impl IdRawEntry {
             OperationError::SerdeCborError
         })?;
         // let id = u64::try_from(self.id).map_err(|_| OperationError::InvalidEntryId)?;
-        Entry::from_dbentry(db_e, self.id).ok_or_else(|| OperationError::CorruptedEntry(self.id))
+        Entry::from_dbentry(db_e, self.id).ok_or(OperationError::CorruptedEntry(self.id))
     }
 }
 
@@ -613,7 +613,7 @@ pub trait BackendTransaction {
                     lperf_segment!(au, "be::search<entry::ftest::allids>", || {
                         entries
                             .into_iter()
-                            .filter(|e| e.entry_match_no_index(&filt))
+                            .filter(|e| e.entry_match_no_index(filt))
                             .collect()
                     })
                 }),
@@ -622,7 +622,7 @@ pub trait BackendTransaction {
                         lperf_segment!(au, "be::search<entry::ftest::partial>", || {
                             entries
                                 .into_iter()
-                                .filter(|e| e.entry_match_no_index(&filt))
+                                .filter(|e| e.entry_match_no_index(filt))
                                 .collect()
                         })
                     })
@@ -632,7 +632,7 @@ pub trait BackendTransaction {
                         lperf_trace_segment!(au, "be::search<entry::ftest::thresh>", || {
                             entries
                                 .into_iter()
-                                .filter(|e| e.entry_match_no_index(&filt))
+                                .filter(|e| e.entry_match_no_index(filt))
                                 .collect()
                         })
                     }),
@@ -733,7 +733,7 @@ pub trait BackendTransaction {
                                     || {
                                         entries
                                             .into_iter()
-                                            .filter(|e| e.entry_match_no_index(&filt))
+                                            .filter(|e| e.entry_match_no_index(filt))
                                             .collect()
                                     }
                                 )
@@ -761,7 +761,7 @@ pub trait BackendTransaction {
         if e.mask_recycled_ts().is_some() {
             let e_uuid = e.get_uuid();
             // We only check these on live entries.
-            let (n2u_add, n2u_rem) = Entry::idx_name2uuid_diff(None, Some(&e));
+            let (n2u_add, n2u_rem) = Entry::idx_name2uuid_diff(None, Some(e));
 
             let n2u_set = match (n2u_add, n2u_rem) {
                 (Some(set), None) => set,
@@ -796,7 +796,7 @@ pub trait BackendTransaction {
                 })?;
 
             let spn = e.get_uuid2spn();
-            match self.get_idlayer().uuid2spn(&e_uuid) {
+            match self.get_idlayer().uuid2spn(e_uuid) {
                 Ok(Some(idx_spn)) => {
                     if spn != idx_spn {
                         admin_error!("Invalid uuid2spn state -> incorrect idx spn value");
@@ -812,7 +812,7 @@ pub trait BackendTransaction {
             };
 
             let rdn = e.get_uuid2rdn();
-            match self.get_idlayer().uuid2rdn(&e_uuid) {
+            match self.get_idlayer().uuid2rdn(e_uuid) {
                 Ok(Some(idx_rdn)) => {
                     if rdn != idx_rdn {
                         admin_error!("Invalid uuid2rdn state -> incorrect idx rdn value");

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -139,7 +139,7 @@ pub fn dbscan_list_indexes_core(config: &Configuration) {
         uuid::Uuid::new_v4(),
         config.log_level,
     );
-    let be = dbscan_setup_be!(audit, &config);
+    let be = dbscan_setup_be!(audit, config);
     let be_rotxn = be.read();
 
     match be_rotxn.list_indexes() {
@@ -162,7 +162,7 @@ pub fn dbscan_list_id2entry_core(config: &Configuration) {
         uuid::Uuid::new_v4(),
         config.log_level,
     );
-    let be = dbscan_setup_be!(audit, &config);
+    let be = dbscan_setup_be!(audit, config);
     let be_rotxn = be.read();
 
     match be_rotxn.list_id2entry() {
@@ -186,13 +186,13 @@ pub fn dbscan_list_index_analysis_core(config: &Configuration) {
         config.log_level,
     );
 
-    let _be = dbscan_setup_be!(audit, &config);
+    let _be = dbscan_setup_be!(audit, config);
     // TBD in after slopes merge.
 }
 
 pub fn dbscan_list_index_core(config: &Configuration, index_name: &str) {
     let mut audit = AuditScope::new("dbscan_list_index", uuid::Uuid::new_v4(), config.log_level);
-    let be = dbscan_setup_be!(audit, &config);
+    let be = dbscan_setup_be!(audit, config);
     let be_rotxn = be.read();
 
     match be_rotxn.list_index_content(index_name) {
@@ -215,7 +215,7 @@ pub fn dbscan_get_id2entry_core(config: &Configuration, id: u64) {
         uuid::Uuid::new_v4(),
         config.log_level,
     );
-    let be = dbscan_setup_be!(audit, &config);
+    let be = dbscan_setup_be!(audit, config);
     let be_rotxn = be.read();
 
     match be_rotxn.get_id2entry(id) {
@@ -238,7 +238,7 @@ pub fn backup_server_core(config: &Configuration, dst_path: &str) {
         }
     };
 
-    let be = match setup_backend(&config, &schema) {
+    let be = match setup_backend(config, &schema) {
         Ok(be) => be,
         Err(e) => {
             error!("Failed to setup BE: {:?}", e);
@@ -261,7 +261,7 @@ pub fn backup_server_core(config: &Configuration, dst_path: &str) {
 
 pub fn restore_server_core(config: &Configuration, dst_path: &str) {
     let mut audit = AuditScope::new("backend_restore", uuid::Uuid::new_v4(), config.log_level);
-    touch_file_or_quit(&config.db_path.as_str());
+    touch_file_or_quit(config.db_path.as_str());
 
     // First, we provide the in-memory schema so that core attrs are indexed correctly.
     let schema = match Schema::new(&mut audit) {
@@ -273,7 +273,7 @@ pub fn restore_server_core(config: &Configuration, dst_path: &str) {
         }
     };
 
-    let be = match setup_backend(&config, &schema) {
+    let be = match setup_backend(config, &schema) {
         Ok(be) => be,
         Err(e) => {
             error!("Failed to setup backend: {:?}", e);
@@ -295,7 +295,7 @@ pub fn restore_server_core(config: &Configuration, dst_path: &str) {
 
     info!("Attempting to init query server ...");
 
-    let (qs, _idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, &config) {
+    let (qs, _idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, config) {
         Ok(t) => t,
         Err(e) => {
             audit.write_log();
@@ -336,7 +336,7 @@ pub fn reindex_server_core(config: &Configuration) {
         }
     };
 
-    let be = match setup_backend(&config, &schema) {
+    let be = match setup_backend(config, &schema) {
         Ok(be) => be,
         Err(e) => {
             error!("Failed to setup BE: {:?}", e);
@@ -363,7 +363,7 @@ pub fn reindex_server_core(config: &Configuration) {
 
     eprintln!("Attempting to init query server ...");
 
-    let (qs, _idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, &config) {
+    let (qs, _idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, config) {
         Ok(t) => t,
         Err(e) => {
             audit.write_log();
@@ -407,7 +407,7 @@ pub fn vacuum_server_core(config: &Configuration) {
 
     // The schema doesn't matter here. Vacuum is run as part of db open to avoid
     // locking.
-    let r = setup_backend_vacuum(&config, &schema, true);
+    let r = setup_backend_vacuum(config, &schema, true);
 
     audit.write_log();
 
@@ -432,7 +432,7 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
     };
 
     // Start the backend.
-    let be = match setup_backend(&config, &schema) {
+    let be = match setup_backend(config, &schema) {
         Ok(be) => be,
         Err(e) => {
             error!("Failed to setup BE: {:?}", e);
@@ -440,7 +440,7 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
         }
     };
     // setup the qs - *with* init of the migrations and schema.
-    let (qs, _idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, &config) {
+    let (qs, _idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, config) {
         Ok(t) => t,
         Err(e) => {
             audit.write_log();
@@ -491,7 +491,7 @@ pub fn verify_server_core(config: &Configuration) {
         }
     };
     // Setup the be
-    let be = match setup_backend(&config, &schema_mem) {
+    let be = match setup_backend(config, &schema_mem) {
         Ok(be) => be,
         Err(e) => {
             error!("Failed to setup BE: {:?}", e);
@@ -530,7 +530,7 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
     };
 
     // Start the backend.
-    let be = match setup_backend(&config, &schema) {
+    let be = match setup_backend(config, &schema) {
         Ok(be) => be,
         Err(e) => {
             error!("Failed to setup BE: {:?}", e);
@@ -538,7 +538,7 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
         }
     };
     // setup the qs - *with* init of the migrations and schema.
-    let (_qs, idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, &config) {
+    let (_qs, idms, _idms_delayed) = match setup_qs_idms(&mut audit, be, schema, config) {
         Ok(t) => t,
         Err(e) => {
             audit.write_log();
@@ -549,7 +549,7 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
 
     // Run the password change.
     let mut idms_prox_write = task::block_on(idms.proxy_write_async(duration_from_epoch_now()));
-    match idms_prox_write.recover_account(&mut audit, &name, None) {
+    match idms_prox_write.recover_account(&mut audit, name, None) {
         Ok(new_pw) => match idms_prox_write.commit(&mut audit) {
             Ok(()) => {
                 audit.write_log();
@@ -705,7 +705,7 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
     // Setup timed events associated to the read thread
     match &config.online_backup {
         Some(cfg) => {
-            IntervalActor::start_online_backup(server_read_ref, &cfg)?;
+            IntervalActor::start_online_backup(server_read_ref, cfg)?;
         }
         None => {
             debug!("Online backup not requested, skipping");

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -192,7 +192,7 @@ impl Password {
             Kdf::SSHA512(salt, key) => {
                 let mut hasher = Sha512::new();
                 hasher.update(cleartext.as_bytes());
-                hasher.update(&salt);
+                hasher.update(salt);
                 let r = hasher.finish();
                 Ok(key == &(r.to_vec()))
             }
@@ -803,7 +803,7 @@ impl Credential {
             CredentialType::PasswordMfa(pw, totp, wan, opt_backup_codes) => {
                 match opt_backup_codes {
                     Some(mut backup_codes) => {
-                        backup_codes.remove(&code_to_remove);
+                        backup_codes.remove(code_to_remove);
                         Ok(Credential {
                             type_: CredentialType::PasswordMfa(pw, totp, wan, Some(backup_codes)),
                             claims: self.claims.clone(),

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1274,6 +1274,8 @@ impl Entry<EntrySealed, EntryCommitted> {
             DbEntryVers::V1(v1) => v1
                 .attrs
                 .into_iter()
+                // Skip anything empty as new VS can't deal with it.
+                .filter(|(_k, vs)| !vs.is_empty())
                 .map(|(k, vs)| {
                     let vv: Result<Option<ValueSet>, ()> =
                         vs.into_iter().map(Value::from_db_valuev1).collect();

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1222,8 +1222,8 @@ impl Entry<EntrySealed, EntryCommitted> {
                             }
                             (Some(pre_vs), Some(post_vs)) => {
                                 // it exists in both, we need to work out the differents within the attr.
-                                let removed_vs = pre_vs.idx_eq_key_difference(&post_vs);
-                                let added_vs = post_vs.idx_eq_key_difference(&pre_vs);
+                                let removed_vs = pre_vs.idx_eq_key_difference(post_vs);
+                                let added_vs = post_vs.idx_eq_key_difference(pre_vs);
 
                                 let mut diff = Vec::with_capacity(
                                     removed_vs.as_ref().map(|v| v.len()).unwrap_or(0)
@@ -1360,7 +1360,7 @@ impl Entry<EntrySealed, EntryCommitted> {
 
         attrs_new.insert(
             AttrString::from("uuid"),
-            ValueSet::new(Value::new_uuidr(&self.get_uuid())),
+            ValueSet::new(Value::new_uuidr(self.get_uuid())),
         );
         attrs_new.insert(AttrString::from("class"), class_ava);
         attrs_new.insert(AttrString::from("last_modified_cid"), last_mod_ava);

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -286,7 +286,7 @@ impl SearchEvent {
         attrs: Option<BTreeSet<AttrString>>,
     ) -> Result<Self, OperationError> {
         // Kanidm Filter from LdapFilter
-        let f = Filter::from_ldap_ro(audit, &ident, &lf, qs)?;
+        let f = Filter::from_ldap_ro(audit, &ident, lf, qs)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;
@@ -540,7 +540,7 @@ impl ModifyEvent {
         // Add any supplemental conditions we have.
         let f = Filter::join_parts_and(f_uuid, filter);
 
-        let m = ModifyList::from(audit, &proto_ml, qs)?;
+        let m = ModifyList::from(audit, proto_ml, qs)?;
         let filter_orig = f
             .validate(qs.get_schema())
             .map_err(OperationError::SchemaViolation)?;

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -625,7 +625,7 @@ impl FilterComp {
                 match schema_attributes.get(&attr_norm) {
                     Some(schema_a) => {
                         schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             // Okay, it worked, transform to a filter component
                             .map(|_| FilterComp::Eq(attr_norm, value.clone()))
                         // On error, pass the error back out.
@@ -640,7 +640,7 @@ impl FilterComp {
                 match schema_attributes.get(&attr_norm) {
                     Some(schema_a) => {
                         schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             // Okay, it worked, transform to a filter component
                             .map(|_| FilterComp::Sub(attr_norm, value.clone()))
                         // On error, pass the error back out.
@@ -666,7 +666,7 @@ impl FilterComp {
                 match schema_attributes.get(&attr_norm) {
                     Some(schema_a) => {
                         schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             // Okay, it worked, transform to a filter component
                             .map(|_| FilterComp::LessThan(attr_norm, value.clone()))
                         // On error, pass the error back out.

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -1837,33 +1837,37 @@ mod tests {
             assert!(cr.is_ok());
 
             // Resolving most times should yield expected results
-            let t1 = Value::new_utf8s("teststring");
-            let r1 = server_txn.resolve_value(audit, &t1);
-            assert!(r1 == Ok("teststring".to_string()));
+            let t1 = ValueSet::new(Value::new_utf8s("teststring"));
+            let r1 = server_txn.resolve_valueset(audit, &t1);
+            assert!(r1 == Ok(vec!["teststring".to_string()]));
 
             // Resolve UUID with matching spn
-            let t_uuid = Value::new_refer_s("cc8e95b4-c24f-4d68-ba54-8bed76f63930").unwrap();
-            let r_uuid = server_txn.resolve_value(audit, &t_uuid);
+            let t_uuid =
+                ValueSet::new(Value::new_refer_s("cc8e95b4-c24f-4d68-ba54-8bed76f63930").unwrap());
+            let r_uuid = server_txn.resolve_valueset(audit, &t_uuid);
             debug!("{:?}", r_uuid);
-            assert!(r_uuid == Ok("testperson1@example.com".to_string()));
+            assert!(r_uuid == Ok(vec!["testperson1@example.com".to_string()]));
 
             // Resolve UUID with matching name
-            let t_uuid = Value::new_refer_s("a67c0c71-0b35-4218-a6b0-22d23d131d27").unwrap();
-            let r_uuid = server_txn.resolve_value(audit, &t_uuid);
+            let t_uuid =
+                ValueSet::new(Value::new_refer_s("a67c0c71-0b35-4218-a6b0-22d23d131d27").unwrap());
+            let r_uuid = server_txn.resolve_valueset(audit, &t_uuid);
             debug!("{:?}", r_uuid);
-            assert!(r_uuid == Ok("testperson2".to_string()));
+            assert!(r_uuid == Ok(vec!["testperson2".to_string()]));
 
             // Resolve UUID non-exist
-            let t_uuid_non = Value::new_refer_s("b83e98f0-3d2e-41d2-9796-d8d993289c86").unwrap();
-            let r_uuid_non = server_txn.resolve_value(audit, &t_uuid_non);
+            let t_uuid_non =
+                ValueSet::new(Value::new_refer_s("b83e98f0-3d2e-41d2-9796-d8d993289c86").unwrap());
+            let r_uuid_non = server_txn.resolve_valueset(audit, &t_uuid_non);
             debug!("{:?}", r_uuid_non);
-            assert!(r_uuid_non == Ok("b83e98f0-3d2e-41d2-9796-d8d993289c86".to_string()));
+            assert!(r_uuid_non == Ok(vec!["b83e98f0-3d2e-41d2-9796-d8d993289c86".to_string()]));
 
             // Resolve UUID to tombstone/recycled (same an non-exst)
-            let t_uuid_ts = Value::new_refer_s("9557f49c-97a5-4277-a9a5-097d17eb8317").unwrap();
-            let r_uuid_ts = server_txn.resolve_value(audit, &t_uuid_ts);
+            let t_uuid_ts =
+                ValueSet::new(Value::new_refer_s("9557f49c-97a5-4277-a9a5-097d17eb8317").unwrap());
+            let r_uuid_ts = server_txn.resolve_valueset(audit, &t_uuid_ts);
             debug!("{:?}", r_uuid_ts);
-            assert!(r_uuid_ts == Ok("9557f49c-97a5-4277-a9a5-097d17eb8317".to_string()));
+            assert!(r_uuid_ts == Ok(vec!["9557f49c-97a5-4277-a9a5-097d17eb8317".to_string()]));
         })
     }
 

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -288,7 +288,7 @@ impl CredHandler {
                     pw_mfa.backup_code.as_ref(),
                 ) {
                     (AuthCredential::Webauthn(resp), _, Some((_, wan_state)), _) => {
-                        match webauthn.authenticate_credential(&resp, &wan_state) {
+                        match webauthn.authenticate_credential(resp, wan_state) {
                             Ok((cid, auth_data)) => {
                                 pw_mfa.mfa_state = CredVerifyState::Success;
                                 // Success. Determine if we need to update the counter
@@ -350,7 +350,7 @@ impl CredHandler {
                         }
                     }
                     (AuthCredential::BackupCode(code_chal), _, _, Some(backup_codes)) => {
-                        if backup_codes.verify(&code_chal) {
+                        if backup_codes.verify(code_chal) {
                             if let Err(_e) =
                                 async_tx.send(DelayedAction::BackupCodeRemoval(BackupCodeRemoval {
                                     target_uuid: who,
@@ -479,7 +479,7 @@ impl CredHandler {
         match cred {
             AuthCredential::Webauthn(resp) => {
                 // lets see how we go.
-                match webauthn.authenticate_credential(&resp, &wan_cred.wan_state) {
+                match webauthn.authenticate_credential(resp, &wan_cred.wan_state) {
                     Ok((cid, auth_data)) => {
                         wan_cred.state = CredVerifyState::Success;
                         // Success. Determine if we need to update the counter

--- a/kanidmd/src/lib/idm/oauth2.rs
+++ b/kanidmd/src/lib/idm/oauth2.rs
@@ -209,7 +209,7 @@ impl<'a> Oauth2ResourceServersWriteTransaction<'a> {
                         .get_ava_single_secret("oauth2_rs_basic_token_key")
                         .ok_or(OperationError::InvalidValueState)
                         .and_then(|key| {
-                            Fernet::new(&key).ok_or(OperationError::CryptographyError)
+                            Fernet::new(key).ok_or(OperationError::CryptographyError)
                         })?;
 
                     // Currently unsure if this is how I want to handle this.

--- a/kanidmd/src/lib/idm/radius.rs
+++ b/kanidmd/src/lib/idm/radius.rs
@@ -60,7 +60,7 @@ impl RadiusAccount {
                 OperationError::InvalidAccountState("Missing attribute: displayname".to_string())
             })?;
 
-        let groups = Group::try_from_account_entry_red_ro(au, &value, qs)?;
+        let groups = Group::try_from_account_entry_red_ro(au, value, qs)?;
 
         let valid_from = value.get_ava_single_datetime("account_valid_from");
 

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -367,7 +367,7 @@ pub trait IdmServerTransaction<'a> {
             token
                 .ok_or(OperationError::NotAuthenticated)
                 .and_then(|token| {
-                    bref.verify(&token).map_err(|e| {
+                    bref.verify(token).map_err(|e| {
                         security_info!(?e, "Unable to verify token");
                         lsecurity!(audit, "Unable to verify token - {:?}", e);
                         OperationError::NotAuthenticated

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -2,7 +2,7 @@
 //! which is used to process authentication, store identities and enforce access controls.
 
 #![recursion_limit = "512"]
-#![deny(warnings)]
+// #![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
@@ -18,6 +18,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[macro_use]
 extern crate log;
+
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
@@ -84,6 +85,7 @@ pub mod prelude {
         QueryServerWriteTransaction,
     };
     pub use crate::value::{IndexType, PartialValue, SyntaxType, Value};
+    pub use crate::valueset::ValueSet;
     pub use crate::{
         admin_error, admin_info, admin_warn, filter_error, filter_info, filter_trace, filter_warn,
         perf_trace, request_error, request_info, request_trace, request_warn, security_access,

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -2,7 +2,7 @@
 //! which is used to process authentication, store identities and enforce access controls.
 
 #![recursion_limit = "512"]
-// #![deny(warnings)]
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -593,7 +593,7 @@ macro_rules! smolset {
         x
     });
     ($e:expr,) => ({
-        btreeset!($e)
+        smolset!($e)
     });
     ($e:expr, $($item:expr),*) => ({
         use smolset::SmolSet;

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -6,6 +6,7 @@ macro_rules! setup_test {
         use env_logger;
 
         ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
+        let _ = crate::tracing_tree::test_init();
         let _ = env_logger::builder()
             .format_timestamp(None)
             .format_level(false)
@@ -35,6 +36,7 @@ macro_rules! setup_test {
         use env_logger;
 
         ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
+        let _ = crate::tracing_tree::test_init();
         let _ = env_logger::builder()
             .format_timestamp(None)
             .format_level(false)
@@ -75,6 +77,7 @@ macro_rules! run_test_no_init {
 
         use env_logger;
         ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
+        let _ = crate::tracing_tree::test_init();
         let _ = env_logger::builder()
             .format_timestamp(None)
             .format_level(false)
@@ -119,6 +122,7 @@ macro_rules! run_test {
 
         use env_logger;
         ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
+        let _ = crate::tracing_tree::test_init();
         let _ = env_logger::builder()
             .format_timestamp(None)
             .format_level(false)
@@ -174,6 +178,7 @@ macro_rules! run_idm_test_inner {
 
         use env_logger;
         ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
+        let _ = crate::tracing_tree::test_init();
         let _ = env_logger::builder()
             .format_timestamp(None)
             .format_level(false)
@@ -564,10 +569,7 @@ macro_rules! btreeset {
         x
     });
     ($e:expr,) => ({
-        use std::collections::BTreeSet;
-        let mut x: BTreeSet<_> = BTreeSet::new();
-        assert!(x.insert($e));
-        x
+        btreeset!($e)
     });
     ($e:expr, $($item:expr),*) => ({
         use std::collections::BTreeSet;
@@ -580,23 +582,73 @@ macro_rules! btreeset {
 
 #[allow(unused_macros)]
 #[macro_export]
+macro_rules! smolset {
+    () => (
+        compile_error!("SmolSet needs at least 1 element")
+    );
+    ($e:expr) => ({
+        use smolset::SmolSet;
+        let mut x: SmolSet<_> = SmolSet::new();
+        assert!(x.insert($e));
+        x
+    });
+    ($e:expr,) => ({
+        btreeset!($e)
+    });
+    ($e:expr, $($item:expr),*) => ({
+        use smolset::SmolSet;
+        let mut x: SmolSet<_> = SmolSet::new();
+        assert!(x.insert($e));
+        $(assert!(x.insert($item));)*
+        x
+    });
+}
+
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! btreemap {
+    () => (
+        compile_error!("BTreeSet needs at least 1 element")
+    );
+    ($e:expr) => ({
+        use std::collections::BTreeMap;
+        let mut x: BTreeMap<_, _> = BTreeMap::new();
+        let (a, b) = $e;
+        x.insert(a, b);
+        x
+    });
+    ($e:expr,) => ({
+        btreemap!($e)
+    });
+    ($e:expr, $($item:expr),*) => ({
+        use std::collections::BTreeMap;
+        let mut x: BTreeMap<_, _> = BTreeMap::new();
+        let (a, b) = $e;
+        x.insert(a, b);
+        $(
+            let (a, b) = $item;
+            x.insert(a, b);
+        )*
+        x
+    });
+}
+
+#[allow(unused_macros)]
+#[macro_export]
 macro_rules! valueset {
     () => (
         compile_error!("ValueSet needs at least 1 element")
     );
     ($e:expr) => ({
         use crate::valueset::ValueSet;
-        let mut x: ValueSet = ValueSet::new();
-        assert!(x.insert($e));
-        x
+        ValueSet::new($e)
     });
     ($e:expr,) => ({
         valueset!($e)
     });
     ($e:expr, $($item:expr),*) => ({
         use crate::valueset::ValueSet;
-        let mut x: ValueSet = ValueSet::new();
-        assert!(x.insert($e));
+        let mut x: ValueSet = ValueSet::new($e);
         $(assert!(x.insert($item));)*
         x
     });

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -143,11 +143,11 @@ impl ModifyList<ModifyInvalid> {
 
         pe.attrs.iter().try_for_each(|(attr, vals)| {
             // Issue a purge to the attr.
-            mods.push(m_purge(&attr));
+            mods.push(m_purge(attr));
             // Now if there are vals, push those too.
             // For each value we want to now be present.
             vals.iter().try_for_each(|val| {
-                qs.clone_value(audit, &attr, &val).map(|resolved_v| {
+                qs.clone_value(audit, attr, val).map(|resolved_v| {
                     mods.push(Modify::Present(attr.as_str().into(), resolved_v));
                 })
             })
@@ -176,7 +176,7 @@ impl ModifyList<ModifyInvalid> {
                     let attr_norm = schema.normalise_attr_name(attr);
                     match schema_attributes.get(&attr_norm) {
                         Some(schema_a) => schema_a
-                            .validate_value(attr_norm.as_str(), &value)
+                            .validate_value(attr_norm.as_str(), value)
                             .map(|_| Modify::Present(attr_norm, value.clone())),
                         None => Err(SchemaError::InvalidAttribute(attr_norm.to_string())),
                     }
@@ -185,7 +185,7 @@ impl ModifyList<ModifyInvalid> {
                     let attr_norm = schema.normalise_attr_name(attr);
                     match schema_attributes.get(&attr_norm) {
                         Some(schema_a) => schema_a
-                            .validate_partialvalue(attr_norm.as_str(), &value)
+                            .validate_partialvalue(attr_norm.as_str(), value)
                             .map(|_| Modify::Removed(attr_norm, value.clone())),
                         None => Err(SchemaError::InvalidAttribute(attr_norm.to_string())),
                     }

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -31,9 +31,9 @@ fn get_cand_attr_set<VALID, STATE>(
             };
             // Get the value and uuid
             //for each value in the ava.
-            e.get_ava(attr)
+            e.get_ava_set(attr)
                 .map(|vs| {
-                    vs.map(|v| v.to_partialvalue()).try_for_each(|v| {
+                    vs.to_partialvalue_iter().try_for_each(|v| {
                         match cand_attr.insert(v, uuid.clone()) {
                             None => Ok(()),
                             Some(vr) => {

--- a/kanidmd/src/lib/plugins/gidnumber.rs
+++ b/kanidmd/src/lib/plugins/gidnumber.rs
@@ -111,7 +111,7 @@ mod tests {
         let e = qs_write.internal_search_uuid(au, &u).unwrap();
         let gidnumber = e.get_ava_single("gidnumber").unwrap();
         let ex_gid = Value::new_uint32(gid);
-        assert!(&ex_gid == gidnumber);
+        assert!(ex_gid == gidnumber);
     }
 
     #[test]

--- a/kanidmd/src/lib/plugins/password_import.rs
+++ b/kanidmd/src/lib/plugins/password_import.rs
@@ -30,12 +30,8 @@ impl Plugin for PasswordImport {
                 if vs.len() > 1 {
                     return Err(OperationError::Plugin(PluginError::PasswordImport("multiple password_imports specified".to_string())))
                 }
-                // Until upstream btreeset supports first(), we need to convert to a vec.
-                let vs: Vec<_> = vs.into_iter().collect();
 
-                debug_assert!(!vs.is_empty());
-                let im_pw = vs.first()
-                    .and_then(|v| v.to_str())
+                let im_pw = vs.to_str_single()
                     .ok_or_else(|| OperationError::Plugin(PluginError::PasswordImport("password_import has incorrect value type".to_string())))?;
 
                 // convert the import_password to a cred
@@ -79,11 +75,8 @@ impl Plugin for PasswordImport {
                     "multiple password_imports specified".to_string(),
                 )));
             }
-            // Until upstream btreeset supports first(), we need to convert to a vec.
-            let vs: Vec<_> = vs.into_iter().collect();
 
-            debug_assert!(!vs.is_empty());
-            let im_pw = vs.first().and_then(|v| v.to_str()).ok_or_else(|| {
+            let im_pw = vs.to_str_single().ok_or_else(|| {
                 OperationError::Plugin(PluginError::PasswordImport(
                     "password_import has incorrect value type".to_string(),
                 ))

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -222,7 +222,7 @@ impl Plugin for Spn {
             match e.get_ava_single("spn") {
                 Some(r_spn) => {
                     ltrace!(au, "verify spn: s {:?} == ex {:?} ?", r_spn, g_spn);
-                    if *r_spn != g_spn {
+                    if r_spn != g_spn {
                         ladmin_error!(
                             au,
                             "Entry {:?} SPN does not match expected s {:?} != ex {:?}",
@@ -371,7 +371,7 @@ mod tests {
                 .expect("must not fail");
 
             let e_pre_spn = e_pre.get_ava_single("spn").expect("must not fail");
-            assert!(*e_pre_spn == ex1);
+            assert!(e_pre_spn == ex1);
 
             // trigger the domain_name change (this will be a cli option to the server
             // in the final version), but it will still call the same qs function to perform the
@@ -388,7 +388,7 @@ mod tests {
             let e_post_spn = e_post.get_ava_single("spn").expect("must not fail");
             debug!("{:?}", e_post_spn);
             debug!("{:?}", ex2);
-            assert!(*e_post_spn == ex2);
+            assert!(e_post_spn == ex2);
 
             server_txn.commit(au).expect("Must not fail");
         });

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -1812,7 +1812,7 @@ mod tests {
             syntax: SyntaxType::SYNTAX_ID,
         };
 
-        let rvs = unsafe { valueset![Value::new_syntaxs("UTF8STRING").unwrap()] };
+        let rvs = ValueSet::new(Value::new_syntaxs("UTF8STRING").unwrap());
         let r6 = single_value_syntax.validate_ava("sv_syntax", &rvs);
         assert_eq!(r6, Ok(()));
 

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -21,6 +21,7 @@ use crate::be::IdxKey;
 use crate::prelude::*;
 use crate::valueset::ValueSet;
 use kanidm_proto::v1::{ConsistencyError, OperationError, SchemaError};
+use tracing::trace;
 
 use hashbrown::{HashMap, HashSet};
 use std::borrow::Borrow;
@@ -148,15 +149,12 @@ impl SchemaAttribute {
         })?;
         let phantom = value.get_ava_single_bool("phantom").unwrap_or(false);
         // index vec
-        // even if empty, it SHOULD be present ... (is that value to put an empty set?)
+        // even if empty, it SHOULD be present ... (is that valid to put an empty set?)
         // The get_ava_opt_index handles the optional case for us :)
-        let index = value
-            .get_ava_opt_index("index")
-            .map(|vv: Vec<&IndexType>| vv.into_iter().cloned().collect())
-            .map_err(|_| {
-                ladmin_error!(audit, "invalid index - {}", name);
-                OperationError::InvalidSchemaState("Invalid index".to_string())
-            })?;
+        let index = value.get_ava_opt_index("index").ok_or_else(|| {
+            ladmin_error!(audit, "invalid index - {}", name);
+            OperationError::InvalidSchemaState("invalid index".to_string())
+        })?;
         // syntax type
         let syntax = value
             .get_ava_single_syntax("syntax")
@@ -224,7 +222,7 @@ impl SchemaAttribute {
     }
 
     pub fn validate_ava(&self, a: &str, ava: &ValueSet) -> Result<(), SchemaError> {
-        // ltrace!("Checking for valid {:?} -> {:?}", self.name, ava);
+        trace!("Checking for valid {:?} -> {:?}", self.name, ava);
         // Check multivalue
         if !self.multivalue && ava.len() > 1 {
             // lrequest_error!("Ava len > 1 on single value attribute!");
@@ -232,29 +230,30 @@ impl SchemaAttribute {
         };
         // If syntax, check the type is correct
         let valid = match self.syntax {
-            SyntaxType::Boolean => ava.iter().all(Value::is_bool),
-            SyntaxType::SYNTAX_ID => ava.iter().all(Value::is_syntax),
-            SyntaxType::Uuid => ava.iter().all(Value::is_uuid),
-            SyntaxType::REFERENCE_UUID => ava.iter().all(Value::is_refer),
-            SyntaxType::INDEX_ID => ava.iter().all(Value::is_index),
-            SyntaxType::Utf8StringInsensitive => ava.iter().all(Value::is_insensitive_utf8),
-            SyntaxType::Utf8StringIname => ava.iter().all(Value::is_iname),
-            SyntaxType::UTF8STRING => ava.iter().all(Value::is_utf8),
-            SyntaxType::JSON_FILTER => ava.iter().all(Value::is_json_filter),
-            SyntaxType::Credential => ava.iter().all(Value::is_credential),
-            SyntaxType::SecretUtf8String => ava.iter().all(Value::is_secret_string),
-            SyntaxType::SshKey => ava.iter().all(Value::is_sshkey),
-            SyntaxType::SecurityPrincipalName => ava.iter().all(Value::is_spn),
-            SyntaxType::UINT32 => ava.iter().all(Value::is_uint32),
-            SyntaxType::Cid => ava.iter().all(Value::is_cid),
-            SyntaxType::NsUniqueId => ava.iter().all(Value::is_nsuniqueid),
-            SyntaxType::DateTime => ava.iter().all(Value::is_datetime),
-            SyntaxType::EmailAddress => ava.iter().all(Value::is_email_address),
-            SyntaxType::Url => ava.iter().all(Value::is_url),
+            SyntaxType::Boolean => ava.is_bool(),
+            SyntaxType::SYNTAX_ID => ava.is_syntax(),
+            SyntaxType::Uuid => ava.is_uuid(),
+            SyntaxType::REFERENCE_UUID => ava.is_refer(),
+            SyntaxType::INDEX_ID => ava.is_index(),
+            SyntaxType::Utf8StringInsensitive => ava.is_insensitive_utf8(),
+            SyntaxType::Utf8StringIname => ava.is_iname(),
+            SyntaxType::UTF8STRING => ava.is_utf8(),
+            SyntaxType::JSON_FILTER => ava.is_json_filter(),
+            SyntaxType::Credential => ava.is_credential(),
+            SyntaxType::SecretUtf8String => ava.is_secret_string(),
+            SyntaxType::SshKey => ava.is_sshkey(),
+            SyntaxType::SecurityPrincipalName => ava.is_spn(),
+            SyntaxType::UINT32 => ava.is_uint32(),
+            SyntaxType::Cid => ava.is_cid(),
+            SyntaxType::NsUniqueId => ava.is_nsuniqueid(),
+            SyntaxType::DateTime => ava.is_datetime(),
+            SyntaxType::EmailAddress => ava.is_email_address(),
+            SyntaxType::Url => ava.is_url(),
         };
         if valid {
             Ok(())
         } else {
+            trace!(?a, "InvalidAttributeSyntax");
             Err(SchemaError::InvalidAttributeSyntax(a.to_string()))
         }
     }
@@ -1741,10 +1740,8 @@ mod tests {
             single_value_string.validate_ava("single_value", &valueset![Value::new_iutf8("test")]);
         assert_eq!(r1, Ok(()));
 
-        let r2 = single_value_string.validate_ava(
-            "single_value",
-            &valueset![Value::new_iutf8("test1"), Value::new_iutf8("test2")],
-        );
+        let rvs = unsafe { valueset![Value::new_iutf8("test1"), Value::new_iutf8("test2")] };
+        let r2 = single_value_string.validate_ava("single_value", &rvs);
         assert_eq!(
             r2,
             Err(SchemaError::InvalidAttributeSyntax(
@@ -1766,10 +1763,8 @@ mod tests {
             syntax: SyntaxType::UTF8STRING,
         };
 
-        let r5 = multi_value_string.validate_ava(
-            "mv_string",
-            &valueset![Value::new_utf8s("test1"), Value::new_utf8s("test2")],
-        );
+        let rvs = unsafe { valueset![Value::new_utf8s("test1"), Value::new_utf8s("test2")] };
+        let r5 = multi_value_string.validate_ava("mv_string", &rvs);
         assert_eq!(r5, Ok(()));
 
         let multi_value_boolean = SchemaAttribute {
@@ -1784,23 +1779,24 @@ mod tests {
             syntax: SyntaxType::Boolean,
         };
 
-        let r3 = multi_value_boolean.validate_ava(
-            "mv_bool",
-            &valueset![
+        // Since valueset now disallows such shenangians at a type level, this can't occur
+        /*
+        let rvs = unsafe {
+            valueset![
                 Value::new_bool(true),
                 Value::new_iutf8("test1"),
                 Value::new_iutf8("test2")
-            ],
-        );
+            ]
+        };
+        let r3 = multi_value_boolean.validate_ava("mv_bool", &rvs);
         assert_eq!(
             r3,
             Err(SchemaError::InvalidAttributeSyntax("mv_bool".to_string()))
         );
+        */
 
-        let r4 = multi_value_boolean.validate_ava(
-            "mv_bool",
-            &valueset![Value::new_bool(true), Value::new_bool(false)],
-        );
+        let rvs = unsafe { valueset![Value::new_bool(true), Value::new_bool(false)] };
+        let r4 = multi_value_boolean.validate_ava("mv_bool", &rvs);
         assert_eq!(r4, Ok(()));
 
         // syntax_id and index_type values
@@ -1816,14 +1812,14 @@ mod tests {
             syntax: SyntaxType::SYNTAX_ID,
         };
 
-        let r6 = single_value_syntax.validate_ava(
-            "sv_syntax",
-            &valueset![Value::new_syntaxs("UTF8STRING").unwrap()],
-        );
+        let rvs = unsafe { valueset![Value::new_syntaxs("UTF8STRING").unwrap()] };
+        let r6 = single_value_syntax.validate_ava("sv_syntax", &rvs);
         assert_eq!(r6, Ok(()));
 
-        let r7 = single_value_syntax
-            .validate_ava("sv_syntax", &valueset![Value::new_utf8s("thaeountaheu")]);
+        let r7 = single_value_syntax.validate_ava(
+            "sv_syntax",
+            &ValueSet::new(Value::new_utf8s("thaeountaheu")),
+        );
         assert_eq!(
             r7,
             Err(SchemaError::InvalidAttributeSyntax("sv_syntax".to_string()))
@@ -1843,12 +1839,12 @@ mod tests {
         //
         let r8 = single_value_index.validate_ava(
             "sv_index",
-            &valueset![Value::new_indexs("EQUALITY").unwrap()],
+            &ValueSet::new(Value::new_indexs("EQUALITY").unwrap()),
         );
         assert_eq!(r8, Ok(()));
 
         let r9 = single_value_index
-            .validate_ava("sv_index", &valueset![Value::new_utf8s("thaeountaheu")]);
+            .validate_ava("sv_index", &ValueSet::new(Value::new_utf8s("thaeountaheu")));
         assert_eq!(
             r9,
             Err(SchemaError::InvalidAttributeSyntax("sv_index".to_string()))

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -258,7 +258,7 @@ pub trait QueryServerTransaction<'a> {
 
                 let lims = ee.get_limits();
 
-                self.get_be_txn().exists(audit, &lims, &vfr).map_err(|e| {
+                self.get_be_txn().exists(audit, lims, &vfr).map_err(|e| {
                     admin_error!(?e, "backend failure");
                     ladmin_error!(audit, "backend failure -> {:?}", e);
                     OperationError::Backend

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -7,7 +7,6 @@ use async_std::task;
 use concread::arcache::{ARCache, ARCacheReadTxn};
 use hashbrown::{HashMap, HashSet};
 use std::cell::Cell;
-use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Semaphore, SemaphorePermit};
@@ -560,7 +559,7 @@ pub trait QueryServerTransaction<'a> {
                             // I think this is unreachable due to how the .or_else works.
                             .ok_or_else(|| OperationError::InvalidAttribute("Invalid Reference syntax".to_string()))
                     }
-                    SyntaxType::JSON_FILTER => Value::new_json_filter(value)
+                    SyntaxType::JSON_FILTER => Value::new_json_filter_s(value)
                         .ok_or_else(|| OperationError::InvalidAttribute("Invalid Filter syntax".to_string())),
                     SyntaxType::Credential => Err(OperationError::InvalidAttribute("Credentials can not be supplied through modification - please use the IDM api".to_string())),
                     SyntaxType::SecretUtf8String => Err(OperationError::InvalidAttribute("Radius secrets can not be supplied through modification - please use the IDM api".to_string())),
@@ -657,7 +656,7 @@ pub trait QueryServerTransaction<'a> {
                             })
                     }
                     SyntaxType::JSON_FILTER => {
-                        PartialValue::new_json_filter(value).ok_or_else(|| {
+                        PartialValue::new_json_filter_s(value).ok_or_else(|| {
                             OperationError::InvalidAttribute("Invalid Filter syntax".to_string())
                         })
                     }
@@ -699,42 +698,51 @@ pub trait QueryServerTransaction<'a> {
 
     // In the opposite direction, we can resolve values for presentation
     // ! TRACING INTEGRATED
-    fn resolve_value(
+    fn resolve_valueset(
         &self,
         audit: &mut AuditScope,
-        value: &Value,
-    ) -> Result<String, OperationError> {
-        // Are we a reference type? Try and resolve.
-        if let Some(ur) = value.to_ref_uuid() {
-            let nv = self.uuid_to_spn(audit, ur)?;
-            return match nv {
-                Some(v) => Ok(v.to_proto_string_clone()),
-                None => Ok(value.to_proto_string_clone()),
-            };
+        value: &ValueSet,
+    ) -> Result<Vec<String>, OperationError> {
+        if let Some(r_set) = value.as_refer_set() {
+            let v: Result<Vec<_>, _> = r_set
+                .iter()
+                .map(|ur| {
+                    let nv = self.uuid_to_spn(audit, ur)?;
+                    match nv {
+                        Some(v) => Ok(v.to_proto_string_clone()),
+                        None => Ok(ValueSet::uuid_to_proto_string(ur)),
+                    }
+                })
+                .collect();
+            v
+        } else {
+            let v: Vec<_> = value.to_proto_string_clone_iter().collect();
+            Ok(v)
         }
-
-        // Not? Okay, do the to string.
-        Ok(value.to_proto_string_clone())
     }
 
     // ! TRACING INTEGRATED
-    fn resolve_value_ldap(
+    fn resolve_valueset_ldap(
         &self,
         audit: &mut AuditScope,
-        value: &Value,
+        value: &ValueSet,
         basedn: &str,
-    ) -> Result<String, OperationError> {
-        if let Some(ur) = value.to_ref_uuid() {
-            let rdn = self.uuid_to_rdn(audit, ur)?;
-            Ok(format!("{},{}", rdn, basedn))
-        } else if value.is_sshkey() {
-            value
-                .get_sshkey()
-                .map(str::to_string)
-                .ok_or(OperationError::InvalidValueState)
+    ) -> Result<Vec<String>, OperationError> {
+        if let Some(r_set) = value.as_refer_set() {
+            let v: Result<Vec<_>, _> = r_set
+                .iter()
+                .map(|ur| {
+                    let rdn = self.uuid_to_rdn(audit, ur)?;
+                    Ok(format!("{},{}", rdn, basedn))
+                })
+                .collect();
+            v
+        } else if let Some(k_set) = value.as_sshkey_map() {
+            let v: Vec<_> = k_set.values().cloned().collect();
+            Ok(v)
         } else {
-            // Not? Okay, do the to string.
-            Ok(value.to_proto_string_clone())
+            let v: Vec<_> = value.to_proto_string_clone_iter().collect();
+            Ok(v)
         }
     }
 
@@ -762,16 +770,9 @@ pub trait QueryServerTransaction<'a> {
         audit: &mut AuditScope,
     ) -> Result<HashSet<String>, OperationError> {
         self.internal_search_uuid(audit, &UUID_SYSTEM_CONFIG)
-            .and_then(|e| match e.get_ava_set("badlist_password") {
-                Some(badlist_entry) => {
-                    let mut badlist_hashset = HashSet::with_capacity(badlist_entry.len());
-                    badlist_entry
-                        .iter()
-                        .filter_map(Value::as_string)
-                        .cloned()
-                        .for_each(|s| {
-                            badlist_hashset.insert(s);
-                        });
+            .and_then(|e| match e.get_ava_as_str("badlist_password") {
+                Some(vs_str_iter) => {
+                    let badlist_hashset: HashSet<_> = vs_str_iter.map(str::to_string).collect();
                     Ok(badlist_hashset)
                 }
                 None => Err(OperationError::InvalidEntryState),
@@ -1960,27 +1961,15 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .map(|er| er.clone().invalidate(self.cid.clone()))
                 .collect();
 
-            candidates.iter_mut().for_each(|er| {
-                let opt_names: Option<BTreeSet<_>> = er.pop_ava("name").map(|vs| {
-                    vs.into_iter()
-                        .filter_map(Value::migrate_iutf8_iname)
-                        .collect()
-                });
-                let opt_dnames: Option<BTreeSet<_>> = er.pop_ava("domain_name").map(|vs| {
-                    vs.into_iter()
-                        .filter_map(Value::migrate_iutf8_iname)
-                        .collect()
-                });
-
-                ltrace!(audit, "{:?}", opt_names);
-                ltrace!(audit, "{:?}", opt_dnames);
-                if let Some(v) = opt_names {
-                    er.set_ava("name", v)
+            candidates.iter_mut().try_for_each(|er| {
+                if let Some(vs) = er.get_ava_mut("name") {
+                    vs.migrate_iutf8_iname()?
                 };
-                if let Some(v) = opt_dnames {
-                    er.set_ava("domain_name", v)
+                if let Some(vs) = er.get_ava_mut("domain_name") {
+                    vs.migrate_iutf8_iname()?
                 };
-            });
+                Ok(())
+            })?;
 
             // Schema check all.
             let res: Result<Vec<Entry<EntrySealed, EntryCommitted>>, SchemaError> = candidates
@@ -2151,6 +2140,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .and_then(|e: Entry<EntryInit, EntryNew>| self.internal_migrate_or_create(audit, e))
         });
         ltrace!(audit, "internal_migrate_or_create_str -> result {:?}", res);
+        trace!(?res, "internal_migrate_or_create_str -> result");
         debug_assert!(res.is_ok());
         res
     }
@@ -2282,12 +2272,15 @@ impl<'a> QueryServerWriteTransaction<'a> {
         // internal_migrate_or_create.
         let r: Result<_, _> = entries.into_iter().try_for_each(|e| {
             ltrace!(audit, "init schema -> {}", e);
+            trace!(?e, "init schema entry");
             self.internal_migrate_or_create(audit, e)
         });
         if r.is_ok() {
             ladmin_info!(audit, "initialise_schema_core -> Ok!");
+            admin_info!("initialise_schema_core -> Ok!");
         } else {
             ladmin_error!(audit, "initialise_schema_core -> Error {:?}", r);
+            admin_info!(?r, "initialise_schema_core -> Error");
         }
         // why do we have error handling if it's always supposed to be `Ok`?
         debug_assert!(r.is_ok());
@@ -4212,15 +4205,12 @@ mod tests {
                 .internal_search_uuid(audit, &UUID_DOMAIN_INFO)
                 .expect("failed");
             // ++ assert all names are iname
-            domain
-                .get_ava("name")
-                .expect("no name?")
-                .for_each(|v| assert!(v.is_iname()));
+            assert!(domain.get_ava_set("name").expect("no name?").is_iname());
             // ++ assert all domain/domain_name are iname
-            domain
-                .get_ava("domain_name")
+            assert!(domain
+                .get_ava_set("domain_name")
                 .expect("no domain_name?")
-                .for_each(|v| assert!(v.is_iname()));
+                .is_iname());
             assert!(server_txn.commit(audit).is_ok());
         })
     }

--- a/kanidmd/src/lib/tracing_tree/formatter.rs
+++ b/kanidmd/src/lib/tracing_tree/formatter.rs
@@ -137,7 +137,7 @@ fn format_json(processed_logs: &TreeProcessed) -> Vec<u8> {
     let mut writer = vec![];
     let mut spans = vec![];
     #[allow(clippy::expect_used)]
-    fmt_rec(&processed_logs, &mut spans, None, &mut writer).expect("Write failed");
+    fmt_rec(processed_logs, &mut spans, None, &mut writer).expect("Write failed");
     writer
 }
 
@@ -291,7 +291,7 @@ fn format_pretty(processed_logs: &TreeProcessed) -> Vec<u8> {
     let mut writer = vec![];
     let mut indent = vec![];
     #[allow(clippy::expect_used)]
-    fmt_rec(&processed_logs, &mut indent, None, None, &mut writer).expect("Write failed");
+    fmt_rec(processed_logs, &mut indent, None, None, &mut writer).expect("Write failed");
     writer
 }
 

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -1483,7 +1483,10 @@ impl Value {
     }
 
     pub fn to_sshkey(self) -> Option<(String, String)> {
-        unimplemented!();
+        match (self.pv, self.data.map(|b| (*b).clone())) {
+            (PartialValue::SshKey(tag), Some(DataValue::SshKey(k))) => Some((tag, k)),
+            _ => None,
+        }
     }
 
     pub fn to_spn(self) -> Option<(String, String)> {

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -299,6 +299,54 @@ pub enum PartialValue {
     Url(Url),
 }
 
+impl From<SyntaxType> for PartialValue {
+    fn from(s: SyntaxType) -> Self {
+        PartialValue::Syntax(s)
+    }
+}
+
+impl From<IndexType> for PartialValue {
+    fn from(i: IndexType) -> Self {
+        PartialValue::Index(i)
+    }
+}
+
+impl From<bool> for PartialValue {
+    fn from(b: bool) -> Self {
+        PartialValue::Bool(b)
+    }
+}
+
+impl From<&bool> for PartialValue {
+    fn from(b: &bool) -> Self {
+        PartialValue::Bool(*b)
+    }
+}
+
+impl From<ProtoFilter> for PartialValue {
+    fn from(i: ProtoFilter) -> Self {
+        PartialValue::JsonFilt(i)
+    }
+}
+
+impl From<u32> for PartialValue {
+    fn from(i: u32) -> Self {
+        PartialValue::Uint32(i)
+    }
+}
+
+impl From<OffsetDateTime> for PartialValue {
+    fn from(i: OffsetDateTime) -> Self {
+        PartialValue::DateTime(i)
+    }
+}
+
+impl From<Url> for PartialValue {
+    fn from(i: Url) -> Self {
+        PartialValue::Url(i)
+    }
+}
+
 impl PartialValue {
     pub fn new_utf8(s: String) -> Self {
         PartialValue::Utf8(s)
@@ -417,7 +465,7 @@ impl PartialValue {
         matches!(self, PartialValue::Syntax(_))
     }
 
-    pub fn new_json_filter(s: &str) -> Option<Self> {
+    pub fn new_json_filter_s(s: &str) -> Option<Self> {
         let pf: ProtoFilter = match serde_json::from_str(s) {
             Ok(pf) => pf,
             Err(_) => return None,
@@ -689,6 +737,42 @@ impl From<IndexType> for Value {
     }
 }
 
+impl From<ProtoFilter> for Value {
+    fn from(i: ProtoFilter) -> Self {
+        Value {
+            pv: PartialValue::JsonFilt(i),
+            data: None,
+        }
+    }
+}
+
+impl From<OffsetDateTime> for Value {
+    fn from(i: OffsetDateTime) -> Self {
+        Value {
+            pv: PartialValue::DateTime(i),
+            data: None,
+        }
+    }
+}
+
+impl From<u32> for Value {
+    fn from(i: u32) -> Self {
+        Value {
+            pv: PartialValue::Uint32(i),
+            data: None,
+        }
+    }
+}
+
+impl From<Url> for Value {
+    fn from(i: Url) -> Self {
+        Value {
+            pv: PartialValue::Url(i),
+            data: None,
+        }
+    }
+}
+
 // Because these are potentially ambiguous, we limit them to tests where we can contain
 // any....mistakes.
 #[cfg(test)]
@@ -836,6 +920,13 @@ impl Value {
         })
     }
 
+    pub fn new_syntax(s: SyntaxType) -> Self {
+        Value {
+            pv: PartialValue::Syntax(s),
+            data: None,
+        }
+    }
+
     pub fn is_syntax(&self) -> bool {
         matches!(self.pv, PartialValue::Syntax(_))
     }
@@ -845,6 +936,13 @@ impl Value {
             pv: PartialValue::new_indexs(s)?,
             data: None,
         })
+    }
+
+    pub fn new_index(i: IndexType) -> Self {
+        Value {
+            pv: PartialValue::Index(i),
+            data: None,
+        }
     }
 
     pub fn is_index(&self) -> bool {
@@ -876,11 +974,18 @@ impl Value {
         matches!(self.pv, PartialValue::Refer(_))
     }
 
-    pub fn new_json_filter(s: &str) -> Option<Self> {
+    pub fn new_json_filter_s(s: &str) -> Option<Self> {
         Some(Value {
-            pv: PartialValue::new_json_filter(s)?,
+            pv: PartialValue::new_json_filter_s(s)?,
             data: None,
         })
+    }
+
+    pub fn new_json_filter(f: ProtoFilter) -> Self {
+        Value {
+            pv: PartialValue::JsonFilt(f),
+            data: None,
+        }
     }
 
     pub fn is_json_filter(&self) -> bool {
@@ -1039,6 +1144,13 @@ impl Value {
         PartialValue::new_datetime_s(s).map(|pv| Value { pv, data: None })
     }
 
+    pub fn new_datetime(dt: OffsetDateTime) -> Self {
+        Value {
+            pv: PartialValue::DateTime(dt),
+            data: None,
+        }
+    }
+
     pub fn to_datetime(&self) -> Option<OffsetDateTime> {
         match &self.pv {
             PartialValue::DateTime(odt) => {
@@ -1066,6 +1178,13 @@ impl Value {
 
     pub fn new_url_s(s: &str) -> Option<Self> {
         PartialValue::new_url_s(s).map(|pv| Value { pv, data: None })
+    }
+
+    pub fn new_url(u: Url) -> Self {
+        Value {
+            pv: PartialValue::Url(u),
+            data: None,
+        }
     }
 
     pub fn is_url(&self) -> bool {
@@ -1123,7 +1242,7 @@ impl Value {
                 data: None,
             }),
             DbValueV1::JsonFilter(s) => Ok(Value {
-                pv: match PartialValue::new_json_filter(s.as_str()) {
+                pv: match PartialValue::new_json_filter_s(s.as_str()) {
                     Some(pv) => pv,
                     None => return Err(()),
                 },
@@ -1326,6 +1445,73 @@ impl Value {
     pub fn to_partialvalue(&self) -> PartialValue {
         // Match on self to become a partialvalue.
         self.pv.clone()
+    }
+
+    pub fn to_utf8(self) -> Option<String> {
+        match self.pv {
+            PartialValue::Utf8(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn to_iutf8(self) -> Option<String> {
+        match self.pv {
+            PartialValue::Iutf8(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn to_iname(self) -> Option<String> {
+        match self.pv {
+            PartialValue::Iname(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn to_jsonfilt(self) -> Option<ProtoFilter> {
+        match self.pv {
+            PartialValue::JsonFilt(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    pub fn to_cred(self) -> Option<(String, Credential)> {
+        match (self.pv, self.data.map(|b| (*b).clone())) {
+            (PartialValue::Cred(tag), Some(DataValue::Cred(c))) => Some((tag, c)),
+            _ => None,
+        }
+    }
+
+    pub fn to_sshkey(self) -> Option<(String, String)> {
+        unimplemented!();
+    }
+
+    pub fn to_spn(self) -> Option<(String, String)> {
+        match self.pv {
+            PartialValue::Spn(n, d) => Some((n, d)),
+            _ => None,
+        }
+    }
+
+    pub fn to_cid(self) -> Option<Cid> {
+        match self.pv {
+            PartialValue::Cid(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn to_nsuniqueid(self) -> Option<String> {
+        match self.pv {
+            PartialValue::Nsuniqueid(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn to_emailaddress(self) -> Option<String> {
+        match self.pv {
+            PartialValue::EmailAddress(s) => Some(s),
+            _ => None,
+        }
     }
 
     pub fn migrate_iutf8_iname(self) -> Option<Self> {

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -601,7 +601,7 @@ impl PartialValue {
 
     pub fn to_url(&self) -> Option<&Url> {
         match self {
-            PartialValue::Url(u) => Some(&u),
+            PartialValue::Url(u) => Some(u),
             _ => None,
         }
     }
@@ -1014,7 +1014,7 @@ impl Value {
         match &self.pv {
             PartialValue::Cred(_) => match &self.data {
                 Some(dv) => match dv.as_ref() {
-                    DataValue::Cred(c) => Some(&c),
+                    DataValue::Cred(c) => Some(c),
                     _ => None,
                 },
                 None => None,
@@ -1383,7 +1383,7 @@ impl Value {
 
     pub fn to_url(&self) -> Option<&Url> {
         match &self.pv {
-            PartialValue::Url(u) => Some(&u),
+            PartialValue::Url(u) => Some(u),
             _ => None,
         }
     }
@@ -1401,28 +1401,28 @@ impl Value {
     // in refint plugin.
     pub fn to_ref_uuid(&self) -> Option<&Uuid> {
         match &self.pv {
-            PartialValue::Refer(u) => Some(&u),
+            PartialValue::Refer(u) => Some(u),
             _ => None,
         }
     }
 
     pub fn to_uuid(&self) -> Option<&Uuid> {
         match &self.pv {
-            PartialValue::Uuid(u) => Some(&u),
+            PartialValue::Uuid(u) => Some(u),
             _ => None,
         }
     }
 
     pub fn to_indextype(&self) -> Option<&IndexType> {
         match &self.pv {
-            PartialValue::Index(i) => Some(&i),
+            PartialValue::Index(i) => Some(i),
             _ => None,
         }
     }
 
     pub fn to_syntaxtype(&self) -> Option<&SyntaxType> {
         match &self.pv {
-            PartialValue::Syntax(s) => Some(&s),
+            PartialValue::Syntax(s) => Some(s),
             _ => None,
         }
     }

--- a/kanidmd/src/lib/valueset.rs
+++ b/kanidmd/src/lib/valueset.rs
@@ -939,10 +939,6 @@ impl ValueSet {
     }
 
     pub fn to_str_single(&self) -> Option<&str> {
-        tracing::event!(
-            tracing::Level::TRACE,
-            valueset = tracing::field::debug(&self.inner)
-        );
         match &self.inner {
             I::Utf8(set) | I::Iutf8(set) | I::Iname(set) => {
                 if set.len() == 1 {
@@ -995,10 +991,6 @@ impl ValueSet {
     }
 
     pub fn as_classname_iter(&self) -> Option<impl Iterator<Item = &str>> {
-        tracing::event!(
-            tracing::Level::TRACE,
-            valueset = tracing::field::debug(&self.inner)
-        );
         match &self.inner {
             I::Iutf8(set) => Some(set.iter().map(|s| s.as_str())),
             _ => None,
@@ -1006,10 +998,6 @@ impl ValueSet {
     }
 
     pub fn as_indextype_set(&self) -> Option<impl Iterator<Item = &IndexType>> {
-        tracing::event!(
-            tracing::Level::TRACE,
-            valueset = tracing::field::debug(&self.inner)
-        );
         match &self.inner {
             I::Index(set) => Some(set.iter()),
             _ => None,
@@ -1146,18 +1134,10 @@ impl ValueSet {
             return Err(OperationError::InvalidValueState);
         };
 
-        tracing::event!(
-            tracing::Level::TRACE,
-            initvalue = tracing::field::debug(&init)
-        );
         let init = init?;
         let mut vs = ValueSet::new(init);
 
         while let Some(maybe_v) = iter.next() {
-            tracing::event!(
-                tracing::Level::TRACE,
-                maybe_v = tracing::field::debug(&maybe_v)
-            );
             let v = maybe_v?;
             // Need to error if wrong type
             vs.insert_checked(v)?;
@@ -1251,11 +1231,7 @@ impl ValueSet {
         if let Some(mut ninner) = ninner {
             std::mem::swap(&mut ninner, &mut self.inner);
         }
-        //trace
-        tracing::event!(
-            tracing::Level::TRACE,
-            valueset = tracing::field::debug(&self.inner)
-        );
+        trace!(valueset = tracing::field::debug(&self.inner));
 
         Ok(())
     }

--- a/kanidmd/src/lib/valueset.rs
+++ b/kanidmd/src/lib/valueset.rs
@@ -52,9 +52,7 @@ macro_rules! mergesets {
         $b:expr
     ) => {{
         $b.iter().for_each(|v| {
-            if !$a.contains(v) {
-                $a.insert(v.clone());
-            }
+            $a.insert(v.clone());
         });
         Ok(())
     }};
@@ -486,7 +484,7 @@ impl ValueSet {
             (I::DateTime(set), PartialValue::DateTime(dt)) => set.contains(dt),
             (I::EmailAddress(set), PartialValue::EmailAddress(e)) => set.contains(e.as_str()),
             (I::Url(set), PartialValue::Url(u)) => set.contains(u),
-            (_, _) => false,
+            _ => false,
         }
     }
 

--- a/kanidmd/src/lib/valueset.rs
+++ b/kanidmd/src/lib/valueset.rs
@@ -1,112 +1,1310 @@
+use crate::credential::Credential;
 use crate::prelude::*;
-// use hashbrown::HashSet;
-use std::borrow::Borrow;
-use std::collections::BTreeSet;
+use crate::repl::cid::Cid;
+use either::Either::{Left, Right};
+use kanidm_proto::v1::Filter as ProtoFilter;
+use smolset::{SmolSet, SmolSetIter};
+use sshkeys::PublicKey as SshPublicKey;
+use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
+use time::OffsetDateTime;
+use tracing::trace;
 
-pub struct ValueSet {
-    inner: BTreeSet<Value>,
+use crate::be::dbvalue::{
+    DbCidV1, DbValueCredV1, DbValueEmailAddressV1, DbValueTaggedStringV1, DbValueV1,
+};
+use crate::value::DataValue;
+
+// SmolSet<[; 1]>
+
+#[derive(Debug, Clone)]
+enum I {
+    Utf8(BTreeSet<String>),
+    Iutf8(BTreeSet<String>),
+    // Could be AttrString?
+    Iname(BTreeSet<String>),
+    Uuid(BTreeSet<Uuid>),
+    Bool(SmolSet<[bool; 1]>),
+    Syntax(SmolSet<[SyntaxType; 1]>),
+    Index(SmolSet<[IndexType; 1]>),
+    Refer(BTreeSet<Uuid>),
+    JsonFilt(SmolSet<[ProtoFilter; 1]>),
+    Cred(BTreeMap<String, Credential>),
+    SshKey(BTreeMap<String, String>),
+    SecretValue(SmolSet<[String; 1]>),
+    Spn(BTreeSet<(String, String)>),
+    Uint32(SmolSet<[u32; 1]>),
+    Cid(SmolSet<[Cid; 1]>),
+    Nsuniqueid(BTreeSet<String>),
+    DateTime(SmolSet<[OffsetDateTime; 1]>),
+    EmailAddress(BTreeSet<String>),
+    Url(SmolSet<[Url; 1]>),
 }
 
-impl Default for ValueSet {
-    fn default() -> Self {
-        ValueSet {
-            inner: BTreeSet::new(),
-        }
-    }
+pub struct ValueSet {
+    inner: I,
+}
+
+macro_rules! mergesets {
+    (
+        $a:expr,
+        $b:expr
+    ) => {{
+        $b.iter().for_each(|v| {
+            if !$a.contains(v) {
+                $a.insert(v.clone());
+            }
+        });
+        Ok(())
+    }};
+}
+
+macro_rules! mergemaps {
+    (
+        $a:expr,
+        $b:expr
+    ) => {{
+        $b.iter().for_each(|(k, v)| {
+            if !$a.contains_key(k) {
+                $a.insert(k.clone(), v.clone());
+            }
+        });
+        Ok(())
+    }};
 }
 
 impl ValueSet {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn uuid_to_proto_string(u: &Uuid) -> String {
+        u.to_hyphenated_ref().to_string()
+    }
+
+    pub fn new(value: Value) -> Self {
+        let Value { pv, data } = value;
+
+        let vs = ValueSet {
+            inner: match pv {
+                PartialValue::Utf8(s) => I::Utf8(btreeset![s]),
+                PartialValue::Iutf8(s) => I::Iutf8(btreeset![s]),
+                PartialValue::Iname(s) => I::Iname(btreeset![s]),
+                PartialValue::Uuid(u) => I::Uuid(btreeset![u]),
+                PartialValue::Bool(b) => I::Bool(smolset![b]),
+                PartialValue::Syntax(s) => I::Syntax(smolset![s]),
+                PartialValue::Index(i) => I::Index(smolset![i]),
+                PartialValue::Refer(u) => I::Refer(btreeset![u]),
+                PartialValue::JsonFilt(f) => I::JsonFilt(smolset![f]),
+                PartialValue::Cred(t) => match data.map(|b| (*b).clone()) {
+                    Some(DataValue::Cred(c)) => I::Cred(btreemap![(t, c)]),
+                    _ => unreachable!(),
+                },
+                PartialValue::SshKey(t) => match data.map(|b| (*b).clone()) {
+                    Some(DataValue::SshKey(k)) => I::SshKey(btreemap![(t, k)]),
+                    _ => unreachable!(),
+                },
+                PartialValue::SecretValue => match data.map(|b| (*b).clone()) {
+                    Some(DataValue::SecretValue(c)) => I::SecretValue(smolset![c]),
+                    _ => unreachable!(),
+                },
+                PartialValue::Spn(n, d) => I::Spn(btreeset![(n, d)]),
+                PartialValue::Uint32(i) => I::Uint32(smolset![i]),
+                PartialValue::Cid(c) => I::Cid(smolset![c]),
+                PartialValue::Nsuniqueid(s) => I::Nsuniqueid(btreeset![s]),
+                PartialValue::DateTime(dt) => I::DateTime(smolset![dt]),
+                PartialValue::EmailAddress(e) => I::EmailAddress(btreeset![e]),
+                PartialValue::Url(u) => I::Url(smolset![u]),
+            },
+        };
+        trace!(?vs, "ValueSet::new");
+        vs
+    }
+
+    pub fn insert_checked(&mut self, value: Value) -> Result<bool, OperationError> {
+        let Value { pv, data } = value;
+
+        match (&mut self.inner, pv) {
+            (I::Utf8(set), PartialValue::Utf8(s)) => Ok(set.insert(s)),
+            (I::Iutf8(set), PartialValue::Iutf8(s)) => Ok(set.insert(s)),
+            (I::Iname(set), PartialValue::Iname(s)) => Ok(set.insert(s)),
+            (I::Uuid(set), PartialValue::Uuid(u)) => Ok(set.insert(u)),
+            (I::Bool(bs), PartialValue::Bool(b)) => {
+                bs.insert(b);
+                Ok(true)
+            }
+            (I::Syntax(set), PartialValue::Syntax(s)) => Ok(set.insert(s)),
+            (I::Index(set), PartialValue::Index(i)) => Ok(set.insert(i)),
+            (I::Refer(set), PartialValue::Refer(u)) => Ok(set.insert(u)),
+            (I::JsonFilt(set), PartialValue::JsonFilt(f)) => Ok(set.insert(f)),
+            (I::Cred(map), PartialValue::Cred(t)) => {
+                if map.contains_key(&t) {
+                    Ok(false)
+                } else {
+                    match data.map(|b| (*b).clone()) {
+                        Some(DataValue::Cred(c)) => Ok(map.insert(t, c).is_none()),
+                        _ => Err(OperationError::InvalidValueState),
+                    }
+                }
+            }
+            (I::SshKey(map), PartialValue::SshKey(t)) => {
+                if map.contains_key(&t) {
+                    Ok(false)
+                } else {
+                    match data.map(|b| (*b).clone()) {
+                        Some(DataValue::SshKey(k)) => Ok(map.insert(t, k).is_none()),
+                        _ => Err(OperationError::InvalidValueState),
+                    }
+                }
+            }
+            (I::SecretValue(set), PartialValue::SecretValue) => match data.map(|b| (*b).clone()) {
+                Some(DataValue::SecretValue(c)) => Ok(set.insert(c)),
+                _ => Err(OperationError::InvalidValueState),
+            },
+            (I::Spn(set), PartialValue::Spn(n, d)) => Ok(set.insert((n, d))),
+            (I::Uint32(set), PartialValue::Uint32(i)) => Ok(set.insert(i)),
+            (I::Cid(set), PartialValue::Cid(c)) => Ok(set.insert(c)),
+            (I::Nsuniqueid(set), PartialValue::Nsuniqueid(u)) => Ok(set.insert(u)),
+            (I::DateTime(set), PartialValue::DateTime(dt)) => Ok(set.insert(dt)),
+            (I::EmailAddress(set), PartialValue::EmailAddress(e)) => Ok(set.insert(e)),
+            (I::Url(set), PartialValue::Url(u)) => Ok(set.insert(u)),
+            (_, _) => Err(OperationError::InvalidValueState),
+        }
     }
 
     // insert
-    pub fn insert(&mut self, value: Value) -> bool {
-        // Return true if the element is new.
-        self.inner.insert(value)
+    pub unsafe fn insert(&mut self, value: Value) -> bool {
+        trace!("ValueSet::insert");
+        self.insert_checked(value).unwrap_or(false)
     }
 
     // set values
     pub fn set(&mut self, iter: impl Iterator<Item = Value>) {
-        self.inner.clear();
-        self.inner.extend(iter);
+        self.clear();
+        self.extend(iter);
     }
 
-    pub fn get<Q>(&self, value: &Q) -> Option<&Value>
-    where
-        Value: Borrow<Q> + Ord,
-        Q: Ord + ?Sized,
-    {
-        self.inner.get(value)
+    pub fn merge(&mut self, other: &Self) -> Result<(), OperationError> {
+        match (&mut self.inner, &other.inner) {
+            (I::Utf8(a), I::Utf8(b)) => mergesets!(a, b),
+            (I::Iutf8(a), I::Iutf8(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Iname(a), I::Iname(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Uuid(a), I::Uuid(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Bool(a), I::Bool(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Syntax(a), I::Syntax(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Index(a), I::Index(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Refer(a), I::Refer(b)) => {
+                mergesets!(a, b)
+            }
+            (I::JsonFilt(a), I::JsonFilt(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Cred(a), I::Cred(b)) => {
+                mergemaps!(a, b)
+            }
+            (I::SshKey(a), I::SshKey(b)) => {
+                mergemaps!(a, b)
+            }
+            (I::SecretValue(a), I::SecretValue(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Spn(a), I::Spn(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Uint32(a), I::Uint32(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Cid(a), I::Cid(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Nsuniqueid(a), I::Nsuniqueid(b)) => {
+                mergesets!(a, b)
+            }
+            (I::DateTime(a), I::DateTime(b)) => {
+                mergesets!(a, b)
+            }
+            (I::EmailAddress(a), I::EmailAddress(b)) => {
+                mergesets!(a, b)
+            }
+            (I::Url(a), I::Url(b)) => {
+                mergesets!(a, b)
+            }
+            // I think that in this case, we need to specify self / everything as we are changing
+            // type and we need to potentially purge everything, so we just return the left side.
+            _ => Err(OperationError::InvalidValueState),
+        }
+    }
+
+    fn extend(&mut self, iter: impl Iterator<Item = Value>) {
+        match &mut self.inner {
+            I::Utf8(set) => {
+                set.extend(iter.filter_map(|v| v.to_utf8()));
+            }
+            I::Iutf8(set) => {
+                set.extend(iter.filter_map(|v| v.to_iutf8()));
+            }
+            I::Iname(set) => {
+                set.extend(iter.filter_map(|v| v.to_iname()));
+            }
+            I::Uuid(set) => {
+                set.extend(iter.filter_map(|v| v.to_uuid().copied()));
+            }
+            I::Bool(set) => {
+                iter.filter_map(|v| v.to_bool()).for_each(|i| {
+                    set.insert(i);
+                });
+            }
+            I::Syntax(set) => {
+                iter.filter_map(|v| v.to_syntaxtype().cloned())
+                    .for_each(|i| {
+                        set.insert(i);
+                    });
+            }
+            I::Index(set) => {
+                iter.filter_map(|v| v.to_indextype().cloned())
+                    .for_each(|i| {
+                        set.insert(i);
+                    });
+            }
+            I::Refer(set) => {
+                set.extend(iter.filter_map(|v| v.to_ref_uuid().copied()));
+            }
+            I::JsonFilt(set) => {
+                iter.filter_map(|v| v.to_jsonfilt()).for_each(|i| {
+                    set.insert(i);
+                });
+            }
+            I::Cred(map) => {
+                map.extend(iter.filter_map(|v| v.to_cred()));
+            }
+            I::SshKey(map) => {
+                map.extend(iter.filter_map(|v| v.to_sshkey()));
+            }
+            I::SecretValue(set) => {
+                iter.filter_map(|v| v.get_secret_str().map(str::to_string))
+                    .for_each(|i| {
+                        set.insert(i);
+                    });
+            }
+            I::Spn(set) => {
+                set.extend(iter.filter_map(|v| v.to_spn()));
+            }
+            I::Uint32(set) => {
+                iter.filter_map(|v| v.to_uint32()).for_each(|i| {
+                    set.insert(i);
+                });
+            }
+            I::Cid(set) => {
+                iter.filter_map(|v| v.to_cid()).for_each(|i| {
+                    set.insert(i);
+                });
+            }
+            I::Nsuniqueid(set) => {
+                set.extend(iter.filter_map(|v| v.to_nsuniqueid()));
+            }
+            I::DateTime(set) => {
+                iter.filter_map(|v| v.to_datetime()).for_each(|i| {
+                    set.insert(i);
+                });
+            }
+            I::EmailAddress(set) => {
+                set.extend(iter.filter_map(|v| v.to_emailaddress()));
+            }
+            I::Url(set) => {
+                iter.filter_map(|v| v.to_url().cloned()).for_each(|i| {
+                    set.insert(i);
+                });
+            }
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        match &mut self.inner {
+            I::Utf8(set) => {
+                set.clear();
+            }
+            I::Iutf8(set) => {
+                set.clear();
+            }
+            I::Iname(set) => {
+                set.clear();
+            }
+            I::Uuid(set) => {
+                set.clear();
+            }
+            I::Bool(set) => {
+                set.clear();
+            }
+            I::Syntax(set) => {
+                set.clear();
+            }
+            I::Index(set) => {
+                set.clear();
+            }
+            I::Refer(set) => {
+                set.clear();
+            }
+            I::JsonFilt(set) => {
+                set.clear();
+            }
+            I::Cred(map) => {
+                map.clear();
+            }
+            I::SshKey(map) => {
+                map.clear();
+            }
+            I::SecretValue(set) => {
+                set.clear();
+            }
+            I::Spn(set) => {
+                set.clear();
+            }
+            I::Uint32(set) => {
+                set.clear();
+            }
+            I::Cid(set) => {
+                set.clear();
+            }
+            I::Nsuniqueid(set) => {
+                set.clear();
+            }
+            I::DateTime(set) => {
+                set.clear();
+            }
+            I::EmailAddress(set) => {
+                set.clear();
+            }
+            I::Url(set) => {
+                set.clear();
+            }
+        };
+        debug_assert!(self.is_empty());
     }
 
     // delete a value
-    pub fn remove<Q>(&mut self, value: &Q) -> bool
-    where
-        Value: Borrow<Q> + Ord,
-        Q: Ord + ?Sized,
-    {
-        self.inner.remove(value)
+    pub fn remove(&mut self, pv: &PartialValue) -> bool {
+        match (&mut self.inner, pv) {
+            (I::Utf8(set), PartialValue::Utf8(s)) => {
+                set.remove(s);
+            }
+            (I::Iutf8(set), PartialValue::Iutf8(s)) => {
+                set.remove(s);
+            }
+            (I::Iname(set), PartialValue::Iname(s)) => {
+                set.remove(s);
+            }
+            (I::Uuid(set), PartialValue::Uuid(u)) => {
+                set.remove(u);
+            }
+            (I::Bool(set), PartialValue::Bool(b)) => {
+                set.remove(b);
+            }
+            (I::Syntax(set), PartialValue::Syntax(s)) => {
+                set.remove(s);
+            }
+            (I::Index(set), PartialValue::Index(i)) => {
+                set.remove(i);
+            }
+            (I::Refer(set), PartialValue::Refer(u)) => {
+                set.remove(u);
+            }
+            (I::JsonFilt(set), PartialValue::JsonFilt(f)) => {
+                set.remove(f);
+            }
+            (I::Cred(map), PartialValue::Cred(t)) => {
+                map.remove(t);
+            }
+            (I::SshKey(map), PartialValue::SshKey(t)) => {
+                map.remove(t);
+            }
+            (I::SecretValue(set), PartialValue::SecretValue) => {}
+            (I::Spn(set), PartialValue::Spn(n, d)) => {
+                set.remove(&(n.to_string(), d.to_string()));
+            }
+            (I::Uint32(set), PartialValue::Uint32(i)) => {
+                set.remove(i);
+            }
+            (I::Cid(set), PartialValue::Cid(c)) => {
+                set.remove(c);
+            }
+            (I::Nsuniqueid(set), PartialValue::Nsuniqueid(u)) => {
+                set.remove(u);
+            }
+            (I::DateTime(set), PartialValue::DateTime(dt)) => {
+                set.remove(dt);
+            }
+            (I::EmailAddress(set), PartialValue::EmailAddress(e)) => {
+                set.remove(e);
+            }
+            (I::Url(set), PartialValue::Url(u)) => {
+                set.remove(u);
+            }
+            (_, _) => {}
+        };
+        true
     }
 
-    pub fn contains<Q>(&self, value: &Q) -> bool
-    where
-        Value: Borrow<Q> + Ord,
-        Q: Ord + ?Sized,
-    {
-        self.inner.contains(value)
+    pub fn contains(&self, pv: &PartialValue) -> bool {
+        match (&self.inner, pv) {
+            (I::Utf8(set), PartialValue::Utf8(s)) => set.contains(s.as_str()),
+            (I::Iutf8(set), PartialValue::Iutf8(s)) => set.contains(s.as_str()),
+            (I::Iname(set), PartialValue::Iname(s)) => set.contains(s.as_str()),
+            (I::Uuid(set), PartialValue::Uuid(u)) => set.contains(&u),
+            (I::Bool(set), PartialValue::Bool(b)) => set.contains(&b),
+            (I::Syntax(set), PartialValue::Syntax(s)) => set.contains(&s),
+            (I::Index(set), PartialValue::Index(i)) => set.contains(&i),
+            (I::Refer(set), PartialValue::Refer(u)) => set.contains(&u),
+            (I::JsonFilt(set), PartialValue::JsonFilt(f)) => set.contains(&f),
+            (I::Cred(map), PartialValue::Cred(t)) => map.contains_key(t.as_str()),
+            (I::SshKey(map), PartialValue::SshKey(t)) => map.contains_key(t.as_str()),
+            (I::SecretValue(set), PartialValue::SecretValue) => false,
+            // Borrowing into a &(&string, &string) doesn't work here, and spn is small so we iterate
+            // instead.
+            (I::Spn(set), PartialValue::Spn(n, d)) => set.iter().any(|(a, b)| a == n && b == d),
+            (I::Uint32(set), PartialValue::Uint32(i)) => set.contains(&i),
+            (I::Cid(set), PartialValue::Cid(c)) => set.contains(&c),
+            (I::Nsuniqueid(set), PartialValue::Nsuniqueid(u)) => set.contains(u.as_str()),
+            (I::DateTime(set), PartialValue::DateTime(dt)) => set.contains(&dt),
+            (I::EmailAddress(set), PartialValue::EmailAddress(e)) => set.contains(e.as_str()),
+            (I::Url(set), PartialValue::Url(u)) => set.contains(&u),
+            (_, _) => false,
+        }
     }
 
-    pub fn substring(&self, value: &PartialValue) -> bool {
-        self.inner.iter().any(|v| v.substring(value))
+    pub fn substring(&self, pv: &PartialValue) -> bool {
+        match (&self.inner, pv) {
+            (I::Utf8(set), PartialValue::Utf8(s2)) => set.iter().any(|s1| s1.contains(s2)),
+            (I::Iutf8(set), PartialValue::Iutf8(s2)) => set.iter().any(|s1| s1.contains(s2)),
+            (I::Iname(set), PartialValue::Iname(s2)) => set.iter().any(|s1| s1.contains(s2)),
+            _ => false,
+        }
     }
 
-    pub fn lessthan(&self, value: &PartialValue) -> bool {
-        self.inner.iter().any(|v| v.lessthan(value))
+    pub fn lessthan(&self, pv: &PartialValue) -> bool {
+        match (&self.inner, pv) {
+            (I::Cid(set), PartialValue::Cid(c2)) => set.iter().any(|c1| c1 < c2),
+            (I::Uint32(set), PartialValue::Uint32(u2)) => set.iter().any(|u1| u1 < u2),
+            _ => false,
+        }
     }
 
     pub fn len(&self) -> usize {
-        self.inner.len()
+        match &self.inner {
+            I::Utf8(set) => set.len(),
+            I::Iutf8(set) => set.len(),
+            I::Iname(set) => set.len(),
+            I::Uuid(set) => set.len(),
+            I::Bool(set) => set.len(),
+            I::Syntax(set) => set.len(),
+            I::Index(set) => set.len(),
+            I::Refer(set) => set.len(),
+            I::JsonFilt(set) => set.len(),
+            I::Cred(map) => map.len(),
+            I::SshKey(map) => map.len(),
+            I::SecretValue(set) => set.len(),
+            I::Spn(set) => set.len(),
+            I::Uint32(set) => set.len(),
+            I::Cid(set) => set.len(),
+            I::Nsuniqueid(set) => set.len(),
+            I::DateTime(set) => set.len(),
+            I::EmailAddress(set) => set.len(),
+            I::Url(set) => set.len(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    // We'll need to be able to do partialeq/intersect etc later.
-
-    pub fn iter(&self) -> Iter {
-        (&self).into_iter()
-    }
-
-    pub fn difference<'a>(&'a self, other: &'a ValueSet) -> Difference<'a> {
-        Difference {
-            iter: self.inner.difference(&other.inner),
+    pub fn generate_idx_eq_keys(&self) -> Vec<String> {
+        match &self.inner {
+            I::Utf8(set) => set.iter().cloned().collect(),
+            I::Iutf8(set) => set.iter().cloned().collect(),
+            I::Iname(set) => set.iter().cloned().collect(),
+            I::Uuid(set) => set
+                .iter()
+                .map(|u| u.to_hyphenated_ref().to_string())
+                .collect(),
+            I::Bool(set) => set.iter().map(|u| u.to_string()).collect(),
+            I::Syntax(set) => set.iter().map(|u| u.to_string()).collect(),
+            I::Index(set) => set.iter().map(|u| u.to_string()).collect(),
+            I::Refer(set) => set
+                .iter()
+                .map(|u| u.to_hyphenated_ref().to_string())
+                .collect(),
+            I::JsonFilt(set) => set
+                .iter()
+                .map(|s| {
+                    #[allow(clippy::expect_used)]
+                    serde_json::to_string(s)
+                        .expect("A json filter value was corrupted during run-time")
+                })
+                .collect(),
+            I::Cred(map) => map.keys().cloned().collect(),
+            I::SshKey(map) => map.keys().cloned().collect(),
+            I::SecretValue(set) => vec![],
+            I::Spn(set) => set.iter().map(|(n, d)| format!("{}@{}", n, d)).collect(),
+            I::Uint32(set) => set.iter().map(|u| u.to_string()).collect(),
+            I::Cid(set) => vec![],
+            I::Nsuniqueid(set) => set.iter().cloned().collect(),
+            I::DateTime(set) => set
+                .iter()
+                .map(|odt| {
+                    debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                    odt.format(time::Format::Rfc3339)
+                })
+                .collect(),
+            I::EmailAddress(set) => set.iter().cloned().collect(),
+            // Don't you dare comment on this quinn, it's a URL not a str.
+            I::Url(set) => set.iter().map(|u| u.to_string()).collect(),
         }
     }
 
-    pub fn symmetric_difference<'a>(&'a self, other: &'a ValueSet) -> SymmetricDifference<'a> {
-        SymmetricDifference {
-            iter: self.inner.symmetric_difference(&other.inner),
+    pub fn idx_eq_key_difference<'a>(&'a self, other: &'a ValueSet) -> Option<ValueSet> {
+        // The values in self, that are not in other.
+        match (&self.inner, &other.inner) {
+            (I::Utf8(a), I::Utf8(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Utf8(x) })
+                }
+            }
+            (I::Iutf8(a), I::Iutf8(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Iutf8(x) })
+                }
+            }
+            (I::Iname(a), I::Iname(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Iname(x) })
+                }
+            }
+            (I::Uuid(a), I::Uuid(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Uuid(x) })
+                }
+            }
+            (I::Bool(a), I::Bool(b)) => {
+                let x: SmolSet<_> = a.difference(b).copied().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Bool(x) })
+                }
+            }
+            (I::Syntax(a), I::Syntax(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::Syntax(x),
+                    })
+                }
+            }
+            (I::Index(a), I::Index(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Index(x) })
+                }
+            }
+            (I::Refer(a), I::Refer(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Refer(x) })
+                }
+            }
+            (I::JsonFilt(a), I::JsonFilt(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::JsonFilt(x),
+                    })
+                }
+            }
+            (I::Cred(a), I::Cred(b)) => {
+                let x: BTreeMap<_, _> = a
+                    .iter()
+                    .filter(|(k, _)| b.contains_key(k.as_str()))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Cred(x) })
+                }
+            }
+            (I::SshKey(a), I::SshKey(b)) => {
+                let x: BTreeMap<_, _> = a
+                    .iter()
+                    .filter(|(k, _)| b.contains_key(k.as_str()))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::SshKey(x),
+                    })
+                }
+            }
+            (I::SecretValue(a), I::SecretValue(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::SecretValue(x),
+                    })
+                }
+            }
+            (I::Spn(a), I::Spn(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Spn(x) })
+                }
+            }
+            (I::Uint32(a), I::Uint32(b)) => {
+                let x: SmolSet<_> = a.difference(b).copied().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::Uint32(x),
+                    })
+                }
+            }
+            (I::Cid(a), I::Cid(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Cid(x) })
+                }
+            }
+            (I::Nsuniqueid(a), I::Nsuniqueid(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::Nsuniqueid(x),
+                    })
+                }
+            }
+            (I::DateTime(a), I::DateTime(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::DateTime(x),
+                    })
+                }
+            }
+            (I::EmailAddress(a), I::EmailAddress(b)) => {
+                let x: BTreeSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet {
+                        inner: I::EmailAddress(x),
+                    })
+                }
+            }
+            (I::Url(a), I::Url(b)) => {
+                let x: SmolSet<_> = a.difference(b).cloned().collect();
+                if x.is_empty() {
+                    None
+                } else {
+                    Some(ValueSet { inner: I::Url(x) })
+                }
+            }
+            // I think that in this case, we need to specify self / everything as we are changing
+            // type and we need to potentially purge everything, so we just return the left side.
+            _ => Some(self.clone()),
         }
+    }
+
+    pub fn get_ssh_tag(&self, tag: &str) -> Option<&str> {
+        match &self.inner {
+            I::SshKey(map) => map.get(tag).map(|s| s.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn as_uuid_set(&self) -> Option<&BTreeSet<Uuid>> {
+        // Need to return refer or not?
+        match &self.inner {
+            I::Uuid(set) => Some(set),
+            _ => None,
+        }
+    }
+
+    pub fn as_refer_set(&self) -> Option<&BTreeSet<Uuid>> {
+        match &self.inner {
+            I::Refer(set) => Some(set),
+            _ => None,
+        }
+    }
+
+    pub fn as_sshkey_map(&self) -> Option<&BTreeMap<String, String>> {
+        match &self.inner {
+            I::SshKey(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    pub fn to_value_single(&self) -> Option<Value> {
+        if self.len() != 1 {
+            return None;
+        }
+        // From here it's guarantee everything is len 1.
+        match &self.inner {
+            I::Utf8(set) => set.iter().take(1).next().cloned().map(Value::new_utf8),
+            I::Iutf8(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .map(|s| s.as_str())
+                .map(Value::new_iutf8),
+            I::Iname(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .map(|s| s.as_str())
+                .map(Value::new_iname),
+            I::Uuid(set) => set.iter().take(1).next().map(Value::new_uuidr),
+            I::Bool(set) => set.iter().take(1).next().copied().map(Value::new_bool),
+            I::Syntax(set) => set.iter().take(1).next().cloned().map(Value::new_syntax),
+            I::Index(set) => set.iter().take(1).next().cloned().map(Value::new_index),
+            I::Refer(set) => set.iter().take(1).next().map(Value::new_refer_r),
+            I::JsonFilt(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .cloned()
+                .map(Value::new_json_filter),
+            I::Cred(map) => map
+                .iter()
+                .take(1)
+                .next()
+                .map(|(t, c)| Value::new_credential(t, c.clone())),
+            I::SshKey(map) => map
+                .iter()
+                .take(1)
+                .next()
+                .map(|(t, k)| Value::new_sshkey_str(t, k)),
+            I::SecretValue(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .map(|s| s.as_str())
+                .map(Value::new_secret_str),
+            I::Spn(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .map(|(n, r)| Value::new_spn_str(n, r)),
+            I::Uint32(set) => set.iter().take(1).next().copied().map(Value::new_uint32),
+            I::Cid(set) => set.iter().take(1).next().cloned().map(Value::new_cid),
+            I::Nsuniqueid(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .map(|s| s.as_str())
+                .map(Value::new_nsuniqueid_s),
+            I::DateTime(set) => set.iter().take(1).next().cloned().map(Value::new_datetime),
+            I::EmailAddress(set) => set
+                .iter()
+                .take(1)
+                .next()
+                .map(|s| s.as_str())
+                .map(Value::new_email_address_s),
+            I::Url(set) => set.iter().take(1).next().cloned().map(Value::new_url),
+        }
+    }
+
+    pub fn to_proto_string_single(&self) -> Option<String> {
+        if self.len() != 1 {
+            None
+        } else {
+            self.to_proto_string_clone_iter().take(1).next()
+        }
+    }
+
+    pub fn to_uuid_single(&self) -> Option<&Uuid> {
+        match &self.inner {
+            I::Uuid(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_bool_single(&self) -> Option<bool> {
+        match &self.inner {
+            I::Bool(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).copied().next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_uint32_single(&self) -> Option<u32> {
+        match &self.inner {
+            I::Uint32(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).copied().next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_syntaxtype_single(&self) -> Option<&SyntaxType> {
+        match &self.inner {
+            I::Syntax(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_credential_single(&self) -> Option<&Credential> {
+        match &self.inner {
+            I::Cred(map) => {
+                if map.len() == 1 {
+                    map.values().take(1).next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_secret_single(&self) -> Option<&str> {
+        match &self.inner {
+            I::SecretValue(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).map(|s| s.as_str()).next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_str_single(&self) -> Option<&str> {
+        tracing::event!(
+            tracing::Level::TRACE,
+            valueset = tracing::field::debug(&self.inner)
+        );
+        match &self.inner {
+            I::Utf8(set) | I::Iutf8(set) | I::Iname(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).next().map(|s| s.as_str())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_datetime_single(&self) -> Option<OffsetDateTime> {
+        match &self.inner {
+            I::DateTime(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).cloned().next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_url_single(&self) -> Option<&Url> {
+        match &self.inner {
+            I::Url(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_json_filter_single(&self) -> Option<&ProtoFilter> {
+        match &self.inner {
+            I::JsonFilt(set) => {
+                if set.len() == 1 {
+                    set.iter().take(1).next()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_classname_iter(&self) -> Option<impl Iterator<Item = &str>> {
+        tracing::event!(
+            tracing::Level::TRACE,
+            valueset = tracing::field::debug(&self.inner)
+        );
+        match &self.inner {
+            I::Iutf8(set) => Some(set.iter().map(|s| s.as_str())),
+            _ => None,
+        }
+    }
+
+    pub fn as_indextype_set(&self) -> Option<impl Iterator<Item = &IndexType>> {
+        tracing::event!(
+            tracing::Level::TRACE,
+            valueset = tracing::field::debug(&self.inner)
+        );
+        match &self.inner {
+            I::Index(set) => Some(set.iter()),
+            _ => None,
+        }
+    }
+
+    pub fn as_str_iter(&self) -> Option<impl Iterator<Item = &str>> {
+        match &self.inner {
+            I::Iutf8(set) | I::Utf8(set) => Some(Left(set.iter().map(|s| s.as_str()))),
+            I::Iname(set) => Some(Right(set.iter().map(|s| s.as_str()))),
+            _ => None,
+        }
+    }
+
+    // Value::Refer
+    pub fn as_ref_uuid_iter(&self) -> Option<impl Iterator<Item = &Uuid>> {
+        match &self.inner {
+            I::Refer(set) => Some(set.iter()),
+            _ => None,
+        }
+    }
+
+    pub fn as_sshpubkey_str_iter(&self) -> Option<impl Iterator<Item = &str>> {
+        match &self.inner {
+            I::SshKey(set) => Some(set.values().map(|s| s.as_str())),
+            _ => None,
+        }
+    }
+
+    pub fn to_proto_string_clone_iter<'a>(&'a self) -> ProtoIter<'a> {
+        // to_proto_string_clone
+        match &self.inner {
+            I::Utf8(set) => ProtoIter::Utf8(set.iter()),
+            I::Iutf8(set) => ProtoIter::Iutf8(set.iter()),
+            I::Iname(set) => ProtoIter::Iname(set.iter()),
+            I::Uuid(set) => ProtoIter::Uuid(set.iter()),
+            I::Bool(set) => ProtoIter::Bool(set.iter()),
+            I::Syntax(set) => ProtoIter::Syntax(set.iter()),
+            I::Index(set) => ProtoIter::Index(set.iter()),
+            I::Refer(set) => ProtoIter::Refer(set.iter()),
+            I::JsonFilt(set) => ProtoIter::JsonFilt(set.iter()),
+            I::Cred(map) => ProtoIter::Cred(map.iter()),
+            I::SshKey(map) => ProtoIter::SshKey(map.iter()),
+            I::SecretValue(set) => ProtoIter::SecretValue(set.iter()),
+            I::Spn(set) => ProtoIter::Spn(set.iter()),
+            I::Uint32(set) => ProtoIter::Uint32(set.iter()),
+            I::Cid(set) => ProtoIter::Cid(set.iter()),
+            I::Nsuniqueid(set) => ProtoIter::Nsuniqueid(set.iter()),
+            I::DateTime(set) => ProtoIter::DateTime(set.iter()),
+            I::EmailAddress(set) => ProtoIter::EmailAddress(set.iter()),
+            I::Url(set) => ProtoIter::Url(set.iter()),
+        }
+    }
+
+    pub fn to_db_valuev1_iter<'a>(&'a self) -> DbValueV1Iter<'a> {
+        match &self.inner {
+            I::Utf8(set) => DbValueV1Iter::Utf8(set.iter()),
+            I::Iutf8(set) => DbValueV1Iter::Iutf8(set.iter()),
+            I::Iname(set) => DbValueV1Iter::Iname(set.iter()),
+            I::Uuid(set) => DbValueV1Iter::Uuid(set.iter()),
+            I::Bool(set) => DbValueV1Iter::Bool(set.iter()),
+            I::Syntax(set) => DbValueV1Iter::Syntax(set.iter()),
+            I::Index(set) => DbValueV1Iter::Index(set.iter()),
+            I::Refer(set) => DbValueV1Iter::Refer(set.iter()),
+            I::JsonFilt(set) => DbValueV1Iter::JsonFilt(set.iter()),
+            I::Cred(map) => DbValueV1Iter::Cred(map.iter()),
+            I::SshKey(map) => DbValueV1Iter::SshKey(map.iter()),
+            I::SecretValue(set) => DbValueV1Iter::SecretValue(set.iter()),
+            I::Spn(set) => DbValueV1Iter::Spn(set.iter()),
+            I::Uint32(set) => DbValueV1Iter::Uint32(set.iter()),
+            I::Cid(set) => DbValueV1Iter::Cid(set.iter()),
+            I::Nsuniqueid(set) => DbValueV1Iter::Nsuniqueid(set.iter()),
+            I::DateTime(set) => DbValueV1Iter::DateTime(set.iter()),
+            I::EmailAddress(set) => DbValueV1Iter::EmailAddress(set.iter()),
+            I::Url(set) => DbValueV1Iter::Url(set.iter()),
+        }
+    }
+
+    pub fn to_partialvalue_iter<'a>(&'a self) -> PartialValueIter<'a> {
+        match &self.inner {
+            I::Utf8(set) => PartialValueIter::Utf8(set.iter()),
+            I::Iutf8(set) => PartialValueIter::Iutf8(set.iter()),
+            I::Iname(set) => PartialValueIter::Iname(set.iter()),
+            I::Uuid(set) => PartialValueIter::Uuid(set.iter()),
+            I::Bool(set) => PartialValueIter::Bool(set.iter()),
+            I::Syntax(set) => PartialValueIter::Syntax(set.iter()),
+            I::Index(set) => PartialValueIter::Index(set.iter()),
+            I::Refer(set) => PartialValueIter::Refer(set.iter()),
+            I::JsonFilt(set) => PartialValueIter::JsonFilt(set.iter()),
+            I::Cred(map) => PartialValueIter::Cred(map.iter()),
+            I::SshKey(map) => PartialValueIter::SshKey(map.iter()),
+            I::SecretValue(set) => PartialValueIter::SecretValue(set.iter()),
+            I::Spn(set) => PartialValueIter::Spn(set.iter()),
+            I::Uint32(set) => PartialValueIter::Uint32(set.iter()),
+            I::Cid(set) => PartialValueIter::Cid(set.iter()),
+            I::Nsuniqueid(set) => PartialValueIter::Nsuniqueid(set.iter()),
+            I::DateTime(set) => PartialValueIter::DateTime(set.iter()),
+            I::EmailAddress(set) => PartialValueIter::EmailAddress(set.iter()),
+            I::Url(set) => PartialValueIter::Url(set.iter()),
+        }
+    }
+
+    pub fn to_value_iter<'a>(&'a self) -> ValueIter<'a> {
+        match &self.inner {
+            I::Utf8(set) => ValueIter::Utf8(set.iter()),
+            I::Iutf8(set) => ValueIter::Iutf8(set.iter()),
+            I::Iname(set) => ValueIter::Iname(set.iter()),
+            I::Uuid(set) => ValueIter::Uuid(set.iter()),
+            I::Bool(set) => ValueIter::Bool(set.iter()),
+            I::Syntax(set) => ValueIter::Syntax(set.iter()),
+            I::Index(set) => ValueIter::Index(set.iter()),
+            I::Refer(set) => ValueIter::Refer(set.iter()),
+            I::JsonFilt(set) => ValueIter::JsonFilt(set.iter()),
+            I::Cred(map) => ValueIter::Cred(map.iter()),
+            I::SshKey(map) => ValueIter::SshKey(map.iter()),
+            I::SecretValue(set) => ValueIter::SecretValue(set.iter()),
+            I::Spn(set) => ValueIter::Spn(set.iter()),
+            I::Uint32(set) => ValueIter::Uint32(set.iter()),
+            I::Cid(set) => ValueIter::Cid(set.iter()),
+            I::Nsuniqueid(set) => ValueIter::Nsuniqueid(set.iter()),
+            I::DateTime(set) => ValueIter::DateTime(set.iter()),
+            I::EmailAddress(set) => ValueIter::EmailAddress(set.iter()),
+            I::Url(set) => ValueIter::Url(set.iter()),
+        }
+    }
+
+    pub fn from_result_value_iter(
+        mut iter: impl Iterator<Item = Result<Value, OperationError>>,
+    ) -> Result<Self, OperationError> {
+        let init = if let Some(v) = iter.next() {
+            v
+        } else {
+            admin_error!("Empty value iterator");
+            return Err(OperationError::InvalidValueState);
+        };
+
+        tracing::event!(
+            tracing::Level::TRACE,
+            initvalue = tracing::field::debug(&init)
+        );
+        let init = init?;
+        let mut vs = ValueSet::new(init);
+
+        while let Some(maybe_v) = iter.next() {
+            tracing::event!(
+                tracing::Level::TRACE,
+                maybe_v = tracing::field::debug(&maybe_v)
+            );
+            let v = maybe_v?;
+            // Need to error if wrong type
+            vs.insert_checked(v)?;
+        }
+        Ok(vs)
+    }
+
+    pub fn is_bool(&self) -> bool {
+        matches!(self.inner, I::Bool(_))
+    }
+
+    pub fn is_syntax(&self) -> bool {
+        matches!(self.inner, I::Syntax(_))
+    }
+
+    pub fn is_uuid(&self) -> bool {
+        matches!(self.inner, I::Uuid(_))
+    }
+
+    pub fn is_refer(&self) -> bool {
+        matches!(self.inner, I::Refer(_))
+    }
+
+    pub fn is_index(&self) -> bool {
+        matches!(self.inner, I::Index(_))
+    }
+
+    pub fn is_insensitive_utf8(&self) -> bool {
+        matches!(self.inner, I::Iutf8(_))
+    }
+
+    pub fn is_iname(&self) -> bool {
+        matches!(self.inner, I::Iname(_))
+    }
+
+    pub fn is_utf8(&self) -> bool {
+        matches!(self.inner, I::Utf8(_))
+    }
+
+    pub fn is_json_filter(&self) -> bool {
+        matches!(self.inner, I::JsonFilt(_))
+    }
+
+    pub fn is_credential(&self) -> bool {
+        matches!(self.inner, I::Cred(_))
+    }
+
+    pub fn is_secret_string(&self) -> bool {
+        matches!(self.inner, I::SecretValue(_))
+    }
+
+    pub fn is_sshkey(&self) -> bool {
+        matches!(self.inner, I::SshKey(_))
+    }
+
+    pub fn is_spn(&self) -> bool {
+        matches!(self.inner, I::Spn(_))
+    }
+
+    pub fn is_uint32(&self) -> bool {
+        matches!(self.inner, I::Uint32(_))
+    }
+
+    pub fn is_cid(&self) -> bool {
+        matches!(self.inner, I::Cid(_))
+    }
+
+    pub fn is_nsuniqueid(&self) -> bool {
+        matches!(self.inner, I::Nsuniqueid(_))
+    }
+
+    pub fn is_datetime(&self) -> bool {
+        matches!(self.inner, I::DateTime(_))
+    }
+
+    pub fn is_email_address(&self) -> bool {
+        matches!(self.inner, I::EmailAddress(_))
+    }
+
+    pub fn is_url(&self) -> bool {
+        matches!(self.inner, I::Url(_))
+    }
+
+    pub fn migrate_iutf8_iname(&mut self) -> Result<(), OperationError> {
+        // Swap iutf8 to Iname internally.
+        let ninner = match &self.inner {
+            I::Iutf8(set) => Some(I::Iname(set.clone())),
+            _ => None,
+        };
+
+        if let Some(mut ninner) = ninner {
+            std::mem::swap(&mut ninner, &mut self.inner);
+        }
+        //trace
+        tracing::event!(
+            tracing::Level::TRACE,
+            valueset = tracing::field::debug(&self.inner)
+        );
+
+        Ok(())
     }
 }
 
 impl PartialEq for ValueSet {
     fn eq(&self, other: &Self) -> bool {
-        self.inner.eq(&other.inner)
+        match (&self.inner, &other.inner) {
+            (I::Utf8(a), I::Utf8(b)) => a.eq(b),
+            (I::Iutf8(a), I::Iutf8(b)) => a.eq(b),
+            (I::Iname(a), I::Iname(b)) => a.eq(b),
+            (I::Uuid(a), I::Uuid(b)) => a.eq(b),
+            (I::Bool(a), I::Bool(b)) => a.eq(b),
+            (I::Syntax(a), I::Syntax(b)) => a.eq(b),
+            (I::Index(a), I::Index(b)) => a.eq(b),
+            (I::Refer(a), I::Refer(b)) => a.eq(b),
+            (I::JsonFilt(a), I::JsonFilt(b)) => a.eq(b),
+            // May not be possible to do?
+            // (I::Cred(a), I::Cred(b)) => a.eq(b),
+            (I::SshKey(a), I::SshKey(b)) => a.eq(b),
+            (I::SecretValue(a), I::SecretValue(b)) => a.eq(b),
+            (I::Spn(a), I::Spn(b)) => a.eq(b),
+            (I::Uint32(a), I::Uint32(b)) => a.eq(b),
+            (I::Cid(a), I::Cid(b)) => a.eq(b),
+            (I::Nsuniqueid(a), I::Nsuniqueid(b)) => a.eq(b),
+            (I::DateTime(a), I::DateTime(b)) => a.eq(b),
+            (I::EmailAddress(a), I::EmailAddress(b)) => a.eq(b),
+            (I::Url(a), I::Url(b)) => a.eq(b),
+            _ => false,
+        }
     }
 }
 
-impl FromIterator<Value> for ValueSet {
+impl FromIterator<Value> for Option<ValueSet> {
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = Value>,
     {
-        ValueSet {
-            inner: BTreeSet::from_iter(iter),
-        }
+        let mut iter = iter.into_iter();
+        // Get a first element, vs has to have at least one.
+        let mut vs = if let Some(v) = iter.next() {
+            ValueSet::new(v)
+        } else {
+            return None;
+        };
+
+        // Now finish it up.
+        vs.extend(iter);
+        Some(vs)
     }
 }
 
@@ -114,76 +1312,6 @@ impl Clone for ValueSet {
     fn clone(&self) -> Self {
         ValueSet {
             inner: self.inner.clone(),
-        }
-    }
-}
-
-pub struct Iter<'a> {
-    iter: std::collections::btree_set::Iter<'a, Value>,
-}
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Value;
-
-    fn next(&mut self) -> Option<&'a Value> {
-        self.iter.next()
-    }
-}
-
-impl<'a> IntoIterator for &'a ValueSet {
-    type Item = &'a Value;
-    type IntoIter = Iter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Iter {
-            iter: (&self.inner).iter(),
-        }
-    }
-}
-
-pub struct Difference<'a> {
-    iter: std::collections::btree_set::Difference<'a, Value>,
-}
-
-impl<'a> Iterator for Difference<'a> {
-    type Item = &'a Value;
-
-    fn next(&mut self) -> Option<&'a Value> {
-        self.iter.next()
-    }
-}
-
-pub struct SymmetricDifference<'a> {
-    iter: std::collections::btree_set::SymmetricDifference<'a, Value>,
-}
-
-impl<'a> Iterator for SymmetricDifference<'a> {
-    type Item = &'a Value;
-
-    fn next(&mut self) -> Option<&'a Value> {
-        self.iter.next()
-    }
-}
-
-pub struct IntoIter {
-    iter: std::collections::btree_set::IntoIter<Value>,
-}
-
-impl Iterator for IntoIter {
-    type Item = Value;
-
-    fn next(&mut self) -> Option<Value> {
-        self.iter.next()
-    }
-}
-
-impl IntoIterator for ValueSet {
-    type Item = Value;
-    type IntoIter = IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            iter: self.inner.into_iter(),
         }
     }
 }
@@ -196,6 +1324,299 @@ impl std::fmt::Debug for ValueSet {
     }
 }
 
+pub enum ValueIter<'a> {
+    Utf8(std::collections::btree_set::Iter<'a, String>),
+    Iutf8(std::collections::btree_set::Iter<'a, String>),
+    Iname(std::collections::btree_set::Iter<'a, String>),
+    Uuid(std::collections::btree_set::Iter<'a, Uuid>),
+    Bool(SmolSetIter<'a, [bool; 1]>),
+    Syntax(SmolSetIter<'a, [SyntaxType; 1]>),
+    Index(SmolSetIter<'a, [IndexType; 1]>),
+    Refer(std::collections::btree_set::Iter<'a, Uuid>),
+    JsonFilt(SmolSetIter<'a, [ProtoFilter; 1]>),
+    Cred(std::collections::btree_map::Iter<'a, String, Credential>),
+    SshKey(std::collections::btree_map::Iter<'a, String, String>),
+    SecretValue(SmolSetIter<'a, [String; 1]>),
+    Spn(std::collections::btree_set::Iter<'a, (String, String)>),
+    Uint32(SmolSetIter<'a, [u32; 1]>),
+    Cid(SmolSetIter<'a, [Cid; 1]>),
+    Nsuniqueid(std::collections::btree_set::Iter<'a, String>),
+    DateTime(SmolSetIter<'a, [OffsetDateTime; 1]>),
+    EmailAddress(std::collections::btree_set::Iter<'a, String>),
+    Url(SmolSetIter<'a, [Url; 1]>),
+}
+
+impl<'a> Iterator for ValueIter<'a> {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        match self {
+            ValueIter::Utf8(iter) => iter.next().map(|i| Value::new_utf8s(i.as_str())),
+            ValueIter::Iutf8(iter) => iter.next().map(|i| Value::new_iutf8(i.as_str())),
+            ValueIter::Iname(iter) => iter.next().map(|i| Value::new_iname(i.as_str())),
+            ValueIter::Uuid(iter) => iter.next().map(|i| Value::new_uuidr(i)),
+            ValueIter::Bool(iter) => iter.next().map(|i|
+                // Use the from bool impl.
+                Value::from(i)),
+            ValueIter::Syntax(iter) => iter.next().map(|i|
+                // Uses the "from syntax type" impl.
+                Value::from(i.clone())),
+            ValueIter::Index(iter) => iter.next().map(|i|
+                // Uses the from index type impl.
+                Value::from(i.clone())),
+            ValueIter::Refer(iter) => iter.next().map(|i| Value::new_refer_r(i)),
+            ValueIter::JsonFilt(iter) => iter.next().map(|i| Value::from(i.clone())),
+            ValueIter::Cred(iter) => iter
+                .next()
+                .map(|(tag, cred)| Value::new_credential(tag.as_str(), cred.clone())),
+            ValueIter::SshKey(iter) => iter
+                .next()
+                .map(|(tag, key)| Value::new_sshkey(tag.clone(), key.clone())),
+            ValueIter::SecretValue(iter) => iter.next().map(|i| Value::new_secret_str(i.as_str())),
+            ValueIter::Spn(iter) => iter
+                .next()
+                .map(|(n, d)| Value::new_spn_str(n.as_str(), d.as_str())),
+            ValueIter::Uint32(iter) => iter.next().map(|i| Value::from(i.clone())),
+            ValueIter::Cid(iter) => iter.next().map(|i| Value::new_cid(i.clone())),
+            ValueIter::Nsuniqueid(iter) => {
+                iter.next().map(|i| Value::new_email_address_s(i.as_str()))
+            }
+            ValueIter::DateTime(iter) => iter.next().map(|i| Value::from(i.clone())),
+            ValueIter::EmailAddress(iter) => {
+                iter.next().map(|i| Value::new_email_address_s(i.as_str()))
+            }
+            ValueIter::Url(iter) => iter.next().map(|i| Value::from(i.clone())),
+        }
+    }
+}
+
+pub enum PartialValueIter<'a> {
+    Utf8(std::collections::btree_set::Iter<'a, String>),
+    Iutf8(std::collections::btree_set::Iter<'a, String>),
+    Iname(std::collections::btree_set::Iter<'a, String>),
+    Uuid(std::collections::btree_set::Iter<'a, Uuid>),
+    Bool(SmolSetIter<'a, [bool; 1]>),
+    Syntax(SmolSetIter<'a, [SyntaxType; 1]>),
+    Index(SmolSetIter<'a, [IndexType; 1]>),
+    Refer(std::collections::btree_set::Iter<'a, Uuid>),
+    JsonFilt(SmolSetIter<'a, [ProtoFilter; 1]>),
+    Cred(std::collections::btree_map::Iter<'a, String, Credential>),
+    SshKey(std::collections::btree_map::Iter<'a, String, String>),
+    SecretValue(SmolSetIter<'a, [String; 1]>),
+    Spn(std::collections::btree_set::Iter<'a, (String, String)>),
+    Uint32(SmolSetIter<'a, [u32; 1]>),
+    Cid(SmolSetIter<'a, [Cid; 1]>),
+    Nsuniqueid(std::collections::btree_set::Iter<'a, String>),
+    DateTime(SmolSetIter<'a, [OffsetDateTime; 1]>),
+    EmailAddress(std::collections::btree_set::Iter<'a, String>),
+    Url(SmolSetIter<'a, [Url; 1]>),
+}
+
+impl<'a> Iterator for PartialValueIter<'a> {
+    type Item = PartialValue;
+
+    fn next(&mut self) -> Option<PartialValue> {
+        match self {
+            PartialValueIter::Utf8(iter) => {
+                iter.next().map(|i| PartialValue::new_utf8s(i.as_str()))
+            }
+            PartialValueIter::Iutf8(iter) => {
+                iter.next().map(|i| PartialValue::new_iutf8(i.as_str()))
+            }
+            PartialValueIter::Iname(iter) => {
+                iter.next().map(|i| PartialValue::new_iname(i.as_str()))
+            }
+            PartialValueIter::Uuid(iter) => iter.next().map(|i| PartialValue::new_uuidr(i)),
+            PartialValueIter::Bool(iter) => iter.next().map(|i|
+                // Use the from bool impl.
+                PartialValue::from(i)),
+            PartialValueIter::Syntax(iter) => iter.next().map(|i|
+                // Uses the "from syntax type" impl.
+                PartialValue::from(i.clone())),
+            PartialValueIter::Index(iter) => iter.next().map(|i|
+                // Uses the from index type impl.
+                PartialValue::from(i.clone())),
+            PartialValueIter::Refer(iter) => iter.next().map(|i| PartialValue::new_refer_r(i)),
+            PartialValueIter::JsonFilt(iter) => iter.next().map(|i| PartialValue::from(i.clone())),
+            PartialValueIter::Cred(iter) => iter
+                .next()
+                .map(|(tag, cred)| PartialValue::new_credential_tag(tag.as_str())),
+            PartialValueIter::SshKey(iter) => iter
+                .next()
+                .map(|(tag, key)| PartialValue::new_sshkey_tag_s(tag.as_str())),
+            PartialValueIter::SecretValue(iter) => {
+                iter.next().map(|_| PartialValue::new_secret_str())
+            }
+            PartialValueIter::Spn(iter) => iter
+                .next()
+                .map(|(n, d)| PartialValue::new_spn_nrs(n.as_str(), d.as_str())),
+            PartialValueIter::Uint32(iter) => iter.next().map(|i| PartialValue::from(i.clone())),
+            PartialValueIter::Cid(iter) => iter.next().map(|i| PartialValue::new_cid(i.clone())),
+            PartialValueIter::Nsuniqueid(iter) => iter
+                .next()
+                .map(|i| PartialValue::new_email_address_s(i.as_str())),
+            PartialValueIter::DateTime(iter) => iter.next().map(|i| PartialValue::from(i.clone())),
+            PartialValueIter::EmailAddress(iter) => iter
+                .next()
+                .map(|i| PartialValue::new_email_address_s(i.as_str())),
+            PartialValueIter::Url(iter) => iter.next().map(|i| PartialValue::from(i.clone())),
+        }
+    }
+}
+
+pub enum DbValueV1Iter<'a> {
+    Utf8(std::collections::btree_set::Iter<'a, String>),
+    Iutf8(std::collections::btree_set::Iter<'a, String>),
+    Iname(std::collections::btree_set::Iter<'a, String>),
+    Uuid(std::collections::btree_set::Iter<'a, Uuid>),
+    Bool(SmolSetIter<'a, [bool; 1]>),
+    Syntax(SmolSetIter<'a, [SyntaxType; 1]>),
+    Index(SmolSetIter<'a, [IndexType; 1]>),
+    Refer(std::collections::btree_set::Iter<'a, Uuid>),
+    JsonFilt(SmolSetIter<'a, [ProtoFilter; 1]>),
+    Cred(std::collections::btree_map::Iter<'a, String, Credential>),
+    SshKey(std::collections::btree_map::Iter<'a, String, String>),
+    SecretValue(SmolSetIter<'a, [String; 1]>),
+    Spn(std::collections::btree_set::Iter<'a, (String, String)>),
+    Uint32(SmolSetIter<'a, [u32; 1]>),
+    Cid(SmolSetIter<'a, [Cid; 1]>),
+    Nsuniqueid(std::collections::btree_set::Iter<'a, String>),
+    DateTime(SmolSetIter<'a, [OffsetDateTime; 1]>),
+    EmailAddress(std::collections::btree_set::Iter<'a, String>),
+    Url(SmolSetIter<'a, [Url; 1]>),
+}
+
+impl<'a> Iterator for DbValueV1Iter<'a> {
+    type Item = DbValueV1;
+
+    fn next(&mut self) -> Option<DbValueV1> {
+        match self {
+            DbValueV1Iter::Utf8(iter) => iter.next().map(|i| DbValueV1::Utf8(i.clone())),
+            DbValueV1Iter::Iutf8(iter) => iter.next().map(|i| DbValueV1::Iutf8(i.clone())),
+            DbValueV1Iter::Iname(iter) => iter.next().map(|i| DbValueV1::Iname(i.clone())),
+            DbValueV1Iter::Uuid(iter) => iter.next().map(|i| DbValueV1::Uuid(*i)),
+            DbValueV1Iter::Bool(iter) => iter.next().map(|i| DbValueV1::Bool(*i)),
+            DbValueV1Iter::Syntax(iter) => iter.next().map(|i| DbValueV1::SyntaxType(i.to_usize())),
+            DbValueV1Iter::Index(iter) => iter.next().map(|i| DbValueV1::IndexType(i.to_usize())),
+            DbValueV1Iter::Refer(iter) => iter.next().map(|i| DbValueV1::Reference(*i)),
+            DbValueV1Iter::JsonFilt(iter) => iter.next().map(|i| {
+                DbValueV1::JsonFilter(
+                    serde_json::to_string(i)
+                        .expect("A json filter value was corrupted during run-time"),
+                )
+            }),
+            DbValueV1Iter::Cred(iter) => iter.next().map(|(tag, cred)| {
+                DbValueV1::Credential(DbValueCredV1 {
+                    tag: tag.clone(),
+                    data: cred.to_db_valuev1(),
+                })
+            }),
+            DbValueV1Iter::SshKey(iter) => iter.next().map(|(tag, key)| {
+                DbValueV1::SshKey(DbValueTaggedStringV1 {
+                    tag: tag.clone(),
+                    data: key.clone(),
+                })
+            }),
+            DbValueV1Iter::SecretValue(iter) => {
+                iter.next().map(|i| DbValueV1::SecretValue(i.clone()))
+            }
+            DbValueV1Iter::Spn(iter) => iter
+                .next()
+                .map(|(n, d)| DbValueV1::Spn(n.clone(), d.clone())),
+            DbValueV1Iter::Uint32(iter) => iter.next().map(|i| DbValueV1::Uint32(*i)),
+            DbValueV1Iter::Cid(iter) => iter.next().map(|c| {
+                DbValueV1::Cid(DbCidV1 {
+                    domain_id: c.d_uuid,
+                    server_id: c.s_uuid,
+                    timestamp: c.ts,
+                })
+            }),
+            DbValueV1Iter::Nsuniqueid(iter) => {
+                iter.next().map(|i| DbValueV1::NsUniqueId(i.clone()))
+            }
+            DbValueV1Iter::DateTime(iter) => iter.next().map(|odt| {
+                debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                DbValueV1::DateTime(odt.format(time::Format::Rfc3339))
+            }),
+            DbValueV1Iter::EmailAddress(iter) => iter
+                .next()
+                .map(|i| DbValueV1::EmailAddress(DbValueEmailAddressV1 { d: i.clone() })),
+            DbValueV1Iter::Url(iter) => iter.next().map(|i| DbValueV1::Url(i.clone())),
+        }
+    }
+}
+
+pub enum ProtoIter<'a> {
+    Utf8(std::collections::btree_set::Iter<'a, String>),
+    Iutf8(std::collections::btree_set::Iter<'a, String>),
+    Iname(std::collections::btree_set::Iter<'a, String>),
+    Uuid(std::collections::btree_set::Iter<'a, Uuid>),
+    Bool(SmolSetIter<'a, [bool; 1]>),
+    Syntax(SmolSetIter<'a, [SyntaxType; 1]>),
+    Index(SmolSetIter<'a, [IndexType; 1]>),
+    Refer(std::collections::btree_set::Iter<'a, Uuid>),
+    JsonFilt(SmolSetIter<'a, [ProtoFilter; 1]>),
+    Cred(std::collections::btree_map::Iter<'a, String, Credential>),
+    SshKey(std::collections::btree_map::Iter<'a, String, String>),
+    SecretValue(SmolSetIter<'a, [String; 1]>),
+    Spn(std::collections::btree_set::Iter<'a, (String, String)>),
+    Uint32(SmolSetIter<'a, [u32; 1]>),
+    Cid(SmolSetIter<'a, [Cid; 1]>),
+    Nsuniqueid(std::collections::btree_set::Iter<'a, String>),
+    DateTime(SmolSetIter<'a, [OffsetDateTime; 1]>),
+    EmailAddress(std::collections::btree_set::Iter<'a, String>),
+    Url(SmolSetIter<'a, [Url; 1]>),
+}
+
+impl<'a> Iterator for ProtoIter<'a> {
+    type Item = String;
+
+    fn next(&mut self) -> Option<String> {
+        match self {
+            ProtoIter::Utf8(iter) => iter.next().map(|i| i.clone()),
+            ProtoIter::Iutf8(iter) => iter.next().map(|i| i.clone()),
+            ProtoIter::Iname(iter) => iter.next().map(|i| i.clone()),
+            ProtoIter::Uuid(iter) => iter.next().map(ValueSet::uuid_to_proto_string),
+
+            ProtoIter::Bool(iter) => iter.next().map(|i| i.to_string()),
+            ProtoIter::Syntax(iter) => iter.next().map(|i| i.to_string()),
+            ProtoIter::Index(iter) => iter.next().map(|i| i.to_string()),
+            ProtoIter::Refer(iter) => iter.next().map(ValueSet::uuid_to_proto_string),
+            ProtoIter::JsonFilt(iter) => iter.next().map(|i| {
+                #[allow(clippy::expect_used)]
+                serde_json::to_string(i).expect("A json filter value was corrupted during run-time")
+            }),
+            ProtoIter::Cred(iter) => iter.next().map(|(tag, cred)|
+                // You can't actually read the credential values because we only display the
+                // tag to the proto side. The credentials private data is stored seperately.
+                tag.to_string()),
+            ProtoIter::SshKey(iter) => {
+                iter.next()
+                    .map(|(tag, key)| match SshPublicKey::from_string(key) {
+                        Ok(spk) => {
+                            let fp = spk.fingerprint();
+                            format!("{}: {}", tag, fp.hash)
+                        }
+                        Err(_) => format!("{}: corrupted ssh public key", tag),
+                    })
+            }
+            ProtoIter::SecretValue(iter) => iter.next().map(|_| "hidden".to_string()),
+            ProtoIter::Spn(iter) => iter.next().map(|(n, d)| format!("{}@{}", n, d)),
+            ProtoIter::Uint32(iter) => iter.next().map(|i| i.to_string()),
+            ProtoIter::Cid(iter) => iter
+                .next()
+                .map(|c| format!("{:?}_{}_{}", c.ts, c.d_uuid, c.s_uuid)),
+            ProtoIter::Nsuniqueid(iter) => iter.next().map(|i| i.clone()),
+            ProtoIter::DateTime(iter) => iter.next().map(|odt| {
+                debug_assert!(odt.offset() == time::UtcOffset::UTC);
+                odt.format(time::Format::Rfc3339)
+            }),
+            ProtoIter::EmailAddress(iter) => iter.next().map(|i| i.clone()),
+            ProtoIter::Url(iter) => iter.next().map(|i| i.to_string()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::value::Value;
@@ -203,8 +1624,9 @@ mod tests {
 
     #[test]
     fn test_valueset_basic() {
-        let mut vs = ValueSet::new();
-        assert!(vs.insert(Value::new_uint32(0)));
-        assert!(!vs.insert(Value::new_uint32(0)));
+        let mut vs = ValueSet::new(Value::new_uint32(0));
+        assert!(vs.insert_checked(Value::new_uint32(0)) == Ok(false));
+        assert!(vs.insert_checked(Value::new_uint32(1)) == Ok(true));
+        assert!(vs.insert_checked(Value::new_uint32(1)) == Ok(false));
     }
 }

--- a/kanidmd/src/lib/valueset.rs
+++ b/kanidmd/src/lib/valueset.rs
@@ -113,7 +113,6 @@ impl ValueSet {
                 PartialValue::Url(u) => I::Url(smolset![u]),
             },
         };
-        trace!(?vs, "ValueSet::new");
         vs
     }
 
@@ -170,7 +169,6 @@ impl ValueSet {
 
     // insert
     pub unsafe fn insert(&mut self, value: Value) -> bool {
-        trace!("ValueSet::insert");
         self.insert_checked(value).unwrap_or(false)
     }
 

--- a/kanidmd_web_ui/src/login.rs
+++ b/kanidmd_web_ui/src/login.rs
@@ -257,7 +257,7 @@ impl LoginApp {
                     let promise = win
                         .navigator()
                         .credentials()
-                        .get_with_options(&challenge)
+                        .get_with_options(challenge)
                         .expect("Unable to create promise");
                     let fut = JsFuture::from(promise);
                     let linkc = self.link.clone();

--- a/kanidmd_web_ui/src/oauth2.rs
+++ b/kanidmd_web_ui/src/oauth2.rs
@@ -239,7 +239,7 @@ impl Component for Oauth2App {
 
                 self.state = match (&self.state, ar) {
                     (State::TokenCheck(token, _), Some(ar)) => {
-                        match Self::fetch_authreq(&token, &ar, &self.link) {
+                        match Self::fetch_authreq(token, &ar, &self.link) {
                             Ok(ft) => State::SubmitAuthReq(token.clone(), ft),
                             Err(e_msg) => {
                                 ConsoleService::log(e_msg.as_str());
@@ -268,7 +268,7 @@ impl Component for Oauth2App {
                 self.state = match &self.state {
                     State::Consent(token, consent_req) => {
                         match Self::fetch_consent_token(
-                            &token,
+                            token,
                             consent_req.consent_token.clone(),
                             &self.link,
                         ) {

--- a/orca/src/preprocess.rs
+++ b/orca/src/preprocess.rs
@@ -113,8 +113,7 @@ impl Record {
                             Some(Entity::Group(_g)) => {
                                 // This could be better! It's quite an evil method at the moment...
                                 let m = rng.gen_range(0..max_m);
-                                let ngrp =
-                                    (&exists).choose_multiple(&mut rng, m).cloned().collect();
+                                let ngrp = exists.choose_multiple(&mut rng, m).cloned().collect();
                                 (*id, Change::Group(ngrp))
                             }
                             None => {


### PR DESCRIPTION
Fixes #468 - this rewrites how we store values internally in entries, making it more consistent and moving the typing check to a better location. Still a few checks for me to do, but I wanted to get it as a PR since it's now passing tests!

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
