### PR TITLE
Change how domain names are handled in our configuration.

### DIFF
--- a/kanidm_book/src/administrivia.md
+++ b/kanidm_book/src/administrivia.md
@@ -48,30 +48,19 @@ by including the `[online_backup]` section in the `server.toml`.
 This allows you to run regular backups, defined by a cron schedule, and maintain
 the number of backup versions to keep. An example is located in [examples/server.toml](../../examples/server.toml).
 
-# Rename the domain
+# Configuration Test
 
-There are some cases where you may need to rename the domain. You should have configured
-this initially in the setup, however you may have a situation where a business is changing
-name, merging, or other needs which may prompt this needing to be changed.
+You can test your configuration will correctly start with the server.
 
-> **WARNING:** This WILL break ALL u2f/webauthn tokens that have been enrolled, which MAY cause
-> accounts to be locked out and unrecoverable until further action is taken. DO NOT CHANGE
-> the `domain_name` unless REQUIRED and have a plan on how to manage these issues.
-
-> **WARNING:** This operation can take an extensive amount of time as ALL accounts and groups
-> in the domain MUST have their SPN's regenerated. This will also cause a large delay in
-> replication once the system is restarted.
-
-You should take a backup before proceeding with this operation.
-
-When you have a created a migration plan and strategy on handling the invalidation of webauthn,
-you can then rename the domain with the commands as follows:
+> **WARNING:** While this is a configuration test, it still needs to open the database so that
+> it can check a number of internal values are consistent with the configuration. As a result,
+> this requires the instance under config test to be stopped!
 
     docker stop <container name>
-    docker run --rm -i -t -v kandimd:/data \
-        kanidm/server:latest /sbin/kanidmd domain_name_change -c /data/server.toml \
-        -n idm.new.domain.name
+    docker run --rm -i -t -v kanidmd:/data \
+        kanidm/server:latest /sbin/kanidmd configtest -c /data/server.toml
     docker start <container name>
+
 
 # Reindexing after schema extension
 
@@ -132,6 +121,37 @@ You can run a verification with:
     docker start <container name>
 
 If you have errors, please contact the project to help support you to resolve these.
+
+# Rename the domain
+
+There are some cases where you may need to rename the domain. You should have configured
+this initially in the setup, however you may have a situation where a business is changing
+name, merging, or other needs which may prompt this needing to be changed.
+
+> **WARNING:** This WILL break ALL u2f/webauthn tokens that have been enrolled, which MAY cause
+> accounts to be locked out and unrecoverable until further action is taken. DO NOT CHANGE
+> the domain name unless REQUIRED and have a plan on how to manage these issues.
+
+> **WARNING:** This operation can take an extensive amount of time as ALL accounts and groups
+> in the domain MUST have their SPN's regenerated. This WILL also cause a large delay in
+> replication once the system is restarted.
+
+You should take a backup before proceeding with this operation.
+
+When you have a created a migration plan and strategy on handling the invalidation of webauthn,
+you can then rename the domain.
+
+First, stop the instance.
+
+    docker stop <container name>
+
+Second, change `domain` and `origin` in `server.toml`.
+
+Third, trigger the database domain rename process.
+
+    docker run --rm -i -t -v kandimd:/data \
+        kanidm/server:latest /sbin/kanidmd domain_name_change -c /data/server.toml
+    docker start <container name>
 
 # Raw actions
 

--- a/kanidm_book/src/server_configuration.md
+++ b/kanidm_book/src/server_configuration.md
@@ -37,9 +37,21 @@ You will also need a config file in the volume named `server.toml` (Within the c
     #   Defaults to "default"
     # log_level = "default"
     #
+    #   The DNS domain name of the server. This is used in a number of security-critical contexts
+    #   such as webauthn, so it *must* match your DNS hostname. It is what is used to create
+    #   security principal names such as `william@idm.example.com` so that in a (future)
+    #   trust configuration it is possible to have unique spn's throughout the topology.
+    #   ⚠️  WARNING ⚠️
+    #   Changing this value WILL break many types of registered credentials for accounts
+    #   including but not limited to webauthn, oauth tokens, and more.
+    #   If you change this value you *must* run `kanidmd domain_name_change` immediately
+    #   after.
+    domain = "idm.example.com"
+    #
     #   The origin for webauthn. This is the url to the server, with the port included if
     #   it is non-standard (any port except 443). This must match or be a descendent of the
-    #   domain name you configure with `kanidmd domain_name_change`
+    #   domain name you configure above. If these two items are not consistent, the server
+    #   WILL refuse to start!
     # origin = "https://idm.example.com"
     origin = "https://idm.example.com:8443"
     #

--- a/kanidm_client/tests/common.rs
+++ b/kanidm_client/tests/common.rs
@@ -67,7 +67,7 @@ pub fn run_test(test_fn: fn(KanidmClient) -> ()) {
             .build()
             .expect("failed to start tokio");
         rt.block_on(async {
-            create_server_core(config)
+            create_server_core(config, false)
                 .await
                 .expect("failed to start server core");
             // We have to yield now to guarantee that the tide elements are setup.

--- a/kanidm_client/tests/oauth2_test.rs
+++ b/kanidm_client/tests/oauth2_test.rs
@@ -60,7 +60,7 @@ fn test_oauth2_openid_basic_flow() {
         rsclient
             .idm_account_person_extend(
                 "admin",
-                Some(&["admin@example.com".to_string()]),
+                Some(&["admin@idm.example.com".to_string()]),
                 Some("Admin Istrator"),
             )
             .expect("Failed to extend account details");
@@ -312,7 +312,7 @@ fn test_oauth2_openid_basic_flow() {
             assert!(tir.active);
             assert!(tir.scope.is_some());
             assert!(tir.client_id.as_deref() == Some("test_integration"));
-            assert!(tir.username.as_deref() == Some("admin@example.com"));
+            assert!(tir.username.as_deref() == Some("admin@idm.example.com"));
             assert!(tir.token_type.as_deref() == Some("access_token"));
             assert!(tir.exp.is_some());
             assert!(tir.iat.is_some());
@@ -337,7 +337,7 @@ fn test_oauth2_openid_basic_flow() {
                     == Url::parse("https://idm.example.com/oauth2/openid/test_integration")
                         .unwrap()
             );
-            assert!(oidc.s_claims.email.as_deref() == Some("admin@example.com"));
+            assert!(oidc.s_claims.email.as_deref() == Some("admin@idm.example.com"));
             assert!(oidc.s_claims.email_verified == Some(true));
 
             let response = client

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -83,7 +83,7 @@ fn test_server_whoami_anonymous() {
             None => panic!(),
         };
         debug!("{}", uat);
-        assert!(uat.spn == "anonymous@example.com");
+        assert!(uat.spn == "anonymous@idm.example.com");
 
         // Do a check of the auth/valid endpoint, tells us if our token
         // is okay.
@@ -109,7 +109,7 @@ fn test_server_whoami_admin_simple_password() {
             None => panic!(),
         };
         debug!("{}", uat);
-        assert!(uat.spn == "admin@example.com");
+        assert!(uat.spn == "admin@idm.example.com");
     });
 }
 
@@ -275,7 +275,7 @@ fn test_server_rest_group_lifecycle() {
             .idm_group_add_members("demo_group", &["admin"])
             .unwrap();
         let members = rsclient.idm_group_get_members("demo_group").unwrap();
-        assert!(members == Some(vec!["admin@example.com".to_string()]));
+        assert!(members == Some(vec!["admin@idm.example.com".to_string()]));
 
         // Set the list of members
         rsclient
@@ -285,8 +285,8 @@ fn test_server_rest_group_lifecycle() {
         assert!(
             members
                 == Some(vec![
-                    "admin@example.com".to_string(),
-                    "demo_group@example.com".to_string()
+                    "admin@idm.example.com".to_string(),
+                    "demo_group@idm.example.com".to_string()
                 ])
         );
 
@@ -295,7 +295,7 @@ fn test_server_rest_group_lifecycle() {
             .idm_group_remove_members("demo_group", &["demo_group"])
             .unwrap();
         let members = rsclient.idm_group_get_members("demo_group").unwrap();
-        assert!(members == Some(vec!["admin@example.com".to_string()]));
+        assert!(members == Some(vec!["admin@idm.example.com".to_string()]));
 
         // purge members
         rsclient.idm_group_purge_members("demo_group").unwrap();
@@ -315,7 +315,7 @@ fn test_server_rest_group_lifecycle() {
         // They should have members
         let members = rsclient.idm_group_get_members("idm_admins").unwrap();
         println!("{:?}", members);
-        assert!(members == Some(vec!["idm_admin@example.com".to_string()]));
+        assert!(members == Some(vec!["idm_admin@idm.example.com".to_string()]));
     });
 }
 
@@ -432,14 +432,14 @@ fn test_server_rest_account_lifecycle() {
 
         // Test adding some mail addrs
         rsclient
-            .idm_account_add_attr("demo_account", "mail", &["demo@example.com"])
+            .idm_account_add_attr("demo_account", "mail", &["demo@idm.example.com"])
             .unwrap();
 
         let r = rsclient
             .idm_account_get_attr("demo_account", "mail")
             .unwrap();
 
-        assert!(r == Some(vec!["demo@example.com".to_string()]));
+        assert!(r == Some(vec!["demo@idm.example.com".to_string()]));
 
         // Delete the account
         rsclient.idm_account_delete("demo_account").unwrap();

--- a/kanidm_unix_int/tests/cache_layer_test.rs
+++ b/kanidm_unix_int/tests/cache_layer_test.rs
@@ -77,7 +77,7 @@ fn run_test(fix_fn: fn(&KanidmClient) -> (), test_fn: fn(CacheLayer, KanidmAsync
             .build()
             .expect("failed to start tokio");
         rt.block_on(async {
-            create_server_core(config)
+            create_server_core(config, false)
                 .await
                 .expect("failed to start server core");
             // We have to yield now to guarantee that the tide elements are setup.

--- a/kanidmd/server.toml
+++ b/kanidmd/server.toml
@@ -7,4 +7,6 @@ tls_key = "../insecure/key.pem"
 # log_level = "perfbasic"
 # log_level = "quiet"
 log_level = "verbose"
+domain = "idm.example.com"
 origin = "https://idm.example.com:8443"
+

--- a/kanidmd/src/lib/be/mod.rs
+++ b/kanidmd/src/lib/be/mod.rs
@@ -534,7 +534,7 @@ pub trait BackendTransaction {
                 })
             })?;
 
-            filter_info!(?fplan, "filter executed plan");
+            filter_trace!(?fplan, "filter executed plan");
 
             match &idl {
                 IdList::AllIds => {
@@ -638,7 +638,7 @@ pub trait BackendTransaction {
                 })
             })?;
 
-            filter_info!(?fplan, "filter executed plan");
+            filter_trace!(?fplan, "filter executed plan");
 
             // Apply limits to the IdList.
             match &idl {

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -90,6 +90,7 @@ pub struct Configuration {
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
     pub log_level: Option<u32>,
     pub online_backup: Option<OnlineBackup>,
+    pub domain: String,
     pub origin: String,
     pub role: ServerRole,
 }
@@ -148,6 +149,7 @@ impl Configuration {
             integration_test_config: None,
             log_level: None,
             online_backup: None,
+            domain: "idm.example.com".to_string(),
             origin: "https://idm.example.com".to_string(),
             role: ServerRole::WriteReplica,
         };
@@ -201,6 +203,10 @@ impl Configuration {
 
     pub fn update_origin(&mut self, o: &str) {
         self.origin = o.to_string();
+    }
+
+    pub fn update_domain(&mut self, d: &str) {
+        self.domain = d.to_string();
     }
 
     pub fn update_role(&mut self, r: ServerRole) {

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -83,7 +83,7 @@ fn setup_qs_idms(
     config: &Configuration,
 ) -> Result<(QueryServer, IdmServer, IdmServerDelayed), OperationError> {
     // Create a query_server implementation
-    let query_server = QueryServer::new(be, schema);
+    let query_server = QueryServer::new(be, schema, config.domain.clone());
 
     // TODO #62: Should the IDM parts be broken out to the IdmServer?
     // What's important about this initial setup here is that it also triggers
@@ -100,6 +100,27 @@ fn setup_qs_idms(
     let (idms, idms_delayed) = IdmServer::new(query_server.clone(), &config.origin)?;
 
     Ok((query_server, idms, idms_delayed))
+}
+
+fn setup_qs(
+    be: Backend,
+    schema: Schema,
+    config: &Configuration,
+) -> Result<QueryServer, OperationError> {
+    // Create a query_server implementation
+    let query_server = QueryServer::new(be, schema, config.domain.clone());
+
+    // TODO #62: Should the IDM parts be broken out to the IdmServer?
+    // What's important about this initial setup here is that it also triggers
+    // the schema and acp reload, so they are now configured correctly!
+    // Initialise the schema core.
+    //
+    // Now search for the schema itself, and validate that the system
+    // in memory matches the BE on disk, and that it's syntactically correct.
+    // Write it out if changes are needed.
+    query_server.initialise_helper(duration_from_epoch_now())?;
+
+    Ok(query_server)
 }
 
 macro_rules! dbscan_setup_be {
@@ -354,7 +375,7 @@ pub fn vacuum_server_core(config: &Configuration) {
     };
 }
 
-pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
+pub fn domain_rename_core(config: &Configuration) {
     let schema = match Schema::new() {
         Ok(s) => s,
         Err(e) => {
@@ -371,18 +392,22 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
             return;
         }
     };
-    // setup the qs - *with* init of the migrations and schema.
-    let (qs, _idms, _idms_delayed) = match setup_qs_idms(be, schema, config) {
+
+    // setup the qs - *with out* init of the migrations and schema.
+    let qs = match setup_qs(be, schema, config) {
         Ok(t) => t,
         Err(e) => {
-            error!("Unable to setup query server or idm server -> {:?}", e);
+            error!("Unable to setup query server -> {:?}", e);
             return;
         }
     };
 
+    let new_domain_name = config.domain.as_str();
+
     // make sure we're actually changing the domain name...
     match task::block_on(qs.read_async()).get_domain_name() {
         Ok(old_domain_name) => {
+            admin_info!(?old_domain_name, ?new_domain_name);
             if &old_domain_name == &new_domain_name {
                 admin_info!("Domain name not changing, stopping.");
                 return;
@@ -395,9 +420,7 @@ pub fn domain_rename_core(config: &Configuration, new_domain_name: &str) {
     }
 
     let qs_write = task::block_on(qs.write_async(duration_from_epoch_now()));
-    let r = qs_write
-        .domain_rename(new_domain_name)
-        .and_then(|_| qs_write.commit());
+    let r = qs_write.domain_rename().and_then(|_| qs_write.commit());
 
     match r {
         Ok(_) => info!("Domain Rename Success!"),
@@ -425,7 +448,7 @@ pub fn verify_server_core(config: &Configuration) {
             return;
         }
     };
-    let server = QueryServer::new(be, schema_mem);
+    let server = QueryServer::new(be, schema_mem, config.domain.clone());
 
     // Run verifications.
     let r = server.verify();
@@ -489,7 +512,7 @@ pub fn recover_account_core(config: &Configuration, name: &str) {
     eprintln!("Success - password reset to -> {}", new_pw);
 }
 
-pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
+pub async fn create_server_core(config: Configuration, config_test: bool) -> Result<(), ()> {
     // Until this point, we probably want to write to the log macro fns.
 
     if config.integration_test_config.is_some() {
@@ -497,7 +520,11 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
         warn!("IF YOU SEE THIS IN PRODUCTION YOU MUST CONTACT SUPPORT IMMEDIATELY.");
     }
 
-    info!("Starting kanidm with configuration: {}", config);
+    info!(
+        "Starting kanidm with configuration: {} {}",
+        if config_test { "TEST" } else { "" },
+        config
+    );
     // Setup umask, so that every we touch or create is secure.
     let _ = unsafe { umask(0o0027) };
 
@@ -621,7 +648,11 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
                     return Err(());
                 }
             };
-            ldaps::create_ldap_server(la.as_str(), opt_ldap_tls_params, server_read_ref).await?;
+            if !config_test {
+                // ⚠️  only start the sockets and listeners in non-config-test modes.
+                ldaps::create_ldap_server(la.as_str(), opt_ldap_tls_params, server_read_ref)
+                    .await?;
+            }
         }
         None => {
             debug!("LDAP not requested, skipping");
@@ -634,19 +665,24 @@ pub async fn create_server_core(config: Configuration) -> Result<(), ()> {
     // domain will come from the qs now!
     let cookie_key: [u8; 32] = config.cookie_key;
 
-    self::https::create_https_server(
-        config.address,
-        // opt_tls_params,
-        config.tls_config.as_ref(),
-        config.role,
-        &cookie_key,
-        &bundy_key,
-        status_ref,
-        server_write_ref,
-        server_read_ref,
-    )?;
+    if config_test {
+        admin_info!("this config rocks! 🪨 ");
+    } else {
+        // ⚠️  only start the sockets and listeners in non-config-test modes.
+        self::https::create_https_server(
+            config.address,
+            // opt_tls_params,
+            config.tls_config.as_ref(),
+            config.role,
+            &cookie_key,
+            &bundy_key,
+            status_ref,
+            server_write_ref,
+            server_read_ref,
+        )?;
 
-    info!("ready to rock! 🧱");
+        admin_info!("ready to rock! 🪨 ");
+    }
 
     Ok(())
 }

--- a/kanidmd/src/lib/core/mod.rs
+++ b/kanidmd/src/lib/core/mod.rs
@@ -405,7 +405,7 @@ pub fn domain_rename_core(config: &Configuration) {
     let new_domain_name = config.domain.as_str();
 
     // make sure we're actually changing the domain name...
-    match task::block_on(qs.read_async()).get_domain_name() {
+    match task::block_on(qs.read_async()).get_db_domain_name() {
         Ok(old_domain_name) => {
             admin_info!(?old_domain_name, ?new_domain_name);
             if &old_domain_name == &new_domain_name {

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -147,6 +147,7 @@ impl IdmServer {
         qs: QueryServer,
         origin: &str,
         // ct: Duration,
+        // do_domain_check: bool
     ) -> Result<(IdmServer, IdmServerDelayed), OperationError> {
         // This is calculated back from:
         //  500 auths / thread -> 0.002 sec per op

--- a/kanidmd/src/lib/idm/server.rs
+++ b/kanidmd/src/lib/idm/server.rs
@@ -147,7 +147,6 @@ impl IdmServer {
         qs: QueryServer,
         origin: &str,
         // ct: Duration,
-        // do_domain_check: bool
     ) -> Result<(IdmServer, IdmServerDelayed), OperationError> {
         // This is calculated back from:
         //  500 auths / thread -> 0.002 sec per op
@@ -163,7 +162,7 @@ impl IdmServer {
         let (rp_id, token_key, pw_badlist_set, oauth2rs_set) = {
             let qs_read = task::block_on(qs.read_async());
             (
-                qs_read.get_domain_name()?,
+                qs_read.get_domain_name().to_string(),
                 qs_read.get_domain_token_key()?,
                 qs_read.get_password_badlist()?,
                 // Add a read/reload of all oauth2 configurations.

--- a/kanidmd/src/lib/macros.rs
+++ b/kanidmd/src/lib/macros.rs
@@ -23,7 +23,7 @@ macro_rules! setup_test {
         let be =
             Backend::new(BackendConfig::new_test(), idxmeta, false).expect("Failed to init BE");
 
-        let qs = QueryServer::new(be, schema_outer);
+        let qs = QueryServer::new(be, schema_outer, "example.com".to_string());
         qs.initialise_helper(duration_from_epoch_now())
             .expect("init failed!");
         qs
@@ -54,7 +54,7 @@ macro_rules! setup_test {
         let be =
             Backend::new(BackendConfig::new_test(), idxmeta, false).expect("Failed to init BE");
 
-        let qs = QueryServer::new(be, schema_outer);
+        let qs = QueryServer::new(be, schema_outer, "example.com".to_string());
         qs.initialise_helper(duration_from_epoch_now())
             .expect("init failed!");
 
@@ -100,7 +100,7 @@ macro_rules! run_test_no_init {
                 panic!()
             }
         };
-        let test_server = QueryServer::new(be, schema_outer);
+        let test_server = QueryServer::new(be, schema_outer, "example.com".to_string());
 
         $test_fn(&test_server);
         // Any needed teardown?

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -40,7 +40,7 @@ impl Plugin for Domain {
                 trace!("plugin_domain: Applying uuid transform");
                 // We only apply this if one isn't provided.
                 if !e.attribute_pres("domain_name") {
-                    let n = Value::new_iname(qs.d_name.as_str());
+                    let n = Value::new_iname(qs.get_domain_name());
                     e.set_ava("domain_name", once(n));
                     trace!("plugin_domain: Applying domain_name transform");
                 }

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -40,7 +40,7 @@ impl Plugin for Domain {
                 trace!("plugin_domain: Applying uuid transform");
                 // We only apply this if one isn't provided.
                 if !e.attribute_pres("domain_name") {
-                    let n = Value::new_iname("example.com");
+                    let n = Value::new_iname(qs.d_name.as_str());
                     e.set_ava("domain_name", once(n));
                     trace!("plugin_domain: Applying domain_name transform");
                 }

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -364,9 +364,11 @@ mod tests {
             // trigger the domain_name change (this will be a cli option to the server
             // in the final version), but it will still call the same qs function to perform the
             // change.
-            server_txn
-                .domain_rename("new.example.com")
-                .expect("should not fail!");
+            unsafe {
+                server_txn
+                    .domain_rename_inner("new.example.com")
+                    .expect("should not fail!");
+            }
 
             // check the spn on admin is admin@<new domain>
             let e_post = server_txn

--- a/kanidmd/src/server/opt.rs
+++ b/kanidmd/src/server/opt.rs
@@ -36,15 +36,6 @@ struct RecoverAccountOpt {
 }
 
 #[derive(Debug, StructOpt)]
-struct DomainOpt {
-    #[structopt(short)]
-    /// The new domain name.
-    new_domain_name: String,
-    #[structopt(flatten)]
-    commonopts: CommonOpt,
-}
-
-#[derive(Debug, StructOpt)]
 struct DbScanListIndex {
     /// The name of the index to list
     index_name: String,
@@ -99,6 +90,9 @@ enum KanidmdOpt {
     #[structopt(name = "server")]
     /// Start the IDM Server
     Server(CommonOpt),
+    #[structopt(name = "configtest")]
+    /// Test the IDM Server configuration, without starting network listeners.
+    ConfigTest(CommonOpt),
     #[structopt(name = "backup")]
     /// Backup the database content (offline)
     Backup(BackupOpt),
@@ -121,7 +115,7 @@ enum KanidmdOpt {
     Vacuum(CommonOpt),
     #[structopt(name = "domain_name_change")]
     /// Change the IDM domain name
-    DomainChange(DomainOpt),
+    DomainChange(CommonOpt),
     #[structopt(name = "db_scan")]
     /// Inspect the internal content of the database datastructures.
     DbScan(DbScanOpt),


### PR DESCRIPTION
Fixes #623 - Improve domain name handling on server startup. Rather than starting with a default domain and expecting a rename, we make the domain name a config value in server.toml. When the server starts up, we use this initially to create the first domain name. When a domain rename is requested, we read the value from server.toml (and skip the origin check by not starting the idms layer).  Finally, this adds a config tester that can check if the server "would start" with this configuration. As always, book chapters have been updated too :) 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ ] design document included (if relevant)
