### PR TITLE
improve webauthn errors

### DIFF
--- a/kanidmd/lib/src/idm/credupdatesession.rs
+++ b/kanidmd/lib/src/idm/credupdatesession.rs
@@ -1372,7 +1372,7 @@ impl<'a> IdmServerCredUpdateTransaction<'a> {
                 session.account.existing_credential_id_list(),
             )
             .map_err(|e| {
-                error!(?e, "Unable to start passkey registration");
+                error!(eclass=?e, emsg=%e, "Unable to start passkey registration");
                 OperationError::Webauthn
             })?;
 
@@ -1401,7 +1401,7 @@ impl<'a> IdmServerCredUpdateTransaction<'a> {
                     .webauthn
                     .finish_passkey_registration(reg, pk_reg)
                     .map_err(|e| {
-                        error!(?e, "Unable to start passkey registration");
+                        error!(eclass=?e, emsg=%e, "Unable to start passkey registration");
                         OperationError::Webauthn
                     })?;
                 let pk_id = Uuid::new_v4();


### PR DESCRIPTION
Fixes #1177 - improve the output of webauthn errors. It is correct that these are a 500 error since they indicate a server misconfiguration in this case rather than a user generated mistake. The errors from webauthn-rs implement thiserror::Error, so they have fmt::display with nice messages. We should display these. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
