### PR TITLE
kanidm_unixd logging - when can't write to sql path, log filename

### DIFF
--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -94,14 +94,15 @@ impl<'a> DbTxn<'a> {
             &self.conn.path()
         );
     }
+
     /// This handles an error coming back from an sqlite transaction and dumps a load of information from it
-    fn sqlite_transaction_error(&self, error: rusqlite::Error, stmt: &rusqlite::Statement) {
+    fn sqlite_transaction_error(&self, error: rusqlite::Error, _stmt: &rusqlite::Statement) {
         error!(
             "sqlite transaction error={:?} db_path={:?}",
             error,
             &self.conn.path(),
         );
-        debug!("Statement: {:?}", stmt);
+        // TODO: one day figure out if there's an easy way to dump the transaction without the token...
     }
 
     pub fn migrate(&self) -> Result<(), ()> {

--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -317,7 +317,7 @@ impl<'a> DbTxn<'a> {
             .map(|token| {
                 // token convert with json.
                 serde_json::from_slice(token.as_slice()).map_err(|e| {
-                    error!("json error -> {:?}", e);
+                    error!("get_accounts json error -> {:?}", e);
                 })
             })
             .collect()
@@ -325,10 +325,10 @@ impl<'a> DbTxn<'a> {
 
     pub fn update_account(&self, account: &UnixUserToken, expire: u64) -> Result<(), ()> {
         let data = serde_json::to_vec(account).map_err(|e| {
-            error!("json error -> {:?}", e);
+            error!("update_account json error -> {:?}", e);
         })?;
         let expire = i64::try_from(expire).map_err(|e| {
-            error!("i64 convert error -> {:?}", e);
+            error!("update_account i64 conversion error -> {:?}", e);
         })?;
 
         // This is needed because sqlites 'insert or replace into', will null the password field
@@ -345,7 +345,7 @@ impl<'a> DbTxn<'a> {
             }
             )
             .map_err(|e| {
-                debug!("sqlite delete account_t duplicate failure -> {:?}", e);
+                self.sqlite_error("delete account_t duplicate", e);
             })
             .map(|_| ())?;
 
@@ -361,7 +361,7 @@ impl<'a> DbTxn<'a> {
             }
             )
             .map_err(|e| {
-                debug!("sqlite delete account_t duplicate failure -> {:?}", e);
+                self.sqlite_error("delete account_t duplicate",e);
             })?;
 
         if updated == 0 {

--- a/kanidm_unix_int/src/db.rs
+++ b/kanidm_unix_int/src/db.rs
@@ -97,11 +97,11 @@ impl<'a> DbTxn<'a> {
     /// This handles an error coming back from an sqlite transaction and dumps a load of information from it
     fn sqlite_transaction_error(&self, error: rusqlite::Error, stmt: &rusqlite::Statement) {
         error!(
-            "sqlite transaction error={:?} db_path={:?} statement={:?}",
+            "sqlite transaction error={:?} db_path={:?}",
             error,
             &self.conn.path(),
-            stmt
         );
+        debug!("Statement: {:?}", stmt);
     }
 
     pub fn migrate(&self) -> Result<(), ()> {
@@ -172,7 +172,7 @@ impl<'a> DbTxn<'a> {
     pub fn commit(mut self) -> Result<(), ()> {
         // debug!("Commiting BE txn");
         if self.committed {
-            error!("Invalid state, txn already commited!");
+            error!("Invalid state, SQL transaction was already commited!");
             return Err(());
         }
         self.committed = true;
@@ -181,7 +181,7 @@ impl<'a> DbTxn<'a> {
             .execute("COMMIT TRANSACTION", [])
             .map(|_| ())
             .map_err(|e| {
-                self.sqlite_error("commit failure", e);
+                self.sqlite_error("commit", e);
             })
     }
 


### PR DESCRIPTION
Fixes #893 - took all the error messages and did my usual DRY thing, prints out the filename and the error, left a TODO for future code-spelunkers to decide to print out the SQL statement if they dare...

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

