### PR TITLE
Resolve issue with migration application order

### DIFF
--- a/kanidmd/idm/src/server.rs
+++ b/kanidmd/idm/src/server.rs
@@ -2261,7 +2261,12 @@ impl<'a> QueryServerWriteTransaction<'a> {
         spanned!("server::migrate_5_to_6", {
             admin_warn!("starting 5 to 6 migration.");
             let filter = filter!(f_eq("uuid", (*PVUUID_DOMAIN_INFO).clone()));
-            let modlist = ModifyList::new_purge("domain_token_key");
+            let mut modlist = ModifyList::new_purge("domain_token_key");
+            // We need to also push the version here so that we pass schema.
+            modlist.push_mod(Modify::Present(
+                AttrString::from("version"),
+                Value::Uint32(0),
+            ));
             self.internal_modify(&filter, &modlist)
             // Complete
         })


### PR DESCRIPTION
Fixes #972 - when migrating from .7 to .9 an ordering issue occured due to changes in the domain entry. The value for domain_token_key has been removed, so it required a modification to purge this from existing entries. However we also added a version field for future use. 

This led to an issue where when we went to delete the domain_token_key from an existing entry, the version field was missing, which prevented the migration succeeding. If the migrations were reversed, adding version first would fail as domain_token_key was still present.

In the normal upgrade case this was avoided because between .7 to .8 domain_token_key was removed, then between .8 to .9 version was added. But trying to do both at the same time highlighted an issue. 

In this situation, force the version to be added as "0" in the domain_token_key removal so that it passes schema checking, and then the value of this version is updated to "1" as part of the init_idm phase. 

Will be backported to 1.1.0-alpha.9

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
