### PR TITLE
Improve handling of openssl3 in md4 tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ dependencies = [
  "libsqlite3-sys",
  "num_enum",
  "openssl",
+ "openssl-sys",
  "profiles",
  "r2d2",
  "r2d2_sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ lru = "^0.8.0"
 mathru = "^0.13.0"
 num_enum = "^0.5.7"
 oauth2_ext = { version = "^4.1.0", package = "oauth2" }
+openssl-sys = "^0.9"
 openssl = "^0.10.41"
 paste = "^1.0.9"
 pkg-config = "^0.3.26"

--- a/kanidmd/lib/Cargo.toml
+++ b/kanidmd/lib/Cargo.toml
@@ -41,6 +41,9 @@ ldap3_proto.workspace = true
 libc.workspace = true
 libsqlite3-sys.workspace = true
 num_enum.workspace = true
+# We need to explicitly ask for openssl-sys so that we get the version propogated
+# into the build.rs for legacy feature checks.
+openssl-sys.workspace = true
 openssl.workspace = true
 r2d2.workspace = true
 r2d2_sqlite.workspace = true

--- a/kanidmd/lib/build.rs
+++ b/kanidmd/lib/build.rs
@@ -1,5 +1,15 @@
 // include!("src/lib/audit_loglevel.rs");
 
+use std::env;
+
 fn main() {
+    if let Ok(v) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&v, 16).unwrap();
+
+        if version >= 0x3_00_00_00_0 {
+            println!("cargo:rustc-cfg=openssl3");
+        }
+    }
+
     profiles::apply_profile();
 }


### PR DESCRIPTION
Fixes #1170 - This improves openssl 3 handling with nt hash imports. Specifically, we warn  correctly at *runtime* if the legacy provider is not available. In tests we simply warn that the provider needs to be enabled. I attempted to enable the provider in the tests-only but it consistently did absolutely nothing, so we sadly have to rely on people to import this. 

Alternately we do a "FreeRADIUS" and hand roll md4 in the project to bypass this. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
