### PR TITLE
Note packages required for development on Fedora

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -40,6 +40,19 @@ You will also need some system libraries to build this:
 
     libudev-devel sqlite3-devel libopenssl-devel npm-default
 
+#### Fedora
+
+You will need to install the rust toolchain packages.
+
+    rust cargo
+
+You will also need some system libraries to build this:
+
+    systemd-devel sqlite-devel openssl-devel pam-devel
+
+Building the web ui requires additional packages:
+
+    perl-FindBin perl-File-Compare rust-std-static-wasm32-unknown-unknown
 
 ### Get involved
 


### PR DESCRIPTION
```
Note packages required for development on Fedora
    
- Notes packages needed for base development on Fedora
- Notes packages required to run the wasm build script with cargo
    
Signed-off-by: Kellin <kellin@retromud.org>
```

The package names were different enough on Fedora that I thought it was worth documenting them for newcomers who may not be aware that `libudev` comes from `systemd-devel`.

Notably, I didn't get any errors building without `npm` in the mix, therefore I have not added it here.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
