### PR TITLE
Fix typo in Dockerfile

### DIFF
--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS builder
-LABEL mantainer william@blackhats.net.au
+LABEL maintainer william@blackhats.net.au
 
 RUN zypper refresh
 RUN zypper dup -y
@@ -46,7 +46,7 @@ RUN if [ "${SCCACHE_REDIS}" != "" ]; \
 	fi;
 
 FROM ${BASE_IMAGE}
-LABEL mantainer william@blackhats.net.au
+LABEL maintainer william@blackhats.net.au
 
 RUN zypper ref
 RUN zypper dup -y


### PR DESCRIPTION
```
Fix typo in Dockerfile

- Change `mantainer` to `maintainer` in the Dockerfile label

Signed-off-by: Kellin <kellin@retromud.org>
````

Tiny fix in the `Dockerfile`.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
