### PR TITLE
Windows automagical buildingtons

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -35,7 +35,7 @@ jobs:
             default: true
             components: cargo
       - name: Run cargo test
-        run: cargo test --workspace
+        run: cargo test -j1
 
   kanidm_build:
     needs: test
@@ -70,6 +70,7 @@ jobs:
           build-args: |
             "KANIDM_BUILD_PROFILE=developer"
             "KANIDM_FEATURES="
+            "KANIDM_BUILD_OPTIONS=-j1"
           file: kanidmd/Dockerfile
   radius_build:
     needs: test

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --bin kanidm --bin orca --bin kanidmd
+          args: --release -p kanidm_client -p kanidm_tools -p orca
   windows_test_kanidm:
     runs-on: windows-latest
     steps:
@@ -47,4 +47,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: -p kanidm_client -p kanidm_tools -p orca

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,5 +1,5 @@
 ---
-name: Windows Binaries
+name: Windows Build and Test
 
 # at the moment this only builds the kanidm  client
 # because @yaleman got tired but it's enough to prove

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --bin kanidm --bin orca --bin kanidmd
+          args: --release --bin kanidm

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --bin kanidm
+          args: --release --bin kanidm --bin orca --bin kanidmd

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,9 +1,11 @@
 ---
 name: Windows Binaries
 
-# this will build regardless,
-# but only push to the container registry
-# when you're committing on the master branch.
+# at the moment this only builds the kanidm  client
+# because @yaleman got tired but it's enough to prove
+# it builds and be able to administer Kanidm from 
+# Windows-land
+
 "on":
   push:
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -29,3 +29,22 @@ jobs:
         with:
           command: build
           args: --release --bin kanidm --bin orca --bin kanidmd
+  windows_test_kanidm:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: ensure openssl and vcpkg is good
+        run: |
+          vcpkg integrate install
+          vcpkg install openssl:x64-windows-static-md
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            components: cargo
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: ensure openssl and vcpkg is good
         run: |
           vcpkg integrate install
-          vcpkg install openssl:x64-windows
+          vcpkg install openssl:x64-windows-static-md
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,0 +1,28 @@
+---
+name: Windows Binaries
+
+# this will build regardless,
+# but only push to the container registry
+# when you're committing on the master branch.
+"on":
+  push:
+
+jobs:
+  windows_build_kanidm:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            components: cargo
+      - name: build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --bin kanidm
+          env: |
+            "KANIDM_BUILD_PROFILE=developer"
+            "KANIDM_FEATURES="

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+      - name: ensure openssl and vcpkg is good
+        run: vcpkg integrate install
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -23,6 +23,3 @@ jobs:
         with:
           command: build
           args: --release --bin kanidm
-          env: |
-            "KANIDM_BUILD_PROFILE=developer"
-            "KANIDM_FEATURES="

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: ensure openssl and vcpkg is good
-        run: vcpkg integrate install
+        run: |
+          vcpkg integrate install
+          vcpkg install openssl:x64-windows
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -3,7 +3,7 @@ name: Windows Binaries
 
 # at the moment this only builds the kanidm  client
 # because @yaleman got tired but it's enough to prove
-# it builds and be able to administer Kanidm from 
+# it builds and be able to administer Kanidm from
 # Windows-land
 
 "on":
@@ -28,4 +28,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --bin kanidm
+          args: --release --bin kanidm --bin orca --bin kanidmd

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -14,6 +14,8 @@ Kanidm currently supports the following Linux distributions:
  * Fedora 34/35
  * CentOS Stream 9
 
+The `kanidm` client has been built and tested from Windows, but is not (yet) packaged routinely.
+
 ### OpenSUSE Tumbleweed
 
 Kanidm has been part of OpenSUSE Tumbleweed since October 2020. You can install

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -89,6 +89,7 @@ pub struct KanidmClient {
     pub(crate) auth_session_id: RwLock<Option<String>>,
 }
 
+#[cfg(target_family = "unix")]
 fn read_file_metadata<P: AsRef<Path>>(path: &P) -> Result<Metadata, ()> {
     metadata(path).map_err(|e| {
         error!(

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -22,7 +22,6 @@ use std::fs::File;
 #[cfg(target_family = "unix")] // not needed for windows builds
 use std::fs::{metadata, Metadata};
 use std::io::ErrorKind;
-#[cfg(target_family = "unix")] // not needed for windows builds
 use std::io::Read;
 
 #[cfg(target_family = "unix")] // not needed for windows builds

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -18,6 +18,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::error::Error as SerdeJsonError;
+#[cfg(target_family = "unix")]
 use std::fs::{metadata, File, Metadata};
 use std::io::ErrorKind;
 use std::io::Read;

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -18,12 +18,14 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::error::Error as SerdeJsonError;
-#[cfg(target_family = "unix")]
-use std::fs::{metadata, File, Metadata};
+use std::fs::File;
+#[cfg(target_family = "unix")] // not needed for windows builds
+use std::fs::{metadata, Metadata};
 use std::io::ErrorKind;
+#[cfg(target_family = "unix")] // not needed for windows builds
 use std::io::Read;
 
-#[cfg(target_family = "unix")]
+#[cfg(target_family = "unix")] // not needed for windows builds
 use std::os::unix::fs::MetadataExt;
 
 use std::collections::BTreeMap;

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /usr/src/kanidm/kanidmd/daemon
 ARG SCCACHE_REDIS=""
 ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE
+ARG KANIDM_BUILD_OPTIONS=""
 
 RUN mkdir /scratch
 RUN echo $KANIDM_BUILD_PROFILE
@@ -36,12 +37,13 @@ ENV CARGO_HOME=/scratch/.cargo
 RUN if [ "${SCCACHE_REDIS}" != "" ]; \
 		then \
 			export CC="/usr/bin/sccache /usr/bin/clang" && \
+      export CARGO_INCREMENTAL=false && \
 			export RUSTC_WRAPPER=sccache && \
 			sccache --start-server; \
 		else \
 			export CC="/usr/bin/clang"; \
 	fi && \
-    cargo build \
+    cargo build ${KANIDM_BUILD_OPTIONS} \
 		--features=${KANIDM_FEATURES} \
 		--target-dir=/usr/src/kanidm/target/ \
 		--release && \

--- a/kanidmd/daemon/Cargo.toml
+++ b/kanidmd/daemon/Cargo.toml
@@ -22,9 +22,11 @@ score = { path = "../score" }
 structopt = { version = "^0.3.26", default-features = false }
 users = "^0.11.0"
 serde = { version = "^1.0.137", features = ["derive"] }
-tikv-jemallocator = "0.5.0"
 tokio = { version = "^1.18.0", features = ["rt-multi-thread", "macros", "signal"] }
 toml = "0.5.9"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/kanidmd/daemon/Cargo.toml
+++ b/kanidmd/daemon/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "^1.0.137", features = ["derive"] }
 tokio = { version = "^1.18.0", features = ["rt-multi-thread", "macros", "signal"] }
 toml = "0.5.9"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(target_family = "windows"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 [build-dependencies]

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
+#[cfg(not(target_family = "windows"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/kanidmd/idm/src/lib.rs
+++ b/kanidmd/idm/src/lib.rs
@@ -14,6 +14,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
+#[cfg(not(target_family = "windows"))]
 #[cfg(all(jemallocator, test))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

--- a/kanidmd/idm/src/lib.rs
+++ b/kanidmd/idm/src/lib.rs
@@ -14,8 +14,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-#[cfg(not(target_family = "windows"))]
-#[cfg(all(jemallocator, test))]
+#[cfg(all(jemallocator, test, not(target_family = "windows")))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/kanidmd/score/src/https/mod.rs
+++ b/kanidmd/score/src/https/mod.rs
@@ -11,8 +11,8 @@ use kanidm::prelude::*;
 use kanidm::status::StatusActor;
 
 use serde::Serialize;
-use std::path::PathBuf;
 use std::fs::canonicalize;
+use std::path::PathBuf;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -366,7 +366,6 @@ pub fn create_https_server(
     qe_w_ref: &'static QueryServerWriteV1,
     qe_r_ref: &'static QueryServerReadV1,
 ) -> Result<(), ()> {
-
     let jws_validator = jws_signer.get_validator().map_err(|e| {
         error!(?e, "Failed to get jws validator");
     })?;
@@ -401,7 +400,6 @@ pub fn create_https_server(
 
     // If we are no-ui, we remove this.
     if !matches!(role, ServerRole::WriteReplicaNoUI) {
-
         let pkg_path = PathBuf::from(env!("KANIDM_WEB_UI_PKG_PATH"));
         if !pkg_path.exists() {
             eprintln!(

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -15,7 +15,7 @@ name = "orca"
 path = "src/main.rs"
 
 [dependencies]
-tikv-jemallocator = "0.5.0"
+
 tracing = "^0.1.34"
 tracing-subscriber = "^0.3.11"
 
@@ -45,6 +45,10 @@ crossbeam = "0.8.1"
 mathru = "^0.12.0"
 
 dialoguer = "0.10.1"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 
 [build-dependencies]
 profiles = { path = "../profiles" }

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -46,7 +46,7 @@ mathru = "^0.12.0"
 
 dialoguer = "0.10.1"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(target_family = "windows"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 

--- a/orca/src/main.rs
+++ b/orca/src/main.rs
@@ -8,6 +8,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
+#[cfg(not(target_family = "windows"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
Because other OSen need 🦀🔪  too.

This makes sure that the `kanidm` client and `orca` build - I tried for `kanidmd` but there's a bunch of very unixy things in there that will likely need code changes, so I left it for now.

- [x] cargo fmt has been run and I'm offended you'd even ask, Your Honour.
- [x] cargo clippy has been run
- [x] cargo test has been run and passes, I think?
- [x] docs updated with a vague note about Windows support.