### PR TITLE
Fix typos of kanidm in the documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@
 * Victor Wai (vcwai)
 * James Hodgkinson (yaleman)
 * Euan Kemp (euank)
+* Kellin (kellinm)
 
 ## Acknowledgements
 

--- a/kanidm_book/src/administrivia.md
+++ b/kanidm_book/src/administrivia.md
@@ -149,7 +149,7 @@ Second, change `domain` and `origin` in `server.toml`.
 
 Third, trigger the database domain rename process.
 
-    docker run --rm -i -t -v kandimd:/data \
+    docker run --rm -i -t -v kanidmd:/data \
         kanidm/server:latest /sbin/kanidmd domain_name_change -c /data/server.toml
 
 Finally, you can now start your instance again.

--- a/kanidm_book/src/pam_and_nsswitch.md
+++ b/kanidm_book/src/pam_and_nsswitch.md
@@ -28,7 +28,7 @@ You can check the privileged tasks daemon is running with
 > it provides supporting Kanidm's capabilities.
 
 Both unixd daemons use the connection configuration from /etc/kanidm/config. This is the covered in
-[client_tools](./client_tools.md#kandim-configuration). 
+[client_tools](./client_tools.md#kanidm-configuration).
 
 You can also configure some unixd specific options with the file /etc/kanidm/unixd.
 

--- a/kanidm_book/src/server_configuration.md
+++ b/kanidm_book/src/server_configuration.md
@@ -111,7 +111,7 @@ An example is located in [examples/server.toml](../../examples/server.toml).
 
 You should test your configuration is valid before you proceed.
 
-    docker run --rm -i -t -v kandimd:/data \
+    docker run --rm -i -t -v kanidmd:/data \
         kanidm/server:latest /sbin/kanidmd configtest -c /data/server.toml
 
 ### Default Admin Account


### PR DESCRIPTION
```
Fix typos of kanidm in the documentation

- Fix volume mount name typo in the server configuration and
  administrivia documentation pages
- Fix typo in link from PAM and nsswitch documentation

Signed-off-by: Kellin <kellin@retromud.org>
```

Very minor patch  to fix some documentation issues I noticed while experimenting with kanidm.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
