### PR TITLE
Tide route map things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "compact_jwt",
  "futures",
  "futures-util",
+ "http-types",
  "kanidm",
  "kanidm_client",
  "kanidm_proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,16 @@ lto = "thin"
 
 [workspace]
 members = [
-    "kanidm_proto",
-    "kanidmd/idm",
-    "kanidmd/score",
-    "kanidmd/daemon",
-    "kanidmd_web_ui",
     "kanidm_client",
+    "kanidm_proto",
     "kanidm_tools",
     "kanidm_unix_int",
     "kanidm_unix_int/nss_kanidm",
     "kanidm_unix_int/pam_kanidm",
+    "kanidmd_web_ui",
+    "kanidmd/daemon",
+    "kanidmd/idm",
+    "kanidmd/score",
     "orca",
     "profiles",
 ]

--- a/kanidm_book/src/SUMMARY.md
+++ b/kanidm_book/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Developer Guide](DEVELOPER_README.md)
 - [Design Documents]()
   - [Access Profiles](developers/designs/access_profiles_and_security.md)
+  - [REST Interface](developers/designs/rest_interface.md)
 - [Python Module](developers/python.md)
 - [RADIUS Integration](developers/radius.md)
 

--- a/kanidm_book/src/developers/designs/rest_interface.md
+++ b/kanidm_book/src/developers/designs/rest_interface.md
@@ -1,0 +1,48 @@
+# REST Interface
+
+
+{{#template  
+    ../../templates/kani-warning.md
+    text=Here begins some early notes on the REST interface - much better ones are in the repository's designs directory.
+}}
+
+There's an endpoint at `/<api_version>/routemap` (for example, https://localhost/v1/routemap) which is based on the API routes as they get instantiated.
+
+It's *very, very, very* early work, and should not be considered stable at all.
+
+An example of some elements of the output is below:
+
+```json
+{
+  "routelist": [
+    {
+      "path": "/",
+      "method": "GET"
+    },
+    {
+      "path": "/robots.txt",
+      "method": "GET"
+    },
+    {
+      "path": "/ui/",
+      "method": "GET"
+    },
+    {
+      "path": "/v1/account/:id/_unix/_token",
+      "method": "GET"
+    },
+    {
+      "path": "/v1/schema/attributetype/:id",
+      "method": "GET"
+    },
+    {
+      "path": "/v1/schema/attributetype/:id",
+      "method": "PUT"
+    },
+    {
+      "path": "/v1/schema/attributetype/:id",
+      "method": "PATCH"
+    }
+  ]
+}
+```

--- a/kanidmd/score/Cargo.toml
+++ b/kanidmd/score/Cargo.toml
@@ -17,6 +17,7 @@ async-std = { version = "^1.12.0", features = ["tokio1"] }
 async-trait = "^0.1.53"
 compact_jwt = "^0.2.3"
 futures-util = "^0.3.21"
+http-types = "^2.12.0"
 kanidm = { path = "../idm" }
 kanidm_client = { path = "../../kanidm_client" }
 kanidm_proto = { path = "../../kanidm_proto" }
@@ -27,9 +28,9 @@ regex = "1.5.6"
 serde = { version = "^1.0.138", features = ["derive"] }
 serde_json = "^1.0.82"
 tide = "^0.16.0"
-tide-openssl = "^0.1.1"
 # I tried including brotli and it didn't work, including "default" pulls a mime-type list from the internet on build
 tide-compress = { version = "0.10.4", default-features = false, features = [ "deflate", "gzip", "regex-check" ] }
+tide-openssl = "^0.1.1"
 tokio = { version = "^1.19.1", features = ["net", "sync", "io-util", "macros"] }
 tokio-openssl = "^0.6.3"
 tokio-util = { version = "^0.7.3", features = ["codec"] }

--- a/kanidmd/score/src/https/routemaps.rs
+++ b/kanidmd/score/src/https/routemaps.rs
@@ -1,10 +1,10 @@
+use crate::https::AppState;
 ///! Route-mapping magic for tide
 ///
 /// Instead of adding routes with (for example) the .post method you add them with .mapped_post, pasing an instance of [RouteMap] and it'll do the rest...
 ///
 use serde::{Deserialize, Serialize};
 use tide::{Endpoint, Route};
-use crate::https::AppState;
 
 // Extends the tide::Route for RouteMaps, this would really be nice if it was generic :(
 pub trait RouteMaps {

--- a/kanidmd/score/src/https/routemaps.rs
+++ b/kanidmd/score/src/https/routemaps.rs
@@ -1,0 +1,95 @@
+///! Route-mapping magic for tide
+///
+/// Instead of adding routes with (for example) the .post method you add them with .mapped_post, pasing an instance of [RouteMap] and it'll do the rest...
+///
+use serde::{Deserialize, Serialize};
+use tide::{Endpoint, Route};
+use crate::https::AppState;
+
+// Extends the tide::Route for RouteMaps, this would really be nice if it was generic :(
+pub trait RouteMaps {
+    fn mapped_method(
+        &mut self,
+        routemap: &mut RouteMap,
+        method: http_types::Method,
+        ep: impl Endpoint<AppState>,
+    ) -> &mut Self;
+    fn mapped_delete(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self;
+    fn mapped_get(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self;
+    fn mapped_patch(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self;
+    fn mapped_post(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self;
+    fn mapped_put(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self;
+    fn mapped_update(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self;
+}
+
+impl RouteMaps for Route<'_, AppState> {
+    // add a mapped method to the list
+    fn mapped_method(
+        &mut self,
+        routemap: &mut RouteMap,
+        method: http_types::Method,
+        ep: impl Endpoint<AppState>,
+    ) -> &mut Self {
+        // TODO: truly weird things involving ASTs and sacrifices to eldritch gods to figure out how to represent the Endpoint
+
+        // if the path is empty then it's the root path...
+        let path_str = self.path().to_string();
+        let path = match path_str.is_empty() {
+            true => String::from("/"),
+            false => path_str,
+        };
+
+        // debug!("Mapping route: {:?}", path);
+        routemap.routelist.push(RouteInfo { path, method });
+        self.method(method, ep)
+    }
+    fn mapped_delete(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self {
+        self.mapped_method(routemap, http_types::Method::Delete, ep)
+    }
+    fn mapped_get(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self {
+        self.mapped_method(routemap, http_types::Method::Get, ep)
+    }
+    fn mapped_patch(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self {
+        self.mapped_method(routemap, http_types::Method::Patch, ep)
+    }
+    fn mapped_post(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self {
+        self.mapped_method(routemap, http_types::Method::Post, ep)
+    }
+    fn mapped_put(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self {
+        self.mapped_method(routemap, http_types::Method::Put, ep)
+    }
+    fn mapped_update(&mut self, routemap: &mut RouteMap, ep: impl Endpoint<AppState>) -> &mut Self {
+        self.mapped_method(routemap, http_types::Method::Update, ep)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Information about a given route
+pub struct RouteInfo {
+    pub path: String,
+    pub method: http_types::Method,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RouteMap {
+    pub routelist: Vec<RouteInfo>,
+}
+
+impl Default for RouteMap {
+    fn default() -> Self {
+        RouteMap {
+            routelist: Vec::new(),
+        }
+    }
+}
+
+impl RouteMap {
+    // Serializes the object out to a pretty JSON blob
+    pub fn do_map(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap()
+    }
+    // Inject the route for the routemap endpoint
+    pub fn push_self(&mut self, path: String, method: http_types::Method) {
+        self.routelist.push(RouteInfo { path, method });
+    }
+}

--- a/kanidmd/score/src/https/v1.rs
+++ b/kanidmd/score/src/https/v1.rs
@@ -11,7 +11,7 @@ use kanidm_proto::v1::{
     ModifyRequest, OperationError, SearchRequest, SetCredentialRequest, SingleStringRequest,
 };
 
-use super::{to_tide_response, AppState, RequestExtensions};
+use super::{to_tide_response, AppState, RequestExtensions, RouteMap};
 use async_std::task;
 use compact_jwt::Jws;
 use std::str::FromStr;
@@ -872,6 +872,13 @@ pub async fn recycle_bin_revive_id_post(req: tide::Request<AppState>) -> tide::R
         .handle_reviverecycled(uat, filter, eventid)
         .await;
     to_tide_response(res, hvalue)
+}
+
+pub async fn do_routemap(req: tide::Request<RouteMap>) -> tide::Result {
+    let mut res = tide::Response::new(200);
+
+    res.set_body(req.state().do_map());
+    Ok(res)
 }
 
 pub async fn do_nothing(_req: tide::Request<AppState>) -> tide::Result {


### PR DESCRIPTION
Adds an endpoint which provides a full list of available routes on the server.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes


This is a super early version, dumps a JSON blob of path/method. There's only minor changes to how the routes are set up, so it's relatively self-maintaining. 

Example output here: https://gist.github.com/yaleman/4fff1994bb1aee8e3f0d401bcc3cdf5f