### PR TITLE
Set default value for SCCACHE_REDIS build arg

### DIFF
--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -22,7 +22,7 @@ RUN zypper install -y \
 COPY . /usr/src/kanidm
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
-ARG SCCACHE_REDIS
+ARG SCCACHE_REDIS=""
 ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE
 


### PR DESCRIPTION
```
Set default value for SCCACHE_REDIS build arg

- Set a default value in the Dockerfile for SCCACHE_REDIS so that, at
  build time, it does not fail with the new behavior because nothing was
  actually being passed into the container.

Signed-off-by: Kellin <kellin@retromud.org>
```

From the, "_how the heck did I miss this when testing the behavior change_" department.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
