### PR TITLE
Resolve session cancellation without an intent token

### DIFF
--- a/kanidmd/idm/src/idm/credupdatesession.rs
+++ b/kanidmd/idm/src/idm/credupdatesession.rs
@@ -861,18 +861,22 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         };
 
         // Apply to the account!
-        trace!(?modlist, "processing change");
+        if !modlist.is_empty() {
+            trace!(?modlist, "processing change");
 
-        self.qs_write
-            .internal_modify(
-                // Filter as executed
-                &filter!(f_eq("uuid", PartialValue::new_uuid(session.account.uuid))),
-                &modlist,
-            )
-            .map_err(|e| {
-                request_error!(error = ?e);
-                e
-            })
+            self.qs_write
+                .internal_modify(
+                    // Filter as executed
+                    &filter!(f_eq("uuid", PartialValue::new_uuid(session.account.uuid))),
+                    &modlist,
+                )
+                .map_err(|e| {
+                    request_error!(error = ?e);
+                    e
+                })
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #966 the modlist was empty when an update was created witohut an intent token, leading to an empty request error. 

It makes me think I need to go on a big improvement of "error" messages to make them more informative. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
