### PR TITLE
Display errors when cli operations fail

### DIFF
--- a/kanidm_tools/src/cli/main.rs
+++ b/kanidm_tools/src/cli/main.rs
@@ -22,7 +22,8 @@ fn main() {
     let fmt_layer = fmt::layer().with_writer(std::io::stderr);
 
     let filter_layer = if opt.debug() {
-        match EnvFilter::try_new("kanidm=debug,kanidm_client=debug,webauthn=debug") {
+        match EnvFilter::try_new("kanidm=debug,kanidm_client=debug,webauthn=debug,kanidm_cli=debug")
+        {
             Ok(f) => f,
             Err(e) => {
                 eprintln!("ERROR! Unable to start tracing {:?}", e);
@@ -32,7 +33,7 @@ fn main() {
     } else {
         match EnvFilter::try_from_default_env() {
             Ok(f) => f,
-            Err(_) => EnvFilter::new("kanidm_client=warn"),
+            Err(_) => EnvFilter::new("kanidm_client=warn,kanidm_cli=warn"),
         }
     };
 


### PR DESCRIPTION
```
# before this change
$ kanidm account delete does-not-exist -D admin
$ # no output; exit status 0

# after this change
$ kanidm account delete does-not-exist -D admin                                                                                                                                        5s
2022-04-01T21:34:51.857904Z ERROR kanidm_cli::account: Error -> Http(404, Some(NoMatchingEntries), "32a34959-2cc9-449e-b9c3-dff8d30a736b")
```

This fixes a regression, introduced in #659, in the CLI's default output.
Since 404 & 403 errors don't trigger any logs further down the stack,
they'd exit eerily silently with the default cli loglevel.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] ~book chapter included (if relevant)~ not relevant
- [ ] ~design document included (if relevant)~ not relevant
