### PR TITLE
adding Serialize to kanidm_client::KanidmClientConfig

### DIFF
--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -64,7 +64,7 @@ pub enum ClientError {
     SystemError,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct KanidmClientConfig {
     uri: Option<String>,
     verify_ca: Option<bool>,

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -66,10 +66,10 @@ pub enum ClientError {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct KanidmClientConfig {
-    uri: Option<String>,
-    verify_ca: Option<bool>,
-    verify_hostnames: Option<bool>,
-    ca_path: Option<String>,
+    pub uri: Option<String>,
+    pub verify_ca: Option<bool>,
+    pub verify_hostnames: Option<bool>,
+    pub ca_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
Fixes #somethingINeedForkanidm-profiles

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
