### PR TITLE
Fixing docs publishing

### DIFF
--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
Fixes the docs not publishing - the "deploy" step was only running when pushing to `main` ... not `master`.