### PR TITLE
Correct issuer to match url of connected client

### DIFF
--- a/kanidm_book/src/oauth2.md
+++ b/kanidm_book/src/oauth2.md
@@ -243,5 +243,32 @@ You can choose to disable other login methods with:
 You can login directly by appending `?direct=1` to your login page still. You can re-enable
 other backends by setting the value to `1`
 
+### Velociraptor
 
+Velociraptor supports OIDC. To configure it select "Authenticate with SSO" then "OIDC" during
+the interactive configuration generator. Alternately, you can set the following keys in server.config.yaml:
+
+    GUI:
+      authenticator:
+        type: OIDC
+        oidc_issuer: https://idm.example.com/oauth2/openid/:client\_id:/
+        oauth_client_id: <resource server name/>
+        oauth_client_secret: <resource server secret>
+
+Velociraptor does not support PKCE. You will need to run the following:
+
+    kanidm system oauth2 warning_insecure_client_disable_pkce <resource server name>
+
+Initial users are mapped via their email in the Velociraptor server.config.yaml config:
+
+    GUI:
+      initial_users:
+      - name: <email address>
+
+Accounts require the `openid` and `email` scopes to be authenticated. It is recommended you limit
+these to a group with a scope map due to Velociraptors high impact.
+
+    # kanidm group create velociraptor_users
+    # kanidm group add_members velociraptor_users ...
+    kanidm system oauth2 create_scope_map <resource server name> velociraptor_users openid email
 

--- a/kanidm_client/tests/oauth2_test.rs
+++ b/kanidm_client/tests/oauth2_test.rs
@@ -132,7 +132,11 @@ fn test_oauth2_openid_basic_flow() {
 
             // Most values are checked in idm/oauth2.rs, but we want to sanity check
             // the urls here as an extended function smoke test.
-            assert!(discovery.issuer == Url::parse("https://idm.example.com/").unwrap());
+            assert!(
+                discovery.issuer
+                    == Url::parse("https://idm.example.com/oauth2/openid/test_integration")
+                        .unwrap()
+            );
 
             assert!(
                 discovery.authorization_endpoint
@@ -328,7 +332,11 @@ fn test_oauth2_openid_basic_flow() {
 
             // This is mostly checked inside of idm/oauth2.rs. This is more to check the oidc
             // token and the userinfo endpoints.
-            assert!(oidc.iss == Url::parse("https://idm.example.com/").unwrap());
+            assert!(
+                oidc.iss
+                    == Url::parse("https://idm.example.com/oauth2/openid/test_integration")
+                        .unwrap()
+            );
             assert!(oidc.s_claims.email.as_deref() == Some("admin@example.com"));
             assert!(oidc.s_claims.email_verified == Some(true));
 


### PR DESCRIPTION
Some OIDC clients assert that the issuer url as configured is the same as the issuer url as returned. Return the exact issuer url for the client in this case. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
