### PR TITLE
fixing up typo and tagging on docker build

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -63,10 +63,10 @@ jobs:
         id: docker_build_kanidmd
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           platforms: ${{matrix.target}}
           # https://github.com/docker/build-push-action/issues/254
-          tags: ghcr.io/${{ github.repository }}/kanidmd:devel
+          tags: ghcr.io/kanidm/kanidmd:devel
           build-args: |
             "KANIDM_BUILD_PROFILE=developer"
             "KANIDM_FEATURES="
@@ -97,8 +97,8 @@ jobs:
         id: docker_build_radius
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           platforms: ${{matrix.target}}
           # https://github.com/docker/build-push-action/issues/254
-          tags: ghcr.io/${{ github.repository }}/radius:devel
+          tags: ghcr.io/kanidm/radius:devel
           context: ./kanidm_rlm_python/


### PR DESCRIPTION
Fixes the fact that I forgot we use `master` not `main`.