### PR TITLE
Stricter name rules

### DIFF
--- a/kanidmd/lib/src/valueset/iname.rs
+++ b/kanidmd/lib/src/valueset/iname.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use crate::prelude::*;
 use crate::schema::SchemaAttribute;
-use crate::value::INAME_RE;
+use crate::value::{DISALLOWED_NAMES, INAME_RE};
 use crate::valueset::{DbValueSetV2, ValueSet};
 
 #[derive(Debug, Clone)]
@@ -102,7 +102,7 @@ impl ValueSetT for ValueSetIname {
                 // It is a uuid, disallow.
                 Ok(_) => false,
                 // Not a uuid, check it against the re.
-                Err(_) => !INAME_RE.is_match(s),
+                Err(_) => INAME_RE.is_match(s) && !DISALLOWED_NAMES.contains(s.as_str()),
             }
         })
     }


### PR DESCRIPTION
Sadly there are too many systems that break with utf8 usernames, so we have to make this stricter. It doesn't affect legalname/displayname though. Makes the disallowed name check more efficient too. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
