### PR TITLE
Docs updates to push all tagged versions + dev

### DIFF
--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -38,7 +38,7 @@ jobs:
         # run: make book
       - name: Make all the books
         run: |
-          git tag -l | grep -E '^v' | xargs -n1 -I{} bash -c 'BOOK_VERSION="{}" make book'
+          git tag -l | grep -E '^v' | xargs -n1 -I{} bash -c 'BOOK_VERSION="{}" make book_versioned'
           ls -la
 
       - name: Deploy

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -11,6 +11,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v3
+        with:
           fetch-depth: 0
           clean: false
 

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -41,5 +41,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ${TMPDIR}/docs
           destination_dir: ./docs

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -2,6 +2,8 @@ name: GitHub Pages
 
 "on":
   push:
+    branches:
+      - master
 
 
 jobs:

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -2,8 +2,7 @@ name: GitHub Pages
 
 "on":
   push:
-    branches:
-      - master
+
 
 jobs:
   deploy_book:
@@ -32,8 +31,10 @@ jobs:
 
       - uses: actions-rs/cargo@v1
 
-      - name: Run make book
-        run: make book
+      # - name: Run make book
+        # run: make book
+      - name: Make all the books
+        run: git tag -l | grep -E '^v' | xargs -n1 -I{} bash -c 'BOOK_VERSION="{}" make book'
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -1,6 +1,6 @@
 name: GitHub Pages
 
-on:
+"on":
   push:
     branches:
       - master

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -10,7 +10,9 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+          fetch-depth: 0
+          clean: false
 
       - name: Install deps
         run: |
@@ -34,7 +36,9 @@ jobs:
       # - name: Run make book
         # run: make book
       - name: Make all the books
-        run: git tag -l | grep -E '^v' | xargs -n1 -I{} bash -c 'BOOK_VERSION="{}" make book'
+        run: |
+          git tag -l | grep -E '^v' | xargs -n1 -I{} bash -c 'BOOK_VERSION="{}" make book'
+          ls -la
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -35,11 +35,13 @@ jobs:
       - uses: actions-rs/cargo@v1
 
       - name: Make all the books
-        run: ./build_all_the_docs.sh
+        run: |
+          export
+          ./build_all_the_docs.sh
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${TMPDIR}/docs
+          publish_dir: ./docs
           destination_dir: ./docs

--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -34,12 +34,8 @@ jobs:
 
       - uses: actions-rs/cargo@v1
 
-      # - name: Run make book
-        # run: make book
       - name: Make all the books
-        run: |
-          git tag -l | grep -E '^v' | xargs -n1 -I{} bash -c 'BOOK_VERSION="{}" make book_versioned'
-          ls -la
+        run: ./build_all_the_docs.sh
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ book_versioned:
 	git pull origin "${BOOK_VERSION}"
 	cargo doc --no-deps --quiet
 	mdbook build kanidm_book
+	mkdir -p ./docs
 	mv ./kanidm_book/book/ ./docs/${BOOK_VERSION}/
 	mkdir -p ./docs/${BOOK_VERSION}/rustdoc/
 	mv ./target/doc/* ./docs/${BOOK_VERSION}/rustdoc/

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ book_versioned:
 	echo "Book version: ${BOOK_VERSION}"
 	rm -rf ./target/doc
 	git switch -c "${BOOK_VERSION}"
-	git pull
+	git pull origin "${BOOK_VERSION}"
 	cargo doc --no-deps --quiet
 	mdbook build kanidm_book
 	mv ./kanidm_book/book/ ./docs/${BOOK_VERSION}/

--- a/Makefile
+++ b/Makefile
@@ -73,15 +73,23 @@ doc:
 	cargo doc --document-private-items
 
 book:
-	echo "Book version: ${BOOK_VERSION}"
-	git switch -c "${BOOK_VERSION}"
 	cargo doc --no-deps
 	mdbook build kanidm_book
 	mv ./kanidm_book/book/ ./docs/
 	mkdir -p ./docs/rustdoc/${BOOK_VERSION}
 	mv ./target/doc/* ./docs/rustdoc/${BOOK_VERSION}/
+
+book_versioned:
+	echo "Book version: ${BOOK_VERSION}"
+	rm -rf ./target/doc
+	git switch "${BOOK_VERSION}"
+	git pull
+	cargo doc --no-deps --quiet
+	mdbook build kanidm_book
+	mv ./kanidm_book/book/ ./docs/${BOOK_VERSION}/
+	mkdir -p ./docs/${BOOK_VERSION}/rustdoc/
+	mv ./target/doc/* ./docs/${BOOK_VERSION}/rustdoc/
 	git switch master
-	exit 1
 
 clean_book:
 	rm -rf ./docs

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ book:
 book_versioned:
 	echo "Book version: ${BOOK_VERSION}"
 	rm -rf ./target/doc
-	git switch "${BOOK_VERSION}"
+	git switch -c "${BOOK_VERSION}"
 	git pull
 	cargo doc --no-deps --quiet
 	mdbook build kanidm_book

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,15 @@ doc:
 	cargo doc --document-private-items
 
 book:
+	echo "Book version: ${BOOK_VERSION}"
+	git switch -c "${BOOK_VERSION}"
 	cargo doc --no-deps
 	mdbook build kanidm_book
 	mv ./kanidm_book/book/ ./docs/
 	mkdir -p ./docs/rustdoc/${BOOK_VERSION}
 	mv ./target/doc/* ./docs/rustdoc/${BOOK_VERSION}/
+	git switch master
+	exit 1
 
 clean_book:
 	rm -rf ./docs

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ treated as such.
 
 ## Documentation / Getting Started / Install
 
-If you want to deploy Kanidm to see what it can do, you should read the [kanidm book]
+If you want to deploy Kanidm to see what it can do, you should read the kanidm book.
 
-We also publish limited [support guidelines].
+- [Kanidm book (Latest commit)](https://kanidm.github.io/kanidm/master/)
+- [Kanidm book (Latest stable)](https://kanidm.github.io/kanidm/stable/)
 
-[kanidm book]: https://kanidm.github.io/kanidm/
-[support guidelines]: https://github.com/kanidm/kanidm/blob/master/project_docs/RELEASE_AND_SUPPORT.md
+
+We also publish limited [support guidelines](https://github.com/kanidm/kanidm/blob/master/project_docs/RELEASE_AND_SUPPORT.md)).
 
 ## Code of Conduct / Ethics
 
@@ -47,14 +48,14 @@ If you want to develop on the server, there is a getting started [guide for deve
 is a diverse topic and we encourage contributions of many kinds in the project, from people of
 all backgrounds.
 
-[guide for developers]: https://github.com/kanidm/kanidm/blob/master/DEVELOPER_README.md
+[guide for developers]: https://kanidm.github.io/kanidm/master/DEVELOPER_README.html
 
 ## Features
 
 ### Implemented
 
 * SSH key distribution for servers
-* Pam/nsswitch clients (with limited offline auth)
+* PAM/nsswitch clients (with limited offline auth)
 * MFA - TOTP
 * Highly concurrent design (MVCC, COW)
 * RADIUS integration

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 export CARGO_TARGET_DIR="${TMPDIR}cargo_target"
-DOCS_DIR="${TMPDIR}docs"
+DOCS_DIR="/tmp/kanidm_docs"
+
+echo "DOCS DIR: ${DOCS_DIR}"
+echo "PWD: $(pwd)"
 
 function build_version() {
     BOOK_VERSION=$1

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export CARGO_TARGET_DIR="${TMPDIR}cargo_target"
+DOCS_DIR="${TMPDIR}docs"
+
+function build_version() {
+    BOOK_VERSION=$1
+    echo "Book version: ${BOOK_VERSION}"
+	git switch -c "${BOOK_VERSION}"
+	git pull origin "${BOOK_VERSION}"
+	cargo doc --no-deps --quiet
+	mdbook build kanidm_book
+	mv ./kanidm_book/book/ "${DOCS_DIR}/${BOOK_VERSION}/"
+	mkdir -p "${DOCS_DIR}/${BOOK_VERSION}/rustdoc/"
+	mv ./target/doc/* "${DOCS_DIR}/${BOOK_VERSION}/rustdoc/"
+}
+
+mkdir -p "${DOCS_DIR}"
+
+for version in $(git tag -l | grep -E '^v' | head -n2); do
+    echo "$version"
+    build_version "${version}"
+done
+
+ls -la "${DOCS_DIR}"

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -6,6 +6,7 @@ DOCS_DIR="${TMPDIR}docs"
 function build_version() {
     BOOK_VERSION=$1
     echo "Book version: ${BOOK_VERSION}"
+    echo "<li><a href=\"/${BOOK_VERSION}\">${BOOK_VERSION}</a></li>" >> "${DOCS_DIR}/index.html"
 	git switch -c "${BOOK_VERSION}"
 	git pull origin "${BOOK_VERSION}"
 	RUSTFLAGS=-Awarnings cargo doc --quiet --no-deps
@@ -17,6 +18,17 @@ function build_version() {
 
 mkdir -p "${DOCS_DIR}"
 
+cat > "${DOCS_DIR}/index.html" <<-'EOM'
+<html>
+<head>
+<title>kanidm docs root</title>
+</head>
+<body>
+<h1>Kanidm docs</h1>
+<ul>
+EOM
+
+
 build_version master
 
 for version in $(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha'); do
@@ -24,4 +36,13 @@ for version in $(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha
     build_version "${version}"
 done
 
+
+cat >> "${DOCS_DIR}/index.html" <<-'EOM'
+
+</ul>
+</body>
+</html>
+EOM
 ls -la "${DOCS_DIR}"
+
+mv "${DOCS_DIR}" ./docs/

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+git config --global pull.ff only
 export CARGO_TARGET_DIR="${TMPDIR}cargo_target"
 DOCS_DIR="/tmp/kanidm_docs"
 
@@ -55,4 +56,4 @@ EOM
 ls -la "${DOCS_DIR}"
 
 mv "${DOCS_DIR}" ./docs/
-ln -s "${LATEST}" ./docs/stable/
+ln -s "${LATEST}" ./docs/stable

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -9,7 +9,7 @@ echo "PWD: $(pwd)"
 function build_version() {
     BOOK_VERSION=$1
     echo "Book version: ${BOOK_VERSION}"
-    echo "<li><a href=\"/${BOOK_VERSION}\">${BOOK_VERSION}</a></li>" >> "${DOCS_DIR}/index.html"
+    echo "<li><a href=\"/kanidm/${BOOK_VERSION}\">${BOOK_VERSION}</a></li>" >> "${DOCS_DIR}/index.html"
 	git switch -c "${BOOK_VERSION}"
 	git pull origin "${BOOK_VERSION}"
 	RUSTFLAGS=-Awarnings cargo doc --quiet --no-deps
@@ -31,15 +31,21 @@ cat > "${DOCS_DIR}/index.html" <<-'EOM'
 <ul>
 EOM
 
-
+# build the current head
 build_version master
 
+# build all the other versions
 for version in $(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha'); do
     echo "$version"
     build_version "${version}"
 done
 
 
+LATEST="$(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha' | head -n1)"
+{
+    echo "<li><strong><a href=\"/kanidm/master/\">Latest Dev Version</a></strong></li>"
+    echo "<li><strong><a href=\"/kanidm/stable/\">Latest Stable Version (${LATEST})</a></strong></li>"
+} >> "${DOCS_DIR}/index.html"
 cat >> "${DOCS_DIR}/index.html" <<-'EOM'
 
 </ul>
@@ -49,3 +55,4 @@ EOM
 ls -la "${DOCS_DIR}"
 
 mv "${DOCS_DIR}" ./docs/
+ln -s "${LATEST}" ./docs/stable/

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -32,6 +32,13 @@ cat > "${DOCS_DIR}/index.html" <<-'EOM'
 <ul>
 EOM
 
+
+LATEST="$(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha' | head -n1)"
+{
+    echo "<li><strong><a href=\"/kanidm/master/\">Latest Dev Version</a></strong></li>"
+    echo "<li><strong><a href=\"/kanidm/stable/\">Latest Stable Version (${LATEST})</a></strong></li>"
+} >> "${DOCS_DIR}/index.html"
+
 # build the current head
 build_version master
 
@@ -41,14 +48,7 @@ for version in $(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha
     build_version "${version}"
 done
 
-
-LATEST="$(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha' | head -n1)"
-{
-    echo "<li><strong><a href=\"/kanidm/master/\">Latest Dev Version</a></strong></li>"
-    echo "<li><strong><a href=\"/kanidm/stable/\">Latest Stable Version (${LATEST})</a></strong></li>"
-} >> "${DOCS_DIR}/index.html"
 cat >> "${DOCS_DIR}/index.html" <<-'EOM'
-
 </ul>
 </body>
 </html>

--- a/build_all_the_docs.sh
+++ b/build_all_the_docs.sh
@@ -8,7 +8,7 @@ function build_version() {
     echo "Book version: ${BOOK_VERSION}"
 	git switch -c "${BOOK_VERSION}"
 	git pull origin "${BOOK_VERSION}"
-	cargo doc --no-deps --quiet
+	RUSTFLAGS=-Awarnings cargo doc --quiet --no-deps
 	mdbook build kanidm_book
 	mv ./kanidm_book/book/ "${DOCS_DIR}/${BOOK_VERSION}/"
 	mkdir -p "${DOCS_DIR}/${BOOK_VERSION}/rustdoc/"
@@ -17,7 +17,9 @@ function build_version() {
 
 mkdir -p "${DOCS_DIR}"
 
-for version in $(git tag -l | grep -E '^v' | head -n2); do
+build_version master
+
+for version in $(git tag -l 'v*' --sort "-version:refname" | grep -v '1.1.0alpha'); do
     echo "$version"
     build_version "${version}"
 done


### PR DESCRIPTION
Ref #646 

It's currently published at https://kanidm.github.io/kanidm/

- Puts the "dev" docs at https://kanidm.github.io/kanidm/master/
- Puts the most recent tagged release at https://kanidm.github.io/kanidm/stable/

Also does all the other versions too.

Really need to redo some of the links on kanidm.com and change some of the docs files in the repo to point to various other places once we decide on a stable docs generation method 😄 

<img width="349" alt="Screen Shot 2022-04-27 at 22 43 04" src="https://user-images.githubusercontent.com/168188/165520516-75243dc1-9ef4-46ff-a180-c0aea889cd99.png">
