### PR TITLE
Add design doc, revive the domain wide enc token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,20 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
-name = "bundy"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70ddb99e1c5a8308abe085b80c9ca05b41577aa73a2f431a5fec6837b5aa054"
-dependencies = [
- "base64 0.13.0",
- "log",
- "openssl",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +606,20 @@ name = "compact_jwt"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e359e67b8bb65fdcdc67e506f65b4aec4a97c7e731f321ed1b4b86c443ca6e"
+dependencies = [
+ "base64 0.13.0",
+ "openssl",
+ "serde",
+ "serde_json",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "compact_jwt"
+version = "0.2.0"
+source = "git+https://github.com/kanidm/compact-jwt.git#f093323d69dacd49189348cbb904d7c8a8f61cbd"
 dependencies = [
  "base64 0.13.0",
  "openssl",
@@ -1887,9 +1887,8 @@ dependencies = [
  "async-std",
  "async-trait",
  "base64 0.13.0",
- "bundy",
  "chrono",
- "compact_jwt",
+ "compact_jwt 0.2.0",
  "compiled-uuid",
  "concread",
  "criterion",
@@ -1945,7 +1944,7 @@ version = "1.1.0-alpha.7"
 dependencies = [
  "async-std",
  "base64 0.13.0",
- "compact_jwt",
+ "compact_jwt 0.1.9",
  "futures",
  "kanidm",
  "kanidm_proto",
@@ -1981,7 +1980,7 @@ dependencies = [
 name = "kanidm_tools"
 version = "1.1.0-alpha.7"
 dependencies = [
- "bundy",
+ "compact_jwt 0.2.0",
  "dialoguer",
  "kanidm_client",
  "kanidm_proto",
@@ -3181,7 +3180,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-trait",
- "bundy",
+ "compact_jwt 0.2.0",
  "futures-util",
  "kanidm",
  "kanidm_proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,6 @@ concread = { git = "https://github.com/kanidm/concread.git" }
 # webauthn-authenticator-rs = { git = "https://github.com/kanidm/webauthn-authenticator-rs.git", rev = "c91205e57a783a7c3a6e09ade377c83a86fe0900" }
 
 # compact_jwt = { path = "../compact_jwt" }
+compact_jwt = { git = "https://github.com/kanidm/compact-jwt.git" }
+
 

--- a/designs/credential-update.rst
+++ b/designs/credential-update.rst
@@ -64,6 +64,14 @@ The credential update session can be rejected by the user, canceling it's progre
 
 A credential update session IS tied to a single server, similar to authentication.
 
+A credential update session has a unique-uuid assigned. When committed, this is added to a history-log
+on the users account so they can see and audit the change.
+
+If an intent token is used, the uuid of the intent token becomes the uuid of the credential update session.
+
+If an intent token is exchanged, and it's uuid already exists in the history-log of the account, the
+intent token is rejected.
+
 Credential Update Process
 =========================
 

--- a/designs/credential-update.rst
+++ b/designs/credential-update.rst
@@ -1,0 +1,154 @@
+
+Credential Update and Onboarding Workflow
+-----------------------------------------
+
+Letting users update their own credentials, but also allowing new users to create their own credentials
+needs a new workflow. Since these are nearly identical, these processes can be combined.
+
+Major considerations are:
+
+* Ability to start the credential creation (onboarding) work flow from a secured link.
+* Delegation of this permission from accounts to provide a reset path to users when needed.
+* Ensure that any credential updates are consistent and atomic.
+* Improved client side feedback around credential policy and rules.
+
+Initiation of the Credential Update Process
+===========================================
+
+The start of this process is that a user requests a credential update to begin for
+themself, or on behalf of another user.
+
+Self Update Workflow
+^^^^^^^^^^^^^^^^^^^^
+
+The user signals intent to update their credentials.
+
+An ACP check is made to check that the user has self-write to the relevant credential fields. If they
+do not, the credential update session is rejected.
+
+If they do have the access, a new credential update session is created, and the user is given a time
+limited token allowing them to interact with the credential update session.
+
+If the credental update session is abandoned it can not be re-accessed until it is expired.
+
+Onboarding/Reset Account Workflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The user signals intent that another users credentials should be updated.
+
+An ACP check is made to assert that the user has rights over the target users credential fields.
+If they do not, the update session is rejected. Note that the target user does *NOT* need self
+write permissions in this situation, which allows for a constrained permission on the target
+users (IE anonymous has no self write).
+
+If the access exists, a intent token is created into a link which can be provided to the user.
+
+Exchange of this intent token, creates the time limited credential update session token.
+
+This allows the intent token to have a seperate time window, to the credential update session token.
+
+If the intent token creates a credential update session, and the credential update session is *not*
+commited, it can be re-started by the intent token.
+
+If the credential update session has been committed, then the intent token can NOT create new
+credential update sessions (it is once-use).
+
+Consistency
+^^^^^^^^^^^
+
+Only one credential update process may exist at a time for a user. Attempts to create a second
+credential update session while an existing session exists is rejected until the previous session
+is committed or timed out.
+
+The credential update session can be rejected by the user, canceling it's progress.
+
+A credential update session IS tied to a single server, similar to authentication.
+
+Credential Update Process
+=========================
+
+The client on initiation of the credential update session is sent the policy related to the current
+update session including:
+
+* The classes of valid credentials that *may* be created
+* The current set of credentials that exist along with their metadata (private elements are NOT disclosed).
+
+The client then can build a set of changes to the set of credentials, expressing:
+
+* Modification of an existing credential.
+* Creation of a new credential.
+* Deletion of a credential.
+
+These changes are stored in the credential update session on the server. The reason for server side
+assistance is that some classes of credentials require the server to be involved for the updates to function
+and for consistent policy enforcement.
+
+Passwords may need to be sent to the server for checking against the badlist - since the badlist can
+be very large, it is infeasible to send this to the client, so server assistance is required.
+
+Webauthn MUST use strong random challenges, and so the server MUST generate these to prevent
+client side tampering. The server also MUST be involved in the attestation process.
+
+TOTP we must be able to detect SHA1 only authenticators.
+
+As a result, the built set of changes *is* persisted on the server in the credential update session
+as the user interacts with and builds the set of changes. This allows the server to enforce that the update
+session *must* represent a valid and complete set of compliant credentials before commit.
+
+The user may cancel the session at anytime, discarding any set of changes they had inflight. This allows
+another session to now begin.
+
+If the user chooses to commit the changes, the server will assemble the changes into a modification 
+and apply it. The write is applied with server internal permissions - since we checked the permissions
+during the create of the update session we can trust that the origin of this update has been validated.
+Additionally since this is not an arbitrary write interface, this constrains potential risk.
+
+The update session MUST have an idle timeout, where a lack of interaction for an extended period causes
+the session to invalidated. Interaction should extend the current time of the session up to a maximum window to
+allow users to update their credentials without rush.
+
+A modification to a credential MUST change the UUID of the credential. This allows replication conflict ordering
+to occur and create a linear and consistent timeline.
+
+A modification to a credential *should* offer a checkbox allowing users to invalidate sessions that were created
+with that credential if they wish.
+
+A *deleted* credential *must* invalidate sessions that were created using that credential.
+
+Addition of Device Credentials
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During a credential update session, a device credential may wish to be added.
+
+This should create a stub credential with a uuid. The client can then poll for updates to this
+stub to determine when the device credential has been registered and it can display in the main user agent.
+
+A link is created that contains an encrypted device enrollment token. This contains the stub uuid
+as well as the credential update session details. The device can partake in the enrollment process.
+
+The device enrollment token contains the relevant information related to the policy of the credential
+so that the server that receives the token can enforce the credential adheres to this policy.
+
+If the client successfully enrolls, a new entry for the enrollment is created in the database. This
+allows replication of the new credential to occur.
+
+The main session of the credential update can then check for the existance of this stub uuid in the
+db and wait for it to replicate in. This can be checked by the "polling" action.
+
+When it has been replicated in, and polling has found the credential, the credentials are added to the session. The credential
+can then have associated metadata altered (IE ident-only).
+
+During the commit, the stub credential object is DELETED.
+
+To prevent issues with DB size/growth, a stub credential reaper task MUST exist (similar to recycle/tombstone reaping).
+
+
+Future Changes to ACP/Credentials
+=================================
+
+Sudo Mode / Ident Only credentials
+
+These need flags in credentials, but we can add these later defaulting currently to the same which
+is that all added credentials are sudo capable.
+
+

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -19,9 +19,9 @@ the clients with:
     zypper ref
     zypper in kanidm-clients
 
-### OpenSUSE Leap 15.3
+### OpenSUSE Leap 15.3/15.4
 
-Leap 15.3 is still not fully supported with Kanidm. For an experimental client, you can
+Leap 15.3/15.4 is still not fully supported with Kanidm. For an experimental client, you can
 try the development repository. Using zypper you can add the repository with:
 
     zypper ar -f obs://network:idm network_idm
@@ -31,15 +31,17 @@ Then you need to refresh your metadata and install the clients.
     zypper ref
     zypper in kanidm-clients
 
-### Fedora
+### Fedora / Centos Stream
 
-Fedora is still experimentally supported through the development repository. You need to add the repository metadata into the correct directory.
+Fedora has limited supported through the development repository. You need to add the repository metadata into the correct directory.
 
     cd /etc/yum.repos.d
-    # 33
-    sudo wget https://download.opensuse.org/repositories/network:/idm/Fedora_33/network:idm.repo
-    # 34
+    # Fedora 34
     sudo wget https://download.opensuse.org/repositories/network:/idm/Fedora_34/network:idm.repo
+    # Fedora 35
+    sudo wget https://download.opensuse.org/repositories/network:/idm/Fedora_35/network:idm.repo
+    # Centos Stream 9
+    sudo wget https://download.opensuse.org/repositories/network:/idm/CentOS_9_Stream/network:idm.repo
 
 You can then install with:
 

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -1,14 +1,15 @@
 # Installing Client Tools
 
-> **NOTE** As this project is in a rapid development phase, running different release versions will likely present incompatibilities. Ensure you're running the same release version of client/server binaries (eg. 1.1.0-alpha5, released 2021-07-07)
+> **NOTE** As this project is in a rapid development phase, running different release versions will likely present incompatibilities. Ensure you're running matching release versions of client and server binaries.
 
 ## From packages
 
 Kanidm currently supports:
 
  * OpenSUSE Tumbleweed
- * OpenSUSE Leap 15.3
- * Fedora 33/34
+ * OpenSUSE Leap 15.3/15.4
+ * Fedora 34/35
+ * Centos Stream 9
 
 ### OpenSUSE Tumbleweed
 

--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -141,8 +141,10 @@ Each of these controls one of the four stages of PAM. The content should look li
 
     # /etc/pam.d/common-account-pc
     account    [default=1 ignore=ignore success=ok] pam_localuser.so
-    account    required    pam_unix.so
-    account    required    pam_kanidm.so ignore_unknown_user
+    account    sufficient  pam_unix.so
+    account    [default=1 ignore=ignore success=ok]  pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
+    account    sufficient    pam_kanidm.so ignore_unknown_user
+    account    pam_deny.so
 
     # /etc/pam.d/common-auth-pc
     auth        required      pam_env.so
@@ -153,17 +155,18 @@ Each of these controls one of the four stages of PAM. The content should look li
     auth        required      pam_deny.so
 
     # /etc/pam.d/common-password-pc
-    password    requisite   pam_pwquality.so
     password    [default=1 ignore=ignore success=ok] pam_localuser.so
     password    required    pam_unix.so use_authtok nullok shadow try_first_pass
+    password    [default=1 ignore=ignore success=ok]  pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
     password    required    pam_kanidm.so
 
     # /etc/pam.d/common-session-pc
     session optional    pam_systemd.so
     session required    pam_limits.so
     session optional    pam_unix.so try_first_pass
-    session optional    pam_kanidm.so
     session optional    pam_umask.so
+    session [default=1 ignore=ignore success=ok] pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
+    session optional    pam_kanidm.so
     session optional    pam_env.so
 
 > **WARNING:** Ensure that `pam_mkhomedir` or `pam_oddjobd` are *not* present in your 

--- a/kanidm_client/src/asynchronous.rs
+++ b/kanidm_client/src/asynchronous.rs
@@ -1363,7 +1363,7 @@ impl KanidmAsyncClient {
     }
 
     pub async fn idm_domain_reset_token_key(&self) -> Result<(), ClientError> {
-        self.perform_delete_request("/v1/domain/_attr/domain_token_key")
+        self.perform_delete_request("/v1/domain/_attr/es256_private_key_der")
             .await
     }
 

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -41,7 +41,7 @@ shellexpand = "2.0"
 rayon = "1.2"
 time = { version = "0.2", features = ["serde", "std"] }
 qrcode = { version = "0.12", default-features = false }
-bundy = "0.1"
+compact_jwt = "^0.2.0"
 
 zxcvbn = "2.0"
 

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -27,8 +27,7 @@ tide = "0.16"
 async-trait = "0.1"
 async-h1 = "2.0"
 fernet = { version = "^0.1.4", features = ["fernet_danger_timestamps"] }
-bundy = "^0.1.1"
-compact_jwt = "^0.1.7"
+compact_jwt = "^0.2.0"
 
 async-std = { version = "1.6", features = ["tokio1"] }
 

--- a/kanidmd/score/Cargo.toml
+++ b/kanidmd/score/Cargo.toml
@@ -28,12 +28,11 @@ tokio-openssl = "0.6"
 openssl = "0.10"
 ldap3_proto = "0.2.2"
 
-bundy = "^0.1.1"
-
 tracing = { version = "0.1", features = ["attributes"] }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
 async-std = { version = "1.6", features = ["tokio1"] }
+compact_jwt = "^0.2.0"
 
 [build-dependencies]
 profiles = { path = "../../profiles" }

--- a/kanidmd/score/src/lib.rs
+++ b/kanidmd/score/src/lib.rs
@@ -51,6 +51,7 @@ use kanidm::utils::{duration_from_epoch_now, touch_file_or_quit};
 use kanidm_proto::v1::OperationError;
 
 use async_std::task;
+use compact_jwt::JwsSigner;
 
 // === internal setup helpers
 
@@ -585,10 +586,10 @@ pub async fn create_server_core(config: Configuration, config_test: bool) -> Res
 
     // Extract any configuration from the IDMS that we may need.
     // For now we just do this per run, but we need to extract this from the db later.
-    let bundy_key = match bundy::hs512::HS512::generate_key() {
+    let jws_signer = match JwsSigner::generate_hs256() {
         Ok(k) => k,
         Err(e) => {
-            error!("Unable to setup bundy -> {:?}", e);
+            error!("Unable to setup jws signer -> {:?}", e);
             return Err(());
         }
     };
@@ -692,7 +693,7 @@ pub async fn create_server_core(config: Configuration, config_test: bool) -> Res
             config.tls_config.as_ref(),
             config.role,
             &cookie_key,
-            &bundy_key,
+            jws_signer,
             status_ref,
             server_write_ref,
             server_read_ref,

--- a/kanidmd/src/lib/constants/acp.rs
+++ b/kanidmd/src/lib/constants/acp.rs
@@ -954,11 +954,13 @@ pub const JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &str = r#"{
             "domain_name",
             "domain_ssid",
             "domain_uuid",
-            "domain_token_key"
+            "fernet_private_key_str",
+            "es256_private_key_der"
         ],
         "acp_modify_removedattr": [
             "domain_ssid",
-            "domain_token_key"
+            "fernet_private_key_str",
+            "es256_private_key_der"
         ],
         "acp_modify_presentattr": [
             "domain_ssid"

--- a/kanidmd/src/lib/constants/entries.rs
+++ b/kanidmd/src/lib/constants/entries.rs
@@ -402,7 +402,7 @@ pub const JSON_SYSTEM_INFO_V1: &str = r#"{
         "class": ["object", "system_info", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
         "description": ["System (local) info and metadata object."],
-        "version": ["5"]
+        "version": ["6"]
     }
 }"#;
 

--- a/kanidmd/src/lib/constants/schema.rs
+++ b/kanidmd/src/lib/constants/schema.rs
@@ -274,6 +274,7 @@ pub const JSON_SCHEMA_ATTR_DOMAIN_SSID: &str = r#"{
       ]
     }
 }"#;
+
 pub const JSON_SCHEMA_ATTR_DOMAIN_TOKEN_KEY: &str = r#"{
     "attrs": {
       "class": [
@@ -282,7 +283,7 @@ pub const JSON_SCHEMA_ATTR_DOMAIN_TOKEN_KEY: &str = r#"{
         "attributetype"
       ],
       "description": [
-        "The domains token signing key, which is shared between IDM servers."
+        "The domain token encryption private key (NOT USED)."
       ],
       "index": [],
       "unique": [
@@ -299,6 +300,35 @@ pub const JSON_SCHEMA_ATTR_DOMAIN_TOKEN_KEY: &str = r#"{
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000088"
+      ]
+    }
+}"#;
+
+pub const JSON_SCHEMA_ATTR_FERNET_PRIVATE_KEY_STR: &str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The token encryption private key."
+      ],
+      "index": [],
+      "unique": [
+        "false"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "fernet_private_key_str"
+      ],
+      "syntax": [
+        "SECRET_UTF8STRING"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000095"
       ]
     }
 }"#;
@@ -953,7 +983,8 @@ pub const JSON_SCHEMA_CLASS_DOMAIN_INFO: &str = r#"
         "name",
         "domain_uuid",
         "domain_name",
-        "domain_token_key"
+        "fernet_private_key_str",
+        "es256_private_key_der"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000052"

--- a/kanidmd/src/lib/constants/uuids.rs
+++ b/kanidmd/src/lib/constants/uuids.rs
@@ -160,6 +160,8 @@ pub const _UUID_SCHEMA_ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE: Uuid =
 pub const _UUID_SCHEMA_ATTR_RS256_PRIVATE_KEY_DER: Uuid =
     uuid!("00000000-0000-0000-0000-ffff00000093");
 pub const _UUID_SCHEMA_CLASS_ORGPERSON: Uuid = uuid!("00000000-0000-0000-0000-ffff00000094");
+pub const UUID_SCHEMA_ATTR_FERNET_PRIVATE_KEY_STR: Uuid =
+    uuid!("00000000-0000-0000-0000-ffff00000095");
 
 // System and domain infos
 // I'd like to strongly criticise william of the past for making poor choices about these allocations.

--- a/kanidmd/src/lib/credential/mod.rs
+++ b/kanidmd/src/lib/credential/mod.rs
@@ -269,7 +269,7 @@ pub struct Credential {
 }
 
 #[derive(Clone, Debug)]
-/// The typo of credential that is stored. Each of these represents a full set of 'what is required'
+/// The type of credential that is stored. Each of these represents a full set of 'what is required'
 /// to complete an authentication session. The reason to have these typed like this is so we can
 /// apply policy later to what classes or levels of credentials can be used. We use these types
 /// to also know what type of auth session handler to initiate.

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -427,8 +427,12 @@ impl Entry<EntryInit, EntryNew> {
                         }).collect();
                         vs.unwrap()
                     }
-                    "domain_token_key" => {
+                    "domain_token_key" | "fernet_private_key_str" => {
                         let vs: Option<ValueSet> = vs.into_iter().map(|v| Value::new_secret_str(&v)).collect();
+                        vs.unwrap()
+                    }
+                    "es256_private_key_der" => {
+                        let vs: Option<ValueSet> = vs.into_iter().map(|v| Value::new_privatebinary_base64(&v)).collect();
                         vs.unwrap()
                     }
                     ia => {

--- a/kanidmd/src/lib/idm/oauth2.rs
+++ b/kanidmd/src/lib/idm/oauth2.rs
@@ -1129,6 +1129,10 @@ impl Oauth2ResourceServersReadTransaction {
         let id_token_signing_alg_values_supported = match &o2rs.jws_signer {
             JwsSigner::ES256 { .. } => vec![IdTokenSignAlg::ES256],
             JwsSigner::RS256 { .. } => vec![IdTokenSignAlg::RS256],
+            JwsSigner::HS256 { .. } => {
+                admin_warn!("Invalid oauth2 configuration - HS256 is not supported!");
+                vec![]
+            }
         };
 
         let userinfo_signing_alg_values_supported = None;

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -23,7 +23,8 @@ lazy_static! {
         m.insert("may");
         // Allow modification of some domain info types for local configuration.
         m.insert("domain_ssid");
-        m.insert("domain_token_key");
+        m.insert("fernet_private_key_str");
+        m.insert("es256_private_key_der");
         m.insert("badlist_password");
         m
     };
@@ -193,10 +194,10 @@ mod tests {
             ],
             "acp_search_attr": ["name", "class", "uuid", "classname", "attributename"],
             "acp_modify_class": ["system", "domain_info"],
-            "acp_modify_removedattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid", "domain_token_key"],
-            "acp_modify_presentattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid", "domain_token_key"],
+            "acp_modify_removedattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid", "fernet_private_key_str", "es256_private_key_der"],
+            "acp_modify_presentattr": ["class", "displayname", "may", "must", "domain_name", "domain_uuid", "domain_ssid", "fernet_private_key_str", "es256_private_key_der"],
             "acp_create_class": ["object", "person", "system", "domain_info"],
-            "acp_create_attr": ["name", "class", "description", "displayname", "domain_name", "domain_uuid", "domain_ssid", "uuid", "domain_token_key"]
+            "acp_create_attr": ["name", "class", "description", "displayname", "domain_name", "domain_uuid", "domain_ssid", "uuid", "fernet_private_key_str", "es256_private_key_der"]
         }
     }"#;
 
@@ -330,7 +331,8 @@ mod tests {
                 "description": ["Demonstration of a remote domain's info being created for uuid generation"],
                 "domain_name": ["example.net.au"],
                 "domain_ssid": ["Example_Wifi"],
-                "domain_token_key": ["ABCD"]
+                "fernet_private_key_str": ["ABCD"],
+                "es256_private_key_der" : ["MTIz"]
             }
         }"#,
         );
@@ -368,7 +370,8 @@ mod tests {
                 "description": ["Demonstration of a remote domain's info being created for uuid generation"],
                 "domain_name": ["example.net.au"],
                 "domain_ssid": ["Example_Wifi"],
-                "domain_token_key": ["ABCD"]
+                "fernet_private_key_str": ["ABCD"],
+                "es256_private_key_der" : ["MTIz"]
             }
         }"#,
         );
@@ -397,7 +400,8 @@ mod tests {
                 "description": ["Demonstration of a remote domain's info being created for uuid generation"],
                 "domain_name": ["example.net.au"],
                 "domain_ssid": ["Example_Wifi"],
-                "domain_token_key": ["ABCD"]
+                "fernet_private_key_str": ["ABCD"],
+                "es256_private_key_der" : ["MTIz"]
             }
         }"#,
         );

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -1179,6 +1179,12 @@ impl Value {
         matches!(&self, Value::OauthScopeMap(_, _))
     }
 
+    #[cfg(test)]
+    pub fn new_privatebinary_base64(der: &str) -> Self {
+        let der = base64::decode(der).unwrap();
+        Value::PrivateBinary(der)
+    }
+
     pub fn new_privatebinary(der: &[u8]) -> Self {
         Value::PrivateBinary(der.to_owned())
     }


### PR DESCRIPTION
Prep work for #383 #170 #164. This revives our domain wide encryption token, adds a design doc, removes bundy in favour of our compact jwt lib since they are almost identical, and cleans up some other docs.

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ x ] design document included (if relevant)
