### PR TITLE
add logging for oauth2 errors

### DIFF
--- a/kanidm_book/src/oauth2.md
+++ b/kanidm_book/src/oauth2.md
@@ -188,12 +188,14 @@ or with an appropriate include.
     OIDCRedirectURI http://resource.example.com/protected/redirect_uri
     OIDCCryptoPassphrase <random password here>
     OIDCProviderMetadataURL https://kanidm.example.com/oauth2/openid/<resource server name>/.well-known/openid-configuration
-    OIDCScope "openid other_scopes"
+    OIDCScope "openid" 
     OIDCUserInfoTokenMethod authz_header
     OIDCClientID <resource server name>
     OIDCClientSecret <resource server password>
     OIDCPKCEMethod S256
     OIDCCookieSameSite On
+
+Other scopes can be added as required to the `OIDCScope` line, eg: `OIDCScope "openid scope2 scope3"`
 
 In the virtual host, to protect a location:
 

--- a/kanidmd/src/lib/core/https/oauth2.rs
+++ b/kanidmd/src/lib/core/https/oauth2.rs
@@ -241,7 +241,7 @@ async fn oauth2_authorise(
             Ok(tide::Response::new(tide::StatusCode::Unauthorized))
         }
         Err(e) => {
-            debug!(
+            error!(
                 "Unable to authorise - Error ID: {} error: {}",
                 &hvalue,
                 &e.to_string()

--- a/kanidmd/src/lib/core/https/oauth2.rs
+++ b/kanidmd/src/lib/core/https/oauth2.rs
@@ -241,7 +241,7 @@ async fn oauth2_authorise(
             Ok(tide::Response::new(tide::StatusCode::Unauthorized))
         }
         Err(e) => {
-            error!(
+            admin_error!(
                 "Unable to authorise - Error ID: {} error: {}",
                 &hvalue,
                 &e.to_string()

--- a/kanidmd/src/lib/core/https/oauth2.rs
+++ b/kanidmd/src/lib/core/https/oauth2.rs
@@ -241,6 +241,11 @@ async fn oauth2_authorise(
             Ok(tide::Response::new(tide::StatusCode::Unauthorized))
         }
         Err(e) => {
+            debug!(
+                "Unable to authorise - Error ID: {} error: {}",
+                &hvalue,
+                &e.to_string()
+            );
             redir_url
                 .query_pairs_mut()
                 .clear()


### PR DESCRIPTION
Fixes #619

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
