### PR TITLE
Add trust x forward for option

### DIFF
--- a/examples/server_container.toml
+++ b/examples/server_container.toml
@@ -10,6 +10,16 @@ bindaddress = "[::]:8443"
 #   Defaults to "" (disabled)
 # ldapbindaddress = "[::]:3636"
 #
+#   HTTPS requests can be reverse proxied by a loadbalancer.
+#   To preserve the original IP of the caller, these systems
+#   will often add a header such as "Forwarded" or
+#   "X-Forwarded-For". If set to true, then this header is
+#   respected as the "authoritive" source of the IP of the
+#   connected client. If you are not using a load balancer
+#   then you should leave this value as default.
+#   Defaults to false
+# trust_x_forward_for = false
+#
 #   The path to the kanidm database.
 db_path = "/data/kanidm.db"
 #

--- a/kanidmd/core/src/config.rs
+++ b/kanidmd/core/src/config.rs
@@ -87,6 +87,7 @@ pub struct Configuration {
     pub db_arc_size: Option<usize>,
     pub maximum_request: usize,
     pub secure_cookies: bool,
+    pub trust_x_forward_for: bool,
     pub tls_config: Option<TlsConfiguration>,
     pub cookie_key: [u8; 32],
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
@@ -113,6 +114,7 @@ impl fmt::Display for Configuration {
             })
             .and_then(|_| write!(f, "max request size: {}b, ", self.maximum_request))
             .and_then(|_| write!(f, "secure cookies: {}, ", self.secure_cookies))
+            .and_then(|_| write!(f, "trust X-Forwarded-For: {}, ", self.trust_x_forward_for))
             .and_then(|_| write!(f, "with TLS: {}, ", self.tls_config.is_some()))
             // TODO: include the backup timings
             .and_then(|_| match &self.online_backup {
@@ -149,6 +151,7 @@ impl Configuration {
             // log path?
             // default true in prd
             secure_cookies: !cfg!(test),
+            trust_x_forward_for: false,
             tls_config: None,
             cookie_key: [0; 32],
             integration_test_config: None,
@@ -177,6 +180,10 @@ impl Configuration {
                 })
             }
         }
+    }
+
+    pub fn update_trust_x_forward_for(&mut self, t: Option<bool>) {
+        self.trust_x_forward_for = t.unwrap_or(false);
     }
 
     pub fn update_db_path(&mut self, p: &str) {

--- a/kanidmd/core/src/https/mod.rs
+++ b/kanidmd/core/src/https/mod.rs
@@ -356,7 +356,9 @@ pub fn create_https_server(
     });
 
     // Add middleware?
-    tserver.with(sketching::middleware::TreeMiddleware::new(trust_x_forward_for));
+    tserver.with(sketching::middleware::TreeMiddleware::new(
+        trust_x_forward_for,
+    ));
     // tserver.with(tide::log::LogMiddleware::new());
     // We do not force a session ttl, because we validate this elsewhere in usage.
     tserver.with(

--- a/kanidmd/core/src/https/mod.rs
+++ b/kanidmd/core/src/https/mod.rs
@@ -300,6 +300,7 @@ pub fn create_https_server(
     // opt_tls_params: Option<SslAcceptorBuilder>,
     opt_tls_params: Option<&TlsConfiguration>,
     role: ServerRole,
+    trust_x_forward_for: bool,
     cookie_key: &[u8; 32],
     jws_signer: JwsSigner,
     status_ref: &'static StatusActor,
@@ -355,7 +356,7 @@ pub fn create_https_server(
     });
 
     // Add middleware?
-    tserver.with(sketching::middleware::TreeMiddleware::default());
+    tserver.with(sketching::middleware::TreeMiddleware::new(trust_x_forward_for));
     // tserver.with(tide::log::LogMiddleware::new());
     // We do not force a session ttl, because we validate this elsewhere in usage.
     tserver.with(

--- a/kanidmd/core/src/lib.rs
+++ b/kanidmd/core/src/lib.rs
@@ -722,6 +722,7 @@ pub async fn create_server_core(config: Configuration, config_test: bool) -> Res
             // opt_tls_params,
             config.tls_config.as_ref(),
             config.role,
+            config.trust_x_forward_for,
             &cookie_key,
             jws_signer,
             status_ref,

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -46,6 +46,7 @@ include!("./opt.rs");
 struct ServerConfig {
     pub bindaddress: Option<String>,
     pub ldapbindaddress: Option<String>,
+    pub trust_x_forward_for: Option<bool>,
     // pub threads: Option<usize>,
     pub db_path: String,
     pub db_fs_type: Option<String>,
@@ -270,6 +271,7 @@ async fn main() {
             config.update_db_arc_size(sconfig.db_arc_size);
             config.update_role(sconfig.role);
             config.update_output_mode(opt.commands.commonopt().output_mode.to_owned().into());
+            config.update_trust_x_forward_for(sconfig.trust_x_forward_for);
 
             /*
             // Apply any cli overrides, normally debug level.

--- a/sketching/src/middleware.rs
+++ b/sketching/src/middleware.rs
@@ -10,7 +10,7 @@ pub struct TreeMiddleware {
 impl TreeMiddleware {
     pub fn new(trust_x_forward_for: bool) -> Self {
         TreeMiddleware {
-            trust_x_forward_for
+            trust_x_forward_for,
         }
     }
 
@@ -31,7 +31,9 @@ impl TreeMiddleware {
             req.remote()
         } else {
             req.peer_addr()
-        }.unwrap_or("-").to_string();
+        }
+        .unwrap_or("-")
+        .to_string();
         let host = req.host().unwrap_or("-").to_string();
         let method = req.method();
         let path = req.url().path().to_string();

--- a/sketching/src/middleware.rs
+++ b/sketching/src/middleware.rs
@@ -3,16 +3,17 @@ use tracing::{self, instrument};
 
 use crate::{request_error, request_info, request_warn, security_info, *};
 
-#[derive(Default)]
-pub struct TreeMiddleware {}
-
-// impl Default for TreeMiddleware {
-//     fn default() -> Self {
-//         TreeMiddleware {}
-//     }
-// }
+pub struct TreeMiddleware {
+    trust_x_forward_for: bool,
+}
 
 impl TreeMiddleware {
+    pub fn new(trust_x_forward_for: bool) -> Self {
+        TreeMiddleware {
+            trust_x_forward_for
+        }
+    }
+
     #[instrument(name = "tide-request", skip(self, req, next))]
     async fn log<'a, State: Clone + Send + Sync + 'static>(
         &'a self,
@@ -26,7 +27,11 @@ impl TreeMiddleware {
         }
         req.set_ext(TreeMiddlewareFinished);
 
-        let remote_address = req.remote().unwrap_or("-").to_string();
+        let remote_address = if self.trust_x_forward_for {
+            req.remote()
+        } else {
+            req.peer_addr()
+        }.unwrap_or("-").to_string();
         let host = req.host().unwrap_or("-").to_string();
         let method = req.method();
         let path = req.url().path().to_string();
@@ -37,7 +42,7 @@ impl TreeMiddleware {
         let path = path.as_str();
 
         security_info!(
-            src = remote_address,
+            remote_addr = remote_address,
             http.host = host,
             http.method = method,
             path,


### PR DESCRIPTION
Fixes #191 - adds a config parameter if the x-forwarded-for or forwarded header should be trusted as the authoritative source of remote peer ip info. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ ] design document included (if relevant)
