### PR TITLE
change for KanidmClientConfig to make it public

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -61,13 +61,15 @@ pub enum ClientError {
 }
 
 #[derive(Debug, Deserialize)]
-struct KanidmClientConfig {
+pub struct KanidmClientConfig {
     uri: Option<String>,
     verify_ca: Option<bool>,
     verify_hostnames: Option<bool>,
     ca_path: Option<String>,
-    // Should we add username/pw later? They could be part of the builder
-    // process ...
+    #[allow(dead_code)]
+    username: Option<String>,
+    #[allow(dead_code)]
+    password: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -66,10 +66,6 @@ pub struct KanidmClientConfig {
     verify_ca: Option<bool>,
     verify_hostnames: Option<bool>,
     ca_path: Option<String>,
-    #[allow(dead_code)]
-    username: Option<String>,
-    #[allow(dead_code)]
-    password: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/kanidmd/idm/src/access.rs
+++ b/kanidmd/idm/src/access.rs
@@ -1231,7 +1231,7 @@ pub trait AccessControlsTransaction<'a> {
                             // if it applies
                             if e.entry_match_no_index(f_res) {
                                 // security_access!(entry = ?e.get_uuid(), acs = %acs.acp.name, "entry matches acs");
-                                Some(acs.attrs.iter().map(|s| s.clone()))
+                                Some(acs.attrs.iter().cloned())
                             } else {
                                 trace!(entry = ?e.get_uuid(), acs = %acs.acp.name, "entry DOES NOT match acs"); // should this be `security_access`?
                                 None
@@ -1267,12 +1267,12 @@ pub trait AccessControlsTransaction<'a> {
 
                     let modify_pres: BTreeSet<AttrString> = modify_scoped_acp
                         .iter()
-                        .flat_map(|acp| acp.presattrs.iter().map(|v| v.clone()))
+                        .flat_map(|acp| acp.presattrs.iter().cloned())
                         .collect();
 
                     let modify_rem: BTreeSet<AttrString> = modify_scoped_acp
                         .iter()
-                        .flat_map(|acp| acp.remattrs.iter().map(|v| v.clone()))
+                        .flat_map(|acp| acp.remattrs.iter().cloned())
                         .collect();
 
                     let modify_class: BTreeSet<AttrString> = modify_scoped_acp

--- a/kanidmd/idm/src/repl/entry.rs
+++ b/kanidmd/idm/src/repl/entry.rs
@@ -254,6 +254,7 @@ impl EntryChangelog {
             self.changes.insert(cid.clone(), Change { s: Vec::new() });
         }
 
+        #[allow(clippy::expect_used)]
         let change = self
             .changes
             .get_mut(cid)
@@ -273,6 +274,7 @@ impl EntryChangelog {
             self.changes.insert(cid.clone(), Change { s: Vec::new() });
         }
 
+        #[allow(clippy::expect_used)]
         let change = self
             .changes
             .get_mut(cid)
@@ -289,6 +291,7 @@ impl EntryChangelog {
             self.changes.insert(cid.clone(), Change { s: Vec::new() });
         }
 
+        #[allow(clippy::expect_used)]
         let change = self
             .changes
             .get_mut(cid)
@@ -303,6 +306,7 @@ impl EntryChangelog {
             self.changes.insert(cid.clone(), Change { s: Vec::new() });
         }
 
+        #[allow(clippy::expect_used)]
         let change = self
             .changes
             .get_mut(cid)
@@ -315,6 +319,7 @@ impl EntryChangelog {
             self.changes.insert(cid.clone(), Change { s: Vec::new() });
         }
 
+        #[allow(clippy::expect_used)]
         let change = self
             .changes
             .get_mut(cid)
@@ -327,6 +332,7 @@ impl EntryChangelog {
             self.changes.insert(cid.clone(), Change { s: Vec::new() });
         }
 
+        #[allow(clippy::expect_used)]
         let change = self
             .changes
             .get_mut(cid)

--- a/kanidmd/idm/src/server.rs
+++ b/kanidmd/idm/src/server.rs
@@ -981,6 +981,8 @@ impl QueryServer {
         }));
 
         // log_event!(log, "Starting query worker ...");
+
+        #[allow(clippy::expect_used)]
         QueryServer {
             s_uuid,
             d_info,
@@ -2615,7 +2617,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             admin_error!("initialise_idm p1 -> result {:?}", res);
         }
         debug_assert!(res.is_ok());
-        let _ = res?;
+        res?;
 
         // The domain info now exists, we should be able to do these migrations as they will
         // cause SPN regenerations to occur
@@ -2637,7 +2639,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             admin_error!("initialise_idm p2 -> result {:?}", res);
         }
         debug_assert!(res.is_ok());
-        let _ = res?;
+        res?;
 
         // Create any system default schema entries.
 
@@ -2727,7 +2729,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             admin_error!(?res, "initialise_idm p3 -> result");
         }
         debug_assert!(res.is_ok());
-        let _ = res?;
+        res?;
 
         self.changed_schema.set(true);
         self.changed_acp.set(true);


### PR DESCRIPTION
I wanna use this in [kanidm-profiles](https://github.com/yaleman/kanidm-profiles), and it should be the canonical definition for a Kanidm client config file 😄 

Also, minor 🖇️-calming.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
