### PR TITLE
20211216 tracing cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,6 @@ dependencies = [
  "tracing",
  "tracing-serde",
  "tracing-subscriber",
- "tracing_tree",
  "url",
  "users",
  "uuid",
@@ -3848,24 +3847,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing_tree"
-version = "1.1.0-alpha.6"
-dependencies = [
- "async-trait",
- "chrono",
- "futures",
- "num_enum",
- "serde",
- "serde_json",
- "tide",
- "tokio",
- "tracing",
- "tracing-serde",
- "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,19 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,12 +1641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,7 +1823,6 @@ dependencies = [
  "concread",
  "criterion",
  "either",
- "env_logger",
  "fernet",
  "filetime",
  "futures",
@@ -1855,7 +1835,6 @@ dependencies = [
  "ldap3_server",
  "libc",
  "libsqlite3-sys",
- "log",
  "num_cpus",
  "num_enum",
  "openssl",
@@ -1885,6 +1864,7 @@ dependencies = [
  "tracing",
  "tracing-serde",
  "tracing-subscriber",
+ "tracing_tree",
  "url",
  "users",
  "uuid",
@@ -1901,11 +1881,9 @@ dependencies = [
  "async-std",
  "base64 0.13.0",
  "compact_jwt",
- "env_logger",
  "futures",
  "kanidm",
  "kanidm_proto",
- "log",
  "oauth2",
  "reqwest",
  "serde",
@@ -1913,6 +1891,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "webauthn-authenticator-rs",
@@ -1939,11 +1919,9 @@ version = "1.1.0-alpha.6"
 dependencies = [
  "bundy",
  "dialoguer",
- "env_logger",
  "kanidm_client",
  "kanidm_proto",
  "libc",
- "log",
  "qrcode",
  "rayon",
  "rpassword",
@@ -1952,6 +1930,8 @@ dependencies = [
  "shellexpand",
  "structopt",
  "time 0.2.27",
+ "tracing",
+ "tracing-subscriber",
  "webauthn-authenticator-rs",
  "zxcvbn",
 ]
@@ -1962,14 +1942,12 @@ version = "1.1.0-alpha.6"
 dependencies = [
  "async-std",
  "bytes",
- "env_logger",
  "futures",
  "kanidm",
  "kanidm_client",
  "kanidm_proto",
  "libc",
  "libsqlite3-sys",
- "log",
  "lru",
  "r2d2",
  "r2d2_sqlite",
@@ -1983,6 +1961,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "users",
 ]
 
@@ -2465,13 +2445,11 @@ dependencies = [
  "async-std",
  "crossbeam",
  "csv",
- "env_logger",
  "futures-util",
  "jemallocator",
  "kanidm_client",
  "kanidm_proto",
  "ldap3_server",
- "log",
  "mathru",
  "openssl",
  "rand 0.8.4",
@@ -2483,6 +2461,8 @@ dependencies = [
  "tokio-openssl",
  "tokio-util",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3544,15 +3524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,6 +3848,24 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing_tree"
+version = "1.1.0-alpha.6"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "num_enum",
+ "serde",
+ "serde_json",
+ "tide",
+ "tokio",
+ "tracing",
+ "tracing-serde",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
     "kanidm_unix_int/nss_kanidm",
     "kanidm_unix_int/pam_kanidm",
     "orca",
-    "tracing_tree",
 ]
 
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "kanidm_unix_int/nss_kanidm",
     "kanidm_unix_int/pam_kanidm",
     "orca",
+    "tracing_tree",
 ]
 
 exclude = [

--- a/kanidm_client/Cargo.toml
+++ b/kanidm_client/Cargo.toml
@@ -10,7 +10,8 @@ homepage = "https://github.com/kanidm/kanidm/"
 repository = "https://github.com/kanidm/kanidm/"
 
 [dependencies]
-log = "0.4"
+tracing = "0.1"
+tracing-subscriber = "0.2"
 reqwest = { version = "0.11", features=["cookies", "json", "native-tls"] }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha" }
 serde = "1.0"
@@ -23,7 +24,6 @@ webauthn-rs = "0.3"
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync", "signal"] }
 
 [dev-dependencies]
-env_logger = "0.9"
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync", "signal"] }
 kanidm = { path = "../kanidmd" }
 futures = "0.3"

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 use serde_derive::Deserialize;
 use serde_json::error::Error as SerdeJsonError;

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -26,13 +26,7 @@ fn is_free_port(port: u16) -> bool {
 // Test external behaviours of the service.
 
 pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
-    // ::std::env::set_var("RUST_LOG", "tide=debug,kanidm=debug");
     let _ = tracing_tree::test_init();
-    let _ = env_logger::builder()
-        .format_timestamp(None)
-        .format_level(false)
-        .is_test(true)
-        .try_init();
 
     let (ready_tx, mut ready_rx) = mpsc::channel(1);
     let (finish_tx, mut finish_rx) = mpsc::channel(1);

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 use std::time::SystemTime;
 
-use log::debug;
+use tracing::debug;
 
 use kanidm::credential::totp::Totp;
 use kanidm_client::KanidmClient;

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -30,11 +30,11 @@ path = "src/badlist_preprocess.rs"
 [dependencies]
 kanidm_client = { path = "../kanidm_client", version = "1.1.0-alpha.4" }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha.4" }
+tracing = "0.1"
+tracing-subscriber = "0.2"
 rpassword = "5.0"
 structopt = { version = "0.3", default-features = false }
 libc = "0.2"
-log = "0.4"
-env_logger = "0.9"
 serde = "1.0"
 serde_json = "1.0"
 shellexpand = "2.0"

--- a/kanidm_tools/src/badlist_preprocess.rs
+++ b/kanidm_tools/src/badlist_preprocess.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use kanidm_proto::v1::Modify;
 
-use log::{debug, error, info};
+use tracing::{debug, error, info};
 use rayon::prelude::*;
 use structopt::StructOpt;
 
@@ -26,10 +26,8 @@ fn main() {
     let opt = BadlistProcOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     if opt.modlist {
         debug!("Running in modlist generation mode");

--- a/kanidm_tools/src/badlist_preprocess.rs
+++ b/kanidm_tools/src/badlist_preprocess.rs
@@ -16,9 +16,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use kanidm_proto::v1::Modify;
 
-use tracing::{debug, error, info};
 use rayon::prelude::*;
 use structopt::StructOpt;
+use tracing::{debug, error, info};
 
 include!("opt/badlist_preprocess.rs");
 

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -9,7 +9,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
+
 use std::path::PathBuf;
 use structopt::StructOpt;
 

--- a/kanidm_tools/src/cli/main.rs
+++ b/kanidm_tools/src/cli/main.rs
@@ -19,10 +19,8 @@ fn main() {
             "RUST_LOG",
             "kanidm=debug,kanidm_client=debug,webauthn=debug",
         );
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info,webauthn=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     opt.exec()
 }

--- a/kanidm_tools/src/ssh_authorizedkeys.rs
+++ b/kanidm_tools/src/ssh_authorizedkeys.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 
 use kanidm_client::{ClientError, KanidmClientBuilder};
 
-use tracing::{debug, error};
 use structopt::StructOpt;
+use tracing::{debug, error};
 
 include!("opt/ssh_authorizedkeys.rs");
 

--- a/kanidm_tools/src/ssh_authorizedkeys.rs
+++ b/kanidm_tools/src/ssh_authorizedkeys.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use kanidm_client::{ClientError, KanidmClientBuilder};
 
-use log::{debug, error};
+use tracing::{debug, error};
 use structopt::StructOpt;
 
 include!("opt/ssh_authorizedkeys.rs");
@@ -25,10 +25,8 @@ fn main() {
     let opt = SshAuthorizedOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let config_path: String = shellexpand::tilde("~/.config/kanidm").into_owned();
     debug!("Attempting to use config {}", "/etc/kanidm/config");

--- a/kanidm_unix_int/Cargo.toml
+++ b/kanidm_unix_int/Cargo.toml
@@ -45,6 +45,10 @@ path =  "src/test_auth.rs"
 kanidm_client = { path = "../kanidm_client", version = "1.1.0-alpha" }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha" }
 kanidm = { path = "../kanidmd", version = "1.1.0-alpha" }
+
+tracing = "0.1"
+tracing-subscriber = "0.2"
+
 toml = "0.5"
 rpassword = "5.0"
 tokio = { version = "1", features = ["rt", "macros", "sync", "time", "net", "io-util"] }
@@ -54,8 +58,6 @@ futures = "0.3"
 bytes = "1.0"
 
 libc = "0.2"
-log = "0.4"
-env_logger = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 serde_cbor = "0.11"

--- a/kanidm_unix_int/src/cache_clear.rs
+++ b/kanidm_unix_int/src/cache_clear.rs
@@ -9,9 +9,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
-use log::debug;
 use structopt::StructOpt;
 
 use futures::executor::block_on;
@@ -27,10 +26,8 @@ async fn main() {
     let opt = CacheClearOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     debug!("Starting cache invalidate tool ...");
 

--- a/kanidm_unix_int/src/cache_invalidate.rs
+++ b/kanidm_unix_int/src/cache_invalidate.rs
@@ -9,9 +9,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
-use log::debug;
 use structopt::StructOpt;
 
 use futures::executor::block_on;
@@ -27,10 +26,8 @@ async fn main() {
     let opt = CacheInvalidateOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     debug!("Starting cache invalidate tool ...");
 

--- a/kanidm_unix_int/src/daemon.rs
+++ b/kanidm_unix_int/src/daemon.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
 
@@ -377,8 +377,7 @@ async fn main() {
         std::process::exit(1);
     }
 
-    // ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));

--- a/kanidm_unix_int/src/daemon_status.rs
+++ b/kanidm_unix_int/src/daemon_status.rs
@@ -9,9 +9,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
-use log::debug;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -27,10 +26,8 @@ fn main() {
     let opt = UnixdStatusOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     debug!("Starting cache status tool ...");
 

--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -705,7 +705,7 @@ mod tests {
 
     #[test]
     fn test_cache_db_account_basic() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt::try_init();
         let db = Db::new("").expect("failed to create.");
         let dbtxn = task::block_on(db.write());
         assert!(dbtxn.migrate().is_ok());
@@ -789,7 +789,7 @@ mod tests {
 
     #[test]
     fn test_cache_db_group_basic() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt::try_init();
         let db = Db::new("").expect("failed to create.");
         let dbtxn = task::block_on(db.write());
         assert!(dbtxn.migrate().is_ok());
@@ -864,7 +864,7 @@ mod tests {
 
     #[test]
     fn test_cache_db_account_group_update() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt::try_init();
         let db = Db::new("").expect("failed to create.");
         let dbtxn = task::block_on(db.write());
         assert!(dbtxn.migrate().is_ok());
@@ -932,7 +932,7 @@ mod tests {
 
     #[test]
     fn test_cache_db_account_password() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt::try_init();
         let db = Db::new("").expect("failed to create.");
         let dbtxn = task::block_on(db.write());
         assert!(dbtxn.migrate().is_ok());
@@ -981,7 +981,7 @@ mod tests {
 
     #[test]
     fn test_cache_db_group_rename_duplicate() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt::try_init();
         let db = Db::new("").expect("failed to create.");
         let dbtxn = task::block_on(db.write());
         assert!(dbtxn.migrate().is_ok());
@@ -1036,7 +1036,7 @@ mod tests {
 
     #[test]
     fn test_cache_db_account_rename_duplicate() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt::try_init();
         let db = Db::new("").expect("failed to create.");
         let dbtxn = task::block_on(db.write());
         assert!(dbtxn.migrate().is_ok());

--- a/kanidm_unix_int/src/lib.rs
+++ b/kanidm_unix_int/src/lib.rs
@@ -11,7 +11,7 @@
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
-extern crate log;
+extern crate tracing;
 #[macro_use]
 extern crate rusqlite;
 

--- a/kanidm_unix_int/src/ssh_authorizedkeys.rs
+++ b/kanidm_unix_int/src/ssh_authorizedkeys.rs
@@ -9,9 +9,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
-use log::debug;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -28,10 +27,8 @@ async fn main() {
     let opt = SshAuthorizedOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     debug!("Starting authorized keys tool ...");
 

--- a/kanidm_unix_int/src/tasks_daemon.rs
+++ b/kanidm_unix_int/src/tasks_daemon.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 use users::{get_effective_gid, get_effective_uid};
 
@@ -210,7 +210,7 @@ async fn main() {
         std::process::exit(1);
     }
 
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let unixd_path = Path::new("/etc/kanidm/unixd");
     let unixd_path_str = match unixd_path.to_str() {

--- a/kanidm_unix_int/src/test_auth.rs
+++ b/kanidm_unix_int/src/test_auth.rs
@@ -1,8 +1,7 @@
 #![deny(warnings)]
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
-use log::debug;
 use structopt::StructOpt;
 
 use futures::executor::block_on;
@@ -24,12 +23,10 @@ async fn main() {
     let opt = ClientOpt::from_args();
     if opt.debug {
         ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
-    } else {
-        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
-    debug!("Starting cache invalidate tool ...");
+    debug!("Starting pam auth tester tool ...");
 
     let cfg = KanidmUnixdConfig::new()
         .read_options_from_optional_config("/etc/kanidm/unixd")

--- a/kanidm_unix_int/tests/cache_layer_test.rs
+++ b/kanidm_unix_int/tests/cache_layer_test.rs
@@ -37,9 +37,7 @@ fn is_free_port(port: u16) -> bool {
 }
 
 fn run_test(fix_fn: fn(&KanidmClient) -> (), test_fn: fn(CacheLayer, KanidmAsyncClient) -> ()) {
-    // ::std::env::set_var("RUST_LOG", "kanidm=debug");
     let _ = tracing_tree::test_init();
-    let _ = env_logger::builder().is_test(true).try_init();
 
     let (ready_tx, mut ready_rx) = mpsc::channel(1);
     let (finish_tx, mut finish_rx) = mpsc::channel(1);

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/server/main.rs"
 
 [dependencies]
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha" }
+tracing_tree = { path = "../tracing_tree", version = "1.1.0-alpha" }
+tracing = { version = "0.1", features = ["attributes"] }
+tracing-subscriber = "0.2"
+tracing-serde = "0.1"
 
 jemallocator = { version = "0.3.0", optional = true }
 either = "1.6"
@@ -34,8 +38,6 @@ compact_jwt = "^0.1.7"
 
 async-std = { version = "1.6", features = ["tokio1"] }
 
-log = "0.4"
-env_logger = "0.9"
 rand = "0.8"
 toml = "0.5"
 
@@ -94,10 +96,7 @@ validator = { version = "0.14", features = ["phone"] }
 touch = "0.0.1"
 filetime = "0.2"
 
-tracing = { version = "0.1", features = ["attributes", "release_max_level_info"] }
-tracing-subscriber = "0.2"
-tracing-serde = "0.1"
-num_enum = "0.5.4"
+num_enum = "0.5"
 
 
 [features]

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/server/main.rs"
 
 [dependencies]
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha" }
-tracing_tree = { path = "../tracing_tree", version = "1.1.0-alpha" }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = "0.2"
 tracing-serde = "0.1"

--- a/kanidmd/src/lib/filter.rs
+++ b/kanidmd/src/lib/filter.rs
@@ -1372,13 +1372,7 @@ mod tests {
 
     #[test]
     fn test_filter_optimise() {
-        use env_logger;
-        ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
-        let _ = env_logger::builder()
-            .format_timestamp(None)
-            .format_level(false)
-            .is_test(true)
-            .try_init();
+        let _ = tracing_subscriber::fmt().try_init();
         // Given sets of "optimisable" filters, optimise them.
         filter_optimise_assert!(
             f_and(vec![f_and(vec![f_eq(

--- a/kanidmd/src/lib/lib.rs
+++ b/kanidmd/src/lib/lib.rs
@@ -19,13 +19,11 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[macro_use]
-extern crate log;
-
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate rusqlite;
-
+#[macro_use]
+extern crate tracing;
 #[macro_use]
 extern crate lazy_static;
 

--- a/kanidmd/src/server/main.rs
+++ b/kanidmd/src/server/main.rs
@@ -213,11 +213,10 @@ async fn main() {
     }
 
     // ::std::env::set_var("RUST_LOG", "tide=info,kanidm=info,webauthn=debug");
-
-    env_logger::builder()
-        .format_timestamp(None)
-        .format_level(false)
-        .init();
+    // env_logger::builder()
+    //     .format_timestamp(None)
+    //     .format_level(false)
+    //     .init();
 
     match opt {
         KanidmdOpt::Server(_sopt) => {

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/main.rs"
 
 [dependencies]
 jemallocator = { version = "0.3.0", optional = true }
+tracing = "0.1"
+tracing-subscriber = "0.2"
 
 structopt = { version = "0.3", default-features = false }
 
@@ -24,8 +26,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 
-log = "0.4"
-env_logger = "0.9"
 rand = "0.8"
 toml = "0.5"
 

--- a/orca/src/main.rs
+++ b/orca/src/main.rs
@@ -13,7 +13,7 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 #[macro_use]
 extern crate serde_derive;
@@ -187,10 +187,8 @@ async fn main() {
             "RUST_LOG",
             "orca=debug,kanidm=debug,kanidm_client=debug,webauthn=debug",
         );
-    } else {
-        ::std::env::set_var("RUST_LOG", "orca=info");
     }
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     info!("Orca - the Kanidm Load Testing Utility.");
     debug!("cli -> {:?}", opt);


### PR DESCRIPTION
Removes log/env_logger in favour of tracing.

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
