### PR TITLE
Orca output dir fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ version = "1.1.0-alpha.8"
 dependencies = [
  "crossbeam",
  "csv",
+ "dialoguer",
  "futures-util",
  "jemallocator",
  "kanidm_client",

--- a/kanidmd/daemon/run_insecure_dev_server.sh
+++ b/kanidmd/daemon/run_insecure_dev_server.sh
@@ -19,4 +19,10 @@ if [ ! -f "/tmp/kanidm/key.pem" ]; then
     exit 1
 fi
 
-cargo run --bin kanidmd server -c "${CONFIG_FILE}"
+COMMAND="server"
+if [ -n "${1}" ]; then
+    COMMAND=$*
+fi
+
+#shellcheck disable=SC2086
+cargo run --bin kanidmd -- ${COMMAND} -c "${CONFIG_FILE}"

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -44,5 +44,7 @@ crossbeam = "0.8.1"
 
 mathru = "^0.12.0"
 
+dialoguer = "0.10.0"
+
 [build-dependencies]
 profiles = { path = "../profiles" }

--- a/orca/src/opt.rs
+++ b/orca/src/opt.rs
@@ -103,7 +103,18 @@ impl std::fmt::Display for TestTypeOpt {
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(about = "Orca Load Testing Utility")]
+#[structopt(name="orca", about = "Orca Load Testing Utility
+
+Orca works in a few steps.
+
+1. (Optional) preprocess an anonymised 389-ds access log (created from an external tool) into an orca data set.
+Create an orca config which defines the targets you want to be able to setup and load test. See example_profiles/small/orca.toml
+2. 'orca setup' the kanidm/389-ds instance from the orca data set. You can see an example of this in example_profiles/small/data.json. This will reset the database, and add tons of entries etc.
+3. 'orca run' one of the metrics, based on that data set. For example:
+
+    orca run -p example_profiles/small/orca.toml kanidm search-basic
+
+")]
 enum OrcaOpt {
     #[structopt(name = "preprocess")]
     /// Preprocess a dataset that can be used for testing
@@ -112,7 +123,7 @@ enum OrcaOpt {
     /// Setup a server as defined by a test profile
     Setup(SetupOpt),
     #[structopt(name = "run")]
-    /// Run the load test as define by the test profile
+    /// Run the load test as defined by the test profile
     Run(RunOpt),
 }
 

--- a/orca/src/runner/mod.rs
+++ b/orca/src/runner/mod.rs
@@ -1,8 +1,8 @@
 use crate::setup::config;
 use crate::{TargetOpt, TestTypeOpt};
-use std::path::{Path, PathBuf};
-use std::fs::create_dir_all;
 use dialoguer::Confirm;
+use std::fs::create_dir_all;
+use std::path::{Path, PathBuf};
 mod search;
 
 pub(crate) async fn doit(
@@ -23,16 +23,25 @@ pub(crate) async fn doit(
 
     let result_path = PathBuf::from(&profile.results);
     if !result_path.exists() {
-        error!("Couldn't find results directory from profile: {:#?}", result_path);
+        debug!(
+            "Couldn't find results directory from profile: {:#?}",
+            result_path
+        );
 
-        match Confirm::new().with_prompt("Would you like to create it?").interact() {
+        match Confirm::new()
+            .with_prompt(
+                format!("I couldn't find the directory you told me to send results to ({:?}). Would you like to create it?",
+                result_path,)
+            )
+            .interact()
+        {
             Ok(_) => match create_dir_all(result_path.as_path()) {
                 Ok(_) => info!("Successfully created {:#?}", result_path.canonicalize()),
                 Err(error) => {
                     error!("{:#?}", error);
-                    return Err(())
-                    }
+                    return Err(());
                 }
+            },
             _ => {
                 println!("Ok, going to quit!");
                 return Err(());


### PR DESCRIPTION
Fixes an issue where if the output dir doesn't exist, orca was bailing - it now prompts the user to create the dir and does so if it can.

<img width="1370" alt="Screen Shot 2022-05-02 at 11 59 13" src="https://user-images.githubusercontent.com/168188/166175728-3e456e44-ed7d-408b-a70f-bc663602baa0.png">

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

