### PR TITLE
Adding metrics listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dtoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5caaa75cbd2b960ff1e5392d2cfb1f44717fffe12fc1f32b7b5d1267f99732a6"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +1996,7 @@ dependencies = [
  "num_enum",
  "openssl",
  "profiles",
+ "prometheus-client",
  "r2d2",
  "r2d2_sqlite",
  "rand 0.8.5",
@@ -2594,6 +2601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "pam_kanidm"
 version = "1.1.0-alpha.7"
 dependencies = [
@@ -2873,6 +2889,29 @@ dependencies = [
  "procfs",
  "protobuf",
  "thiserror",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a896938cc6018c64f279888b8c7559d3725210d5db9a3a1ee6bc7188d51d34"
+dependencies = [
+ "dtoa",
+ "itoa 1.0.1",
+ "owning_ref",
+ "prometheus-client-derive-text-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-text-encode"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3291,12 +3330,12 @@ dependencies = [
  "oauth2",
  "openssl",
  "profiles",
+ "prometheus-client",
  "reqwest",
  "serde",
  "serde_json",
  "tide",
  "tide-openssl",
- "tide-prometheus",
  "tokio",
  "tokio-openssl",
  "tokio-util",
@@ -3587,6 +3626,12 @@ dependencies = [
  "byteorder",
  "sha2 0.8.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "smolset",
  "sshkeys",
  "tide",
+ "tide-prometheus",
  "time 0.2.27",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1223,18 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1655,6 +1682,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -2282,6 +2315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,6 +2835,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "profiles"
 version = "1.1.0"
 dependencies = [
@@ -2800,6 +2856,29 @@ dependencies = [
  "serde",
  "toml",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "psl-types"
@@ -3216,6 +3295,7 @@ dependencies = [
  "serde_json",
  "tide",
  "tide-openssl",
+ "tide-prometheus",
  "tokio",
  "tokio-openssl",
  "tokio-util",
@@ -3737,6 +3817,16 @@ dependencies = [
  "futures-util",
  "openssl",
  "openssl-sys",
+ "tide",
+]
+
+[[package]]
+name = "tide-prometheus"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9aad7fdcd7adf9af8f4ff74c741cebc7c4bc140a1ff1366ba51386a0a0c27"
+dependencies = [
+ "prometheus",
  "tide",
 ]
 

--- a/examples/insecure_server.toml
+++ b/examples/insecure_server.toml
@@ -1,4 +1,3 @@
-
 bindaddress = "127.0.0.1:8443"
 ldapbindaddress = "127.0.0.1:3636"
 metrics_listener = "127.0.0.1:31292"

--- a/examples/insecure_server.toml
+++ b/examples/insecure_server.toml
@@ -1,5 +1,7 @@
+
 bindaddress = "127.0.0.1:8443"
 ldapbindaddress = "127.0.0.1:3636"
+metrics_listener = "127.0.0.1:31292"
 
 db_fs_type = "zfs"
 db_path = "/tmp/kanidm/kanidm.db"

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -49,6 +49,9 @@ origin = "https://idm.example.com:8443"
 #   Defaults to "WriteReplica".
 # role = "WriteReplica"
 #
+# Enable an OpenMetrics/Prometheus HTTP listener at http://127.0.0.1:31292/metrics
+metrics_listener = "127.0.0.1:31292"
+#
 # [online_backup]
 #   The path to the output folder for online backups
 # path = "/var/lib/kanidm/backups/"

--- a/kanidm_book/src/DevelopmentNotes/metrics.md
+++ b/kanidm_book/src/DevelopmentNotes/metrics.md
@@ -1,0 +1,7 @@
+# Metrics Development Notes
+
+Mad keen notes bruh.
+
+The bedrock of Kanidm is the Backend, so that's where the metrics registry lives.
+
+Each layer of the system gets its own sub-registry, so the Backend, the QueryServer and the Idm for example each have their own sub-registries, to simplify ownership/management of metrics.

--- a/kanidm_book/src/monitoring.md
+++ b/kanidm_book/src/monitoring.md
@@ -4,6 +4,8 @@ The monitoring design of Kanidm is still very much in its infancy - [take part i
 
 ## kanidmd
 
+### Health Checks
+
 kanidmd currently responds to HTTP GET requests at the `/status` endpoint with a JSON object of either "true" or "false". `true` indicates that the platform is responding to requests.
 
 | URL | `<hostname>/status` |
@@ -13,3 +15,29 @@ kanidmd currently responds to HTTP GET requests at the `/status` endpoint with a
 | Additional Headers | x-kanidm-opid
 | Content Type | application/json |
 | Cookies | kanidm-session |
+
+### Metrics
+
+Enable the metrics listener by setting `metrics_listener` in the server configuration.
+
+To listen on localhost, port 31292:
+
+```
+metrics_listener = "127.0.0.1:31292"
+```
+
+Or to open it up globally, if you want to configure remote monitoring:
+
+```
+metrics_listener = "0.0.0.0:31292"
+```
+
+This exposes an OpenMetrics port with (currently) basic counters for the number of requests which have reached the `kanidmd` web server.
+
+The endpoint is at `/metrics`, so if you set `127.0.0.1:31292` above, you can check it's working by running:
+
+```
+curl http://localhost:31292/metrics
+```
+
+If you don't see results and you've just started `kanidmd`, access the web server then re-run the query. The statistics aren't enabled until a connection is made.

--- a/kanidm_book/src/server_configuration.md
+++ b/kanidm_book/src/server_configuration.md
@@ -68,6 +68,8 @@ You will also need a config file in the volume named `server.toml` (Within the c
     #   Defaults to "WriteReplica".
     # role = "WriteReplica"
     #
+    # Enable an OpenMetrics/Prometheus HTTP listener at http://127.0.0.1:31292/metrics
+    metrics_listener = "127.0.0.1:31292"
     # [online_backup]
     #   The path to the output folder for online backups
     # path = "/var/lib/kanidm/backups/"

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -60,7 +60,7 @@ RUN zypper ref && \
 COPY --from=builder /usr/src/kanidm/target/release/kanidmd /sbin/
 COPY --from=builder /usr/src/kanidm/kanidmd_web_ui/pkg /pkg
 
-EXPOSE 8443 3636
+EXPOSE 8443 3636 31292
 VOLUME /data
 
 ENV RUST_BACKTRACE 1

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -58,6 +58,7 @@ struct ServerConfig {
     pub origin: String,
     #[serde(default)]
     pub role: ServerRole,
+    pub metrics_listener: Option<String>,
 }
 
 impl ServerConfig {
@@ -205,12 +206,13 @@ async fn main() {
     }
 
     config.update_log_level(ll);
-    config.update_db_path(&sconfig.db_path.as_str());
     config.update_db_fs_type(&sconfig.db_fs_type);
+    config.update_db_path(&sconfig.db_path.as_str());
     config.update_origin(&sconfig.origin.as_str());
     config.update_domain(&sconfig.domain.as_str());
     config.update_db_arc_size(sconfig.db_arc_size);
     config.update_role(sconfig.role);
+    config.update_metrics_listener(sconfig.metrics_listener);
 
     // Apply any cli overrides, normally debug level.
     if let Some(dll) = opt.commonopt().debug.as_ref() {

--- a/kanidmd/idm/Cargo.toml
+++ b/kanidmd/idm/Cargo.toml
@@ -85,8 +85,14 @@ filetime = "^0.2.16"
 
 num_enum = "^0.5.7"
 
+
+# used for metrics
+tide-prometheus = { version = "0.1.0", features = ["process"] }
+
 [features]
-# default = [ "libsqlite3-sys/bundled", "openssl/vendored" ]
+default = [ "metrics" ]
+metrics = [ ]
+
 
 [dev-dependencies]
 criterion = { version = "^0.3.5", features = ["html_reports"] }

--- a/kanidmd/idm/Cargo.toml
+++ b/kanidmd/idm/Cargo.toml
@@ -88,6 +88,7 @@ num_enum = "^0.5.7"
 
 # used for metrics
 tide-prometheus = { version = "0.1.0", features = ["process"] }
+prometheus-client = "0.15.1"
 
 [features]
 default = [ "metrics" ]

--- a/kanidmd/idm/src/config.rs
+++ b/kanidmd/idm/src/config.rs
@@ -93,6 +93,7 @@ pub struct Configuration {
     pub domain: String,
     pub origin: String,
     pub role: ServerRole,
+    pub metrics_listener: Option<String>,
 }
 
 impl fmt::Display for Configuration {
@@ -123,9 +124,13 @@ impl fmt::Display for Configuration {
             .and_then(|_| {
                 write!(
                     f,
-                    "integration mode: {}",
+                    "integration mode: {}, ",
                     self.integration_test_config.is_some()
                 )
+            })
+            .and_then(|_| match &self.metrics_listener {
+                Some(val) => write!(f, "metrics listener is enabled at: {}, ", val.to_string()),
+                None => write!(f, "metrics listener is disabled, "),
             })
     }
 }
@@ -157,6 +162,7 @@ impl Configuration {
             domain: "idm.example.com".to_string(),
             origin: "https://idm.example.com".to_string(),
             role: ServerRole::WriteReplica,
+            metrics_listener: None,
         };
         let mut rng = StdRng::from_entropy();
         rng.fill(&mut c.cookie_key);
@@ -216,6 +222,9 @@ impl Configuration {
 
     pub fn update_role(&mut self, r: ServerRole) {
         self.role = r;
+    }
+    pub fn update_metrics_listener(&mut self, address: Option<String>) {
+        self.metrics_listener = address;
     }
 
     pub fn update_tls(&mut self, chain: &Option<String>, key: &Option<String>) {

--- a/kanidmd/idm/src/server.rs
+++ b/kanidmd/idm/src/server.rs
@@ -118,7 +118,7 @@ pub(crate) struct ModifyPartial<'a> {
 
 // This is the core of the server. It implements all
 // the search and modify actions, applies access controls
-// and get's everything ready to push back to the fe code
+// and gets everything ready to push back to the fe code
 /// The `QueryServerTransaction` trait provides a set of common read only operations to be
 /// shared between [`QueryServerReadTransaction`] and [`QueryServerWriteTransaction`]s.
 ///

--- a/kanidmd/score/Cargo.toml
+++ b/kanidmd/score/Cargo.toml
@@ -39,7 +39,7 @@ async-std = { version = "^1.11.0", features = ["tokio1"] }
 compact_jwt = "^0.2.1"
 
 # used for metrics
-tide-prometheus = { version = "0.1.0", features = ["process"] }
+prometheus-client = "0.15.1"
 
 [build-dependencies]
 profiles = { path = "../../profiles" }

--- a/kanidmd/score/Cargo.toml
+++ b/kanidmd/score/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "score"
 version = "0.1.0"
-authors = ["William Brown <william@blackhats.net.au>"]
+authors = [
+    "William Brown <william@blackhats.net.au>",
+    "James Hodgkinson <james@terminaloutcomes.com>",
+    ]
 rust-version = "1.59"
 edition = "2021"
 license = "MPL-2.0"
@@ -34,6 +37,9 @@ serde = { version = "^1.0.136", features = ["derive"] }
 async-trait = "^0.1.53"
 async-std = { version = "^1.11.0", features = ["tokio1"] }
 compact_jwt = "^0.2.1"
+
+# used for metrics
+tide-prometheus = { version = "0.1.0", features = ["process"] }
 
 [build-dependencies]
 profiles = { path = "../../profiles" }

--- a/kanidmd/score/src/https/mod.rs
+++ b/kanidmd/score/src/https/mod.rs
@@ -321,9 +321,11 @@ pub fn create_https_server(
     });
 
     // metrics middleware
-    if enable_metrics {
-        tserver.with(tide_prometheus::Prometheus::new("tide"));
-    }
+    // TODO: re-implement the tide metrics work this out
+    eprintln!("In tide, metrics enabled, but unimplemented: {}", enable_metrics);
+    // if enable_metrics {
+        // something
+    // }
 
     // Add middleware?
     tserver.with(TreeMiddleware::with_stdout());

--- a/kanidmd/score/src/https/mod.rs
+++ b/kanidmd/score/src/https/mod.rs
@@ -301,6 +301,7 @@ pub fn create_https_server(
     status_ref: &'static StatusActor,
     qe_w_ref: &'static QueryServerWriteV1,
     qe_r_ref: &'static QueryServerReadV1,
+    enable_metrics: bool,
 ) -> Result<(), ()> {
     info!("WEB_UI_PKG_PATH -> {}", env!("KANIDM_WEB_UI_PKG_PATH"));
 
@@ -319,7 +320,10 @@ pub fn create_https_server(
         jws_validator,
     });
 
-    // tide::log::with_level(tide::log::LevelFilter::Debug);
+    // metrics middleware
+    if enable_metrics {
+        tserver.with(tide_prometheus::Prometheus::new("tide"));
+    }
 
     // Add middleware?
     tserver.with(TreeMiddleware::with_stdout());

--- a/kanidmd/score/src/metrics.rs
+++ b/kanidmd/score/src/metrics.rs
@@ -1,0 +1,28 @@
+use tide::Redirect;
+use kanidm::tracing_tree::TreeMiddleware;
+
+
+/// Starts the metrics server - but this won't block the entire platform if it fails.
+pub fn create_metrics_server(
+    address: String,
+) -> Result<(), ()> {
+    debug!("Attempting to start the metrics listener on address: {}", &address);
+
+    let mut metrics_server = tide::new();
+    metrics_server.with(TreeMiddleware::with_stdout());
+    // because it's just nice, y'know
+    metrics_server.at("/").get(Redirect::temporary("/metrics"));
+    metrics_server.at("/metrics").get(tide_prometheus::metrics_endpoint);
+
+    tokio::spawn(async move {
+        if let Err(e) = metrics_server.listen(&address).await {
+            error!(
+                "Failed to start metrics listener on address {:?} -> {:?}",
+                &address, e,
+            );
+        }
+    });
+
+    Ok(())
+
+}

--- a/kanidmd/score/src/metrics.rs
+++ b/kanidmd/score/src/metrics.rs
@@ -1,6 +1,6 @@
 use tide::Redirect;
 use kanidm::tracing_tree::TreeMiddleware;
-
+// TODO: look at the "push" functionality for prometheus
 
 /// Starts the metrics server - but this won't block the entire platform if it fails.
 pub fn create_metrics_server(
@@ -11,7 +11,7 @@ pub fn create_metrics_server(
     let mut metrics_server = tide::new();
     metrics_server.with(TreeMiddleware::with_stdout());
     // because it's just nice, y'know
-    metrics_server.at("/").get(Redirect::temporary("/metrics"));
+    metrics_server.at("/").get(Redirect::permanent("/metrics"));
     metrics_server.at("/metrics").get(tide_prometheus::metrics_endpoint);
 
     tokio::spawn(async move {

--- a/kanidmd/score/src/metrics.rs
+++ b/kanidmd/score/src/metrics.rs
@@ -1,19 +1,44 @@
-use tide::Redirect;
 use kanidm::tracing_tree::TreeMiddleware;
+use tide::Redirect;
+use kanidm::be::Backend;
+
 // TODO: look at the "push" functionality for prometheus
+#[derive(Clone)]
+struct MetricState {
+    be: kanidm::be::Backend,
+}
+
+impl MetricState{
+    pub fn new(be: Backend) -> Self {
+        MetricState {
+            be: be,
+        }
+    }
+}
 
 /// Starts the metrics server - but this won't block the entire platform if it fails.
 pub fn create_metrics_server(
-    address: String,
-) -> Result<(), ()> {
-    debug!("Attempting to start the metrics listener on address: {}", &address);
+    be: Backend,
+    address: String) -> Result<(), ()> {
+    debug!(
+        "Attempting to start the metrics listener on address: {}",
+        &address
+    );
 
-    let mut metrics_server = tide::new();
+    let mut metrics_server = tide::with_state(
+        MetricState::new(be));
     metrics_server.with(TreeMiddleware::with_stdout());
     // because it's just nice, y'know
     metrics_server.at("/").get(Redirect::permanent("/metrics"));
-    metrics_server.at("/metrics").get(tide_prometheus::metrics_endpoint);
-
+    metrics_server.at("/metrics")
+        .get(|req: tide::Request<MetricState>| async move {
+            let encoded: Vec<u8> = req.state().be.get_metrics_encoded();
+            let response = tide::Response::builder(200)
+                .body(encoded)
+                .content_type("application/openmetrics-text; version=1.0.0; charset=utf-8")
+                .build();
+            Ok(response)
+        });
     tokio::spawn(async move {
         if let Err(e) = metrics_server.listen(&address).await {
             error!(
@@ -24,5 +49,4 @@ pub fn create_metrics_server(
     });
 
     Ok(())
-
 }


### PR DESCRIPTION
Ref #644, Ref #216 

Adds an optional metrics listener which exposes tide request counts, but is (I think?) Pretty easily extensible.

I've added metrics to the QueryServer behind a feature flag because they might trash performance - once #728 has some details I'll do more testing (and add automated reporting for said testing).

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
