### PR TITLE
Moving an info message because that's how I roll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0f08911ab0fee2c5009580f04615fa868898ee57de10692a45da0c3bcc3e5e"
+checksum = "f07b0a1390e01c0fc35ebb26b28ced33c9a3808f7f9fbe94d3cc01e233bfeed5"
 dependencies = [
  "idna",
  "lazy_static",
@@ -4132,14 +4132,13 @@ dependencies = [
  "serde_json",
  "url",
  "validator_derive",
- "validator_types",
 ]
 
 [[package]]
 name = "validator_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85135714dba11a1bd0b3eb1744169266f1a38977bf4e3ff5e2e1acb8c2b7eee"
+checksum = "ea7ed5e8cf2b6bdd64a6c4ce851da25388a89327b17b88424ceced6bd5017923"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -4153,9 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded9d97e1d42327632f5f3bae6403c04886e2de3036261ef42deebd931a6a291"
+checksum = "d2ddf34293296847abfc1493b15c6e2f5d3cd19f57ad7d22673bf4c6278da329"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/kanidmd/score/src/https/mod.rs
+++ b/kanidmd/score/src/https/mod.rs
@@ -12,6 +12,7 @@ use kanidm::status::StatusActor;
 
 use serde::Serialize;
 use std::path::PathBuf;
+use std::fs::canonicalize;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -365,7 +366,6 @@ pub fn create_https_server(
     qe_w_ref: &'static QueryServerWriteV1,
     qe_r_ref: &'static QueryServerReadV1,
 ) -> Result<(), ()> {
-    info!("WEB_UI_PKG_PATH -> {}", env!("KANIDM_WEB_UI_PKG_PATH"));
 
     let jws_validator = jws_signer.get_validator().map_err(|e| {
         error!(?e, "Failed to get jws validator");
@@ -401,6 +401,7 @@ pub fn create_https_server(
 
     // If we are no-ui, we remove this.
     if !matches!(role, ServerRole::WriteReplicaNoUI) {
+
         let pkg_path = PathBuf::from(env!("KANIDM_WEB_UI_PKG_PATH"));
         if !pkg_path.exists() {
             eprintln!(
@@ -409,6 +410,7 @@ pub fn create_https_server(
             );
             std::process::exit(1);
         }
+        info!("Web UI package path: {:?}", canonicalize(pkg_path).unwrap());
 
         let mut static_tserver = tserver.at("");
         static_tserver.with(StaticContentMiddleware::default());


### PR DESCRIPTION
Fixes #788

- [x] cargo fmt has been run and I refuse to tell you what happened
- [x] cargo clippy has been run
- [x] cargo test has been run and passes, much to my surprise
- [x] had ice cream

I like showing what it looks like when I change something, so here it is:
```
```

Yep, nothing shows up when the UI's disabled, because that's the point.

I did change something else, so now it does this:
```
<snip timestamp> [info]: Web UI package path: "/supersecretcodingplace/kanidm/kanidmd_web_ui/pkg"
```

ie, it'll show the full canonical path of where it's looking for the pkg, not just `../../blah`