### PR TITLE
Version argument for kanidm and kanidmd 

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -23,5 +23,9 @@ jobs:
           libssl-dev \
           libsqlite3-dev
 
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -25,6 +25,10 @@ jobs:
           libssl-dev \
           libsqlite3-dev
 
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
     - name: Run tests
       run: cargo test --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.3",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -1959,7 +1959,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.3",
+ "itoa 1.0.2",
  "pin-project-lite 0.2.9",
  "socket2",
  "tokio",
@@ -2085,9 +2085,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -2205,8 +2205,11 @@ version = "1.1.0-alpha.9"
 dependencies = [
  "clap 3.2.17",
  "clap_complete",
+ "compact_jwt",
+ "dialoguer",
  "kanidm_client",
  "kanidm_proto",
+ "libc",
  "qrcode",
  "rayon",
  "rpassword 7.0.0",
@@ -2337,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
 
 [[package]]
 name = "libgit2-sys"
@@ -3597,7 +3600,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -3629,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.3",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -4094,7 +4097,8 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.2",
+ "js-sys",
  "libc",
  "num_threads",
  "time-macros 0.2.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gloo"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2192,7 @@ dependencies = [
  "clap_complete",
  "compact_jwt",
  "dialoguer",
+ "git-version",
  "kanidm_client",
  "kanidm_proto",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1587,25 +1590,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-version"
-version = "0.3.5"
+name = "git2"
+version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
 dependencies = [
- "git-version-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -2085,6 +2081,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2180,7 @@ version = "1.1.0-alpha.9"
 dependencies = [
  "base32",
  "base64urlsafedata",
+ "last-git-commit",
  "serde",
  "serde_json",
  "time 0.2.27",
@@ -2192,7 +2198,6 @@ dependencies = [
  "clap_complete",
  "compact_jwt",
  "dialoguer",
- "git-version",
  "kanidm_client",
  "kanidm_proto",
  "libc",
@@ -2274,6 +2279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "last-git-commit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2e5243385b2ea0443d79fd6f5ea97b0509f2571e8f39e99d1ead2bcc1c89c0"
+dependencies = [
+ "git2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2336,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libnss"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,6 +2372,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libudev"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2403,18 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,7 +4098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa 1.0.2",
- "js-sys",
  "libc",
  "num_threads",
  "time-macros 0.2.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "anymap2"
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1983,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+checksum = "ef5528d9c2817db4e10cc78f8d4c8228906e5854f389ff6b076cee3572a09d35"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libgit2-sys"
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oncemutex"
@@ -2903,18 +2903,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,11 +2205,8 @@ version = "1.1.0-alpha.9"
 dependencies = [
  "clap 3.2.17",
  "clap_complete",
- "compact_jwt",
- "dialoguer",
  "kanidm_client",
  "kanidm_proto",
- "libc",
  "qrcode",
  "rayon",
  "rpassword 7.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -83,6 +83,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "anymap2"
@@ -128,7 +137,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
 ]
 
 [[package]]
@@ -156,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -391,10 +400,10 @@ dependencies = [
 
 [[package]]
 name = "authenticator"
-version = "0.3.1"
-source = "git+https://github.com/Firstyear/authenticator-rs.git?branch=webauthn-authenticator-rs#8e2f599dadd2039cf6b1776cdc501bec02317054"
+version = "0.3.2"
+source = "git+https://github.com/Firstyear/authenticator-rs.git?branch=webauthn-authenticator-rs#19eab7b05c6d8362c33247bcb58dec242ecdde49"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.13.0",
  "bitflags",
  "cfg-if 1.0.0",
  "core-foundation",
@@ -402,16 +411,17 @@ dependencies = [
  "libc",
  "libudev",
  "log",
- "nom 5.1.2",
+ "memoffset",
+ "nom 7.1.1",
  "openssl",
  "openssl-sys",
- "rand 0.7.3",
+ "rand 0.8.5",
  "runloop",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2 0.8.2",
+ "sha2 0.10.2",
  "winapi",
 ]
 
@@ -432,15 +442,6 @@ name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -527,7 +528,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -536,7 +537,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -645,10 +646,11 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
@@ -664,7 +666,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -680,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -697,18 +699,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.2.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+checksum = "e4179da71abd56c26b54dd0c248cc081c1f43b0a1a7e8448e28e57a29baa993d"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -838,7 +840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding",
- "time 0.3.12",
+ "time 0.3.13",
  "version_check",
 ]
 
@@ -854,7 +856,7 @@ dependencies = [
  "publicsuffix",
  "serde",
  "serde_json",
- "time 0.3.12",
+ "time 0.3.13",
  "url",
 ]
 
@@ -1009,7 +1011,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "typenum",
 ]
 
@@ -1019,7 +1021,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
@@ -1029,7 +1031,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
@@ -1078,7 +1080,7 @@ dependencies = [
 name = "daemon"
 version = "1.1.0-alpha.9"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
  "clap_complete",
  "kanidm",
  "kanidm_proto",
@@ -1215,7 +1217,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1434,9 +1436,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1449,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1459,15 +1461,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1476,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-lite"
@@ -1497,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1508,21 +1510,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1547,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -1812,12 +1814,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1832,7 +1828,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1888,7 +1884,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.3",
 ]
 
 [[package]]
@@ -1963,7 +1959,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "pin-project-lite 0.2.9",
  "socket2",
  "tokio",
@@ -1983,6 +1979,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -2026,7 +2035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2076,9 +2085,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -2116,7 +2125,7 @@ dependencies = [
  "filetime",
  "futures",
  "futures-util",
- "hashbrown 0.12.3",
+ "hashbrown",
  "idlset",
  "kanidm_proto",
  "lazy_static",
@@ -2194,7 +2203,7 @@ dependencies = [
 name = "kanidm_tools"
 version = "1.1.0-alpha.9"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
  "clap_complete",
  "compact_jwt",
  "dialoguer",
@@ -2222,7 +2231,7 @@ name = "kanidm_unix_int"
 version = "1.1.0-alpha.9"
 dependencies = [
  "bytes",
- "clap 3.2.16",
+ "clap 3.2.17",
  "clap_complete",
  "futures",
  "kanidm",
@@ -2331,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "libgit2-sys"
@@ -2450,7 +2459,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2773,7 +2782,7 @@ dependencies = [
 name = "orca"
 version = "1.1.0-alpha.9"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
  "crossbeam",
  "csv",
  "dialoguer",
@@ -2799,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "pam_kanidm"
@@ -2996,10 +3005,11 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
@@ -3036,9 +3046,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -3054,18 +3064,16 @@ dependencies = [
 
 [[package]]
 name = "psl-types"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eda7c62d9ecaafdf8b62374c006de0adf61666ae96a96ba74a37134aa4e470"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "publicsuffix"
-version = "2.1.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292972edad6bbecc137ab84c5e36421a4a6c979ea31d3cc73540dd04315b33e1"
+checksum = "aeeedb0b429dc462f30ad27ef3de97058b060016f47790c066757be38ef792b4"
 dependencies = [
- "byteorder",
- "hashbrown 0.11.2",
  "idna",
  "psl-types",
 ]
@@ -3096,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -3398,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "saffron"
@@ -3528,9 +3536,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -3549,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
  "serde",
 ]
@@ -3568,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3592,16 +3600,16 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7868ad3b8196a8a0aea99a8220b124278ee5320a55e4fde97794b6f85b1a377"
+checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
 dependencies = [
  "serde",
 ]
@@ -3624,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -3885,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3956,18 +3964,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4085,12 +4093,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
- "itoa 1.0.2",
- "js-sys",
+ "itoa 1.0.3",
  "libc",
  "num_threads",
  "time-macros 0.2.4",
@@ -4336,9 +4343,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -4367,7 +4374,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
@@ -4810,7 +4817,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
 ]
 
 [[package]]
@@ -4930,5 +4937,5 @@ dependencies = [
  "lazy_static",
  "quick-error",
  "regex",
- "time 0.3.12",
+ "time 0.3.13",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.3",
 ]
 
 [[package]]
@@ -1959,7 +1959,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "pin-project-lite 0.2.9",
  "socket2",
  "tokio",
@@ -2085,9 +2085,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "libgit2-sys"
@@ -3600,7 +3600,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -3632,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -4097,7 +4097,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "libc",
  "num_threads",
  "time-macros 0.2.4",

--- a/kanidm_proto/Cargo.toml
+++ b/kanidm_proto/Cargo.toml
@@ -14,13 +14,14 @@ repository = "https://github.com/kanidm/kanidm/"
 wasm = ["webauthn-rs-proto/wasm"]
 
 [dependencies]
-serde = { version = "^1.0.142", features = ["derive"] }
-serde_json = "^1.0.83"
-uuid = { version = "^1.1.2", features = ["serde"] }
 base32 = "^0.4.0"
 base64urlsafedata = "0.1.0"
-webauthn-rs-proto = "0.4.2-beta.3"
+last-git-commit = "0.2.0"
+serde = { version = "^1.0.142", features = ["derive"] }
+serde_json = "^1.0.83"
 # Can not upgrade due to breaking timezone apis.
 time = { version = "=0.2.27", features = ["serde", "std"] }
 url = { version = "^2.2.2", features = ["serde"] }
 urlencoding = "2.1.0"
+uuid = { version = "^1.1.2", features = ["serde"] }
+webauthn-rs-proto = "0.4.2-beta.3"

--- a/kanidm_proto/src/lib.rs
+++ b/kanidm_proto/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod messages;
 pub mod oauth2;
+pub mod utils;
 pub mod v1;
 
 pub use webauthn_rs_proto as webauthn;

--- a/kanidm_proto/src/utils.rs
+++ b/kanidm_proto/src/utils.rs
@@ -1,0 +1,14 @@
+/// Shows the version string and current git commit status at build
+pub fn show_version(name: &str) {
+    println!("{}", get_version(name));
+}
+
+pub fn get_version(name: &str) -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    let lgc = match last_git_commit::LastGitCommit::new().build() {
+        Ok(value) => value.id().short(),
+        Err(_) => String::from("Unknown git commit"),
+    };
+
+    format!("{} {} ({})", name, version, lgc)
+}

--- a/kanidm_proto/src/utils.rs
+++ b/kanidm_proto/src/utils.rs
@@ -5,10 +5,8 @@ pub fn show_version(name: &str) {
 
 pub fn get_version(name: &str) -> String {
     let version = env!("CARGO_PKG_VERSION");
-    let lgc = match last_git_commit::LastGitCommit::new().build() {
-        Ok(value) => value.id().short(),
-        Err(_) => String::from("Unknown git commit"),
-    };
-
-    format!("{} {} ({})", name, version, lgc)
+    match last_git_commit::LastGitCommit::new().build() {
+        Ok(value) => format!("{} {} {}", name, version, value.id().short()),
+        Err(_) => format!("{} {}", name, version),
+    }
 }

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -29,32 +29,28 @@ name = "kanidm_badlist_preprocess"
 path = "src/badlist_preprocess.rs"
 
 [dependencies]
+clap = { version = "^3.2", features = ["derive", "env"] }
+compact_jwt = "^0.2.3"
+dialoguer =  "^0.10.1"
+git-version = "0.3.5"
+libc = "^0.2.127"
 kanidm_client = { path = "../kanidm_client", version = "1.1.0-alpha.8" }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha.8" }
-tracing = "^0.1.35"
-tracing-subscriber = { version = "^0.3.14", features = ["env-filter", "fmt"] }
+qrcode = { version = "^0.12.0", default-features = false }
+rayon = "^1.5.3"
 rpassword = "^7.0.0"
-clap = { version = "^3.2", features = ["derive", "env"] }
-libc = "^0.2.127"
 serde = { version = "^1.0.142", features = ["derive"] }
 serde_json = "^1.0.83"
 shellexpand = "^2.1.2"
-rayon = "^1.5.3"
 time = { version = "=0.2.27", features = ["serde", "std"] }
-qrcode = { version = "^0.12.0", default-features = false }
-compact_jwt = "^0.2.3"
-
-zxcvbn = "^2.2.1"
-
-dialoguer =  "^0.10.1"
-
-# webauthn-authenticator-rs = { version = "0.4.2-beta.3", features = ["u2fhid"] }
-webauthn-authenticator-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360", features = ["u2fhid"] }
-
+tracing = "^0.1.35"
+tracing-subscriber = { version = "^0.3.14", features = ["env-filter", "fmt"] }
 tokio = { version = "^1.20.0", features = ["rt", "macros"] }
-
 url = { version = "^2.2.2", features = ["serde"] }
 uuid = "^1.1.2"
+# webauthn-authenticator-rs = { version = "0.4.2-beta.3", features = ["u2fhid"] }
+webauthn-authenticator-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360", features = ["u2fhid"] }
+zxcvbn = "^2.2.1"
 
 [build-dependencies]
 clap = { version = "^3.2", features = ["derive"] }

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -32,7 +32,6 @@ path = "src/badlist_preprocess.rs"
 clap = { version = "^3.2", features = ["derive", "env"] }
 compact_jwt = "^0.2.3"
 dialoguer =  "^0.10.1"
-git-version = "0.3.5"
 libc = "^0.2.127"
 kanidm_client = { path = "../kanidm_client", version = "1.1.0-alpha.8" }
 kanidm_proto = { path = "../kanidm_proto", version = "1.1.0-alpha.8" }

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -91,15 +91,6 @@ impl SystemOpt {
     }
 }
 
-/// Shows the version string and current git commit status at build
-fn show_version() -> bool {
-    let version = env!("CARGO_PKG_VERSION");
-    let git_status = git_version::git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback="unknown git version");
-    println!("kanidm {} ({})", version, git_status);
-
-    true
-}
-
 impl KanidmClientOpt {
     pub fn debug(&self) -> bool {
         match self {
@@ -112,7 +103,10 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.debug(),
             KanidmClientOpt::System { commands } => commands.debug(),
             KanidmClientOpt::Recycle { commands } => commands.debug(),
-            KanidmClientOpt::Version {} => show_version(),
+            KanidmClientOpt::Version {} => {
+                kanidm_proto::utils::show_version("kanidm");
+                true
+            }
         }
     }
 
@@ -127,7 +121,7 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.exec().await,
             KanidmClientOpt::System { commands } => commands.exec().await,
             KanidmClientOpt::Recycle { commands } => commands.exec().await,
-            KanidmClientOpt::Version { } => (),
+            KanidmClientOpt::Version {} => (),
         }
     }
 }

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -91,15 +91,6 @@ impl SystemOpt {
     }
 }
 
-/// Shows the version string and current git commit status at build
-fn show_version() -> bool {
-    let version = env!("CARGO_PKG_VERSION");
-    let git_status = git_version::git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback="unknown git version");
-    println!("kanidm {} ({})", version, git_status);
-
-    true
-}
-
 impl KanidmClientOpt {
     pub fn debug(&self) -> bool {
         match self {
@@ -112,14 +103,10 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.debug(),
             KanidmClientOpt::System { commands } => commands.debug(),
             KanidmClientOpt::Recycle { commands } => commands.debug(),
-<<<<<<< HEAD
             KanidmClientOpt::Version {} => {
                 kanidm_proto::utils::show_version("kanidm");
                 true
             }
-=======
-            KanidmClientOpt::Version {} => show_version(),
->>>>>>> 99be0c7f (first commit of this change)
         }
     }
 
@@ -134,11 +121,7 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.exec().await,
             KanidmClientOpt::System { commands } => commands.exec().await,
             KanidmClientOpt::Recycle { commands } => commands.exec().await,
-<<<<<<< HEAD
             KanidmClientOpt::Version {} => (),
-=======
-            KanidmClientOpt::Version { } => (),
->>>>>>> 99be0c7f (first commit of this change)
         }
     }
 }

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -91,6 +91,14 @@ impl SystemOpt {
     }
 }
 
+/// Shows the version string and current git commit status at build
+fn show_version() -> bool {
+    let version = env!("CARGO_PKG_VERSION");
+    let git_status = git_version::git_version!(cargo_prefix = "cargo:", fallback="unknown git version");
+    println!("kanidm {} ({})", version, git_status);
+    true
+}
+
 impl KanidmClientOpt {
     pub fn debug(&self) -> bool {
         match self {
@@ -103,10 +111,14 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.debug(),
             KanidmClientOpt::System { commands } => commands.debug(),
             KanidmClientOpt::Recycle { commands } => commands.debug(),
+<<<<<<< HEAD
             KanidmClientOpt::Version {} => {
                 kanidm_proto::utils::show_version("kanidm");
                 true
             }
+=======
+            KanidmClientOpt::Version {} => show_version(),
+>>>>>>> 99be0c7f (first commit of this change)
         }
     }
 
@@ -121,7 +133,11 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.exec().await,
             KanidmClientOpt::System { commands } => commands.exec().await,
             KanidmClientOpt::Recycle { commands } => commands.exec().await,
+<<<<<<< HEAD
             KanidmClientOpt::Version {} => (),
+=======
+            KanidmClientOpt::Version { } => (),
+>>>>>>> 99be0c7f (first commit of this change)
         }
     }
 }

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -91,6 +91,14 @@ impl SystemOpt {
     }
 }
 
+/// Shows the version string and current git commit status at build
+fn show_version() -> bool {
+    let version = env!("CARGO_PKG_VERSION");
+    let git_status = git_version::git_version!(cargo_prefix = "cargo:", fallback="unknown git version");
+    println!("kanidm {} ({})", version, git_status);
+    true
+}
+
 impl KanidmClientOpt {
     pub fn debug(&self) -> bool {
         match self {
@@ -103,6 +111,7 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.debug(),
             KanidmClientOpt::System { commands } => commands.debug(),
             KanidmClientOpt::Recycle { commands } => commands.debug(),
+            KanidmClientOpt::Version {} => show_version(),
         }
     }
 
@@ -117,6 +126,7 @@ impl KanidmClientOpt {
             KanidmClientOpt::Group { commands } => commands.exec().await,
             KanidmClientOpt::System { commands } => commands.exec().await,
             KanidmClientOpt::Recycle { commands } => commands.exec().await,
+            KanidmClientOpt::Version { } => (),
         }
     }
 }

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -94,8 +94,9 @@ impl SystemOpt {
 /// Shows the version string and current git commit status at build
 fn show_version() -> bool {
     let version = env!("CARGO_PKG_VERSION");
-    let git_status = git_version::git_version!(cargo_prefix = "cargo:", fallback="unknown git version");
+    let git_status = git_version::git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback="unknown git version");
     println!("kanidm {} ({})", version, git_status);
+
     true
 }
 

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -556,6 +556,10 @@ pub enum KanidmClientOpt {
         #[clap(subcommand)]
         commands: RawOpt,
     },
+    /// Show the client version
+    Version {
+
+    }
 }
 
 #[derive(Debug, clap::Parser)]

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -556,6 +556,10 @@ pub enum KanidmClientOpt {
         #[clap(subcommand)]
         commands: RawOpt,
     },
+    /// Print the program version and exit
+    Version {
+
+    }
 }
 
 #[derive(Debug, clap::Parser)]

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -556,7 +556,7 @@ pub enum KanidmClientOpt {
         #[clap(subcommand)]
         commands: RawOpt,
     },
-    /// Show the client version
+    /// Print the program version and exit
     Version {
 
     }

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -556,10 +556,6 @@ pub enum KanidmClientOpt {
         #[clap(subcommand)]
         commands: RawOpt,
     },
-    /// Print the program version and exit
-    Version {
-
-    }
 }
 
 #[derive(Debug, clap::Parser)]

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -28,6 +28,7 @@ use std::os::unix::fs::MetadataExt;
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::exit;
 use std::str::FromStr;
 
 use sketching::tracing_forest::{self, traits::*, util::*};
@@ -119,6 +120,7 @@ impl KanidmdOpt {
             KanidmdOpt::Database {
                 commands: DbCommands::Vacuum(copt),
             } => &copt,
+            KanidmdOpt::Version(copt) => &copt,
         }
     }
 }
@@ -192,6 +194,12 @@ async fn main() {
 
             // Read cli args, determine if we should backup/restore
             let opt = KanidmdParser::parse();
+
+            // print the app version and bail
+            if let KanidmdOpt::Version(_) = &opt.commands {
+                kanidm_proto::utils::show_version("kanidmd");
+                exit(0);
+            };
 
             let mut config = Configuration::new();
             // Check the permissions are OK.
@@ -446,6 +454,9 @@ async fn main() {
                 } => {
                     eprintln!("Running in vacuum mode ...");
                     vacuum_server_core(&config);
+                }
+                _ => {
+                    panic!("How'd you get here?");
                 }
             }
         })

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -455,8 +455,8 @@ async fn main() {
                     eprintln!("Running in vacuum mode ...");
                     vacuum_server_core(&config);
                 }
-                _ => {
-                    panic!("How'd you get here?");
+                KanidmdOpt::Version(_) => {
+                    return
                 }
             }
         })

--- a/kanidmd/daemon/src/opt.rs
+++ b/kanidmd/daemon/src/opt.rs
@@ -3,7 +3,7 @@ struct CommonOpt {
     #[clap(short, long, env = "KANIDM_DEBUG")]
     /// Logging level. quiet, default, filter, verbose, perffull
     debug: Option<LogLevel>,
-    #[clap(parse(from_os_str), default_value = "/data/server.toml", short, long = "config", env = "KANIDM_CONFIG")]
+    #[clap(parse(from_os_str), default_value = "", short, long = "config", env = "KANIDM_CONFIG")]
     /// Path to the server's configuration file. If it does not exist, it will be created.
     config_path: PathBuf,
     /// Log format (still in very early development)

--- a/kanidmd/daemon/src/opt.rs
+++ b/kanidmd/daemon/src/opt.rs
@@ -3,7 +3,7 @@ struct CommonOpt {
     #[clap(short, long, env = "KANIDM_DEBUG")]
     /// Logging level. quiet, default, filter, verbose, perffull
     debug: Option<LogLevel>,
-    #[clap(parse(from_os_str), short, long = "config", env = "KANIDM_CONFIG")]
+    #[clap(parse(from_os_str), default_value = "/data/server.toml", short, long = "config", env = "KANIDM_CONFIG")]
     /// Path to the server's configuration file. If it does not exist, it will be created.
     config_path: PathBuf,
     /// Log format (still in very early development)
@@ -152,4 +152,7 @@ enum KanidmdOpt {
         #[clap(subcommand)]
         commands: DomainSettingsCmds,
     },
+    /// Print the program version and exit
+    #[clap(name="version")]
+    Version(CommonOpt)
 }

--- a/orca/Cargo.toml
+++ b/orca/Cargo.toml
@@ -15,36 +15,26 @@ name = "orca"
 path = "src/main.rs"
 
 [dependencies]
-
-tracing = "^0.1.35"
-tracing-subscriber = "^0.3.14"
-
 clap = { version = "^3.2", features = ["derive"] }
-
-uuid = { version = "^1.1.2", features = ["serde", "v4" ] }
+crossbeam = "0.8.1"
 csv = "1.1.6"
+dialoguer = "0.10.1"
+futures-util = { version = "^0.3.21", features = ["sink"] }
+kanidm_client = { path = "../kanidm_client" }
+kanidm_proto = { path = "../kanidm_proto" }
+ldap3_proto = "^0.2.3"
+mathru = "^0.13.0"
+openssl = "^0.10.41"
+rand = "^0.8.5"
 serde = { version = "^1.0.142", features = ["derive"] }
 serde_json = "^1.0.83"
-
-rand = "^0.8.5"
-toml = "^0.5.9"
-
-kanidm_proto = { path = "../kanidm_proto" }
-kanidm_client = { path = "../kanidm_client" }
-
 tokio = { version = "^1.20.0", features = ["rt-multi-thread"] }
-tokio-util = { version = "^0.7.3", features = ["codec"] }
 tokio-openssl = "^0.6.3"
-futures-util = { version = "^0.3.21", features = ["sink"] }
-openssl = "^0.10.41"
-
-ldap3_proto = "^0.2.3"
-
-crossbeam = "0.8.1"
-
-mathru = "^0.13.0"
-
-dialoguer = "0.10.1"
+tokio-util = { version = "^0.7.3", features = ["codec"] }
+toml = "^0.5.9"
+tracing = "^0.1.35"
+tracing-subscriber = "^0.3.14"
+uuid = { version = "^1.1.2", features = ["serde", "v4" ] }
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/sketching/src/lib.rs
+++ b/sketching/src/lib.rs
@@ -11,7 +11,7 @@ pub use tracing;
 pub use tracing_forest;
 pub use tracing_subscriber;
 
-pub fn test_init() -> () {
+pub fn test_init() {
     // tracing_subscriber::fmt::try_init()
     let _ = tracing_forest::test_init();
     /*

--- a/sketching/src/middleware.rs
+++ b/sketching/src/middleware.rs
@@ -4,13 +4,14 @@ use tracing::{self, instrument};
 
 use crate::*;
 
+#[derive(Default)]
 pub struct TreeMiddleware {}
 
-impl Default for TreeMiddleware {
-    fn default() -> Self {
-        TreeMiddleware {}
-    }
-}
+// impl Default for TreeMiddleware {
+//     fn default() -> Self {
+//         TreeMiddleware {}
+//     }
+// }
 
 impl TreeMiddleware {
     #[instrument(name = "tide-request", skip(self, req, next))]


### PR DESCRIPTION
Relates to #989, implements `version` for kanidm and kanidmd.

The tweaks in `sketching` were me not being able to leave a clippy lint alone. :)

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes


Example output:

```
# kanidmd version
kanidmd 1.1.0-alpha.9 (b8d09ab)
```