### PR TITLE
Improve description of how the suse pam files work

### DIFF
--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -128,25 +128,29 @@ PAM config in a way that will cause you to be unable to authenticate to your mac
 
     cp -a /etc/pam.d /root/pam.d.backup
 
-### SUSE
+### SUSE / OpenSUSE
 
-To configure PAM on suse you must module four files:
+To configure PAM on suse you must modify four files, which control the various stages of authentication.
 
     /etc/pam.d/common-account
     /etc/pam.d/common-auth
     /etc/pam.d/common-password
     /etc/pam.d/common-session
 
-Each of these controls one of the four stages of PAM. The content should look like:
+> **IMPORTANT** By default these files are symlinks to their corresponding `-pc` file, for example
+> `common-account -> common-account-pc`. If you directly edit these you are updating the inner
+> content of the `-pc` file and it WILL be reset on a future upgrade. To prevent this you must
+> first copy the `-pc` files. You can then edit the files safely.
 
-    # /etc/pam.d/common-account-pc
-    account    [default=1 ignore=ignore success=ok] pam_localuser.so
-    account    sufficient  pam_unix.so
-    account    [default=1 ignore=ignore success=ok]  pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
-    account    sufficient    pam_kanidm.so ignore_unknown_user
-    account    pam_deny.so
+    cp /etc/pam.d/common-account-pc  /etc/pam.d/common-account
+    cp /etc/pam.d/common-auth-pc     /etc/pam.d/common-auth
+    cp /etc/pam.d/common-password-pc /etc/pam.d/common-password
+    cp /etc/pam.d/common-session-pc  /etc/pam.d/common-session
+
+The content should look like:
 
     # /etc/pam.d/common-auth-pc
+    # Controls authentication to this system (verification of credentials)
     auth        required      pam_env.so
     auth        [default=1 ignore=ignore success=ok] pam_localuser.so
     auth        sufficient    pam_unix.so nullok try_first_pass
@@ -154,13 +158,25 @@ Each of these controls one of the four stages of PAM. The content should look li
     auth        sufficient    pam_kanidm.so ignore_unknown_user
     auth        required      pam_deny.so
 
+    # /etc/pam.d/common-account-pc
+    # Controls authorisation to this system (who may login)
+    account    [default=1 ignore=ignore success=ok] pam_localuser.so
+    account    sufficient  pam_unix.so
+    account    [default=1 ignore=ignore success=ok]  pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
+    account    sufficient    pam_kanidm.so ignore_unknown_user
+    account    pam_deny.so
+
     # /etc/pam.d/common-password-pc
+    # Controls flow of what happens when a user invokes the passwd command. Currently does NOT
+    # interact with kanidm.
     password    [default=1 ignore=ignore success=ok] pam_localuser.so
     password    required    pam_unix.so use_authtok nullok shadow try_first_pass
     password    [default=1 ignore=ignore success=ok]  pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
     password    required    pam_kanidm.so
 
     # /etc/pam.d/common-session-pc
+    # Controls setup of the user session once a successful authentication and authorisation has
+    # occured.
     session optional    pam_systemd.so
     session required    pam_limits.so
     session optional    pam_unix.so try_first_pass
@@ -169,10 +185,10 @@ Each of these controls one of the four stages of PAM. The content should look li
     session optional    pam_kanidm.so
     session optional    pam_env.so
 
-> **WARNING:** Ensure that `pam_mkhomedir` or `pam_oddjobd` are *not* present in your 
+> **WARNING:** Ensure that `pam_mkhomedir` or `pam_oddjobd` are *not* present in any stage of your
 > pam configuration, as they interfere with the correct operation of the kanidm tasks daemon.
 
-### Fedora 33
+### Fedora / CentOS
 
 > **WARNING:** Kanidm currently has no support for SELinux policy - this may mean you need to
 > run the daemon with permissive mode for the unconfined_service_t daemon type. To do this run:


### PR DESCRIPTION
Fixes #662 - It was reported by @vdorst that the pam config was being reset. Apparently I had forgotten to document this quirk of suse pam-config. This has been fixed in the examples. 

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
