### PR TITLE
Cleanup display output

### DIFF
--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/badlist_preprocess.rs"
 kanidm_client = { path = "../kanidm_client", version = "1.1.0-alpha.4" }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha.4" }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 rpassword = "5.0"
 structopt = { version = "0.3", default-features = false }
 libc = "0.2"

--- a/kanidm_tools/src/cli/account.rs
+++ b/kanidm_tools/src/cli/account.rs
@@ -100,7 +100,7 @@ impl AccountOpt {
                             );
                         }
                         Err(e) => {
-                            eprintln!("Error -> {:?}", e);
+                            error!("Error -> {:?}", e);
                         }
                     }
                 }
@@ -114,7 +114,7 @@ impl AccountOpt {
                         ) {
                         Ok(v) => v,
                         Err(e) => {
-                            eprintln!("Error Starting Registration -> {:?}", e);
+                            error!("Error Starting Registration -> {:?}", e);
                             return;
                         }
                     };
@@ -126,7 +126,7 @@ impl AccountOpt {
                     let rego = match wa.do_registration(client.get_origin(), chal) {
                         Ok(rego) => rego,
                         Err(e) => {
-                            eprintln!("Error Signing -> {:?}", e);
+                            error!("Error Signing -> {:?}", e);
                             return;
                         }
                     };
@@ -140,7 +140,7 @@ impl AccountOpt {
                             println!("Webauthn token registration success.");
                         }
                         Err(e) => {
-                            eprintln!("Error Completing -> {:?}", e);
+                            error!("Error Completing -> {:?}", e);
                         }
                     }
                 }
@@ -154,7 +154,7 @@ impl AccountOpt {
                             println!("Webauthn removal success.");
                         }
                         Err(e) => {
-                            eprintln!("Error Removing Webauthn from account -> {:?}", e);
+                            error!("Error Removing Webauthn from account -> {:?}", e);
                         }
                     }
                 }
@@ -165,7 +165,7 @@ impl AccountOpt {
                     ) {
                         Ok(v) => v,
                         Err(e) => {
-                            eprintln!("Error Starting Registration -> {:?}", e);
+                            error!("Error Starting Registration -> {:?}", e);
                             return;
                         }
                     };
@@ -176,7 +176,7 @@ impl AccountOpt {
                     let code = match QrCode::new(tok.to_uri().as_str()) {
                         Ok(c) => c,
                         Err(e) => {
-                            eprintln!("Failed to generate QR code -> {:?}", e);
+                            error!("Failed to generate QR code -> {:?}", e);
                             return;
                         }
                     };
@@ -206,7 +206,7 @@ impl AccountOpt {
                         // Finish the line?
                         eprintln!();
                         if let Err(e) = input_result {
-                            eprintln!("Failed to read from stdin -> {:?}", e);
+                            error!("Failed to read from stdin -> {:?}", e);
                             break;
                         };
 
@@ -214,7 +214,7 @@ impl AccountOpt {
                         let totp = match totp_input.trim().parse::<u32>() {
                             Ok(v) => v,
                             Err(e) => {
-                                eprintln!("Invalid TOTP -> {:?}", e);
+                                error!("Invalid TOTP -> {:?}", e);
                                 // Try again.
                                 continue;
                             }
@@ -238,7 +238,7 @@ impl AccountOpt {
 
                                 let mut confirm_input = String::new();
                                 if let Err(e) = io::stdin().read_line(&mut confirm_input) {
-                                    eprintln!("Failed to read from stdin -> {:?}", e);
+                                    error!("Failed to read from stdin -> {:?}", e);
                                 };
 
                                 if confirm_input.to_lowercase().trim() == "i am sure" {
@@ -250,7 +250,7 @@ impl AccountOpt {
                                             println!("TOTP registration success.");
                                         }
                                         Err(e) => {
-                                            eprintln!("Error Completing -> {:?}", e);
+                                            error!("Error Completing -> {:?}", e);
                                         }
                                     };
                                 } else {
@@ -264,7 +264,7 @@ impl AccountOpt {
                                 continue;
                             }
                             Err(e) => {
-                                eprintln!("Error Completing -> {:?}", e);
+                                error!("Error Completing -> {:?}", e);
                                 break;
                             }
                         }
@@ -279,7 +279,7 @@ impl AccountOpt {
                             println!("TOTP removal success.");
                         }
                         Err(e) => {
-                            eprintln!("Error Removing TOTP from account -> {:?}", e);
+                            error!("Error Removing TOTP from account -> {:?}", e);
                         }
                     }
                 }
@@ -295,7 +295,7 @@ impl AccountOpt {
                             println!("---");
                         }
                         Err(e) => {
-                            eprintln!("Error generating Backup Codes for account -> {:?}", e);
+                            error!("Error generating Backup Codes for account -> {:?}", e);
                         }
                     }
                 }
@@ -308,7 +308,7 @@ impl AccountOpt {
                             println!("BackupCodeRemove success.");
                         }
                         Err(e) => {
-                            eprintln!("Error BackupCodeRemove for account -> {:?}", e);
+                            error!("Error BackupCodeRemove for account -> {:?}", e);
                         }
                     }
                 }
@@ -320,7 +320,7 @@ impl AccountOpt {
                             print!("{}", status);
                         }
                         Err(e) => {
-                            eprintln!("Error displaying credential status -> {:?}", e);
+                            error!("Error displaying credential status -> {:?}", e);
                         }
                     }
                 }
@@ -336,7 +336,7 @@ impl AccountOpt {
                         Ok(Some(s)) => println!("Radius secret: {}", s),
                         Ok(None) => println!("NO Radius secret"),
                         Err(e) => {
-                            eprintln!("Error -> {:?}", e);
+                            error!("Error -> {:?}", e);
                         }
                     }
                 }
@@ -345,7 +345,7 @@ impl AccountOpt {
                     if let Err(e) = client
                         .idm_account_radius_credential_regenerate(aopt.aopts.account_id.as_str())
                     {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
                 AccountRadius::Delete(aopt) => {
@@ -353,7 +353,7 @@ impl AccountOpt {
                     if let Err(e) =
                         client.idm_account_radius_credential_delete(aopt.aopts.account_id.as_str())
                     {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
             }, // end AccountOpt::Radius
@@ -363,7 +363,7 @@ impl AccountOpt {
                     match client.idm_account_unix_token_get(aopt.aopts.account_id.as_str()) {
                         Ok(token) => println!("{}", token),
                         Err(e) => {
-                            eprintln!("Error -> {:?}", e);
+                            error!("Error -> {:?}", e);
                         }
                     }
                 }
@@ -374,7 +374,7 @@ impl AccountOpt {
                         aopt.gidnumber,
                         aopt.shell.as_deref(),
                     ) {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
                 AccountPosix::SetPassword(aopt) => {
@@ -391,7 +391,7 @@ impl AccountOpt {
                         aopt.aopts.account_id.as_str(),
                         password.as_str(),
                     ) {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
             }, // end AccountOpt::Posix
@@ -403,7 +403,7 @@ impl AccountOpt {
                         aopt.mail.as_deref(),
                         aopt.legalname.as_deref(),
                     ) {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
             }, // end AccountOpt::Person
@@ -414,7 +414,7 @@ impl AccountOpt {
                     match client.idm_account_get_ssh_pubkeys(aopt.aopts.account_id.as_str()) {
                         Ok(pkeys) => pkeys.iter().for_each(|pkey| println!("{}", pkey)),
                         Err(e) => {
-                            eprintln!("Error -> {:?}", e);
+                            error!("Error -> {:?}", e);
                         }
                     }
                 }
@@ -425,7 +425,7 @@ impl AccountOpt {
                         aopt.tag.as_str(),
                         aopt.pubkey.as_str(),
                     ) {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
                 AccountSsh::Delete(aopt) => {
@@ -434,7 +434,7 @@ impl AccountOpt {
                         aopt.aopts.account_id.as_str(),
                         aopt.tag.as_str(),
                     ) {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
             }, // end AccountOpt::Ssh
@@ -442,7 +442,7 @@ impl AccountOpt {
                 let client = copt.to_client();
                 match client.idm_account_list() {
                     Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             AccountOpt::Get(aopt) => {
@@ -450,13 +450,13 @@ impl AccountOpt {
                 match client.idm_account_get(aopt.aopts.account_id.as_str()) {
                     Ok(Some(e)) => println!("{}", e),
                     Ok(None) => println!("No matching entries"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             AccountOpt::Delete(aopt) => {
                 let client = aopt.copt.to_client();
                 if let Err(e) = client.idm_account_delete(aopt.aopts.account_id.as_str()) {
-                    eprintln!("Error -> {:?}", e)
+                    error!("Error -> {:?}", e)
                 }
             }
             AccountOpt::Create(acopt) => {
@@ -465,7 +465,7 @@ impl AccountOpt {
                     acopt.aopts.account_id.as_str(),
                     acopt.display_name.as_str(),
                 ) {
-                    eprintln!("Error -> {:?}", e)
+                    error!("Error -> {:?}", e)
                 }
             }
             AccountOpt::Validity(avopt) => match avopt {
@@ -517,7 +517,7 @@ impl AccountOpt {
                                 println!("expire: never");
                             }
                         }
-                        Err(e) => eprintln!("Error -> {:?}", e),
+                        Err(e) => error!("Error -> {:?}", e),
                     }
                 }
                 AccountValidity::ExpireAt(ano) => {
@@ -527,14 +527,14 @@ impl AccountOpt {
                         match client
                             .idm_account_purge_attr(ano.aopts.account_id.as_str(), "account_expire")
                         {
-                            Err(e) => eprintln!("Error -> {:?}", e),
+                            Err(e) => error!("Error -> {:?}", e),
                             _ => println!("Success"),
                         }
                     } else {
                         if let Err(e) =
                             OffsetDateTime::parse(ano.datetime.as_str(), time::Format::Rfc3339)
                         {
-                            eprintln!("Error -> {:?}", e);
+                            error!("Error -> {:?}", e);
                             return;
                         }
 
@@ -543,7 +543,7 @@ impl AccountOpt {
                             "account_expire",
                             &[ano.datetime.as_str()],
                         ) {
-                            Err(e) => eprintln!("Error -> {:?}", e),
+                            Err(e) => error!("Error -> {:?}", e),
                             _ => println!("Success"),
                         }
                     }
@@ -556,7 +556,7 @@ impl AccountOpt {
                             ano.aopts.account_id.as_str(),
                             "account_valid_from",
                         ) {
-                            Err(e) => eprintln!("Error -> {:?}", e),
+                            Err(e) => error!("Error -> {:?}", e),
                             _ => println!("Success"),
                         }
                     } else {
@@ -564,7 +564,7 @@ impl AccountOpt {
                         if let Err(e) =
                             OffsetDateTime::parse(ano.datetime.as_str(), time::Format::Rfc3339)
                         {
-                            eprintln!("Error -> {:?}", e);
+                            error!("Error -> {:?}", e);
                             return;
                         }
 
@@ -573,7 +573,7 @@ impl AccountOpt {
                             "account_valid_from",
                             &[ano.datetime.as_str()],
                         ) {
-                            Err(e) => eprintln!("Error -> {:?}", e),
+                            Err(e) => error!("Error -> {:?}", e),
                             _ => println!("Success"),
                         }
                     }

--- a/kanidm_tools/src/cli/common.rs
+++ b/kanidm_tools/src/cli/common.rs
@@ -87,7 +87,7 @@ impl CommonOpt {
                     match prompt_for_username_get_token() {
                         Ok(value) => value,
                         Err(msg) => {
-                            eprintln!("{}", msg);
+                            error!("{}", msg);
                             std::process::exit(1);
                         }
                     }
@@ -98,7 +98,7 @@ impl CommonOpt {
         let jwtu = match JwsUnverified::from_str(&token) {
             Ok(jwtu) => jwtu,
             Err(e) => {
-                eprintln!("Unable to parse token - {:?}", e);
+                error!("Unable to parse token - {:?}", e);
                 std::process::exit(1);
             }
         };
@@ -139,7 +139,7 @@ pub fn prompt_for_username_get_values() -> Result<(String, String), String> {
         _ => return Err("Error retrieving authentication token store".to_string()),
     };
     if tokens.is_empty() {
-        eprintln!("No tokens in store, quitting!");
+        error!("No tokens in store, quitting!");
         std::process::exit(1);
     }
     let mut options = Vec::new();
@@ -153,7 +153,7 @@ pub fn prompt_for_username_get_values() -> Result<(String, String), String> {
         .interact();
     let selection = match user_select {
         Err(error) => {
-            eprintln!("Failed to handle user input: {:?}", error);
+            error!("Failed to handle user input: {:?}", error);
             std::process::exit(1);
         }
         Ok(value) => value,
@@ -168,7 +168,7 @@ pub fn prompt_for_username_get_values() -> Result<(String, String), String> {
             Ok((f_uname.to_string(), f_token.to_string()))
         }
         None => {
-            eprintln!("Memory corruption trying to read token store, quitting!");
+            error!("Memory corruption trying to read token store, quitting!");
             std::process::exit(1);
         }
     }

--- a/kanidm_tools/src/cli/domain.rs
+++ b/kanidm_tools/src/cli/domain.rs
@@ -13,14 +13,14 @@ impl DomainOpt {
                 let client = copt.to_client();
                 match client.idm_domain_get() {
                     Ok(e) => println!("{}", e),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             DomainOpt::ResetTokenKey(copt) => {
                 let client = copt.to_client();
                 match client.idm_domain_reset_token_key() {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
         }

--- a/kanidm_tools/src/cli/group.rs
+++ b/kanidm_tools/src/cli/group.rs
@@ -24,7 +24,7 @@ impl GroupOpt {
             GroupOpt::List(copt) => {
                 let client = copt.to_client();
                 match client.idm_group_list() {
-                    Ok(r) => r.iter().for_each(|ent| info!("{}", ent)),
+                    Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
                     Err(e) => error!("Error -> {:?}", e),
                 }
             }
@@ -32,8 +32,8 @@ impl GroupOpt {
                 let client = gcopt.copt.to_client();
                 // idm_group_get
                 match client.idm_group_get(gcopt.name.as_str()) {
-                    Ok(Some(e)) => info!("{}", e),
-                    Ok(None) => info!("No matching group '{}'", gcopt.name.as_str()),
+                    Ok(Some(e)) => println!("{}", e),
+                    Ok(None) => warn!("No matching group '{}'", gcopt.name.as_str()),
                     Err(e) => error!("Error -> {:?}", e),
                 }
             }
@@ -41,21 +41,21 @@ impl GroupOpt {
                 let client = gcopt.copt.to_client();
                 match client.idm_group_create(gcopt.name.as_str()) {
                     Err(e) => error!("Error -> {:?}", e),
-                    Ok(_) => info!("Successfully created group '{}'", gcopt.name.as_str()),
+                    Ok(_) => println!("Successfully created group '{}'", gcopt.name.as_str()),
                 }
             }
             GroupOpt::Delete(gcopt) => {
                 let client = gcopt.copt.to_client();
                 match client.idm_group_delete(gcopt.name.as_str()) {
                     Err(e) => error!("Error -> {:?}", e),
-                    Ok(_) => info!("Successfully deleted group {}", gcopt.name.as_str()),
+                    Ok(_) => println!("Successfully deleted group {}", gcopt.name.as_str()),
                 }
             }
             GroupOpt::PurgeMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
                 match client.idm_group_purge_members(gcopt.name.as_str()) {
                     Err(e) => error!("Error -> {:?}", e),
-                    Ok(_) => info!(
+                    Ok(_) => println!(
                         "Successfully purged members of group {}",
                         gcopt.name.as_str()
                     ),
@@ -64,8 +64,8 @@ impl GroupOpt {
             GroupOpt::ListMembers(gcopt) => {
                 let client = gcopt.copt.to_client();
                 match client.idm_group_get_members(gcopt.name.as_str()) {
-                    Ok(Some(groups)) => groups.iter().for_each(|m| info!("{:?}", m)),
-                    Ok(None) => info!("No members in group {}", gcopt.name.as_str()),
+                    Ok(Some(groups)) => groups.iter().for_each(|m| println!("{:?}", m)),
+                    Ok(None) => warn!("No members in group {}", gcopt.name.as_str()),
                     Err(e) => error!("Error -> {:?}", e),
                 }
             }
@@ -75,7 +75,7 @@ impl GroupOpt {
 
                 match client.idm_group_add_members(gcopt.name.as_str(), &new_members) {
                     Err(e) => error!("Error -> {:?}", e),
-                    Ok(_) => info!("Successfully added members to {}", gcopt.name.as_str()),
+                    Ok(_) => warn!("Successfully added members to {}", gcopt.name.as_str()),
                 }
             }
 
@@ -85,7 +85,7 @@ impl GroupOpt {
 
                 match client.idm_group_remove_members(gcopt.name.as_str(), &remove_members) {
                     Err(e) => error!("Failed to remove members -> {:?}", e),
-                    Ok(_) => info!("Successfully removed members from {}", gcopt.name.as_str()),
+                    Ok(_) => println!("Successfully removed members from {}", gcopt.name.as_str()),
                 }
             }
 
@@ -95,14 +95,14 @@ impl GroupOpt {
 
                 match client.idm_group_set_members(gcopt.name.as_str(), &new_members) {
                     Err(e) => error!("Error -> {:?}", e),
-                    Ok(_) => info!("Successfully set members for group {}", gcopt.name.as_str()),
+                    Ok(_) => println!("Successfully set members for group {}", gcopt.name.as_str()),
                 }
             }
             GroupOpt::Posix(gpopt) => match gpopt {
                 GroupPosix::Show(gcopt) => {
                     let client = gcopt.copt.to_client();
                     match client.idm_group_unix_token_get(gcopt.name.as_str()) {
-                        Ok(token) => info!("{}", token),
+                        Ok(token) => println!("{}", token),
                         Err(e) => error!("Error -> {:?}", e),
                     }
                 }
@@ -110,7 +110,7 @@ impl GroupOpt {
                     let client = gcopt.copt.to_client();
                     match client.idm_group_unix_extend(gcopt.name.as_str(), gcopt.gidnumber) {
                         Err(e) => error!("Error -> {:?}", e),
-                        Ok(_) => info!(
+                        Ok(_) => println!(
                             "Success adding POSIX configuration for group {}",
                             gcopt.name.as_str()
                         ),

--- a/kanidm_tools/src/cli/oauth2.rs
+++ b/kanidm_tools/src/cli/oauth2.rs
@@ -24,7 +24,7 @@ impl Oauth2Opt {
                 let client = copt.to_client();
                 match client.idm_oauth2_rs_list() {
                     Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::Get(nopt) => {
@@ -32,7 +32,7 @@ impl Oauth2Opt {
                 match client.idm_oauth2_rs_get(nopt.name.as_str()) {
                     Ok(Some(e)) => println!("{}", e),
                     Ok(None) => println!("No matching entries"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::CreateBasic(cbopt) => {
@@ -43,7 +43,7 @@ impl Oauth2Opt {
                     cbopt.origin.as_str(),
                 ) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::SetImplictScopes(cbopt) => {
@@ -59,7 +59,7 @@ impl Oauth2Opt {
                     false,
                 ) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::CreateScopeMap(cbopt) => {
@@ -70,7 +70,7 @@ impl Oauth2Opt {
                     cbopt.scopes.iter().map(|s| s.as_str()).collect(),
                 ) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::DeleteScopeMap(cbopt) => {
@@ -79,7 +79,7 @@ impl Oauth2Opt {
                     .idm_oauth2_rs_delete_scope_map(cbopt.nopt.name.as_str(), cbopt.group.as_str())
                 {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::ResetSecrets(cbopt) => {
@@ -95,42 +95,42 @@ impl Oauth2Opt {
                     true,
                 ) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::Delete(nopt) => {
                 let client = nopt.copt.to_client();
                 match client.idm_oauth2_rs_delete(nopt.name.as_str()) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::EnablePkce(nopt) => {
                 let client = nopt.copt.to_client();
                 match client.idm_oauth2_rs_enable_pkce(nopt.name.as_str()) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::DisablePkce(nopt) => {
                 let client = nopt.copt.to_client();
                 match client.idm_oauth2_rs_disable_pkce(nopt.name.as_str()) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::EnableLegacyCrypto(nopt) => {
                 let client = nopt.copt.to_client();
                 match client.idm_oauth2_rs_enable_legacy_crypto(nopt.name.as_str()) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             Oauth2Opt::DisableLegacyCrypto(nopt) => {
                 let client = nopt.copt.to_client();
                 match client.idm_oauth2_rs_disable_legacy_crypto(nopt.name.as_str()) {
                     Ok(_) => println!("Success"),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
         }

--- a/kanidm_tools/src/cli/raw.rs
+++ b/kanidm_tools/src/cli/raw.rs
@@ -34,14 +34,14 @@ impl RawOpt {
                 let filter: Filter = match serde_json::from_str(sopt.filter.as_str()) {
                     Ok(f) => f,
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                         return;
                     }
                 };
 
                 match client.search(filter) {
                     Ok(rset) => rset.iter().for_each(|e| println!("{}", e)),
-                    Err(e) => eprintln!("Error -> {:?}", e),
+                    Err(e) => error!("Error -> {:?}", e),
                 }
             }
             RawOpt::Create(copt) => {
@@ -50,7 +50,7 @@ impl RawOpt {
                 let r_entries: Vec<BTreeMap<String, Vec<String>>> = match read_file(&copt.file) {
                     Ok(r) => r,
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                         return;
                     }
                 };
@@ -58,7 +58,7 @@ impl RawOpt {
                 let entries = r_entries.into_iter().map(|b| Entry { attrs: b }).collect();
 
                 if let Err(e) = client.create(entries) {
-                    eprintln!("Error -> {:?}", e);
+                    error!("Error -> {:?}", e);
                 }
             }
             RawOpt::Modify(mopt) => {
@@ -67,7 +67,7 @@ impl RawOpt {
                 let filter: Filter = match serde_json::from_str(mopt.filter.as_str()) {
                     Ok(f) => f,
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                         return;
                     }
                 };
@@ -75,14 +75,14 @@ impl RawOpt {
                 let r_list: Vec<Modify> = match read_file(&mopt.file) {
                     Ok(r) => r,
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                         return;
                     }
                 };
 
                 let modlist = ModifyList::new_list(r_list);
                 if let Err(e) = client.modify(filter, modlist) {
-                    eprintln!("Error -> {:?}", e);
+                    error!("Error -> {:?}", e);
                 }
             }
             RawOpt::Delete(dopt) => {
@@ -90,13 +90,13 @@ impl RawOpt {
                 let filter: Filter = match serde_json::from_str(dopt.filter.as_str()) {
                     Ok(f) => f,
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                         return;
                     }
                 };
 
                 if let Err(e) = client.delete(filter) {
-                    eprintln!("Error -> {:?}", e);
+                    error!("Error -> {:?}", e);
                 }
             }
         }

--- a/kanidm_tools/src/cli/recycle.rs
+++ b/kanidm_tools/src/cli/recycle.rs
@@ -16,7 +16,7 @@ impl RecycleOpt {
                 match client.recycle_bin_list() {
                     Ok(r) => r.iter().for_each(|e| println!("{}", e)),
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
             }
@@ -26,14 +26,14 @@ impl RecycleOpt {
                     Ok(Some(e)) => println!("{}", e),
                     Ok(None) => println!("No matching entries"),
                     Err(e) => {
-                        eprintln!("Error -> {:?}", e);
+                        error!("Error -> {:?}", e);
                     }
                 }
             }
             RecycleOpt::Revive(nopt) => {
                 let client = nopt.copt.to_client();
                 if let Err(e) = client.recycle_bin_revive(nopt.name.as_str()) {
-                    eprintln!("Error -> {:?}", e);
+                    error!("Error -> {:?}", e);
                 }
             }
         }

--- a/kanidm_tools/src/cli/session.rs
+++ b/kanidm_tools/src/cli/session.rs
@@ -127,7 +127,7 @@ fn get_index_choice_dialoguer(msg: &str, options: &[String]) -> usize {
 
     let selection = match user_select {
         Err(error) => {
-            eprintln!("Failed to handle user input: {:?}", error);
+            error!("Failed to handle user input: {:?}", error);
             std::process::exit(1);
         }
         Ok(value) => value,
@@ -158,7 +158,7 @@ impl LoginOpt {
         let mut backup_code = String::new();
         loop {
             if let Err(e) = io::stdin().read_line(&mut backup_code) {
-                eprintln!("Failed to read from stdin -> {:?}", e);
+                error!("Failed to read from stdin -> {:?}", e);
                 return Err(ClientError::SystemError);
             };
             if !backup_code.trim().is_empty() {
@@ -173,11 +173,11 @@ impl LoginOpt {
             print!("Enter TOTP: ");
             // We flush stdout so it'll write the buffer to screen, continuing operation. Without it, the application halts.
             if let Err(e) = io::stdout().flush() {
-                eprintln!("Somehow we failed to flush stdout: {:?}", e);
+                error!("Somehow we failed to flush stdout: {:?}", e);
             };
             let mut buffer = String::new();
             if let Err(e) = io::stdin().read_line(&mut buffer) {
-                eprintln!("Failed to read from stdin -> {:?}", e);
+                error!("Failed to read from stdin -> {:?}", e);
                 return Err(ClientError::SystemError);
             };
 
@@ -360,7 +360,7 @@ impl LogoutOpt {
                 _tmp_username = match prompt_for_username_get_username() {
                     Ok(value) => value,
                     Err(msg) => {
-                        eprintln!("{}", msg);
+                        error!("{}", msg);
                         std::process::exit(1);
                     }
                 };
@@ -379,9 +379,9 @@ impl LogoutOpt {
                 error!("Error persisting authentication token store");
                 std::process::exit(1);
             };
-            info!("Removed session for {}", username);
+            println!("Removed session for {}", username);
         } else {
-            info!("No sessions for {}", username);
+            println!("No sessions for {}", username);
         }
     }
 }


### PR DESCRIPTION
Fixes #652 - this cleans up how we setup the tracing log levels initially, and seperates user information with println/eprintln, and our logging. This way we can have user defined log levels via the env, and by default we can split things by stdout/stderr. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
