### PR TITLE
Update docs with some personal experience

### DIFF
--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -1,6 +1,6 @@
 # Installing Client Tools
 
-> **NOTE** As this project is in a rapid development phase, running different release versions will likely present incompatibilities. Ensure you're running matching release versions of client and server binaries.
+> **NOTE** As this project is in a rapid development phase, running different release versions will likely present incompatibilities. Ensure you're running matching release versions of client and server binaries. If you have any issues check that you are running the latest software.
 
 ## From packages
 
@@ -9,7 +9,7 @@ Kanidm currently supports:
  * OpenSUSE Tumbleweed
  * OpenSUSE Leap 15.3/15.4
  * Fedora 34/35
- * Centos Stream 9 (alpha 7 only)
+ * CentOS Stream 9
 
 ### OpenSUSE Tumbleweed
 

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -9,7 +9,7 @@ Kanidm currently supports:
  * OpenSUSE Tumbleweed
  * OpenSUSE Leap 15.3/15.4
  * Fedora 34/35
- * Centos Stream 9
+ * Centos Stream 9 (alpha 7 only)
 
 ### OpenSUSE Tumbleweed
 
@@ -33,7 +33,7 @@ Then you need to refresh your metadata and install the clients.
 
 ### Fedora / Centos Stream
 
-Fedora has limited supported through the development repository. You need to add the repository metadata into the correct directory.
+Fedora has limited support through the development repository. You need to add the repository metadata into the correct directory.
 
     cd /etc/yum.repos.d
     # Fedora 34

--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -198,6 +198,7 @@ The content should look like:
 
 These files are managed by authselect as symlinks. You can either work with authselect, or remove the symlinks first.
 
+#### Without authselect
 If you just remove the symlinks:
 edit the content.
 
@@ -260,6 +261,7 @@ edit the content.
     session     required                                     pam_unix.so
     session     optional                                     pam_kanidm.so
 
+#### With authselect
 To work with authselect:
 You will need to [create a new profile](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_authentication_and_authorization_in_rhel/configuring-user-authentication-using-authselect_configuring-authentication-and-authorization-in-rhel#creating-and-deploying-your-own-authselect-profile_configuring-user-authentication-using-authselect). First run
 
@@ -274,7 +276,7 @@ A new folder, /etc/authselect/custom/kanidm, should be created. Inside that fold
     services:   sss files
     netgroup:   sss files
     automount:  sss files
-
+    
     aliases:    files
     ethers:     files
     gshadow:    files
@@ -282,6 +284,12 @@ A new folder, /etc/authselect/custom/kanidm, should be created. Inside that fold
     protocols:  files
     publickey:  files
     rpc:        files
+
+finally run
+
+    authselect select custom/kanidm
+
+to update your profile.
 
 ## Troubleshooting
 

--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -196,7 +196,9 @@ The content should look like:
 >
 > You may also need to run `audit2allow` for sshd and other types to be able to access the unix daemon sockets.
 
-These files are managed by authselect as symlinks. You will need to remove the symlinks first, then
+These files are managed by authselect as symlinks. You can either work with authselect, or remove the symlinks first.
+
+If you just remove the symlinks:
 edit the content.
 
     # /etc/pam.d/password-auth
@@ -206,18 +208,18 @@ edit the content.
     auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
     auth        sufficient                                   pam_unix.so nullok try_first_pass
     auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
-    auth        sufficient                                   pam_kanidm.so debug ignore_unknown_user
+    auth        sufficient                                   pam_kanidm.so ignore_unknown_user
     auth        required                                     pam_deny.so
     
     account     sufficient                                   pam_unix.so
     account     sufficient                                   pam_localuser.so
     account     sufficient                                   pam_usertype.so issystem
-    account     sufficient                                   pam_kanidm.so debug ignore_unknown_user
+    account     sufficient                                   pam_kanidm.so ignore_unknown_user
     account     required                                     pam_permit.so
     
     password    requisite                                    pam_pwquality.so try_first_pass local_users_only
     password    sufficient                                   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
-    password    sufficient                                   pam_kanidm.so debug
+    password    sufficient                                   pam_kanidm.so
     password    required                                     pam_deny.so
     
     session     optional                                     pam_keyinit.so revoke
@@ -225,7 +227,7 @@ edit the content.
     -session    optional                                     pam_systemd.so
     session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
     session     required                                     pam_unix.so
-    session     optional                                     pam_kanidm.so debug
+    session     optional                                     pam_kanidm.so
 
 -
 
@@ -237,18 +239,18 @@ edit the content.
     auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
     auth        sufficient                                   pam_unix.so nullok try_first_pass
     auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
-    auth        sufficient                                   pam_kanidm.so debug ignore_unknown_user
+    auth        sufficient                                   pam_kanidm.so ignore_unknown_user
     auth        required                                     pam_deny.so
 
     account     sufficient                                   pam_unix.so
     account     sufficient                                   pam_localuser.so
     account     sufficient                                   pam_usertype.so issystem
-    account     sufficient                                   pam_kanidm.so debug ignore_unknown_user
+    account     sufficient                                   pam_kanidm.so ignore_unknown_user
     account     required                                     pam_permit.so
 
     password    requisite                                    pam_pwquality.so try_first_pass local_users_only
     password    sufficient                                   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
-    password    sufficient                                   pam_kanidm.so debug
+    password    sufficient                                   pam_kanidm.so
     password    required                                     pam_deny.so
 
     session     optional                                     pam_keyinit.so revoke
@@ -256,7 +258,30 @@ edit the content.
     -session    optional                                     pam_systemd.so
     session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
     session     required                                     pam_unix.so
-    session     optional                                     pam_kanidm.so debug
+    session     optional                                     pam_kanidm.so
+
+To work with authselect:
+You will need to [create a new profile](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_authentication_and_authorization_in_rhel/configuring-user-authentication-using-authselect_configuring-authentication-and-authorization-in-rhel#creating-and-deploying-your-own-authselect-profile_configuring-user-authentication-using-authselect). First run
+
+    authselect create-profile kanidm -b sssd
+
+A new folder, /etc/authselect/custom/kanidm, should be created. Inside that folder, create or overwrite the following 3 files: nsswitch.conf, password-auth, system-auth. password-auth and system-auth should be the same as above. nsswitch should be modified for your usecase, but a working example looks like this:
+
+    passwd: compat kanidm sss files systemd
+    group: compat kanidm sss files systemd
+    shadow:     files
+    hosts:      files dns myhostname
+    services:   sss files
+    netgroup:   sss files
+    automount:  sss files
+
+    aliases:    files
+    ethers:     files
+    gshadow:    files
+    networks:   files dns
+    protocols:  files
+    publickey:  files
+    rpc:        files
 
 ## Troubleshooting
 

--- a/kanidm_book/src/posix_accounts.md
+++ b/kanidm_book/src/posix_accounts.md
@@ -108,8 +108,7 @@ special or separate type of membership for posix members required.
 
 ### Subid conflicts with Podman
 
-Due to the way that podman operates, in some cases using the kanidm client inside non-root containers with
-kanidm accounts may fail with an error such as:
+Due to the way that podman operates, in some cases using the kanidm client inside non-root containers with kanidm accounts may fail with an error such as:
 
     ERRO[0000] cannot find UID/GID for user NAME: No subuid ranges found for user "NAME" in /etc/subuid
 

--- a/kanidm_book/src/posix_accounts.md
+++ b/kanidm_book/src/posix_accounts.md
@@ -108,7 +108,7 @@ special or separate type of membership for posix members required.
 
 ### Subid conflicts with Podman
 
-Due to the way that podman operates, in some cases using non-root containers with
+Due to the way that podman operates, in some cases using the kanidm client inside non-root containers with
 kanidm accounts may fail with an error such as:
 
     ERRO[0000] cannot find UID/GID for user NAME: No subuid ranges found for user "NAME" in /etc/subuid


### PR DESCRIPTION
Just changes a few bits in the documentation:
- Fixed a typo and added a note about centos 9 compat in installing client tools  
- Added a clarification to posix accounts about podman having issues with kanidm client, not kanidm server
- Added a section on working with authselect instead of overriding symlinks

Hopefully this is up to par, the checklist provided seemed to be focused on adding functionality instead of docs so I apologize if I'm breaking any rules for your pull request process. 