### PR TITLE
Improve clarity of checks around iname validation

### DIFF
--- a/kanidm_tools/src/cli/oauth2.rs
+++ b/kanidm_tools/src/cli/oauth2.rs
@@ -14,6 +14,7 @@ impl Oauth2Opt {
             Oauth2Opt::ShowBasicSecret(nopt) => nopt.copt.debug,
             Oauth2Opt::Delete(nopt) => nopt.copt.debug,
             Oauth2Opt::SetDisplayname(cbopt) => cbopt.nopt.copt.debug,
+            Oauth2Opt::SetName { nopt, .. } => nopt.copt.debug,
             Oauth2Opt::EnablePkce(nopt) => nopt.copt.debug,
             Oauth2Opt::DisablePkce(nopt) => nopt.copt.debug,
             Oauth2Opt::EnableLegacyCrypto(nopt) => nopt.copt.debug,
@@ -145,6 +146,24 @@ impl Oauth2Opt {
                         cbopt.nopt.name.as_str(),
                         None,
                         Some(cbopt.displayname.as_str()),
+                        None,
+                        false,
+                        false,
+                        false,
+                    )
+                    .await
+                {
+                    Ok(_) => println!("Success"),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+            Oauth2Opt::SetName { nopt, name } => {
+                let client = nopt.copt.to_client().await;
+                match client
+                    .idm_oauth2_rs_update(
+                        nopt.name.as_str(),
+                        Some(name.as_str()),
+                        None,
                         None,
                         false,
                         false,

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -650,6 +650,16 @@ pub enum Oauth2Opt {
     /// Set a new displayname for a resource server
     #[clap(name = "set_displayname")]
     SetDisplayname(Oauth2SetDisplayname),
+    /// Set a new name for this resource server. You may need to update
+    /// your integrated applications after this so that they continue to
+    /// function correctly.
+    #[clap(name = "set_name")]
+    SetName {
+        #[clap(flatten)]
+        nopt: Named,
+        #[clap(name = "newname")]
+        name: String,
+    },
     #[clap(name = "enable_pkce")]
     /// Enable PKCE on this oauth2 resource server. This defaults to being enabled.
     EnablePkce(Named),

--- a/kanidmd/daemon/run_insecure_dev_server.sh
+++ b/kanidmd/daemon/run_insecure_dev_server.sh
@@ -7,7 +7,7 @@ if [ -z "$KANI_TMP" ]; then
 fi
 
 if [ -z "$KANI_CARGO_OPTS" ]; then
-    KANI_CARGO_OPTS=--debug
+    KANI_CARGO_OPTS=""
 fi
 
 CONFIG_FILE="../../examples/insecure_server.toml"

--- a/kanidmd/lib/src/valueset/iname.rs
+++ b/kanidmd/lib/src/valueset/iname.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 
 use crate::prelude::*;
 use crate::schema::SchemaAttribute;
-use crate::value::{DISALLOWED_NAMES, INAME_RE};
 use crate::valueset::{DbValueSetV2, ValueSet};
 
 #[derive(Debug, Clone)]
@@ -97,14 +96,7 @@ impl ValueSetT for ValueSetIname {
     }
 
     fn validate(&self, _schema_attr: &SchemaAttribute) -> bool {
-        self.set.iter().all(|s| {
-            match Uuid::parse_str(s) {
-                // It is a uuid, disallow.
-                Ok(_) => false,
-                // Not a uuid, check it against the re.
-                Err(_) => INAME_RE.is_match(s) && !DISALLOWED_NAMES.contains(s.as_str()),
-            }
-        })
+        self.set.iter().all(|s| Value::validate_iname(s.as_str()))
     }
 
     fn to_proto_string_clone_iter(&self) -> Box<dyn Iterator<Item = String> + '_> {


### PR DESCRIPTION
Fixes #1126 - This improves clarity of messages around iname handling. This also allows renaming of oauth2 rs servers which allows upgrades to proceed. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
