### PR TITLE
TLS is now required for all connections

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -23,9 +23,9 @@ db_path = "/var/lib/kanidm/kanidm.db"
 #   an automatic heuristic is used to scale this.
 # db_arc_size = 2048
 #
-#   TLS chain and key in pem format. Both must be commented, or both must be present
-# tls_chain = "/data/chain.pem"
-# tls_key = "/data/key.pem"
+#   TLS chain and key in pem format. Both must be present
+tls_chain = "/data/chain.pem"
+tls_key = "/data/key.pem"
 #
 #   The log level of the server. May be default, verbose, perfbasic, perffull
 #   Defaults to "default"

--- a/examples/server_container.toml
+++ b/examples/server_container.toml
@@ -30,10 +30,9 @@ db_path = "/data/kanidm.db"
 #   an automatic heuristic is used to scale this.
 # db_arc_size = 2048
 #
-#   TLS chain and key in pem format. Both must be
-#   commented, or both must be present
-# tls_chain = "/data/chain.pem"
-# tls_key = "/data/key.pem"
+#   TLS chain and key in pem format. Both must be present
+tls_chain = "/data/chain.pem"
+tls_key = "/data/key.pem"
 #
 #   The log level of the server. May be default, verbose,
 #   perfbasic, perffull

--- a/kanidm_book/src/developers/designs.md
+++ b/kanidm_book/src/developers/designs.md
@@ -1,1 +1,2 @@
 # Designs
+

--- a/kanidm_book/src/developers/designs/rest_interface.md
+++ b/kanidm_book/src/developers/designs/rest_interface.md
@@ -3,6 +3,7 @@
 {{#template  
     ../../templates/kani-warning.md
     imagepath=../../images/
+    title=Note!
     text=Here begins some early notes on the REST interface - much better ones are in the repository's designs directory.
 }}
 

--- a/kanidm_book/src/integrations/ldap.md
+++ b/kanidm_book/src/integrations/ldap.md
@@ -59,10 +59,8 @@ we don't believe this is a limitation for the consuming applications.
 ### TLS
 
 StartTLS is not supported due to security risks. LDAPS is the only secure method
-of communicating to any LDAP server. Kanidm, if configured with certificates, will
-use them for LDAPS (and will not listen on a plaintext LDAP port). If no certificates exist
-Kanidm will listen on a plaintext LDAP port, and you MUST TLS terminate in front
-of the Kanidm system to secure data and authentication.
+of communicating to any LDAP server. Kanidm, when configured with certificates, will
+use them for LDAPS (and will not listen on a plaintext LDAP port).
 
 ### Access Controls
 

--- a/kanidm_book/src/integrations/radius.md
+++ b/kanidm_book/src/integrations/radius.md
@@ -145,7 +145,6 @@ radius_groups = [
 # A mapping of clients and their authentication tokens
 radius_clients = [
     { name = "test", ipaddr = "127.0.0.1", secret  = "testing123" },
-    # TODO: see if this works - it gets written out to the file
     { name = "docker" , ipaddr = "172.17.0.0/16", secret = "testing123" },
 ]
 

--- a/kanidm_book/src/why_tls.md
+++ b/kanidm_book/src/why_tls.md
@@ -1,10 +1,10 @@
 
 # Why TLS?
 
-You may have noticed that Kanidm requires you to configure TLS in
-your container - or that you provide something *with* TLS in front, like haproxy.
+You may have noticed that Kanidm requires you to configure TLS in your container.
 
-This is due to a single setting on the server - `secure_cookies`
+We are a secure-by-design rather than secure-by-installation system, so TLS for 
+all connections is considered mandatory.
 
 ## What are Secure Cookies?
 
@@ -27,6 +27,6 @@ If you do NOT have a HTTPS URL, the cookie with the session-id is not transmitte
 The server detects this as an invalid-state request in the authentication design, 
 and immediately breaks the connection, because it appears insecure.
 
-Simply put, we are trying to use settings like secure_cookies to add constraints
+Simply put, we are trying to use settings like `secure_cookies` to add constraints
 to the server so that you *must* perform and adhere to best practices - such
 as having TLS present on your communication channels.

--- a/kanidmd/score/src/ldaps.rs
+++ b/kanidmd/score/src/ldaps.rs
@@ -139,23 +139,23 @@ async fn tls_acceptor(
 }
 
 /// Plain TCP LDAP Listener, hands off to [client_process]
-async fn acceptor(listener: TcpListener, qe_r_ref: &'static QueryServerReadV1) {
-    loop {
-        match listener.accept().await {
-            Ok((tcpstream, client_socket_addr)) => {
-                // Start the event
-                let (r, w) = tokio::io::split(tcpstream);
-                let r = FramedRead::new(r, LdapCodec);
-                let w = FramedWrite::new(w, LdapCodec);
-                // Let it rip.
-                tokio::spawn(client_process(r, w, client_socket_addr, qe_r_ref));
-            }
-            Err(e) => {
-                error!("LDAP acceptor error, continuing -> {:?}", e);
-            }
-        }
-    }
-}
+// async fn acceptor(listener: TcpListener, qe_r_ref: &'static QueryServerReadV1) {
+//     loop {
+//         match listener.accept().await {
+//             Ok((tcpstream, client_socket_addr)) => {
+//                 // Start the event
+//                 let (r, w) = tokio::io::split(tcpstream);
+//                 let r = FramedRead::new(r, LdapCodec);
+//                 let w = FramedWrite::new(w, LdapCodec);
+//                 // Let it rip.
+//                 tokio::spawn(client_process(r, w, client_socket_addr, qe_r_ref));
+//             }
+//             Err(e) => {
+//                 error!("LDAP acceptor error, continuing -> {:?}", e);
+//             }
+//         }
+//     }
+// }
 
 pub(crate) async fn create_ldap_server(
     address: &str,
@@ -169,12 +169,12 @@ pub(crate) async fn create_ldap_server(
     };
 
     let addr = net::SocketAddr::from_str(address).map_err(|e| {
-        eprintln!("Could not parse ldap server address {} -> {:?}", address, e);
+        eprintln!("Could not parse LDAP server address {} -> {:?}", address, e);
     })?;
 
     let listener = TcpListener::bind(&addr).await.map_err(|e| {
         eprintln!(
-            "Could not bind to ldap server address {} -> {:?}",
+            "Could not bind to LDAP server address {} -> {:?}",
             address, e
         );
     })?;
@@ -186,8 +186,8 @@ pub(crate) async fn create_ldap_server(
             tokio::spawn(tls_acceptor(listener, tls_parms, qe_r_ref));
         }
         None => {
-            eprintln!("Starting LDAP interface ldap://{} ...", address);
-            tokio::spawn(acceptor(listener, qe_r_ref));
+            eprintln!("The server won't run without TLS!");
+            return Err(());
         }
     }
 

--- a/kanidmd/score/src/lib.rs
+++ b/kanidmd/score/src/lib.rs
@@ -551,6 +551,10 @@ pub async fn create_server_core(config: Configuration, config_test: bool) -> Res
     if config.integration_test_config.is_some() {
         warn!("RUNNING IN INTEGRATION TEST MODE.");
         warn!("IF YOU SEE THIS IN PRODUCTION YOU MUST CONTACT SUPPORT IMMEDIATELY.");
+    } else if config.tls_config.is_none() {
+        // TLS is great! We won't run without it.
+        error!("Running without TLS is not supported! Quitting!");
+        return Err({});
     }
 
     info!(


### PR DESCRIPTION
- adding block for non-TLS mode and updating docs/examples.

Fixes #something

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter updated
