### PR TITLE
Fix pam unix sock timeouts

### DIFF
--- a/kanidm_unix_int/nss_kanidm/src/lib.rs
+++ b/kanidm_unix_int/nss_kanidm/src/lib.rs
@@ -36,7 +36,7 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccounts;
-        call_daemon_blocking(cfg.sock_path.as_str(), &req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssAccounts(l) => l.into_iter().map(passwd_from_nssuser).collect(),
                 _ => Vec::new(),
@@ -54,7 +54,7 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByUid(uid);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -74,7 +74,7 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByName(name);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -99,7 +99,7 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroups;
-        call_daemon_blocking(cfg.sock_path.as_str(), &req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssGroups(l) => l.into_iter().map(group_from_nssgroup).collect(),
                 _ => Vec::new(),
@@ -117,7 +117,7 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByGid(gid);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)
@@ -137,7 +137,7 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByName(name);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req)
+        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)

--- a/kanidm_unix_int/pam_kanidm/src/lib.rs
+++ b/kanidm_unix_int/pam_kanidm/src/lib.rs
@@ -95,7 +95,7 @@ impl PamHooks for PamKanidm {
         let req = ClientRequest::PamAccountAllowed(account_id);
         // PamResultCode::PAM_IGNORE
 
-        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout) {
             Ok(r) => match r {
                 ClientResponse::PamStatus(Some(true)) => {
                     if opts.debug {
@@ -215,7 +215,7 @@ impl PamHooks for PamKanidm {
         };
         let req = ClientRequest::PamAuthenticate(account_id, authtok);
 
-        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout) {
             Ok(r) => match r {
                 ClientResponse::PamStatus(Some(true)) => {
                     // println!("PAM_SUCCESS");
@@ -306,7 +306,7 @@ impl PamHooks for PamKanidm {
         };
         let req = ClientRequest::PamAccountBeginSession(account_id);
 
-        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout) {
             Ok(ClientResponse::Ok) => {
                 // println!("PAM_SUCCESS");
                 PamResultCode::PAM_SUCCESS

--- a/kanidm_unix_int/src/client_sync.rs
+++ b/kanidm_unix_int/src/client_sync.rs
@@ -5,23 +5,16 @@ use std::time::{Duration, SystemTime};
 
 use crate::unix_proto::{ClientRequest, ClientResponse};
 
-const TIMEOUT: u64 = 2000;
-
 pub fn call_daemon_blocking(
     path: &str,
     req: &ClientRequest,
+    timeout: u64,
 ) -> Result<ClientResponse, Box<dyn Error>> {
+    let timeout = Duration::from_secs(timeout);
+
     let mut stream = UnixStream::connect(path)
-        .and_then(|socket| {
-            socket
-                .set_read_timeout(Some(Duration::from_millis(TIMEOUT)))
-                .map(|_| socket)
-        })
-        .and_then(|socket| {
-            socket
-                .set_write_timeout(Some(Duration::from_millis(TIMEOUT)))
-                .map(|_| socket)
-        })
+        .and_then(|socket| socket.set_read_timeout(Some(timeout)).map(|_| socket))
+        .and_then(|socket| socket.set_write_timeout(Some(timeout)).map(|_| socket))
         .map_err(|e| {
             error!("stream setup error -> {:?}", e);
             e
@@ -45,7 +38,6 @@ pub fn call_daemon_blocking(
 
     // Now wait on the response.
     let start = SystemTime::now();
-    let timeout = Duration::from_millis(TIMEOUT);
     let mut read_started = false;
     let mut data = Vec::with_capacity(1024);
     let mut counter = 0;

--- a/kanidm_unix_int/src/daemon.rs
+++ b/kanidm_unix_int/src/daemon.rs
@@ -727,7 +727,7 @@ async fn main() {
                             tokio::spawn(async move {
                                 if let Err(e) = handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
                                 {
-                                    error!("an error occured; error = {:?}", e);
+                                    error!("handle_client error occured; error = {:?}", e);
                                 }
                             });
                         }

--- a/kanidm_unix_int/src/daemon_status.rs
+++ b/kanidm_unix_int/src/daemon_status.rs
@@ -51,7 +51,7 @@ fn main() {
             cfg.sock_path
         )
     } else {
-        match call_daemon_blocking(cfg.sock_path.as_str(), &req) {
+        match call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout) {
             Ok(r) => match r {
                 ClientResponse::Ok => println!("working!"),
                 _ => {

--- a/kanidm_unix_int/src/unix_config.rs
+++ b/kanidm_unix_int/src/unix_config.rs
@@ -75,6 +75,7 @@ pub struct KanidmUnixdConfig {
     pub task_sock_path: String,
     pub conn_timeout: u64,
     pub cache_timeout: u64,
+    pub unix_sock_timeout: u64,
     pub pam_allowed_login_groups: Vec<String>,
     pub default_shell: String,
     pub home_prefix: String,
@@ -96,6 +97,7 @@ impl Display for KanidmUnixdConfig {
         writeln!(f, "sock_path: {}", self.sock_path)?;
         writeln!(f, "task_sock_path: {}", self.task_sock_path)?;
         writeln!(f, "conn_timeout: {}", self.conn_timeout)?;
+        writeln!(f, "unix_sock_timeout: {}", self.unix_sock_timeout)?;
         writeln!(f, "cache_timeout: {}", self.cache_timeout)?;
         writeln!(
             f,
@@ -126,6 +128,7 @@ impl KanidmUnixdConfig {
             sock_path: DEFAULT_SOCK_PATH.to_string(),
             task_sock_path: DEFAULT_TASK_SOCK_PATH.to_string(),
             conn_timeout: DEFAULT_CONN_TIMEOUT,
+            unix_sock_timeout: DEFAULT_CONN_TIMEOUT * 2,
             cache_timeout: DEFAULT_CACHE_TIMEOUT,
             pam_allowed_login_groups: Vec::new(),
             default_shell: DEFAULT_SHELL.to_string(),
@@ -185,6 +188,7 @@ impl KanidmUnixdConfig {
             sock_path: config.sock_path.unwrap_or(self.sock_path),
             task_sock_path: config.task_sock_path.unwrap_or(self.task_sock_path),
             conn_timeout: config.conn_timeout.unwrap_or(self.conn_timeout),
+            unix_sock_timeout: config.conn_timeout.unwrap_or(self.conn_timeout) * 2,
             cache_timeout: config.cache_timeout.unwrap_or(self.cache_timeout),
             pam_allowed_login_groups: config
                 .pam_allowed_login_groups


### PR DESCRIPTION
Sometimes when logging into a system you would see:

```
# ssh host
william@host: Permission denied (publickey).
# ssh host
..... (success)
```

This would be accompanied by logs to the effect of:

`[error]: an error occured; error = Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }`

What was occuring was that the socket between ssh/pam to kanidm unixd was timing out before the response from kanidm was returned to the unixd layer. Then on the second attempt, the cache would return fast enough.

To resolve this, make the unix sock timeout longer than the connection timeout to account for possible connection delays.

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
