### PR TITLE
Check before rename for #622

### DIFF
--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -387,7 +387,7 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
         Ok(old_domain_name) => {
             if &old_domain_name == &new_domain_name {
                 admin_info!("Domain name not changing, stopping.");
-                std::process::exit(2);
+                std::process::exit(125); // ECANCELED
             }
         }
         Err(e) => {

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -387,7 +387,7 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
         Ok(old_domain_name) => {
             if &old_domain_name == &new_domain_name {
                 admin_info!("Domain name not changing, stopping.");
-                std::process::exit(125); // ECANCELED
+                return;
             }
         }
         Err(e) => {

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -382,6 +382,20 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
         }
     };
 
+    // make sure we're actually changing the domain name...
+    match task::block_on(qs.read_async()).get_domain_name() {
+        Ok(old_domain_name) => {
+            if &old_domain_name == &new_domain_name {
+                admin_info!("Domain name not changing, stopping.");
+                std::process::exit(2);
+            }
+        }
+        Err(e) => {
+            admin_error!("Failed to query domain name, quitting! -> {:?}", e);
+            return;
+        }
+    }
+
     let qs_write = task::block_on(qs.write_async(duration_from_epoch_now()));
     let r = qs_write
         .domain_rename(new_domain_name)


### PR DESCRIPTION
This checks you're actually changing the domain name and quits if it's not. Still pretty noisy from a logging perspective because it has to boot up the QueryServer, but it's quick (0.7s in my testing)

In the case of a non-change, you'll get:

    00000000-0000-0000-0000-000000000000 2021-11-29T23:13:56.450842+00:00 INFO     💬 [admin.info]: Domain name not changing, stopping.

And a return code of `125` (ECANCELED/Operation Cancelled) to note the change wasn't made.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

