### PR TITLE
Add domain key to example server configuration

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -31,6 +31,22 @@ db_path = "/var/lib/kanidm/kanidm.db"
 #   Defaults to "default"
 # log_level = "default"
 #
+#   The DNS domain name of the server. This is used in a
+#   number of security-critical contexts
+#   such as webauthn, so it *must* match your DNS
+#   hostname. It is used to create
+#   security principal names such as `william@idm.example.com`
+#   so that in a (future)
+#   trust configuration it is possible to have unique Service
+#   Principal Names (spns) throughout the topology.
+#   ⚠️  WARNING ⚠️
+#   Changing this value WILL break many types of registered
+#   credentials for accounts
+#   including but not limited to webauthn, oauth tokens, and more.
+#   If you change this value you *must* run
+#   `kanidmd domain_name_change` immediately after.
+domain = "idm.example.com"
+#
 #   The origin for webauthn. This is the url to the server, with the port included if
 #   it is non-standard (any port except 443)
 # origin = "https://idm.example.com"
@@ -59,4 +75,3 @@ origin = "https://idm.example.com:8443"
 # schedule = "03 */6 * * *"
 #   Number of backups to keep (default 7)
 # versions = 7
-#


### PR DESCRIPTION
```
Add domain key to example server configuration

- Adds the mandatory `domain` configuration key documentation to the
  configuration file at `examples/server.toml`.

Signed-off-by: Kellin <kellin@retromud.org>
```

While working through standing up an instance, I used the `examples/server.toml` file as a quick template to stand up the service. Immediately got an error message for the missing `domain` configuration key, found it over in the book documentation.

This just copies that section verbatim into the example file.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
