### PR TITLE
Fix credential parsing

### DIFF
--- a/kanidmd/idm/src/be/dbvalue.rs
+++ b/kanidmd/idm/src/be/dbvalue.rs
@@ -1,5 +1,6 @@
 use hashbrown::HashSet;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
@@ -25,8 +26,8 @@ pub enum DbPasswordV1 {
     SSHA512(Vec<u8>, Vec<u8>),
 }
 
-impl std::fmt::Debug for DbPasswordV1 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for DbPasswordV1 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             DbPasswordV1::PBKDF2(_, _, _) => write!(f, "PBKDF2"),
             DbPasswordV1::SSHA512(_, _) => write!(f, "SSHA512"),
@@ -180,6 +181,100 @@ pub enum DbCred {
         webauthn: Vec<(String, SecurityKeyV4)>,
         uuid: Uuid,
     },
+}
+
+impl fmt::Display for DbCred {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DbCred::Pw {
+                password,
+                webauthn,
+                totp,
+                backup_code,
+                claims,
+                uuid,
+            } => write!(
+                f,
+                "Pw (p {}, w {}, t {}, b {}, c {}, u {})",
+                password.is_some(),
+                webauthn.is_some(),
+                totp.is_some(),
+                backup_code.is_some(),
+                claims.len(),
+                uuid
+            ),
+            DbCred::GPw {
+                password,
+                webauthn,
+                totp,
+                backup_code,
+                claims,
+                uuid,
+            } => write!(
+                f,
+                "GPw (p {}, w {}, t {}, b {}, c {}, u {})",
+                password.is_some(),
+                webauthn.is_some(),
+                totp.is_some(),
+                backup_code.is_some(),
+                claims.len(),
+                uuid
+            ),
+            DbCred::PwMfa {
+                password,
+                webauthn,
+                totp,
+                backup_code,
+                claims,
+                uuid,
+            } => write!(
+                f,
+                "PwMfa (p {}, w {}, t {}, b {}, c {}, u {})",
+                password.is_some(),
+                webauthn.is_some(),
+                totp.is_some(),
+                backup_code.is_some(),
+                claims.len(),
+                uuid
+            ),
+            DbCred::Wn {
+                password,
+                webauthn,
+                totp,
+                backup_code,
+                claims,
+                uuid,
+            } => write!(
+                f,
+                "Wn (p {}, w {}, t {}, b {}, c {}, u {})",
+                password.is_some(),
+                webauthn.is_some(),
+                totp.is_some(),
+                backup_code.is_some(),
+                claims.len(),
+                uuid
+            ),
+            DbCred::TmpWn { webauthn, uuid } => {
+                write!(f, "TmpWn ( w {}, u {} )", webauthn.len(), uuid)
+            }
+            DbCred::V2Password { password: _, uuid } => write!(f, "V2Pw ( u {} )", uuid),
+            DbCred::V2GenPassword { password: _, uuid } => write!(f, "V2GPw ( u {} )", uuid),
+            DbCred::V2PasswordMfa {
+                password: _,
+                totp,
+                backup_code,
+                webauthn,
+                uuid,
+            } => write!(
+                f,
+                "Wn (p true, w {}, t {}, b {}, u {})",
+                webauthn.len(),
+                totp.is_some(),
+                backup_code.is_some(),
+                uuid
+            ),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/kanidmd/idm/src/be/dbvalue.rs
+++ b/kanidmd/idm/src/be/dbvalue.rs
@@ -267,7 +267,7 @@ impl fmt::Display for DbCred {
                 uuid,
             } => write!(
                 f,
-                "Wn (p true, w {}, t {}, b {}, u {})",
+                "V2PwMfa (p true, w {}, t {}, b {}, u {})",
                 webauthn.len(),
                 totp.is_some(),
                 backup_code.is_some(),

--- a/kanidmd/idm/src/credential/mod.rs
+++ b/kanidmd/idm/src/credential/mod.rs
@@ -375,8 +375,7 @@ impl TryFrom<DbCred> for Credential {
                 };
 
                 let v_webauthn = match maybe_db_webauthn {
-                    Some(db_webauthn) => {
-                        db_webauthn
+                    Some(db_webauthn) => db_webauthn
                         .into_iter()
                         .map(|wc| {
                             (
@@ -390,8 +389,7 @@ impl TryFrom<DbCred> for Credential {
                                 })),
                             )
                         })
-                        .collect()
-                    }
+                        .collect(),
                     None => Default::default(),
                 };
 
@@ -456,14 +454,18 @@ impl TryFrom<DbCred> for Credential {
             }
             DbCred::V2PasswordMfa {
                 password: db_password,
-                totp: Some(db_totp),
+                totp: maybe_db_totp,
                 backup_code,
                 webauthn: db_webauthn,
                 uuid,
             } => {
                 let v_password = Password::try_from(db_password)?;
 
-                let v_totp = Some(Totp::try_from(db_totp)?);
+                let v_totp = if let Some(db_totp) = maybe_db_totp {
+                    Some(Totp::try_from(db_totp)?)
+                } else {
+                    None
+                };
 
                 let v_backup_code = match backup_code {
                     Some(dbb) => Some(BackupCodes::try_from(dbb)?),

--- a/kanidmd/idm/src/credential/mod.rs
+++ b/kanidmd/idm/src/credential/mod.rs
@@ -325,9 +325,9 @@ impl TryFrom<DbCred> for Credential {
             }
             | DbCred::Pw {
                 password: Some(db_password),
-                webauthn: None,
-                totp: None,
-                backup_code: None,
+                webauthn: _,
+                totp: _,
+                backup_code: _,
                 claims: _,
                 uuid,
             } => {
@@ -345,9 +345,9 @@ impl TryFrom<DbCred> for Credential {
             }
             | DbCred::GPw {
                 password: Some(db_password),
-                webauthn: None,
-                totp: None,
-                backup_code: None,
+                webauthn: _,
+                totp: _,
+                backup_code: _,
                 claims: _,
                 uuid,
             } => {
@@ -361,7 +361,7 @@ impl TryFrom<DbCred> for Credential {
             }
             DbCred::PwMfa {
                 password: Some(db_password),
-                webauthn: Some(db_webauthn),
+                webauthn: maybe_db_webauthn,
                 totp,
                 backup_code,
                 claims: _,
@@ -374,21 +374,26 @@ impl TryFrom<DbCred> for Credential {
                     None => None,
                 };
 
-                let v_webauthn = db_webauthn
-                    .into_iter()
-                    .map(|wc| {
-                        (
-                            wc.label,
-                            SecurityKey::from(WebauthnCredential::from(CredentialV3 {
-                                cred_id: wc.id,
-                                cred: wc.cred,
-                                counter: wc.counter,
-                                verified: wc.verified,
-                                registration_policy: wc.registration_policy,
-                            })),
-                        )
-                    })
-                    .collect();
+                let v_webauthn = match maybe_db_webauthn {
+                    Some(db_webauthn) => {
+                        db_webauthn
+                        .into_iter()
+                        .map(|wc| {
+                            (
+                                wc.label,
+                                SecurityKey::from(WebauthnCredential::from(CredentialV3 {
+                                    cred_id: wc.id,
+                                    cred: wc.cred,
+                                    counter: wc.counter,
+                                    verified: wc.verified,
+                                    registration_policy: wc.registration_policy,
+                                })),
+                            )
+                        })
+                        .collect()
+                    }
+                    None => Default::default(),
+                };
 
                 let v_backup_code = match backup_code {
                     Some(dbb) => Some(BackupCodes::try_from(dbb)?),
@@ -405,10 +410,10 @@ impl TryFrom<DbCred> for Credential {
                 }
             }
             DbCred::Wn {
-                password: None,
+                password: _,
                 webauthn: Some(db_webauthn),
-                totp: None,
-                backup_code: None,
+                totp: _,
+                backup_code: _,
                 claims: _,
                 uuid,
             } => {
@@ -436,8 +441,18 @@ impl TryFrom<DbCred> for Credential {
                     Err(())
                 }
             }
-            DbCred::TmpWn { .. } => {
-                todo!()
+            DbCred::TmpWn {
+                webauthn: db_webauthn,
+                uuid,
+            } => {
+                let v_webauthn = db_webauthn.into_iter().collect();
+                let type_ = CredentialType::Webauthn(v_webauthn);
+
+                if type_.is_valid() {
+                    Ok(Credential { type_, uuid })
+                } else {
+                    Err(())
+                }
             }
             DbCred::V2PasswordMfa {
                 password: db_password,
@@ -466,8 +481,10 @@ impl TryFrom<DbCred> for Credential {
                     Err(())
                 }
             }
-            _ => {
-                error!("Database content may be corrupt - invalid credential");
+            credential => {
+                error!("Database content may be corrupt - invalid credential state");
+                debug!(%credential);
+                debug!(?credential);
                 Err(())
             }
         }


### PR DESCRIPTION
Fixes #972 - In the last dev cycle I made credential parsing too strict in some cases that may cause the entries to falsely flag as invalid. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
