### PR TITLE
Remove dependency on git webauthn authentication versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,9 +399,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "authenticator"
-version = "0.3.2"
-source = "git+https://github.com/Firstyear/authenticator-rs.git?branch=webauthn-authenticator-rs#19eab7b05c6d8362c33247bcb58dec242ecdde49"
+name = "authenticator-ctap2-2021"
+version = "0.3.2-dev.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06c690e5e2800f70c0cf8773a9fe7680d66e719dae9b4cabedd13ef4885d056"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
@@ -458,7 +459,8 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "base64urlsafedata"
 version = "0.1.1"
-source = "git+https://github.com/kanidm/webauthn-rs.git?rev=7a8e6c6b351ab7544f08cf8ba48424baacee1360#7a8e6c6b351ab7544f08cf8ba48424baacee1360"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02340c3f25c8422ba85d481123406dd7506505485bac1c694b26eb538da8daf"
 dependencies = [
  "base64 0.13.0",
  "serde",
@@ -4623,14 +4625,16 @@ dependencies = [
 
 [[package]]
 name = "webauthn-authenticator-rs"
-version = "0.4.2-beta.3"
-source = "git+https://github.com/kanidm/webauthn-rs.git?rev=7a8e6c6b351ab7544f08cf8ba48424baacee1360#7a8e6c6b351ab7544f08cf8ba48424baacee1360"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f0a0f2b3f25205903b27ecea9012dcff4ad272ee792a41ab46dae6bbabefd4d"
 dependencies = [
- "authenticator",
+ "authenticator-ctap2-2021",
  "base64urlsafedata",
  "nom 7.1.1",
  "openssl",
  "rpassword 5.0.1",
+ "serde",
  "serde_cbor",
  "serde_json",
  "tracing",
@@ -4640,8 +4644,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs"
-version = "0.4.2-beta.3"
-source = "git+https://github.com/kanidm/webauthn-rs.git?rev=7a8e6c6b351ab7544f08cf8ba48424baacee1360#7a8e6c6b351ab7544f08cf8ba48424baacee1360"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b813b9663ddc0b5594b5c54dec399eba428c199a8bb75ed6fde757ec2deca82"
 dependencies = [
  "base64urlsafedata",
  "serde",
@@ -4653,8 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.4.2-beta.3"
-source = "git+https://github.com/kanidm/webauthn-rs.git?rev=7a8e6c6b351ab7544f08cf8ba48424baacee1360#7a8e6c6b351ab7544f08cf8ba48424baacee1360"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68452d453abbd5bb7101fa5c97698940dbdea5cdc7f49a4bea1d546f3dc0f46"
 dependencies = [
  "base64 0.13.0",
  "base64urlsafedata",
@@ -4676,8 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.4.2-beta.3"
-source = "git+https://github.com/kanidm/webauthn-rs.git?rev=7a8e6c6b351ab7544f08cf8ba48424baacee1360#7a8e6c6b351ab7544f08cf8ba48424baacee1360"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f44e65fa62541ef22540ab8050866604b1a6a9e73a80c8e85adc1036afb7a2"
 dependencies = [
  "base64urlsafedata",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,10 @@ exclude = [
 
 # ldap3_server = { path = "../ldap3_server" }
 
-base64urlsafedata = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360" }
 # webauthn-rs = { path = "../webauthn-rs/webauthn-rs" }
-webauthn-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360" }
 # webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
-webauthn-rs-core = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360" }
 # webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
-webauthn-rs-proto = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360" }
 # webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs" }
-webauthn-authenticator-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360" }
 
 # compact_jwt = { path = "../compact_jwt" }
 # compact_jwt = { git = "https://github.com/kanidm/compact-jwt.git" }

--- a/kanidm_client/Cargo.toml
+++ b/kanidm_client/Cargo.toml
@@ -20,5 +20,5 @@ tokio = { version = "^1.20.0", features = ["rt", "net", "time", "macros", "sync"
 toml = "^0.5.9"
 uuid = { version = "^1.1.2", features = ["serde", "v4"] }
 url = { version = "^2.2.2", features = ["serde"] }
-webauthn-rs-proto = { version = "0.4.2-beta.3", features = ["wasm"] }
+webauthn-rs-proto = { version = "0.4.5", features = ["wasm"] }
 

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -47,8 +47,7 @@ tracing-subscriber = { version = "^0.3.14", features = ["env-filter", "fmt"] }
 tokio = { version = "^1.20.0", features = ["rt", "macros"] }
 url = { version = "^2.2.2", features = ["serde"] }
 uuid = "^1.1.2"
-# webauthn-authenticator-rs = { version = "0.4.2-beta.3", features = ["u2fhid"] }
-webauthn-authenticator-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "7a8e6c6b351ab7544f08cf8ba48424baacee1360", features = ["u2fhid"] }
+webauthn-authenticator-rs = { version = "0.4.5", features = ["u2fhid"] }
 zxcvbn = "^2.2.1"
 
 [build-dependencies]

--- a/kanidmd/idm/Cargo.toml
+++ b/kanidmd/idm/Cargo.toml
@@ -62,7 +62,7 @@ url = { version = "^2.2.2", features = ["serde"] }
 urlencoding = "2.1.0"
 uuid = { version = "^1.1.2", features = ["serde", "v4" ] }
 validator = { version = "^0.16.0", features = ["phone"] }
-webauthn-rs = { version = "0.4.2-beta.3", features = ["resident_key_support"] }
+webauthn-rs = { version = "0.4.5", features = ["resident-key-support", "preview-features", "danger-credential-internals"] }
 webauthn-rs-core = "0.4.2-beta.3"
 zxcvbn = "^2.2.1"
 

--- a/kanidmd/score/Cargo.toml
+++ b/kanidmd/score/Cargo.toml
@@ -44,7 +44,7 @@ profiles = { path = "../../profiles" }
 kanidm_client = { path = "../../kanidm_client" }
 futures = "^0.3.21"
 
-webauthn-authenticator-rs = "0.4.2-beta.3"
+webauthn-authenticator-rs = "0.4.5"
 oauth2_ext = { package = "oauth2", version = "^4.1.0", default-features = false }
 base64 = "^0.13.0"
 


### PR DESCRIPTION
Should make it nicer to vendor/build 

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
