### PR TITLE
Add tools container support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,17 @@ buildx/kanidmd:
 		$(CONTAINER_BUILD_ARGS) .
 	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/server:$(IMAGE_VERSION)
 
+buildx/kanidm_tools: ## Build multiarch kanidm tool images and push to docker hub
+buildx/kanidm_tools:
+	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) \
+		--pull --push --platform $(IMAGE_ARCH) \
+		-f kanidm_tools/Dockerfile \
+		-t $(IMAGE_BASE)/tools:$(IMAGE_VERSION) \
+		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
+		--build-arg "KANIDM_FEATURES=" \
+		$(CONTAINER_BUILD_ARGS) .
+	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/tools:$(IMAGE_VERSION)
+
 buildx/radiusd: ## Build multi-arch radius docker images and push to docker hub
 buildx/radiusd:
 	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) \
@@ -43,7 +54,7 @@ buildx/radiusd:
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) .
 	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/radius:$(IMAGE_VERSION)
 
-buildx: buildx/kanidmd buildx/radiusd
+buildx: buildx/kanidmd/x86_64_v3 buildx/kanidmd buildx/kanidm_tools buildx/radiusd
 
 build/kanidmd:	## Build the kanidmd docker image locally
 build/kanidmd:

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -69,7 +69,7 @@ tools from a docker container instead.
         kanidm/tools:latest \
         /sbin/kanidm --help
 
-If you have a ca.pem you may need to bind mound this in as requried.
+If you have a ca.pem you may need to bind mount this in as required.
 
 > **TIP** You can alias the docker run command to make the tools easier to access such as:
 

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -11,7 +11,7 @@ Kanidm currently supports the following Linux distributions:
 
  * OpenSUSE Tumbleweed
  * OpenSUSE Leap 15.3/15.4
- * Fedora 34/35
+ * Fedora 36
  * CentOS Stream 9
 
 The `kanidm` client has been built and tested from Windows, but is not (yet) packaged routinely.
@@ -26,8 +26,7 @@ the clients with:
 
 ### OpenSUSE Leap 15.3/15.4
 
-Leap 15.3/15.4 does not have full Kanidm support. For an experimental client, you can
-try the development repository. Using zypper you can add the repository with:
+Using zypper you can add the Kanidm leap repository with:
 
     zypper ar -f obs://network:idm network_idm
 
@@ -38,20 +37,43 @@ Then you need to refresh your metadata and install the clients.
 
 ### Fedora / Centos Stream
 
-Fedora has limited support through the development repository. You need to add the repository 
+Fedora has limited support through the development repository. You need to add the repository
 metadata into the correct directory:
 
-    cd /etc/yum.repos.d
-    # Fedora 34
-    wget https://download.opensuse.org/repositories/network:/idm/Fedora_34/network:idm.repo
-    # Fedora 35
-    wget https://download.opensuse.org/repositories/network:/idm/Fedora_35/network:idm.repo
+    # Fedora
+    wget https://download.opensuse.org/repositories/network:/idm/Fedora_36/network:idm.repo
     # Centos Stream 9
     wget https://download.opensuse.org/repositories/network:/idm/CentOS_9_Stream/network:idm.repo
 
 You can then install with:
 
     dnf install kanidm-clients
+
+{{#template
+    templates/kani-warning.md
+    imagepath=images
+    title=Take Note!
+    text=Kanidm frequently uses new Rust versions and features, however Fedora and Centos frequently are behind in Rust releases. As a result, they may not always have the latest Kanidm versions available.
+}}
+
+## Tools Container
+
+In some cases if your distribution does not have native kanidm-client support, you can use the cli
+tools from a docker container instead.
+
+    docker pull kanidm/tools:latest
+    docker run --rm -i -t \
+        -v /etc/kanidm/config:/etc/kanidm/config:ro \
+        -v ~/.config/kanidm:/home/kanidm/.config/kanidm:ro \
+        -v ~/.cache/kanidm_tokens:/home/kanidm/.cache/kanidm_tokens \
+        kanidm/tools:latest \
+        /sbin/kanidm --help
+
+If you have a ca.pem you may need to bind mound this in as requried.
+
+> **TIP** You can alias the docker run command to make the tools easier to access such as:
+
+    alias kanidm="docker run ..."
 
 ## From source (CLI only, not recommended)
 

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -68,9 +68,9 @@ You can then install with:
 
 The tools are available as a cargo download if you have a rust tool chain available. To install
 rust you should follow the documentation for [rustup](https://rustup.rs/). These will be installed
-into your home directory. To update these, re-run the install command.
+into your home directory. To update these, re-run the install command with the new version.
 
-    cargo install kanidm_tools
+    cargo install --version 1.1.0-alpha.10 kanidm_tools
 
 ## Tools Container
 

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -35,7 +35,22 @@ Then you need to refresh your metadata and install the clients.
     zypper ref
     zypper in kanidm-clients
 
+### MacOS - Brew
+
+[Homebrew](https://brew.sh/) allows addition of third party repositories for installing tools. On
+MacOS you can use this to install the Kanidm tools.
+
+    brew tap kanidm/kanidm
+    brew install kanidm
+
 ### Fedora / Centos Stream
+
+{{#template
+    templates/kani-warning.md
+    imagepath=images
+    title=Take Note!
+    text=Kanidm frequently uses new Rust versions and features, however Fedora and Centos frequently are behind in Rust releases. As a result, they may not always have the latest Kanidm versions available.
+}}
 
 Fedora has limited support through the development repository. You need to add the repository
 metadata into the correct directory:
@@ -49,17 +64,18 @@ You can then install with:
 
     dnf install kanidm-clients
 
-{{#template
-    templates/kani-warning.md
-    imagepath=images
-    title=Take Note!
-    text=Kanidm frequently uses new Rust versions and features, however Fedora and Centos frequently are behind in Rust releases. As a result, they may not always have the latest Kanidm versions available.
-}}
+## Cargo
+
+The tools are available as a cargo download if you have a rust tool chain available. To install
+rust you should follow the documentation for [rustup](https://rustup.rs/). These will be installed
+into your home directory. To update these, re-run the install command.
+
+    cargo install kanidm_tools
 
 ## Tools Container
 
-In some cases if your distribution does not have native kanidm-client support, you can use the cli
-tools from a docker container instead.
+In some cases if your distribution does not have native kanidm-client support, and you can't access
+cargo for the install for some reason, you can use the cli tools from a docker container instead.
 
     docker pull kanidm/tools:latest
     docker run --rm -i -t \
@@ -74,13 +90,6 @@ If you have a ca.pem you may need to bind mount this in as required.
 > **TIP** You can alias the docker run command to make the tools easier to access such as:
 
     alias kanidm="docker run ..."
-
-## From source (CLI only, not recommended)
-
-After you check out the source (see [GitHub](https://github.com/kanidm/kanidm)), navigate to:
-
-    cd kanidm_tools
-    cargo install --path .
 
 ## Checking that the tools work
 

--- a/kanidm_book/src/installing_client_tools.md
+++ b/kanidm_book/src/installing_client_tools.md
@@ -1,16 +1,19 @@
 # Installing Client Tools
 
-> **NOTE** As this project is in a rapid development phase, running different 
-release versions will likely present incompatibilities. Ensure you're running 
-matching release versions of client and server binaries. If you have any issues, 
+> **NOTE** As this project is in a rapid development phase, running different
+release versions will likely present incompatibilities. Ensure you're running
+matching release versions of client and server binaries. If you have any issues,
 check that you are running the latest software.
 
 ## From packages
 
-Kanidm currently supports the following Linux distributions:
+Kanidm currently is packaged for the following systems:
 
  * OpenSUSE Tumbleweed
  * OpenSUSE Leap 15.3/15.4
+ * MacOS
+ * Arch Linux
+ * NixOS
  * Fedora 36
  * CentOS Stream 9
 
@@ -42,6 +45,14 @@ MacOS you can use this to install the Kanidm tools.
 
     brew tap kanidm/kanidm
     brew install kanidm
+
+### Arch Linux
+
+[Kanidm on AUR](https://aur.archlinux.org/packages?O=0&K=kanidm)
+
+### NixOS
+
+[Kanidm in NixOS](https://search.nixos.org/packages?sort=relevance&type=packages&query=kanidm)
 
 ### Fedora / Centos Stream
 

--- a/kanidm_book/src/server_configuration.md
+++ b/kanidm_book/src/server_configuration.md
@@ -26,10 +26,12 @@ You should test your configuration is valid before you proceed.
 
 ### Default Admin Account
 
-Then you can setup the initial admin account and initialise the database into your volume.
+Then you can setup the initial admin account and initialise the database into your volume. This command
+will generate a new random password for the admin account.
 
     docker run --rm -i -t -v kanidmd:/data \
         kanidm/server:latest /sbin/kanidmd recover_account -c /data/server.toml admin
+    # success - recover_account password for user admin: vv...
 
 ### Run the Server
 

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -208,6 +208,12 @@ impl KanidmClientBuilder {
         config_path: P,
     ) -> Result<Self, ()> {
         debug!("Attempting to load configuration from {:#?}", &config_path);
+
+        if !config_path.as_ref().exists() {
+            debug!("{:?} does not exist", config_path);
+            return Ok(self);
+        };
+
         // If the file does not exist, we skip this function.
         let mut f = match File::open(&config_path) {
             Ok(f) => {

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -209,6 +209,10 @@ impl KanidmClientBuilder {
     ) -> Result<Self, ()> {
         debug!("Attempting to load configuration from {:#?}", &config_path);
 
+        // We have to check the .exists case manually, because there are some weird overlayfs
+        // issues in docker where when the file does NOT exist, but we "open it" we get an
+        // error describing that the file is actually a directory rather than a not exists
+        // error. This check enforces that we get the CORRECT error message instead.
         if !config_path.as_ref().exists() {
             debug!("{:?} does not exist", config_path);
             return Ok(self);

--- a/kanidm_tools/Dockerfile
+++ b/kanidm_tools/Dockerfile
@@ -32,7 +32,6 @@ ENV KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE:-container_generic}
 RUN echo Features $KANIDM_FEATURES
 
 ENV CARGO_HOME=/scratch/.cargo
-ENV RUSTFLAGS="-Clinker=clang"
 ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.lld"
 
 # set up sccache if you've done the thing
@@ -63,18 +62,21 @@ RUN if [ "${SCCACHE_REDIS}" != "" ]; then sccache -s; fi
 
 RUN ls -al /usr/src/kanidm/target/release
 
+# == Construct the tools container
 FROM repos
 
-RUN zypper install -y timezone busybox-adduser
-RUN zypper clean -a
+RUN zypper install -y timezone busybox-adduser && \
+    zypper clean -a
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 RUN chmod +x /sbin/kanidm
 ENV RUST_BACKTRACE 1
 
 RUN adduser -D -H kanidm
-RUN zypper remove -y busybox-adduser
+RUN mkdir /etc/kanidm && \
+    touch /etc/kanidm/config
 
 USER kanidm
 
-CMD [ "/sbin/kanidm", "-c", "/data/kanidm.toml" ]
+CMD [ "/sbin/kanidm", "-h" ]
+

--- a/kanidm_tools/src/cli/common.rs
+++ b/kanidm_tools/src/cli/common.rs
@@ -16,9 +16,21 @@ impl CommonOpt {
 
         let client_builder = KanidmClientBuilder::new()
             .read_options_from_optional_config(DEFAULT_CLIENT_CONFIG_PATH)
-            .and_then(|cb| cb.read_options_from_optional_config(&config_path))
-            .unwrap_or_else(|e| {
-                error!("Failed to parse config (if present) -- {:?}", e);
+            .map_err(|e| {
+                error!(
+                    "Failed to parse config ({:?}) -- {:?}",
+                    DEFAULT_CLIENT_CONFIG_PATH, e
+                );
+                e
+            })
+            .and_then(|cb| {
+                cb.read_options_from_optional_config(&config_path)
+                    .map_err(|e| {
+                        error!("Failed to parse config ({:?}) -- {:?}", config_path, e);
+                        e
+                    })
+            })
+            .unwrap_or_else(|_e| {
                 std::process::exit(1);
             });
         debug!(

--- a/kanidm_unix_int/src/tasks_daemon.rs
+++ b/kanidm_unix_int/src/tasks_daemon.rs
@@ -11,8 +11,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 use std::ffi::CString;
-use std::os::unix::fs::symlink;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::time::Duration;
 use std::{fs, io};
@@ -81,7 +81,11 @@ fn chown(path: &Path, gid: u32) -> Result<(), String> {
     Ok(())
 }
 
-fn create_home_directory(info: &HomeDirectoryInfo, home_prefix: &str, use_etc_skel: bool) -> Result<(), String> {
+fn create_home_directory(
+    info: &HomeDirectoryInfo,
+    home_prefix: &str,
+    use_etc_skel: bool,
+) -> Result<(), String> {
     // Final sanity check to prevent certain classes of attacks.
     let name = info
         .name

--- a/kanidmd/core/src/lib.rs
+++ b/kanidmd/core/src/lib.rs
@@ -546,7 +546,7 @@ pub async fn recover_account_core(config: &Configuration, name: &str) {
             src_user: String::from("command-line invocation"),
             dest_user: name.to_string(),
             result: new_pw,
-            action: String::from("recover_account"),
+            action: String::from("recover_account password"),
         }
     );
 }


### PR DESCRIPTION
Fixes #1176 - Add a tools container and improve some docs adjacent to tools install. I intend to backport this to the .10 release. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
