### PR TITLE
setting default log level of INFO when --debug is not set

### DIFF
--- a/kanidm_tools/src/cli/main.rs
+++ b/kanidm_tools/src/cli/main.rs
@@ -21,6 +21,8 @@ fn main() {
             "RUST_LOG",
             "kanidm=debug,kanidm_client=debug,webauthn=debug",
         );
+    } else {
+        ::std::env::set_var("RUST_LOG", "kanidm=INFO,kanidm_client=INFO,webauthn=INFO");
     }
     tracing_subscriber::fmt::init();
 


### PR DESCRIPTION
fixes #652 - previously when things like `info!("blah")` are run nothing's output by default, ref @cuberoot74088's [comment here](https://github.com/kanidm/kanidm/pull/591#issuecomment-1079779727)

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
