### PR TITLE
Allow disabling networked tests in python client library

### DIFF
--- a/pykanidm/pyproject.toml
+++ b/pykanidm/pyproject.toml
@@ -55,6 +55,9 @@ load-plugins="pylint_pydantic,pylint_pytest"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "network: Tests that require network access",
+]
 
 [tool.coverage.run]
 source = ["kanidm"]

--- a/pykanidm/tests/test_authenticate.py
+++ b/pykanidm/tests/test_authenticate.py
@@ -18,6 +18,7 @@ from kanidm.types import AuthBeginResponse
 logging.basicConfig(level=logging.DEBUG)
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_auth_init(client_configfile: KanidmClient) -> None:
     """tests the auth init step"""
@@ -34,6 +35,7 @@ async def test_auth_init(client_configfile: KanidmClient) -> None:
     assert result.sessionid
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_auth_begin(client_configfile: KanidmClient) -> None:
     """tests the auth begin step"""
@@ -66,6 +68,7 @@ async def test_auth_begin(client_configfile: KanidmClient) -> None:
         assert AuthBeginResponse.parse_obj(retval)
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_authenticate_flow(client_configfile: KanidmClient) -> None:
     """tests the authenticate() flow"""
@@ -76,6 +79,7 @@ async def test_authenticate_flow(client_configfile: KanidmClient) -> None:
     print(result)
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_authenticate_flow_fail(client_configfile: KanidmClient) -> None:
     """tests the authenticate() flow with a valid (hopefully) usernamd and invalid password"""
@@ -139,6 +143,7 @@ async def test_authenticate_inputs_validation(
             await client.authenticate_password()
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_auth_step_password(client: KanidmClient) -> None:
     """tests things"""

--- a/pykanidm/tests/test_ssl_ca.py
+++ b/pykanidm/tests/test_ssl_ca.py
@@ -11,6 +11,7 @@ import pytest
 from kanidm import KanidmClient
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_valid() -> None:
     """tests a valid connection"""
@@ -28,6 +29,7 @@ async def test_ssl_valid() -> None:
         print(f"{result.status_code=}")
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_self_signed() -> None:
     """tests with a self-signed cert"""
@@ -44,6 +46,7 @@ async def test_ssl_self_signed() -> None:
             await client.call_get("/")
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_self_signed_with_verify() -> None:
     """tests with a self-signed cert"""
@@ -58,6 +61,7 @@ async def test_ssl_self_signed_with_verify() -> None:
         assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_self_signed_no_verify_certificate() -> None:
     """tests with a self-signed cert"""
@@ -72,6 +76,7 @@ async def test_ssl_self_signed_no_verify_certificate() -> None:
         assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_wrong_hostname_throws_error() -> None:
     """tests with validate hostnames and wrong hostname in the cert"""
@@ -88,6 +93,7 @@ async def test_ssl_wrong_hostname_throws_error() -> None:
             assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_wrong_hostname_dont_verify_hostnames() -> None:
     """tests with validate hostnames and wrong hostname in the cert"""
@@ -102,6 +108,7 @@ async def test_ssl_wrong_hostname_dont_verify_hostnames() -> None:
         assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_wrong_hostname_verify_certificate() -> None:
     """tests with validate hostnames and wrong hostname in the cert"""
@@ -117,6 +124,7 @@ async def test_ssl_wrong_hostname_verify_certificate() -> None:
         assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_revoked() -> None:
     """tests with a revoked certificate, it'll pass but one day this should be a thing"""
@@ -130,6 +138,7 @@ async def test_ssl_revoked() -> None:
         assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_expired() -> None:
     """tests with an expired certificate"""
@@ -147,6 +156,7 @@ async def test_ssl_expired() -> None:
             assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_expired_ignore() -> None:
     """tests with an expired certificate"""
@@ -161,6 +171,7 @@ async def test_ssl_expired_ignore() -> None:
         assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_untrusted_root_throws() -> None:
     """tests with an untrusted root, which should throw an error"""
@@ -178,6 +189,7 @@ async def test_ssl_untrusted_root_throws() -> None:
             assert result.content
 
 
+@pytest.mark.network
 @pytest.mark.asyncio
 async def test_ssl_untrusted_root_configured() -> None:
     """tests with an untrusted root, which should throw an error"""

--- a/pykanidm/tests/test_types.py
+++ b/pykanidm/tests/test_types.py
@@ -52,6 +52,8 @@ def test_kanidmconfig_parse_toml() -> None:
     config = KanidmClientConfig()
     config.parse_toml("uri = 'https://crabzrool.example.com'")
 
+
+@pytest.mark.network
 def test_radius_client_bad_hostname() -> None:
     """tests with a bad hostname"""
     with pytest.raises(pydantic.error_wrappers.ValidationError):


### PR DESCRIPTION
Distros often build packages in sandboxes, which will make tests that
access the network fail. Marking these tests with a network mark is a
good way to allow downstreams to disable just this subset of tests.

Fixes tests of python client library test in package build sandboxes.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
