### PR TITLE
Fix metadata issues before sorcerer installation

### DIFF
--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
+RUN zypper dup -y
 # To help mirrors not be as bad
 RUN zypper install -y mirrorsorcerer
 RUN /usr/sbin/mirrorsorcerer -x; true


### PR DESCRIPTION
```
Fix metadata issues before sorcerer installation

- When installing mirror-sourcerer in the container, it is possible to
  run into a metadata failure in Tumbleweed immediately causing zypper
  to exit with code 126. To avoid this, zypper -dup must be run first.

Signed-off-by: Kellin <kellin@retromud.org>
```

Ran into this message when trying to build a container today:

```
1 new package to install.
Overall download size: 1.0 MiB. Already cached: 0 B. After the operation, additional 3.4 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package mirrorsorcerer-0.1.0~13-1.2.x86_64 (1/1),   1.0 MiB (  3.4 MiB unpacked)
Retrieving: mirrorsorcerer-0.1.0~13-1.2.x86_64.rpm [.done (1.8 MiB/s)]

Checking for file conflicts: [...done]
(1/1) Installing: mirrorsorcerer-0.1.0~13-1.2.x86_64 [............done]
Error: error building at STEP "RUN zypper install -y mirrorsorcerer": error while running runtime: exit status 106
make: *** [Makefile:46: build/kanidmd] Error 125
```

This forces the metadata to resolve/work prior to attempting to install `mirror-sorcerer`.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
