### PR TITLE
Use pkg-config to link against pam

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,9 +14,9 @@
 * Samuel Cabrero (scabrero)
 * Victor Wai (vcwai)
 * James Hodgkinson (yaleman)
+* Euan Kemp (euank)
 
 ## Acknowledgements
 
 * M. Gerstner
 * Perri Boulton
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,6 +2528,7 @@ version = "1.1.0-alpha.7"
 dependencies = [
  "kanidm_unix_int",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2675,9 +2676,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"

--- a/kanidm_unix_int/pam_kanidm/Cargo.toml
+++ b/kanidm_unix_int/pam_kanidm/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.1.0-alpha.7"
 authors = ["William Brown <william@blackhats.net.au>"]
 rust-version = "1.59"
 edition = "2021"
+links = "pam"
 
 [lib]
 name = "pam_kanidm"
@@ -13,3 +14,6 @@ path =  "src/lib.rs"
 [dependencies]
 kanidm_unix_int = { path = "../", version = "1.1.0-alpha" }
 libc = "0.2"
+
+[build-dependencies]
+pkg-config = "0.3.25"

--- a/kanidm_unix_int/pam_kanidm/build.rs
+++ b/kanidm_unix_int/pam_kanidm/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // ignore errors here since older versions of pam do not ship the pkg-config `pam.pc` file.
+    // Not setting anything here will fall back on just blindly linking with `-lpam`,
+    // which will work on environments with libpam.so, but no pkg-config file.
+    let _ = pkg_config::Config::new()
+        .atleast_version("1.3.0")
+        .probe("pam");
+}


### PR DESCRIPTION
Some distros, such as nixos, require more than just '-lpam' to locate
the library. Adding a naive pkg-config invocation to the pam FFI
crate allows pam_kanidm to build on my system, where before this change it did not.



- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] ~book chapter included (if relevant)~ not relevant
- [ ] ~design document included (if relevant)~ not relevant
