### PR TITLE
Add version header and warnings

### DIFF
--- a/kanidm_unix_int/src/tasks_daemon.rs
+++ b/kanidm_unix_int/src/tasks_daemon.rs
@@ -11,8 +11,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 use std::ffi::CString;
-use std::os::unix::fs::symlink;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::time::Duration;
 use std::{fs, io};
@@ -81,7 +81,11 @@ fn chown(path: &Path, gid: u32) -> Result<(), String> {
     Ok(())
 }
 
-fn create_home_directory(info: &HomeDirectoryInfo, home_prefix: &str, use_etc_skel: bool) -> Result<(), String> {
+fn create_home_directory(
+    info: &HomeDirectoryInfo,
+    home_prefix: &str,
+    use_etc_skel: bool,
+) -> Result<(), String> {
     // Final sanity check to prevent certain classes of attacks.
     let name = info
         .name

--- a/kanidmd/core/src/https/middleware.rs
+++ b/kanidmd/core/src/https/middleware.rs
@@ -211,3 +211,21 @@ impl<State: Clone + Send + Sync + 'static> tide::Middleware<State>
         Ok(response)
     }
 }
+
+const KANIDM_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+#[derive(Default)]
+pub struct VersionHeaderMiddleware;
+
+#[async_trait::async_trait]
+impl<State: Clone + Send + Sync + 'static> tide::Middleware<State> for VersionHeaderMiddleware {
+    async fn handle(
+        &self,
+        request: tide::Request<State>,
+        next: tide::Next<'_, State>,
+    ) -> tide::Result {
+        let mut response = next.run(request).await;
+        response.insert_header("X-KANIDM-VERSION", KANIDM_VERSION);
+        Ok(response)
+    }
+}


### PR DESCRIPTION
Relates #989 add client / server version mismatch warning. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
