### PR TITLE
Further test improvements

### DIFF
--- a/kanidmd/lib-macros/src/entry.rs
+++ b/kanidmd/lib-macros/src/entry.rs
@@ -97,3 +97,84 @@ pub(crate) fn qs_test(_args: &TokenStream, item: TokenStream, with_init: bool) -
 
     result.into()
 }
+
+pub(crate) fn idm_test(_args: &TokenStream, item: TokenStream) -> TokenStream {
+    let input: syn::ItemFn = match syn::parse(item.clone()) {
+        Ok(it) => it,
+        Err(e) => return token_stream_with_error(item, e),
+    };
+
+    if let Some(attr) = input.attrs.iter().find(|attr| attr.path.is_ident("test")) {
+        let msg = "second test attribute is supplied";
+        return token_stream_with_error(item, syn::Error::new_spanned(&attr, msg));
+    };
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the `async` keyword is missing from the function declaration";
+        return token_stream_with_error(item, syn::Error::new_spanned(input.sig.fn_token, msg));
+    }
+
+    // If type mismatch occurs, the current rustc points to the last statement.
+    let (last_stmt_start_span, _last_stmt_end_span) = {
+        let mut last_stmt = input
+            .block
+            .stmts
+            .last()
+            .map(ToTokens::into_token_stream)
+            .unwrap_or_default()
+            .into_iter();
+        // `Span` on stable Rust has a limitation that only points to the first
+        // token, not the whole tokens. We can work around this limitation by
+        // using the first/last span of the tokens like
+        // `syn::Error::new_spanned` does.
+        let start = last_stmt.next().map_or_else(Span::call_site, |t| t.span());
+        let end = last_stmt.last().map_or(start, |t| t.span());
+        (start, end)
+    };
+
+    let rt = quote_spanned! {last_stmt_start_span=>
+        tokio::runtime::Builder::new_current_thread()
+    };
+
+    let header = quote! {
+        #[::core::prelude::v1::test]
+    };
+
+    let test_fn = &input.sig.ident;
+    let test_driver = Ident::new(&format!("idm_{}", test_fn), input.sig.span());
+
+    // Effectively we are just injecting a real test function around this which we will
+    // call.
+
+    let result = quote! {
+        #input
+
+        #header
+        fn #test_driver() {
+            let body = async {
+                let (test_server, mut idms_delayed)  = crate::testkit::setup_idm_test().await;
+
+                #test_fn(&test_server, &mut idms_delayed).await;
+
+                // Any needed teardown?
+                // Make sure there are no errors.
+                let mut idm_read_txn = test_server.proxy_read().await;
+                let verifications = idm_read_txn.qs_read.verify();
+                trace!("Verification result: {:?}", verifications);
+                assert!(verifications.len() == 0);
+
+                idms_delayed.check_is_empty_or_panic();
+            };
+            #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
+            {
+                return #rt
+                    .enable_all()
+                    .build()
+                    .expect("Failed building the Runtime")
+                    .block_on(body);
+            }
+        }
+    };
+
+    result.into()
+}

--- a/kanidmd/lib-macros/src/lib.rs
+++ b/kanidmd/lib-macros/src/lib.rs
@@ -26,3 +26,8 @@ pub fn qs_test(args: TokenStream, item: TokenStream) -> TokenStream {
 pub fn qs_test_no_init(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::qs_test(&args, item, false)
 }
+
+#[proc_macro_attribute]
+pub fn idm_test(args: TokenStream, item: TokenStream) -> TokenStream {
+    entry::idm_test(&args, item)
+}

--- a/kanidmd/lib/src/idm/server.rs
+++ b/kanidmd/lib/src/idm/server.rs
@@ -1,4 +1,3 @@
-use core::task::{Context, Poll};
 use std::convert::TryFrom;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -11,8 +10,6 @@ use concread::cowcell::{CowCellReadTxn, CowCellWriteTxn};
 use concread::hashmap::HashMap;
 use concread::CowCell;
 use fernet::Fernet;
-// #[cfg(any(test,bench))]
-use futures::task as futures_task;
 use hashbrown::HashSet;
 use kanidm_proto::v1::{
     ApiToken, BackupCodesView, CredentialStatus, PasswordFeedback, RadiusAuthToken, UatPurpose,
@@ -343,8 +340,12 @@ impl IdmServer {
 }
 
 impl IdmServerDelayed {
-    // #[cfg(any(test,bench))]
+    // I think we can just make this async in the future?
+    #[cfg(test)]
     pub(crate) fn check_is_empty_or_panic(&mut self) {
+        use core::task::{Context, Poll};
+        use futures::task as futures_task;
+
         let waker = futures_task::noop_waker();
         let mut cx = Context::from_waker(&waker);
         match self.async_rx.poll_recv(&mut cx) {
@@ -365,6 +366,9 @@ impl IdmServerDelayed {
 
     #[cfg(test)]
     pub(crate) fn try_recv(&mut self) -> Result<DelayedAction, OperationError> {
+        use core::task::{Context, Poll};
+        use futures::task as futures_task;
+
         let waker = futures_task::noop_waker();
         let mut cx = Context::from_waker(&waker);
         match self.async_rx.poll_recv(&mut cx) {

--- a/kanidmd/lib/src/lib.rs
+++ b/kanidmd/lib/src/lib.rs
@@ -52,8 +52,7 @@ mod repl;
 pub mod schema;
 pub mod server;
 pub mod status;
-#[cfg(test)]
-mod testkit;
+pub mod testkit;
 
 /// A prelude of imports that should be imported by all other Kanidm modules to
 /// help make imports cleaner.
@@ -79,6 +78,7 @@ pub mod prelude {
         FilterInvalid, FC,
     };
     pub use crate::identity::{AccessScope, IdentType, Identity, IdentityId};
+    pub use crate::idm::server::{IdmServer, IdmServerDelayed};
     pub use crate::modify::{m_pres, m_purge, m_remove, Modify, ModifyInvalid, ModifyList};
     pub use crate::server::{
         QueryServer, QueryServerReadTransaction, QueryServerTransaction,

--- a/kanidmd/lib/src/macros.rs
+++ b/kanidmd/lib/src/macros.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 macro_rules! setup_test {
     () => {{
         let _ = sketching::test_init();
@@ -71,6 +72,7 @@ macro_rules! entry_str_to_account {
     }};
 }
 
+#[cfg(test)]
 macro_rules! run_idm_test_inner {
     ($test_fn:expr) => {{
         #[allow(unused_imports)]
@@ -110,18 +112,6 @@ macro_rules! run_idm_test {
         let _ = sketching::test_init();
         run_idm_test_inner!($test_fn);
     }};
-}
-
-pub fn run_idm_test_no_logging<F>(mut test_fn: F)
-where
-    F: FnMut(
-        &crate::server::QueryServer,
-        &crate::idm::server::IdmServer,
-        &crate::idm::server::IdmServerDelayed,
-    ),
-{
-    sketching::test_init();
-    run_idm_test_inner!(test_fn);
 }
 
 // Test helpers for all plugins.

--- a/kanidmd/lib/src/schema.rs
+++ b/kanidmd/lib/src/schema.rs
@@ -1603,6 +1603,7 @@ impl Schema {
         }
     }
 
+    #[cfg(any(test))]
     pub(crate) fn write_blocking(&self) -> SchemaWriteTransaction<'_> {
         self.write()
     }

--- a/kanidmd/lib/src/server.rs
+++ b/kanidmd/lib/src/server.rs
@@ -820,7 +820,7 @@ impl<'a> QueryServerReadTransaction<'a> {
     // Verify the data content of the server is as expected. This will probably
     // call various functions for validation, including possibly plugin
     // verifications.
-    fn verify(&mut self) -> Vec<Result<(), ConsistencyError>> {
+    pub(crate) fn verify(&mut self) -> Vec<Result<(), ConsistencyError>> {
         // If we fail after backend, we need to return NOW because we can't
         // assert any other faith in the DB states.
         //  * backend

--- a/kanidmd/lib/src/testkit.rs
+++ b/kanidmd/lib/src/testkit.rs
@@ -19,3 +19,13 @@ pub async fn setup_test() -> QueryServer {
     // Init is called via the proc macro
     qs
 }
+
+pub async fn setup_idm_test() -> (IdmServer, IdmServerDelayed) {
+    let qs = setup_test().await;
+
+    qs.initialise_helper(duration_from_epoch_now())
+        .await
+        .expect("init failed!");
+
+    IdmServer::new(qs, "https://idm.example.com").expect("Failed to setup idms")
+}


### PR DESCRIPTION
Further test improvements and work toward removing async_std. This adds the idm_test proc macro, which allows async and fixtures in idm tests. I still need to think about how to add the plugin tests after this. I didn't convert every test over yet, that's future williams problem. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
