### PR TITLE
Add support for storing security token key in domain config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,9 +499,9 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "bundy"
@@ -3640,9 +3640,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.7",
@@ -3693,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ buildx/kanidmd/simd:
 		$(ARGS) .
 	@docker buildx imagetools $(EXT_OPTS) inspect $(IMAGE_BASE)/server:$(IMAGE_VERSION)
 
+buildx/kanidmd/x86_64_v3: ## build multiarch server images
+buildx/kanidmd/x86_64_v3:
+	@docker buildx build $(EXT_OPTS) --pull --push --platform "linux/amd64" \
+		--allow security.insecure \
+		-f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:x86_64_$(IMAGE_VERSION) \
+		--build-arg "KANIDM_BUILD_PROFILE=container_x86_64_v3" \
+		--build-arg "KANIDM_FEATURES=" \
+		$(ARGS) .
+	@docker buildx imagetools $(EXT_OPTS) inspect $(IMAGE_BASE)/server:$(IMAGE_VERSION)
+
 buildx/kanidmd: ## build multiarch server images
 buildx/kanidmd:
 	@docker buildx build $(EXT_OPTS) --pull --push --platform $(IMAGE_ARCH) \

--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -1318,18 +1318,13 @@ impl KanidmAsyncClient {
     }
 
     // ==== domain_info (aka domain)
-    pub async fn idm_domain_list(&self) -> Result<Vec<Entry>, ClientError> {
-        self.perform_get_request("/v1/domain").await
+    pub async fn idm_domain_get(&self) -> Result<Entry, ClientError> {
+        let r: Result<Vec<Entry>, ClientError> = self.perform_get_request("/v1/domain").await;
+        r.and_then(|mut v| v.pop().ok_or(ClientError::EmptyResponse))
     }
 
-    pub async fn idm_domain_get(&self, id: &str) -> Result<Entry, ClientError> {
-        self.perform_get_request(format!("/v1/domain/{}", id).as_str())
-            .await
-    }
-
-    // pub fn idm_domain_get_attr
-    pub async fn idm_domain_get_ssid(&self, id: &str) -> Result<String, ClientError> {
-        self.perform_get_request(format!("/v1/domain/{}/_attr/domain_ssid", id).as_str())
+    pub async fn idm_domain_get_ssid(&self) -> Result<String, ClientError> {
+        self.perform_get_request("/v1/domain/_attr/domain_ssid")
             .await
             .and_then(|mut r: Vec<String>|
                 // Get the first result
@@ -1339,13 +1334,14 @@ impl KanidmAsyncClient {
                 ))
     }
 
-    // pub fn idm_domain_put_attr
-    pub async fn idm_domain_set_ssid(&self, id: &str, ssid: &str) -> Result<(), ClientError> {
-        self.perform_put_request(
-            format!("/v1/domain/{}/_attr/domain_ssid", id).as_str(),
-            vec![ssid.to_string()],
-        )
-        .await
+    pub async fn idm_domain_set_ssid(&self, ssid: &str) -> Result<(), ClientError> {
+        self.perform_put_request("/v1/domain/_attr/domain_ssid", vec![ssid.to_string()])
+            .await
+    }
+
+    pub async fn idm_domain_reset_token_key(&self) -> Result<(), ClientError> {
+        self.perform_delete_request("/v1/domain/_attr/domain_token_key")
+            .await
     }
 
     // ==== schema

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -846,22 +846,22 @@ impl KanidmClient {
     }
 
     // ==== domain_info (aka domain)
-    pub fn idm_domain_list(&self) -> Result<Vec<Entry>, ClientError> {
-        tokio_block_on(self.asclient.idm_domain_list())
-    }
-
-    pub fn idm_domain_get(&self, id: &str) -> Result<Entry, ClientError> {
-        tokio_block_on(self.asclient.idm_domain_get(id))
+    pub fn idm_domain_get(&self) -> Result<Entry, ClientError> {
+        tokio_block_on(self.asclient.idm_domain_get())
     }
 
     // pub fn idm_domain_get_attr
-    pub fn idm_domain_get_ssid(&self, id: &str) -> Result<String, ClientError> {
-        tokio_block_on(self.asclient.idm_domain_get_ssid(id))
+    pub fn idm_domain_get_ssid(&self) -> Result<String, ClientError> {
+        tokio_block_on(self.asclient.idm_domain_get_ssid())
     }
 
     // pub fn idm_domain_put_attr
-    pub fn idm_domain_set_ssid(&self, id: &str, ssid: &str) -> Result<(), ClientError> {
-        tokio_block_on(self.asclient.idm_domain_set_ssid(id, ssid))
+    pub fn idm_domain_set_ssid(&self, ssid: &str) -> Result<(), ClientError> {
+        tokio_block_on(self.asclient.idm_domain_set_ssid(ssid))
+    }
+
+    pub fn idm_domain_reset_token_key(&self) -> Result<(), ClientError> {
+        tokio_block_on(self.asclient.idm_domain_reset_token_key())
     }
 
     // ==== schema

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -505,19 +505,12 @@ fn test_server_rest_domain_lifecycle() {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
-        let mut dlist = rsclient.idm_domain_list().unwrap();
-        assert!(dlist.len() == 1);
-
-        let dlocal = rsclient.idm_domain_get("domain_local").unwrap();
-        // There should be one, and it's the domain_local
-        assert!(dlist.pop().unwrap().attrs == dlocal.attrs);
+        let _dlocal = rsclient.idm_domain_get().unwrap();
 
         // Change the ssid
-        rsclient
-            .idm_domain_set_ssid("domain_local", "new_ssid")
-            .unwrap();
+        rsclient.idm_domain_set_ssid("new_ssid").unwrap();
         // check get and get the ssid and domain info
-        let nssid = rsclient.idm_domain_get_ssid("domain_local").unwrap();
+        let nssid = rsclient.idm_domain_get_ssid().unwrap();
         assert!(nssid == "new_ssid");
     });
 }

--- a/kanidm_tools/src/cli/domain.rs
+++ b/kanidm_tools/src/cli/domain.rs
@@ -1,0 +1,28 @@
+use crate::DomainOpt;
+
+impl DomainOpt {
+    pub fn debug(&self) -> bool {
+        match self {
+            DomainOpt::Show(copt) | DomainOpt::ResetTokenKey(copt) => copt.debug,
+        }
+    }
+
+    pub fn exec(&self) {
+        match self {
+            DomainOpt::Show(copt) => {
+                let client = copt.to_client();
+                match client.idm_domain_get() {
+                    Ok(e) => println!("{}", e),
+                    Err(e) => eprintln!("Error -> {:?}", e),
+                }
+            }
+            DomainOpt::ResetTokenKey(copt) => {
+                let client = copt.to_client();
+                match client.idm_domain_reset_token_key() {
+                    Ok(_) => println!("Success"),
+                    Err(e) => eprintln!("Error -> {:?}", e),
+                }
+            }
+        }
+    }
+}

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -17,6 +17,7 @@ include!("../opt/kanidm.rs");
 
 pub mod account;
 pub mod common;
+pub mod domain;
 pub mod group;
 pub mod oauth2;
 pub mod raw;
@@ -76,12 +77,14 @@ impl SystemOpt {
     pub fn debug(&self) -> bool {
         match self {
             SystemOpt::Oauth2(oopt) => oopt.debug(),
+            SystemOpt::Domain(dopt) => dopt.debug(),
         }
     }
 
     pub fn exec(&self) {
         match self {
             SystemOpt::Oauth2(oopt) => oopt.exec(),
+            SystemOpt::Domain(dopt) => dopt.exec(),
         }
     }
 }

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -380,10 +380,24 @@ pub enum Oauth2Opt {
 }
 
 #[derive(Debug, StructOpt)]
+pub enum DomainOpt {
+    #[structopt(name = "show")]
+    /// Show information about this systems domain
+    Show(CommonOpt),
+    #[structopt(name = "reset_token_key")]
+    /// Reset this domain token signing key. This will cause all user sessions to be
+    /// invalidated (logged out).
+    ResetTokenKey(CommonOpt),
+}
+
+#[derive(Debug, StructOpt)]
 pub enum SystemOpt {
     #[structopt(name = "oauth2")]
     /// Configure and display oauth2/oidc resource server configuration
     Oauth2(Oauth2Opt),
+    #[structopt(name = "domain")]
+    /// Configure and display domain configuration
+    Domain(DomainOpt),
 }
 
 #[derive(Debug, StructOpt)]

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -2,7 +2,8 @@ ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS builder
 LABEL mantainer william@blackhats.net.au
 
-RUN zypper -vv ref && \
+RUN zypper ar obs://devel:languages:rust devel:languages:rust && \
+    zypper --gpg-auto-import-keys ref --force && \
     zypper dup -y && \
     zypper install -y \
         cargo \

--- a/kanidmd/src/lib/constants/acp.rs
+++ b/kanidmd/src/lib/constants/acp.rs
@@ -826,10 +826,12 @@ pub const JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &str = r#"{
             "uuid",
             "domain_name",
             "domain_ssid",
-            "domain_uuid"
+            "domain_uuid",
+            "domain_token_key"
         ],
         "acp_modify_removedattr": [
-            "domain_ssid"
+            "domain_ssid",
+            "domain_token_key"
         ],
         "acp_modify_presentattr": [
             "domain_ssid"

--- a/kanidmd/src/lib/constants/entries.rs
+++ b/kanidmd/src/lib/constants/entries.rs
@@ -346,7 +346,7 @@ pub const JSON_SYSTEM_INFO_V1: &str = r#"{
         "class": ["object", "system_info", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
         "description": ["System (local) info and metadata object."],
-        "version": ["3"]
+        "version": ["4"]
     }
 }"#;
 

--- a/kanidmd/src/lib/constants/schema.rs
+++ b/kanidmd/src/lib/constants/schema.rs
@@ -274,6 +274,34 @@ pub const JSON_SCHEMA_ATTR_DOMAIN_SSID: &str = r#"{
       ]
     }
 }"#;
+pub const JSON_SCHEMA_ATTR_DOMAIN_TOKEN_KEY: &str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The domains token signing key, which is shared between IDM servers."
+      ],
+      "index": [],
+      "unique": [
+        "false"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "domain_token_key"
+      ],
+      "syntax": [
+        "SECRET_UTF8STRING"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000088"
+      ]
+    }
+}"#;
 
 pub const JSON_SCHEMA_ATTR_GIDNUMBER: &str = r#"{
     "attrs": {
@@ -748,7 +776,8 @@ pub const JSON_SCHEMA_CLASS_DOMAIN_INFO: &str = r#"
       "systemmust": [
         "name",
         "domain_uuid",
-        "domain_name"
+        "domain_name",
+        "domain_token_key"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000052"

--- a/kanidmd/src/lib/constants/uuids.rs
+++ b/kanidmd/src/lib/constants/uuids.rs
@@ -142,8 +142,8 @@ pub const _STR_UUID_SCHEMA_ATTR_OAUTH2_RS_BASIC_TOKEN_KEY: &str =
     "00000000-0000-0000-0000-ffff00000084";
 pub const STR_UUID_SCHEMA_CLASS_OAUTH2_RS: &str = "00000000-0000-0000-0000-ffff00000085";
 pub const STR_UUID_SCHEMA_CLASS_OAUTH2_RS_BASIC: &str = "00000000-0000-0000-0000-ffff00000086";
-
 pub const STR_UUID_SCHEMA_ATTR_CN: &str = "00000000-0000-0000-0000-ffff00000087";
+pub const STR_UUID_SCHEMA_ATTR_DOMAIN_TOKEN_KEY: &str = "00000000-0000-0000-0000-ffff00000088";
 
 // System and domain infos
 // I'd like to strongly criticise william of the past for making poor choices about these allocations.
@@ -321,4 +321,6 @@ lazy_static! {
         Uuid::parse_str(STR_UUID_SCHEMA_CLASS_OAUTH2_RS).unwrap();
     pub static ref UUID_SCHEMA_CLASS_OAUTH2_RS_BASIC: Uuid =
         Uuid::parse_str(STR_UUID_SCHEMA_CLASS_OAUTH2_RS_BASIC).unwrap();
+    pub static ref UUID_SCHEMA_ATTR_DOMAIN_TOKEN_KEY: Uuid =
+        Uuid::parse_str(STR_UUID_SCHEMA_ATTR_DOMAIN_TOKEN_KEY).unwrap();
 }

--- a/kanidmd/src/lib/core/https/mod.rs
+++ b/kanidmd/src/lib/core/https/mod.rs
@@ -553,11 +553,11 @@ pub fn create_https_server(
 
     let mut domain_route = appserver.at("/v1/domain");
     domain_route.at("/").get(domain_get);
-    domain_route.at("/:id").get(domain_id_get);
     domain_route
-        .at("/:id/_attr/:attr")
-        .get(domain_id_get_attr)
-        .put(domain_id_put_attr);
+        .at("/_attr/:attr")
+        .get(domain_get_attr)
+        .put(domain_put_attr)
+        .delete(domain_delete_attr);
 
     let mut recycle_route = appserver.at("/v1/recycle_bin");
     recycle_route.at("/").get(recycle_bin_get);

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -459,11 +459,9 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
 
     // Run the password change.
     let mut idms_prox_write = task::block_on(idms.proxy_write_async(duration_from_epoch_now()));
-    match idms_prox_write.recover_account(name, None) {
+    let new_pw = match idms_prox_write.recover_account(name, None) {
         Ok(new_pw) => match idms_prox_write.commit() {
-            Ok(()) => {
-                eprintln!("Password reset to -> {}", new_pw);
-            }
+            Ok(_) => new_pw,
             Err(e) => {
                 error!("A critical error during commit occured {:?}", e);
                 std::process::exit(1);
@@ -476,6 +474,7 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
             std::process::exit(1);
         }
     };
+    eprintln!("Success - password reset to -> {}", new_pw);
 }
 
 pub async fn create_server_core(config: Configuration) -> Result<(), ()> {

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -428,6 +428,10 @@ impl Entry<EntryInit, EntryNew> {
                         }).collect();
                         vs.unwrap()
                     }
+                    "domain_token_key" => {
+                        let vs: Option<ValueSet> = vs.into_iter().map(|v| Value::new_secret_str(&v)).collect();
+                        vs.unwrap()
+                    }
                     ia => {
                         warn!("WARNING: Allowing invalid attribute {} to be interpretted as UTF8 string. YOU MAY ENCOUNTER ODD BEHAVIOUR!!!", ia);
                         let vs: Option<ValueSet> = vs.into_iter().map(|v| Value::new_utf8(v)).collect();

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -248,7 +248,7 @@ macro_rules! run_create_test {
             {
                 let qs_write = qs.write(duration_from_epoch_now());
                 let r = qs_write.create(&ce);
-                debug!("test result: {:?}", r);
+                trace!("test result: {:?}", r);
                 assert!(r == $expect);
                 $check(&qs_write);
                 match r {
@@ -261,9 +261,9 @@ macro_rules! run_create_test {
                 }
             }
             // Make sure there are no errors.
-            debug!("starting verification");
+            trace!("starting verification");
             let ver = qs.verify();
-            debug!("verification -> {:?}", ver);
+            trace!("verification -> {:?}", ver);
             assert!(ver.len() == 0);
         });
     }};
@@ -303,7 +303,7 @@ macro_rules! run_modify_test {
                 spanned!("plugins::macros::run_modify_test -> post_test check", {
                     $check(&qs_write)
                 });
-                debug!("test result: {:?}", r);
+                trace!("test result: {:?}", r);
                 assert!(r == $expect);
                 match r {
                     Ok(_) => {
@@ -315,9 +315,9 @@ macro_rules! run_modify_test {
                 }
             }
             // Make sure there are no errors.
-            debug!("starting verification");
+            trace!("starting verification");
             let ver = qs.verify();
-            debug!("verification -> {:?}", ver);
+            trace!("verification -> {:?}", ver);
             assert!(ver.len() == 0);
         });
     }};
@@ -352,7 +352,7 @@ macro_rules! run_delete_test {
             {
                 let qs_write = qs.write(duration_from_epoch_now());
                 let r = qs_write.delete(&de);
-                debug!("test result: {:?}", r);
+                trace!("test result: {:?}", r);
                 $check(&qs_write);
                 assert!(r == $expect);
                 match r {
@@ -365,9 +365,9 @@ macro_rules! run_delete_test {
                 }
             }
             // Make sure there are no errors.
-            debug!("starting verification");
+            trace!("starting verification");
             let ver = qs.verify();
-            debug!("verification -> {:?}", ver);
+            trace!("verification -> {:?}", ver);
             assert!(ver.len() == 0);
         });
     }};

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -166,6 +166,7 @@ impl Plugins {
                 .and_then(|_| password_import::PasswordImport::pre_modify(qs, cand, me))
                 .and_then(|_| oauth2::Oauth2Secrets::pre_modify(qs, cand, me))
                 .and_then(|_| gidnumber::GidNumber::pre_modify(qs, cand, me))
+                .and_then(|_| domain::Domain::pre_modify(qs, cand, me))
                 .and_then(|_| spn::Spn::pre_modify(qs, cand, me))
                 // attr unique should always be last
                 .and_then(|_| attrunique::AttrUnique::pre_modify(qs, cand, me))

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -23,6 +23,7 @@ lazy_static! {
         m.insert("may");
         // Allow modification of some domain info types for local configuration.
         m.insert("domain_ssid");
+        m.insert("domain_token_key");
         m.insert("badlist_password");
         m
     };
@@ -192,10 +193,10 @@ mod tests {
             ],
             "acp_search_attr": ["name", "class", "uuid", "classname", "attributename"],
             "acp_modify_class": ["system", "domain_info"],
-            "acp_modify_removedattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid"],
-            "acp_modify_presentattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid"],
+            "acp_modify_removedattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid", "domain_token_key"],
+            "acp_modify_presentattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid", "domain_token_key"],
             "acp_create_class": ["object", "person", "system", "domain_info"],
-            "acp_create_attr": ["name", "class", "description", "displayname", "domain_name", "domain_uuid", "domain_ssid", "uuid"]
+            "acp_create_attr": ["name", "class", "description", "displayname", "domain_name", "domain_uuid", "domain_ssid", "uuid", "domain_token_key"]
         }
     }"#;
 
@@ -326,9 +327,10 @@ mod tests {
                 "name": ["domain_example.net.au"],
                 "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
                 "domain_uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
-                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generation"],
                 "domain_name": ["example.net.au"],
-                "domain_ssid": ["Example_Wifi"]
+                "domain_ssid": ["Example_Wifi"],
+                "domain_token_key": ["ABCD"]
             }
         }"#,
         );
@@ -363,9 +365,10 @@ mod tests {
                 "name": ["domain_example.net.au"],
                 "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
                 "domain_uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
-                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generation"],
                 "domain_name": ["example.net.au"],
-                "domain_ssid": ["Example_Wifi"]
+                "domain_ssid": ["Example_Wifi"],
+                "domain_token_key": ["ABCD"]
             }
         }"#,
         );
@@ -391,9 +394,10 @@ mod tests {
                 "name": ["domain_example.net.au"],
                 "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
                 "domain_uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
-                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generation"],
                 "domain_name": ["example.net.au"],
-                "domain_ssid": ["Example_Wifi"]
+                "domain_ssid": ["Example_Wifi"],
+                "domain_token_key": ["ABCD"]
             }
         }"#,
         );


### PR DESCRIPTION
Fixes #568 - this moves token signing keys into the domain config, and adds the tooling for reseting this. This means user sessions no longer are invalidated on server restart. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
