### PR TITLE
Make sure that effective domain actually is descendant of rp_id

### DIFF
--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -178,7 +178,10 @@ impl IdmServer {
             })
             .and_then(|url| {
                 let valid = url.domain().map(|effective_domain| {
-                    effective_domain.ends_with(&(".".to_string() + rp_id.as_str())) || effective_domain == rp_id
+                    // We need to prepend the '.' here to ensure that myexample.com != example.com,
+                    // rather than just ends with.
+                    effective_domain.ends_with(&format!(".{}", rp_id)) 
+                    || effective_domain == rp_id
                 }).unwrap_or(false);
 
                 if valid {

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -178,7 +178,7 @@ impl IdmServer {
             })
             .and_then(|url| {
                 let valid = url.domain().map(|effective_domain| {
-                    effective_domain.ends_with(&rp_id)
+                    effective_domain.ends_with(&(".".to_string() + rp_id.as_str())) || effective_domain == rp_id
                 }).unwrap_or(false);
 
                 if valid {


### PR DESCRIPTION
More of a minor nit.

Before that

- ed: `example.com`
- rp_id: `myexample.com`

would have been valid.

- [X] cargo fmt has been run
- [X] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
