### PR TITLE
Added `num-enum` support for runtime enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1803,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "num_cpus",
+ "num_enum",
  "openssl",
  "r2d2",
  "r2d2_sqlite",
@@ -2243,6 +2255,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "oauth2"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2561,16 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/kanidm_tools/src/cli/session.rs
+++ b/kanidm_tools/src/cli/session.rs
@@ -116,7 +116,6 @@ pub fn write_tokens(tokens: &BTreeMap<String, String>) -> Result<(), ()> {
 
 /// An interactive dialog to choose from given options
 fn get_index_choice_dialoguer(msg: &str, options: &Vec<String>) -> usize {
-
     let user_select = Select::with_theme(&ColorfulTheme::default())
         .with_prompt(msg)
         .default(0)
@@ -126,7 +125,7 @@ fn get_index_choice_dialoguer(msg: &str, options: &Vec<String>) -> usize {
     let selection = match user_select {
         Err(error) => {
             eprintln!("Failed to handle user input: {:?}", error);
-        std::process::exit(1);
+            std::process::exit(1);
         }
         Ok(value) => value,
     };

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -97,6 +97,8 @@ filetime = "0.2"
 tracing = { version = "0.1", features = ["attributes", "release_max_level_info"] }
 tracing-subscriber = "0.2"
 tracing-serde = "0.1"
+num_enum = "0.5.4"
+
 
 [features]
 simd_support = [ "concread/simd_support" ]

--- a/kanidmd/src/lib/tracing_tree/event_tag.rs
+++ b/kanidmd/src/lib/tracing_tree/event_tag.rs
@@ -1,6 +1,7 @@
-use std::convert::TryFrom;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, IntoPrimitive, TryFromPrimitive)]
+#[repr(u64)]
 pub enum EventTag {
     AdminError,
     AdminWarn,
@@ -49,55 +50,6 @@ impl EventTag {
             RequestTrace | FilterTrace | PerfTrace => "📍",
             SecurityCritical => "🔐",
             SecurityAccess => "🔓",
-        }
-    }
-}
-
-impl From<EventTag> for u64 {
-    fn from(tag: EventTag) -> Self {
-        use EventTag::*;
-        match tag {
-            AdminError => 0,
-            AdminWarn => 1,
-            AdminInfo => 2,
-            RequestError => 3,
-            RequestWarn => 4,
-            RequestInfo => 5,
-            RequestTrace => 6,
-            SecurityCritical => 7,
-            SecurityInfo => 8,
-            SecurityAccess => 9,
-            FilterError => 10,
-            FilterWarn => 11,
-            FilterInfo => 12,
-            FilterTrace => 13,
-            PerfTrace => 14,
-        }
-    }
-}
-
-impl TryFrom<u64> for EventTag {
-    type Error = ();
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        use EventTag::*;
-        match value {
-            0 => Ok(AdminError),
-            1 => Ok(AdminWarn),
-            2 => Ok(AdminInfo),
-            3 => Ok(RequestError),
-            4 => Ok(RequestWarn),
-            5 => Ok(RequestInfo),
-            6 => Ok(RequestTrace),
-            7 => Ok(SecurityCritical),
-            8 => Ok(SecurityInfo),
-            9 => Ok(SecurityAccess),
-            10 => Ok(FilterError),
-            11 => Ok(FilterWarn),
-            12 => Ok(FilterInfo),
-            13 => Ok(FilterTrace),
-            14 => Ok(PerfTrace),
-            _ => Err(()),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/kanidm/kanidm/issues/582

- [x] cargo fmt has been run
- [ ] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
