### PR TITLE
Add access control allowing all persons to read oauth2 applications.

### DIFF
--- a/kanidmd/lib/src/constants/acp.rs
+++ b/kanidmd/lib/src/constants/acp.rs
@@ -1265,3 +1265,28 @@ pub const JSON_IDM_HP_ACP_SERVICE_ACCOUNT_INTO_PERSON_MIGRATE_V1: &str = r#"{
         "acp_modify_class": ["service_account", "person"]
     }
 }"#;
+
+pub const JSON_IDM_ACP_OAUTH2_READ_PRIV_V1: &str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search"
+        ],
+        "name": ["idm_acp_oauth2_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000043"],
+        "description": ["Builtin IDM Control allowing persons to view oauth2 applications they can access"],
+        "acp_receiver": [
+            "{\"eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000035\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"and\": [{\"eq\": [\"class\",\"oauth2_resource_server\"]},{\"andnot\": {\"or\": [{\"eq\": [\"class\", \"tombstone\"]}, {\"eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class",
+            "displayname",
+            "oauth2_rs_name",
+            "oauth2_rs_origin"
+        ]
+    }
+}"#;

--- a/kanidmd/lib/src/constants/uuids.rs
+++ b/kanidmd/lib/src/constants/uuids.rs
@@ -270,6 +270,7 @@ pub const _UUID_IDM_PEOPLE_SELF_ACP_WRITE_MAIL_V1: Uuid =
     uuid!("00000000-0000-0000-0000-ffffff000041");
 pub const _UUID_IDM_HP_ACP_SERVICE_ACCOUNT_INTO_PERSON_MIGRATE_V1: Uuid =
     uuid!("00000000-0000-0000-0000-ffffff000042");
+pub const _UUID_IDM_ACP_OAUTH2_READ_PRIV_V1: Uuid = uuid!("00000000-0000-0000-0000-ffffff000043");
 
 // End of system ranges
 pub const UUID_DOES_NOT_EXIST: Uuid = uuid!("00000000-0000-0000-0000-fffffffffffe");

--- a/kanidmd/lib/src/server.rs
+++ b/kanidmd/lib/src/server.rs
@@ -2806,6 +2806,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             JSON_IDM_ACP_RADIUS_SECRET_READ_PRIV_V1,
             JSON_IDM_ACP_RADIUS_SECRET_WRITE_PRIV_V1,
             JSON_IDM_HP_ACP_SERVICE_ACCOUNT_INTO_PERSON_MIGRATE_V1,
+            JSON_IDM_ACP_OAUTH2_READ_PRIV_V1,
         ];
 
         let res: Result<(), _> = idm_entries


### PR DESCRIPTION
Add an access control allowing all persons to read limited details of connected ouath2 applications, allowing the creation of an "app" portal. Currently this lets all persons read all applications, but as part of the access control rework, we will tighten this so that only applications where the user has scope-access with be granted visibility. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
