### PR TITLE
Systemd Unit Files in Deb packages

### DIFF
--- a/examples/systemd/kanidm-unixd-tasks.service
+++ b/examples/systemd/kanidm-unixd-tasks.service
@@ -1,0 +1,31 @@
+# You should not need to edit this file. Instead, use a drop-in file:
+#   systemctl edit kanidm-unixd-tasks.service
+
+[Unit]
+Description=Kanidm Local Tasks
+After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
+
+[Service]
+User=root
+Type=simple
+ExecStart=/usr/local/sbin/kanidm_unixd_tasks
+
+ReadWritePaths=/home /var/run/kanidm-unixd
+
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateNetwork=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/kanidm-unixd.service
+++ b/examples/systemd/kanidm-unixd.service
@@ -1,0 +1,18 @@
+# You should not need to edit this file. Instead, use a drop-in file by running:
+#   systemctl edit kanidm-unixd-tasks.service
+
+[Unit]
+Description=Kanidm Local Client Resolver
+After=chronyd.service ntpd.service network-online.target
+
+[Service]
+DynamicUser=yes
+Type=simple
+ExecStart=/usr/local/sbin/kanidm_unixd
+
+CacheDirectory=kanidm-unixd
+RuntimeDirectory=kanidm-unixd
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/kanidmd.service
+++ b/examples/systemd/kanidmd.service
@@ -1,0 +1,20 @@
+# You should not need to edit this file. Instead, use a drop-in file by running:
+#   systemctl edit kanidm-unixd-tasks.service
+
+[Unit]
+Description=Kanidm, the IDM for rustaceans
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+ExecStart=/usr/local/sbin/kanidmd server --config=/etc/kanidm/server.toml
+Restart=on-failure
+RestartSec=15s
+WorkingDirectory=/var/lib/kanidm
+DynamicUser=yes
+StateDirectory=kanidm
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/debian/kanidm-unixd/rules
+++ b/platform/debian/kanidm-unixd/rules
@@ -37,9 +37,9 @@ override_dh_installinit:
 	install -g root -o root \
 		examples/systemd/${PACKAGE}-tasks.service \
 		debian/
-	dh_systemd_enable -p${PACKAGE}-tasks --name=${PACKAGE}-tasks ${PACKAGE}-tasks.service
-	dh_installinit -p${PACKAGE}-tasks --no-start --noscripts
-	dh_systemd_start -p${PACKAGE}-tasks --no-restart-on-upgrade
+	dh_systemd_enable -p${PACKAGE} --name=${PACKAGE}-tasks ${PACKAGE}-tasks.service
+	dh_installinit -p${PACKAGE} --no-start --noscripts
+	dh_systemd_start -p${PACKAGE} --no-restart-on-upgrade
 
 override_dh_systemd_start:
 	echo "Not running dh_systemd_start"

--- a/platform/debian/kanidm-unixd/rules
+++ b/platform/debian/kanidm-unixd/rules
@@ -30,19 +30,19 @@ override_dh_installinit:
 	install -g root -o root \
 		examples/systemd/${PACKAGE}.service \
 		debian/
-    dh_systemd_enable -p${PACKAGE} --name=${PACKAGE} ${PACKAGE}.service
-    dh_installinit -p${PACKAGE} --no-start --noscripts
-    dh_systemd_start -p${PACKAGE} --no-restart-on-upgrade
+	dh_systemd_enable -p${PACKAGE} --name=${PACKAGE} ${PACKAGE}.service
+	dh_installinit -p${PACKAGE} --no-start --noscripts
+	dh_systemd_start -p${PACKAGE} --no-restart-on-upgrade
 
 	install -g root -o root \
 		examples/systemd/${PACKAGE}-tasks.service \
 		debian/
-    dh_systemd_enable -p${PACKAGE}-tasks --name=${PACKAGE}-tasks ${PACKAGE}-tasks.service
-    dh_installinit -p${PACKAGE}-tasks --no-start --noscripts
-    dh_systemd_start -p${PACKAGE}-tasks --no-restart-on-upgrade
+	dh_systemd_enable -p${PACKAGE}-tasks --name=${PACKAGE}-tasks ${PACKAGE}-tasks.service
+	dh_installinit -p${PACKAGE}-tasks --no-start --noscripts
+	dh_systemd_start -p${PACKAGE}-tasks --no-restart-on-upgrade
 
 override_dh_systemd_start:
-    echo "Not running dh_systemd_start"
+	echo "Not running dh_systemd_start"
 
 override_dh_auto_install:
 	mkdir -p ${BINDIR}

--- a/platform/debian/kanidm-unixd/rules
+++ b/platform/debian/kanidm-unixd/rules
@@ -70,7 +70,6 @@ override_dh_auto_install:
 
 override_dh_installexamples:
 	mkdir -p ${SHARED_DIR}
-	install
 	install -D \
 		-g root -o root \
 		examples/kanidm \

--- a/platform/debian/kanidm-unixd/rules
+++ b/platform/debian/kanidm-unixd/rules
@@ -12,7 +12,7 @@ BINDIR=${PKGDIR}/usr/sbin/
 SHARED_DIR=${PKGDIR}/usr/share/${PACKAGE}
 
 %:
-	dh $@
+	dh $@ --with systemd
 
 override_dh_auto_clean:
 
@@ -24,6 +24,25 @@ override_dh_auto_build:
 override_dh_auto_test:
 override_dh_shlibdeps:
 override_dh_strip:
+
+# Do the systemd things
+override_dh_installinit:
+	install -g root -o root \
+		examples/systemd/${PACKAGE}.service \
+		debian/
+    dh_systemd_enable -p${PACKAGE} --name=${PACKAGE} ${PACKAGE}.service
+    dh_installinit -p${PACKAGE} --no-start --noscripts
+    dh_systemd_start -p${PACKAGE} --no-restart-on-upgrade
+
+	install -g root -o root \
+		examples/systemd/${PACKAGE}-tasks.service \
+		debian/
+    dh_systemd_enable -p${PACKAGE}-tasks --name=${PACKAGE}-tasks ${PACKAGE}-tasks.service
+    dh_installinit -p${PACKAGE}-tasks --no-start --noscripts
+    dh_systemd_start -p${PACKAGE}-tasks --no-restart-on-upgrade
+
+override_dh_systemd_start:
+    echo "Not running dh_systemd_start"
 
 override_dh_auto_install:
 	mkdir -p ${BINDIR}
@@ -51,6 +70,7 @@ override_dh_auto_install:
 
 override_dh_installexamples:
 	mkdir -p ${SHARED_DIR}
+	install
 	install -D \
 		-g root -o root \
 		examples/kanidm \

--- a/platform/debian/kanidmd/rules
+++ b/platform/debian/kanidmd/rules
@@ -14,7 +14,7 @@ BINDIR=${PKGDIR}/usr/sbin/
 SHARED_DIR=${PKGDIR}/usr/share/${PACKAGE}
 
 %:
-	dh $@
+	dh $@ --with systemd
 
 override_dh_auto_clean:
 # cargo clean

--- a/platform/debian/kanidmd/rules
+++ b/platform/debian/kanidmd/rules
@@ -31,6 +31,19 @@ override_dh_auto_test:
 override_dh_shlibdeps:
 override_dh_strip:
 
+
+# Do the systemd things
+override_dh_installinit:
+	install -g root -o root \
+		examples/systemd/${PACKAGE}.service \
+		debian/
+	dh_systemd_enable -p${PACKAGE} --name=${PACKAGE} ${PACKAGE}.service
+	dh_installinit -p${PACKAGE} --no-start --noscripts
+	dh_systemd_start -p${PACKAGE} --no-restart-on-upgrade
+
+override_dh_systemd_start:
+	echo "Not running dh_systemd_start"
+
 override_dh_auto_install:
 	mkdir -p ${BINDIR}
 	install \


### PR DESCRIPTION
Fixes #1093, adds systemd service files for `kanidmd`, `kanidm-unixd` and `kanidm-unixd-tasks` in their respective folders

