### PR TITLE
Fixing the Github Actions Kanidmd build

### DIFF
--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -30,6 +30,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         # don't log in if we're not going to push!
         if: ${{ github.ref == 'refs/heads/master' }}
+
       - name: Build and push kanidmd
         id: docker_build_kanidmd
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -30,7 +30,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         # don't log in if we're not going to push!
         if: ${{ github.ref == 'refs/heads/master' }}
-
       - name: Build and push kanidmd
         id: docker_build_kanidmd
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -8,8 +8,8 @@ name: Container - Kanidmd
 "on":
   pull_request:
   push:
-    branches:
-      - master
+    # branches:
+      # - master
 
 jobs:
   kanidmd_build:

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -8,8 +8,8 @@ name: Container - Kanidmd
 "on":
   pull_request:
   push:
-    # branches:
-      # - master
+    branches:
+      - master
 
 jobs:
   kanidmd_build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07b0a1390e01c0fc35ebb26b28ced33c9a3808f7f9fbe94d3cc01e233bfeed5"
+checksum = "32ad5bf234c7d3ad1042e5252b7eddb2c4669ee23f32c7dd0e9b7705f07ef591"
 dependencies = [
  "idna",
  "lazy_static",
@@ -4354,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7ed5e8cf2b6bdd64a6c4ce851da25388a89327b17b88424ceced6bd5017923"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -4370,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ddf34293296847abfc1493b15c6e2f5d3cd19f57ad7d22673bf4c6278da329"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -37,7 +37,6 @@ RUN echo $KANIDM_FEATURES
 ENV KANIDM_BUILD_PROFILE="${KANIDM_BUILD_PROFILE}"
 
 ENV CARGO_HOME=/scratch/.cargo
-ENV RUSTFLAGS="-Clinker=clang"
 
 WORKDIR /usr/src/kanidm/kanidmd_web_ui
 RUN if [ "${SCCACHE_REDIS}" != "" ]; \
@@ -48,6 +47,7 @@ RUN if [ "${SCCACHE_REDIS}" != "" ]; \
     fi && \
     ./build_wasm.sh
 
+ENV RUSTFLAGS="-Clinker=clang"
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
 ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.lld"

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -33,8 +33,6 @@ RUN mkdir /scratch
 RUN echo $KANIDM_BUILD_PROFILE
 RUN echo $KANIDM_FEATURES
 
-# Set the build profile
-ENV KANIDM_BUILD_PROFILE="${KANIDM_BUILD_PROFILE}"
 
 ENV CARGO_HOME=/scratch/.cargo
 
@@ -46,8 +44,11 @@ RUN if [ "${SCCACHE_REDIS}" != "" ]; \
             sccache --start-server; \
     fi && \
     ./build_wasm.sh
-
+# This has to be after the WASM build because weird reasons.
+# Set the build profile
+ENV KANIDM_BUILD_PROFILE="${KANIDM_BUILD_PROFILE}"
 ENV RUSTFLAGS="-Clinker=clang"
+
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
 ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.lld"


### PR DESCRIPTION
- moves rustflags and build config to stop the WASM build blowing up in the container because reasons.

