### PR TITLE
Add support for multiple new password imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hashbrown",
+ "hex",
  "idlset",
  "kanidm_proto",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ futures-util = "^0.3.21"
 gloo = "^0.8.0"
 gloo-net = "0.2.4"
 hashbrown = { version = "0.12.3", features = ["serde", "inline-more", "ahash"] }
+hex = "^0.4.3"
 http-types = "^2.12.0"
 idlset = "^0.2.4"
 # idlset = { path = "../idlset" }

--- a/iam_migrations/freeipa/notes.txt
+++ b/iam_migrations/freeipa/notes.txt
@@ -1,0 +1,25 @@
+
+
+OTP tokens are stored in *related* entries:
+
+Not sure how you would determine this in an import?
+
+token key is base64 standard no pad
+
+entryuuid: 94dbeb81-45f8-11ed-a50d-919b4b1a5ec0
+syncstate: Add
+dn: ipatokenuniqueid=16b6d328-cead-4b71-af5e-0a7b8622b204,cn=otp,dc=dev,dc=blackhats,dc=net,dc=au
+ipatokenOTPalgorithm: sha1
+ipatokenOTPdigits: 6
+ipatokenOTPkey: iWM6XXyQt9GZV/yiPHYW/w4qjpaIJ8IlF6DlFndHe+C/zu4
+ipatokenOwner: uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au
+ipatokenTOTPclockOffset: 0
+ipatokenTOTPtimeStep: 30
+ipatokenUniqueID: 16b6d328-cead-4b71-af5e-0a7b8622b204
+objectClass: ipatoken
+objectClass: ipatokentotp
+objectClass: top
+
+
+
+

--- a/kanidmd/lib/Cargo.toml
+++ b/kanidmd/lib/Cargo.toml
@@ -32,6 +32,7 @@ filetime.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 hashbrown.workspace = true
+hex.workspace = true
 idlset.workspace = true
 kanidm_proto.workspace = true
 lazy_static.workspace = true

--- a/kanidmd/lib/src/be/dbvalue.rs
+++ b/kanidmd/lib/src/be/dbvalue.rs
@@ -21,16 +21,23 @@ pub struct DbCidV1 {
 }
 
 #[derive(Serialize, Deserialize)]
+#[allow(non_camel_case_types)]
 pub enum DbPasswordV1 {
     PBKDF2(usize, Vec<u8>, Vec<u8>),
+    PBKDF2_SHA1(usize, Vec<u8>, Vec<u8>),
+    PBKDF2_SHA512(usize, Vec<u8>, Vec<u8>),
     SSHA512(Vec<u8>, Vec<u8>),
+    NT_MD4(Vec<u8>),
 }
 
 impl fmt::Debug for DbPasswordV1 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             DbPasswordV1::PBKDF2(_, _, _) => write!(f, "PBKDF2"),
+            DbPasswordV1::PBKDF2_SHA1(_, _, _) => write!(f, "PBKDF2_SHA1"),
+            DbPasswordV1::PBKDF2_SHA512(_, _, _) => write!(f, "PBKDF2_SHA512"),
             DbPasswordV1::SSHA512(_, _) => write!(f, "SSHA512"),
+            DbPasswordV1::NT_MD4(_) => write!(f, "NT_MD4"),
         }
     }
 }

--- a/kanidmd/lib/src/credential/policy.rs
+++ b/kanidmd/lib/src/credential/policy.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
 
-use super::Password;
-
-const PBKDF2_MIN_NIST_COST: u64 = 10000;
+use super::{Password, PBKDF2_MIN_NIST_COST};
 
 #[derive(Debug)]
 pub struct CryptoPolicy {
@@ -20,7 +18,7 @@ impl CryptoPolicy {
     pub fn time_target(t: Duration) -> Self {
         let r = match Password::bench_pbkdf2((PBKDF2_MIN_NIST_COST * 10) as usize) {
             Some(bt) => {
-                let ubt = bt.as_nanos() as u64;
+                let ubt = bt.as_nanos() as usize;
 
                 // Get the cost per thousand rounds
                 let per_thou = (PBKDF2_MIN_NIST_COST * 10) / 1000;
@@ -28,7 +26,7 @@ impl CryptoPolicy {
                 // eprintln!("{} / {}", ubt, per_thou);
 
                 // Now we need the attacker work in nanos
-                let attack_time = t.as_nanos() as u64;
+                let attack_time = t.as_nanos() as usize;
                 let r = (attack_time / t_per_thou) * 1000;
 
                 // eprintln!("({} / {} ) * 1000", attack_time, t_per_thou);


### PR DESCRIPTION
Part of #736, #735 and #734. Support password hash imports from various other systems in a variety of formats. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
