### PR TITLE
fix account_and_group docs

### DIFF
--- a/kanidm_book/src/accounts_and_groups.md
+++ b/kanidm_book/src/accounts_and_groups.md
@@ -80,7 +80,7 @@ An example can be easily shown with:
     kanidm group create group_2 --name idm_admin
     kanidm account create nest_example "Nesting Account Example" --name idm_admin
     kanidm group add_members group_1 group_2 --name idm_admin
-    kanidm group add_members group2 nest_example --name idm_admin
+    kanidm group add_members group_2 nest_example --name idm_admin
     kanidm account get nest_example --name anonymous
 
 ## Account Validity


### PR DESCRIPTION
fix typo "group2" to "group_2"

Fixes #

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
