### PR TITLE
adding notes about OIDCRemoteUserClaim to the oauth2 book chapter

### DIFF
--- a/kanidm_book/src/oauth2.md
+++ b/kanidm_book/src/oauth2.md
@@ -194,7 +194,7 @@ or with an appropriate include.
     OIDCClientSecret <resource server password>
     OIDCPKCEMethod S256
     OIDCCookieSameSite On
-    # To set the `REMOTE_USER` field to the `preferred_username` instead of the UUID
+    # Set the `REMOTE_USER` field to the `preferred_username` instead of the UUID.
     # Remember that the username can change, but this can help with systems like Nagios which use this as a display name.
     # OIDCRemoteUserClaim preferred_username
 

--- a/kanidm_book/src/oauth2.md
+++ b/kanidm_book/src/oauth2.md
@@ -182,10 +182,10 @@ To enable legacy cryptograhy (RSA PKCS1-5 SHA256):
 
 ### Apache mod\_auth\_openidc
 
-Add the following to a mod\_auth\_openidc.conf. It should be included in a mods\_enabled folder
+Add the following to a `mod_auth_openidc.conf`. It should be included in a `mods_enabled` folder
 or with an appropriate include.
 
-    OIDCRedirectURI http://resource.example.com/protected/redirect_uri
+    OIDCRedirectURI /protected/redirect_uri
     OIDCCryptoPassphrase <random password here>
     OIDCProviderMetadataURL https://kanidm.example.com/oauth2/openid/<resource server name>/.well-known/openid-configuration
     OIDCScope "openid" 
@@ -195,14 +195,16 @@ or with an appropriate include.
     OIDCPKCEMethod S256
     OIDCCookieSameSite On
 
-Other scopes can be added as required to the `OIDCScope` line, eg: `OIDCScope "openid scope2 scope3"`
-
 In the virtual host, to protect a location:
 
     <Location />
         AuthType openid-connect
         Require valid-user
     </Location>
+
+Other scopes can be added as required to the `OIDCScope` line, eg: `OIDCScope "openid scope2 scope3"`
+
+If you want to set the `REMOTE_USER` field to the `preferred_username` instead of the UUID, add the line `OIDCRemoteUserClaim preferred_username`. Remember that the username can change, but this can help with systems like Nagios which use this as a display name.
 
 ### Nextcloud
 

--- a/kanidm_book/src/oauth2.md
+++ b/kanidm_book/src/oauth2.md
@@ -194,6 +194,11 @@ or with an appropriate include.
     OIDCClientSecret <resource server password>
     OIDCPKCEMethod S256
     OIDCCookieSameSite On
+    # To set the `REMOTE_USER` field to the `preferred_username` instead of the UUID
+    # Remember that the username can change, but this can help with systems like Nagios which use this as a display name.
+    # OIDCRemoteUserClaim preferred_username
+
+Other scopes can be added as required to the `OIDCScope` line, eg: `OIDCScope "openid scope2 scope3"`
 
 In the virtual host, to protect a location:
 
@@ -201,10 +206,6 @@ In the virtual host, to protect a location:
         AuthType openid-connect
         Require valid-user
     </Location>
-
-Other scopes can be added as required to the `OIDCScope` line, eg: `OIDCScope "openid scope2 scope3"`
-
-If you want to set the `REMOTE_USER` field to the `preferred_username` instead of the UUID, add the line `OIDCRemoteUserClaim preferred_username`. Remember that the username can change, but this can help with systems like Nagios which use this as a display name.
 
 ### Nextcloud
 


### PR DESCRIPTION
- [x] cargo fmt has been run
- [ ] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)

The `OIDCRedirectURI` setting can have a relative path, which simplifies things.