### PR TITLE
Add "oauth2 set_displayname" commad

### DIFF
--- a/kanidm_tools/src/cli/oauth2.rs
+++ b/kanidm_tools/src/cli/oauth2.rs
@@ -11,6 +11,7 @@ impl Oauth2Opt {
             Oauth2Opt::DeleteScopeMap(cbopt) => cbopt.nopt.copt.debug,
             Oauth2Opt::ResetSecrets(cbopt) => cbopt.copt.debug,
             Oauth2Opt::Delete(nopt) => nopt.copt.debug,
+            Oauth2Opt::SetDisplayname(cbopt) => cbopt.nopt.copt.debug,
             Oauth2Opt::EnablePkce(nopt) => nopt.copt.debug,
             Oauth2Opt::DisablePkce(nopt) => nopt.copt.debug,
             Oauth2Opt::EnableLegacyCrypto(nopt) => nopt.copt.debug,
@@ -101,6 +102,22 @@ impl Oauth2Opt {
             Oauth2Opt::Delete(nopt) => {
                 let client = nopt.copt.to_client();
                 match client.idm_oauth2_rs_delete(nopt.name.as_str()) {
+                    Ok(_) => println!("Success"),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+            Oauth2Opt::SetDisplayname(cbopt) => {
+                let client = cbopt.nopt.copt.to_client();
+                match client.idm_oauth2_rs_update(
+                    cbopt.nopt.name.as_str(),
+                    None,
+                    Some(&cbopt.displayname.as_str()),
+                    None,
+                    None,
+                    false,
+                    false,
+                    false,
+                ) {
                     Ok(_) => println!("Success"),
                     Err(e) => error!("Error -> {:?}", e),
                 }

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -385,6 +385,14 @@ pub struct Oauth2BasicCreateOpt {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct Oauth2SetDisplayname {
+    #[structopt(flatten)]
+    nopt: Named,
+    #[structopt(name = "displayname")]
+    displayname: String,
+}
+
+#[derive(Debug, StructOpt)]
 pub struct Oauth2SetImplicitScopes {
     #[structopt(flatten)]
     nopt: Named,
@@ -439,6 +447,9 @@ pub enum Oauth2Opt {
     #[structopt(name = "delete")]
     /// Delete a oauth2 resource server
     Delete(Named),
+    /// Set a new displayname for a resource server
+    #[structopt(name = "set_displayname")]
+    SetDisplayname(Oauth2SetDisplayname),
     #[structopt(name = "enable_pkce")]
     /// Enable PKCE on this oauth2 resource server. This defaults to being enabled.
     EnablePkce(Named),


### PR DESCRIPTION
This allows to update the displayname on an existing resource server.

Let me know if I should add or rework something.

Fixes #669 

- [X] cargo fmt has been run
- [-] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
