### PR TITLE
20221103 ipa import driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,9 +2253,15 @@ dependencies = [
  "clap_complete",
  "kanidm_client",
  "kanidm_proto",
+ "kanidmd_lib",
  "ldap3_client",
  "scim_proto",
+ "serde",
  "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "users",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,13 +2249,13 @@ dependencies = [
 name = "kanidm-ipa-sync"
 version = "1.1.0-alpha.11-dev"
 dependencies = [
+ "base64urlsafedata",
  "clap",
  "clap_complete",
  "kanidm_client",
  "kanidm_proto",
  "kanidmd_lib",
  "ldap3_client",
- "scim_proto",
  "serde",
  "serde_json",
  "tokio",
@@ -2545,6 +2545,7 @@ name = "ldap3_client"
 version = "0.3.0"
 dependencies = [
  "base64 0.13.1",
+ "base64urlsafedata",
  "futures-util",
  "ldap3_proto",
  "openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanidm-ipa-sync"
+version = "1.1.0-alpha.11-dev"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "kanidm_client",
+ "kanidm_proto",
+ "ldap3_client",
+ "scim_proto",
+ "tokio",
+]
+
+[[package]]
 name = "kanidm_client"
 version = "1.1.0-alpha.11-dev"
 dependencies = [
@@ -2519,15 +2532,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ldap3_client"
+version = "0.3.0"
+dependencies = [
+ "base64 0.13.1",
+ "futures-util",
+ "ldap3_proto",
+ "openssl",
+ "serde",
+ "tokio",
+ "tokio-openssl",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "ldap3_proto"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d7f04b6dc4d5401b817596e424ecb4a0931db1418f3987a27e0ab69320665e"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "lber",
+ "nom 7.1.1",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3745,6 +3775,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "scim_proto"
+version = "0.1.0"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "time 0.2.27",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,6 +2543,7 @@ dependencies = [
 [[package]]
 name = "ldap3_client"
 version = "0.3.0"
+source = "git+https://github.com/kanidm/ldap3.git#6b0d146d3f85a32add3bdc3639ba4146822eb861"
 dependencies = [
  "base64 0.13.1",
  "base64urlsafedata",
@@ -2561,6 +2562,7 @@ dependencies = [
 [[package]]
 name = "ldap3_proto"
 version = "0.3.0"
+source = "git+https://github.com/kanidm/ldap3.git#6b0d146d3f85a32add3bdc3639ba4146822eb861"
 dependencies = [
  "bytes",
  "lber",
@@ -3781,6 +3783,7 @@ dependencies = [
 [[package]]
 name = "scim_proto"
 version = "0.1.0"
+source = "git+https://github.com/kanidm/scim.git#f7a9241bf413ac2e40cb974876d2b0433a866c74"
 dependencies = [
  "base64urlsafedata",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.16",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -596,9 +596,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
 
 [[package]]
 name = "byteorder"
@@ -769,9 +769,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "compact_jwt"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5656b98b1584764a52906e67caec20dfb9b0179ac2052d0d5937b083bc39a120"
+checksum = "51f9032b96a89dd79ffc5f62523d5351ebb40680cbdfc4029393b511b9e971aa"
 dependencies = [
  "base64 0.13.1",
  "base64urlsafedata",
@@ -869,7 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
 dependencies = [
  "percent-encoding",
- "time 0.3.16",
+ "time 0.3.17",
  "version_check",
 ]
 
@@ -885,7 +885,7 @@ dependencies = [
  "publicsuffix",
  "serde",
  "serde_json",
- "time 0.3.16",
+ "time 0.3.17",
  "url",
 ]
 
@@ -2193,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -2257,10 +2257,12 @@ dependencies = [
  "ldap3_client",
  "scim_proto",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "users",
 ]
 
@@ -2288,6 +2290,7 @@ dependencies = [
  "base32",
  "base64urlsafedata",
  "last-git-commit",
+ "scim_proto",
  "serde",
  "serde_json",
  "time 0.2.27",
@@ -2804,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2922,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -2949,15 +2952,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3292,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
@@ -3543,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3575,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -4461,16 +4455,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa 1.0.4",
- "libc",
- "num_threads",
  "serde",
  "time-core",
- "time-macros 0.2.5",
+ "time-macros 0.2.6",
 ]
 
 [[package]]
@@ -4491,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -5300,7 +5292,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.16",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -5420,5 +5412,5 @@ dependencies = [
  "lazy_static",
  "quick-error",
  "regex",
- "time 0.3.16",
+ "time 0.3.17",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ lto = "thin"
 
 [workspace]
 members = [
+    "iam_migrations/freeipa",
     "kanidm_client",
     "kanidm_proto",
     "kanidm_tools",
@@ -83,7 +84,13 @@ kanidm_unix_int = { path = "./kanidm_unix_int" }
 last-git-commit = "0.2.0"
 # REMOVE this
 lazy_static = "^1.4.0"
-ldap3_proto = "^0.2.3"
+# ldap3_client = "^0.3.0"
+# ldap3_proto = "^0.3.0"
+
+ldap3_client = { path = "../ldap3/client", version = "0.3.0" }
+ldap3_proto = { path = "../ldap3/proto", version = "0.3.0" }
+scim_proto = { path = "../scim/proto", version = "0.1.0" }
+
 libc = "^0.2.135"
 libnss = "^0.4.0"
 libsqlite3-sys = "^0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,13 @@ lazy_static = "^1.4.0"
 # ldap3_client = "^0.3.0"
 # ldap3_proto = "^0.3.0"
 
-ldap3_client = { path = "../ldap3/client", version = "0.3.0" }
-ldap3_proto = { path = "../ldap3/proto", version = "0.3.0" }
-scim_proto = { path = "../scim/proto", version = "0.1.0" }
+# ldap3_client = { path = "../ldap3/client", version = "0.3.0" }
+# ldap3_proto = { path = "../ldap3/proto", version = "0.3.0" }
+# scim_proto = { path = "../scim/proto", version = "0.1.0" }
+
+ldap3_client = { git = "https://github.com/kanidm/ldap3.git", version = "0.3.0" }
+ldap3_proto = { git = "https://github.com/kanidm/ldap3.git", version = "0.3.0" }
+scim_proto = { git = "https://github.com/kanidm/scim.git", version = "0.1.0" }
 
 libc = "^0.2.135"
 libnss = "^0.4.0"

--- a/iam_migrations/freeipa/00config-mod.ldif
+++ b/iam_migrations/freeipa/00config-mod.ldif
@@ -1,4 +1,4 @@
 dn: cn=Retro Changelog Plugin,cn=plugins,cn=config
 changetype: modify
 add: nsslapd-include-suffix
-nsslapd-include-suffix: cn=accounts,dc=dev,dc=kanidm,dc=com
+nsslapd-include-suffix: dc=dev,dc=kanidm,dc=com

--- a/iam_migrations/freeipa/Cargo.toml
+++ b/iam_migrations/freeipa/Cargo.toml
@@ -24,7 +24,9 @@ users.workspace = true
 ldap3_client.workspace = true
 scim_proto.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 toml.workspace = true
+url = { workspace = true, features = ["serde"] }
 
 # For file metadata, should this me moved out?
 kanidmd_lib.workspace = true

--- a/iam_migrations/freeipa/Cargo.toml
+++ b/iam_migrations/freeipa/Cargo.toml
@@ -16,9 +16,18 @@ clap = { workspace = true, features = ["derive", "env"] }
 kanidm_client.workspace = true
 kanidm_proto.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+users.workspace = true
 
 ldap3_client.workspace = true
 scim_proto.workspace = true
+serde = { workspace = true, features = ["derive"] }
+toml.workspace = true
+
+# For file metadata, should this me moved out?
+kanidmd_lib.workspace = true
 
 [build-dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/iam_migrations/freeipa/Cargo.toml
+++ b/iam_migrations/freeipa/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "kanidm-ipa-sync"
+description = "Kanidm Client Tools"
+documentation = "https://kanidm.github.io/kanidm/stable/"
+
+version.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+clap = { workspace = true, features = ["derive", "env"] }
+kanidm_client.workspace = true
+kanidm_proto.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
+
+ldap3_client.workspace = true
+scim_proto.workspace = true
+
+[build-dependencies]
+clap = { workspace = true, features = ["derive"] }
+clap_complete.workspace = true

--- a/iam_migrations/freeipa/Cargo.toml
+++ b/iam_migrations/freeipa/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+base64urlsafedata.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 kanidm_client.workspace = true
 kanidm_proto.workspace = true
@@ -22,7 +23,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 users.workspace = true
 
 ldap3_client.workspace = true
-scim_proto.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 toml.workspace = true

--- a/iam_migrations/freeipa/src/config.rs
+++ b/iam_migrations/freeipa/src/config.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub sync_token: String,
+    pub ipa_uri: String,
+    pub ipa_sync_dn: String,
+    pub ipa_sync_pw: String,
+    pub ipa_sync_base_dn: String,
+}

--- a/iam_migrations/freeipa/src/config.rs
+++ b/iam_migrations/freeipa/src/config.rs
@@ -1,9 +1,11 @@
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub sync_token: String,
-    pub ipa_uri: String,
+    pub ipa_uri: Url,
+    pub ipa_ca: String,
     pub ipa_sync_dn: String,
     pub ipa_sync_pw: String,
     pub ipa_sync_base_dn: String,

--- a/iam_migrations/freeipa/src/main.rs
+++ b/iam_migrations/freeipa/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iam_migrations/freeipa/src/main.rs
+++ b/iam_migrations/freeipa/src/main.rs
@@ -1,3 +1,220 @@
+// #![deny(warnings)]
+
+#![warn(unused_extern_crates)]
+#![deny(clippy::todo)]
+#![deny(clippy::unimplemented)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::unreachable)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
+// We allow expect since it forces good error messages at the least.
+#![allow(clippy::expect_used)]
+
+mod config;
+
+use crate::config::Config;
+use clap::Parser;
+use std::fs::metadata;
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::thread;
+use tokio::runtime;
+use tracing::{debug, error, info, warn};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{fmt, EnvFilter};
+
+use kanidm_client::KanidmClientBuilder;
+use kanidmd_lib::utils::file_permissions_readonly;
+
+use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
+
+include!("./opt.rs");
+
+async fn driver_main(opt: Opt) {
+    debug!("Starting kanidm freeipa sync driver.");
+    // Parse the configs.
+
+    let mut f = match File::open(&opt.ipa_sync_config) {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Unable to open profile file [{:?}] 🥺", e);
+            return;
+        }
+    };
+
+    let mut contents = String::new();
+    if let Err(e) = f.read_to_string(&mut contents) {
+        error!("unable to read profile contents {:?}", e);
+        return;
+    };
+
+    let sync_config: Config = match toml::from_str(contents.as_str()) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("unable to parse config {:?}", e);
+            return;
+        }
+    };
+
+    debug!(?sync_config);
+
+    let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&opt.client_config)
+    {
+        Ok(v) => v,
+        Err(_) => {
+            error!("Failed to parse {}", opt.client_config.to_string_lossy());
+            return;
+        }
+    };
+
+    // Do we need this?
+    // let cb = cb.connect_timeout(cfg.conn_timeout);
+
+    let rsclient = match cb.build() {
+        Ok(rsc) => rsc,
+        Err(_e) => {
+            error!("Failed to build async client");
+            return;
+        }
+    };
+
+    rsclient.set_token(sync_config.sync_token.clone());
+
+    // Preflight check.
+    //  * can we connect to ipa?
+    //  * can we connect to kanidm?
+
+    // - get the current sync cookie from kanidm.
+    let scim_sync_status = match rsclient.scim_v1_sync_status().await {
+        Ok(s) => {
+            debug!(?s);
+        }
+        Err(e) => {
+            error!(?e, "Failed to access scim sync status");
+        }
+    };
+
+    // - sync repl from ipa.
+
+    // pre-process the entries.
+
+    // dump
+    // OR
+    // send sync req.
+
+    // done!
+}
+
+fn config_security_checks(cfg_path: &Path) -> bool {
+    let cfg_path_str = cfg_path.to_string_lossy();
+
+    if !cfg_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "Config missing from {} - cannot start up. Quitting.",
+            cfg_path_str
+        );
+        return false;
+    } else {
+        let cfg_meta = match metadata(&cfg_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
+                return false;
+            }
+        };
+        if !file_permissions_readonly(&cfg_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                cfg_path_str
+                );
+        }
+
+        let cuid = get_current_uid();
+        let ceuid = get_effective_uid();
+
+        if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
+            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+                cfg_path_str
+            );
+        }
+
+        true
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
+    let cuid = get_current_uid();
+    let ceuid = get_effective_uid();
+    let cgid = get_current_gid();
+    let cegid = get_effective_gid();
+
+    let opt = Opt::parse();
+
+    let fmt_layer = fmt::layer().with_writer(std::io::stderr);
+
+    let filter_layer = if opt.debug {
+        match EnvFilter::try_new("kanidm_client=debug,kanidm_ipa_sync=debug") {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("ERROR! Unable to start tracing {:?}", e);
+                return;
+            }
+        }
+    } else {
+        match EnvFilter::try_from_default_env() {
+            Ok(f) => f,
+            Err(_) => EnvFilter::new("kanidm_client=warn,kanidm_ipa_sync=info"),
+        }
+    };
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .init();
+
+    // Startup sanity checks.
+    if opt.skip_root_check {
+        warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
+        // TODO: this wording is not great m'kay.
+    } else {
+        if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
+            error!("Refusing to run - this process must not operate as root.");
+            return;
+        }
+    };
+
+    if !config_security_checks(&opt.client_config) || !config_security_checks(&opt.ipa_sync_config)
+    {
+        return;
+    }
+
+    let par_count = thread::available_parallelism()
+        .expect("Failed to determine available parallelism")
+        .get();
+
+    let rt = runtime::Builder::new_current_thread()
+        // We configure this as we use parallel workers at some points.
+        .max_blocking_threads(par_count)
+        .enable_all()
+        .build()
+        .expect("Failed to initialise tokio runtime!");
+
+    tracing::debug!("Using {} worker threads", par_count);
+
+    rt.block_on(async move { driver_main(opt).await });
+
+    info!("Success!");
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn it_works() {
+        assert!(true)
+    }
 }

--- a/iam_migrations/freeipa/src/main.rs
+++ b/iam_migrations/freeipa/src/main.rs
@@ -88,14 +88,16 @@ async fn driver_main(opt: Opt) {
     //  * can we connect to kanidm?
 
     // - get the current sync cookie from kanidm.
-    let _scim_sync_status = match rsclient.scim_v1_sync_status().await {
-        Ok(s) => {
-            debug!(?s);
-        }
+    let scim_sync_status = match rsclient.scim_v1_sync_status().await {
+        Ok(s) => 
+            s,
         Err(e) => {
             error!(?e, "Failed to access scim sync status");
+            return;
         }
     };
+
+    debug!(state=?scim_sync_status);
 
     // - sync repl from ipa.
 

--- a/iam_migrations/freeipa/src/main.rs
+++ b/iam_migrations/freeipa/src/main.rs
@@ -1,5 +1,4 @@
-// #![deny(warnings)]
-
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
@@ -82,14 +81,14 @@ async fn driver_main(opt: Opt) {
         }
     };
 
-    rsclient.set_token(sync_config.sync_token.clone());
+    rsclient.set_token(sync_config.sync_token.clone()).await;
 
     // Preflight check.
     //  * can we connect to ipa?
     //  * can we connect to kanidm?
 
     // - get the current sync cookie from kanidm.
-    let scim_sync_status = match rsclient.scim_v1_sync_status().await {
+    let _scim_sync_status = match rsclient.scim_v1_sync_status().await {
         Ok(s) => {
             debug!(?s);
         }

--- a/iam_migrations/freeipa/src/main.rs
+++ b/iam_migrations/freeipa/src/main.rs
@@ -213,7 +213,12 @@ async fn driver_main(opt: Opt) {
             error!(?e, "Failed to serialise scim sync request");
         };
     } else {
-        todo!();
+        if let Err(e) = rsclient.scim_v1_sync_update(&scim_sync_request).await {
+            error!(
+                ?e,
+                "Failed to submit scim sync update - see the kanidmd server log for more details."
+            );
+        };
     }
     // done!
 }

--- a/iam_migrations/freeipa/src/opt.rs
+++ b/iam_migrations/freeipa/src/opt.rs
@@ -1,0 +1,31 @@
+
+
+use kanidm_proto::constants::DEFAULT_CLIENT_CONFIG_PATH;
+pub const DEFAULT_IPA_CONFIG_PATH: &str = "/etc/kanidm/ipa-sync";
+
+
+#[derive(Debug, clap::Parser)]
+#[clap(about = "Kanidm FreeIPA Sync Driver")]
+pub struct Opt {
+    /// Enable debbuging of the sync driver
+    #[clap(short, long, env = "KANIDM_DEBUG")]
+    pub debug: bool,
+    /// Path to the client config file.
+    #[clap(parse(from_os_str), short, long, default_value_os_t = DEFAULT_CLIENT_CONFIG_PATH.into())]
+    pub client_config: PathBuf,
+
+    /// Path to the ipa-sync config file.
+    #[clap(parse(from_os_str), short, long, default_value_os_t = DEFAULT_IPA_CONFIG_PATH.into())]
+    pub ipa_sync_config: PathBuf,
+
+    #[clap(short, long, hide = true)]
+    /// Dump the ldap protocol inputs, as well as the scim outputs. This can be used
+    /// to create test cases for testing the parser.
+    ///
+    /// No actions are taken on the kanidm instance, this is purely a dump of the
+    /// state in/out.
+    pub proto_dump: bool,
+
+    #[clap(short, long, hide = true)]
+    pub skip_root_check: bool,
+}

--- a/iam_migrations/freeipa/src/tests.rs
+++ b/iam_migrations/freeipa/src/tests.rs
@@ -1,0 +1,1486 @@
+use ldap3_client::LdapSyncRepl;
+
+#[tokio::test]
+async fn test_ldap_to_scim() {
+    let _sync_request: LdapSyncRepl =
+        serde_json::from_str(TEST_LDAP_SYNC_REPL_1).expect("failed to parse ldap sync");
+
+    // need to setup a fake ldap sync result.
+
+    // What do we expect?
+}
+
+const TEST_LDAP_SYNC_REPL_1: &str = r#"
+{
+  "cookie": "aXBhLXN5bmNyZXBsLWthbmkuZGV2LmJsYWNraGF0cy5uZXQuYXU6Mzg5I2NuPWRpcmVjdG9yeSBtYW5hZ2VyOmNuPWFjY291bnRzLGRjPWRldixkYz1ibGFja2hhdHMsZGM9bmV0LGRjPWF1OihvYmplY3RDbGFzcz0qKSM3OA",
+  "refresh_deletes": false,
+  "entries": [
+    {
+      "entry_uuid": "ac600325-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "accounts"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac600326-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "users"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac600327-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "groups"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac600328-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "services"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac600329-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "computers"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60032a-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=hostgroups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "hostgroups"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60032b-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=ipservices,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "ipservices"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60034b-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Administrator"
+          ],
+          "gecos": [
+            "Administrator"
+          ],
+          "gidNumber": [
+            "8200000"
+          ],
+          "homeDirectory": [
+            "/home/admin"
+          ],
+          "ipaNTHash": [
+            "CVBguEizG80swI8sftaknw"
+          ],
+          "ipaNTSecurityIdentifier": [
+            "S-1-5-21-148961183-2750130983-218252910-500"
+          ],
+          "ipaUniqueID": [
+            "ad15f644-3498-11ed-95c3-5254006b0418"
+          ],
+          "krbExtraData": [
+            "AAL4hSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastAdminUnlock": [
+            "20220915015504Z"
+          ],
+          "krbLastFailedAuth": [
+            "20221007043105Z"
+          ],
+          "krbLastPwdChange": [
+            "20220915015504Z"
+          ],
+          "krbLoginFailedCount": [
+            "0"
+          ],
+          "krbPasswordExpiration": [
+            "20221214015504Z"
+          ],
+          "krbPrincipalKey": [
+            "MIIB1KADAgEBoQMCAQGiAwIBAaMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBBgeEMvRkhoVWphRX0iKXxCoVUwU6ADAgEUoUwESiAAuyt8szEUVLiWVjSTuUgbgCf8heFMeIhSmGTgJpwL50kddprbdeKuOYvyxepdAil/MqHs4qdqj54reDDqFW0T2bg1Iv9O1cZEMGSgGzAZoAMCAQShEgQQU2xOXT16V21hPFkzPClsJKFFMEOgAwIBE6E8BDoQALfdG+243xBQDt01+bFr46DcZnlHctoSyUQKw8I8FzvRE1LK9Ttl5qkkOHADpA7XSj1lQ2RFqBsSMHSgGzAZoAMCAQShEgQQay9XSC9tPDJJVjIwUDxFRKFVMFOgAwIBEqFMBEogADJjxICRFFzpOcsxMY3xVedF3IBd7qzsQJlSvShaeKwyhTBFI/wvVDtQq6ogWKlACUcAVk2N6p91VtRHHjxXVhKQvT0kt/KS7zBkoBswGaADAgEEoRIEEE5nNTh5SmgpZic0bDAmNUWhRTBDoAMCARGhPAQ6EAClGqBf9jZWixZo/evVMVH01NkI1VpR0fNrGyvtML78p5j6TAne5Nms/wj9BtVawuv+h+Gz1fjdfw"
+          ],
+          "krbPrincipalName": [
+            "admin@DEV.BLACKHATS.NET.AU",
+            "root@DEV.BLACKHATS.NET.AU"
+          ],
+          "loginShell": [
+            "/bin/bash"
+          ],
+          "memberOf": [
+            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=trust admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "inetuser",
+            "ipaNTUserAttrs",
+            "ipaSshGroupOfPubKeys",
+            "ipaobject",
+            "ipasshuser",
+            "krbprincipalaux",
+            "krbticketpolicyaux",
+            "person",
+            "posixaccount",
+            "top"
+          ],
+          "sn": [
+            "Administrator"
+          ],
+          "uid": [
+            "admin"
+          ],
+          "uidNumber": [
+            "8200000"
+          ],
+          "userPassword": [
+            "{PBKDF2_SHA256}AAAIAJ3EnyWJXp/ytIk6sqf1BbLO9fzObD3q5I4y2bRFfgAFVo6CaRAaZ7KPYzU6Y340VSUV4NGRRcBjeU8q+aoTOkuzQM91jl+xlCydiB0CjeIDZ0tGy4NmQUFzfg7+exsKhNk2MfUrHcaqfZBtT7Lkfei4Rk7810TQf3NlHIRO8K3egPQ8Ox52Upw1E5QGEKQmDOjrtLtOF5gbyFtR5wc0wUJfmMhd/g65GkqFIr5vbPan3kL3ZqMhh1rrj4ISi9Ui8P7E8GDicoJDPwPf6YD9D0dx6yk72GyiuYt6p2aGJWMY897xqgB+YMgPptiDPik22ExoBAoHeJNIzKjITc2ohLLn6RkCk4GcCwMVZmcxesl/T/OMeSkNvoOM1zy7ANsGbQeaLqpViJSV0xT5PJ6NoIKMU2pIP57Q17VAlYigtCPU"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60034c-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "admins"
+          ],
+          "description": [
+            "Account administrators group"
+          ],
+          "gidNumber": [
+            "8200000"
+          ],
+          "ipaNTSecurityIdentifier": [
+            "S-1-5-21-148961183-2750130983-218252910-512"
+          ],
+          "ipaUniqueID": [
+            "ad17b06a-3498-11ed-afaa-5254006b0418"
+          ],
+          "member": [
+            "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "memberOf": [
+            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "ipaNTGroupAttrs",
+            "ipaobject",
+            "ipausergroup",
+            "nestedGroup",
+            "posixgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60034d-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=ipausers,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "ipausers"
+          ],
+          "description": [
+            "Default group for all users"
+          ],
+          "ipaUniqueID": [
+            "ad18f36c-3498-11ed-8668-5254006b0418"
+          ],
+          "member": [
+            "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "ipaobject",
+            "ipausergroup",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60034e-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=editors,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "editors"
+          ],
+          "description": [
+            "Limited admins who can edit other users"
+          ],
+          "gidNumber": [
+            "8200002"
+          ],
+          "ipaNTSecurityIdentifier": [
+            "S-1-5-21-148961183-2750130983-218252910-1002"
+          ],
+          "ipaUniqueID": [
+            "ad191e00-3498-11ed-b143-5254006b0418"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "ipantgroupattrs",
+            "ipaobject",
+            "ipausergroup",
+            "nestedGroup",
+            "posixgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60034f-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=ipaservers,cn=hostgroups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "ipaservers"
+          ],
+          "description": [
+            "IPA server hosts"
+          ],
+          "ipaUniqueID": [
+            "ad196cd4-3498-11ed-b143-5254006b0418"
+          ],
+          "member": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "memberOf": [
+            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupOfNames",
+            "ipahostgroup",
+            "ipaobject",
+            "nestedGroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60035d-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=cosTemplates,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "cosTemplates"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac600368-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "roles"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac60036c-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=helpdesk,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "helpdesk"
+          ],
+          "description": [
+            "Helpdesk"
+          ],
+          "memberOf": [
+            "cn=Modify Group membership,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify Users and Reset passwords,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Change User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage User Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify External Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac6003a8-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "krbprincipalname=ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "ipaKrbPrincipalAlias": [
+            "ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "ipaUniqueID": [
+            "ae89dcfc-3498-11ed-bd3d-5254006b0418"
+          ],
+          "krbCanonicalName": [
+            "ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AAK8hCJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastPwdChange": [
+            "20220915014948Z"
+          ],
+          "krbLoginFailedCount": [
+            "0"
+          ],
+          "krbPrincipalKey": [
+            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAIt4+Fj03b3othVOnbkGcFJre/qKqofqp4Cesx6wkgLEnLLV5SDqtc/xhJuiqO4NvQgEdebViuxzA7bXMkMFIe1xCD+nVN8rczBHoUUwQ6ADAgERoTwEOhAAoAUnjH3biykn+eZWsiN9f6Xp6ygrYwKxLEOQqph766yNlX1Dfr+0pjYEqmmnf2jq/bRFQlIcJW8wR6FFMEOgAwIBE6E8BDoQAJDDCOlnFEs25wcosS7KQBwv2hEmxtIaBVVAGRc947sl0AavVW1xZ7meuTwpTJoylGdNSTCIQF9cMFehVTBToAMCARShTARKIACdaPkMQSiKQ3nVoihxLeQDyRJ4Bz0E+vtDWZHLRncmmVbtmzzhSeTNk9+9uZZAUbv/mmy3y/FdvfgkBo/2buwaI3WnMXMiI1kwR6FFMEOgAwIBGaE8BDoQABAuW5X9h0BFx6+AkoqzUF1vi0bL99KJBj2ufVf3GvQ4RatalbeYvQZRLGiA+f6T0Tck5f3d4d3VMFehVTBToAMCARqhTARKIACBBonLVHBKTlVDNCVK7iDwojO5Vhtm7XG5D4NeCiM5zhqoPlXTa/7XzEENLRFG/jMC20cKGWzy9Y6iD2uJEfWbCjbVQGnIxIg"
+          ],
+          "krbPrincipalName": [
+            "ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "krbTicketFlags": [
+            "128"
+          ],
+          "managedBy": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "memberOf": [
+            "cn=replication managers,cn=sysaccounts,cn=etc,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipakrbprincipal",
+            "ipaobject",
+            "ipaservice",
+            "krbTicketPolicyAux",
+            "krbprincipal",
+            "krbprincipalaux",
+            "pkiuser",
+            "top"
+          ],
+          "userCertificate": [
+            "MIIFsTCCBBmgAwIBAgIBCDANBgkqhkiG9w0BAQsFADA/MR0wGwYDVQQKDBRERVYuQkxBQ0tIQVRTLk5FVC5BVTEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDkxNTAxNTE1OFoXDTI0MDkxNTAxNTE1OFowUDEdMBsGA1UECgwUREVWLkJMQUNLSEFUUy5ORVQuQVUxLzAtBgNVBAMMJmlwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1hu4DO2P6coC30ivQScItRA8TnliBr4Rf9vHcSMgFbJIUWD+VhfF5l42XXpAJU29kyaTWhMv0suC/youFQ0NKaVcuvUcPdd4bgcLjzHxNRMxUKXEuvffUzARV0KIdZoJQ1s8MT76mTgNmezJoqt8T+q0f5d/2J2jjEIbEC8V2igUR+YLHRahvRZZIYxZZ0hflZyUOtTiMa7sAhjGgbSPGp7QsErHTeoJ2J0R3EJWOvvGHkKgg69wSBZENEoyxlg/pk3aVXbFsIIkO5XooGE8b+EVm52xw9Uk0xDlWm0ZJuB6yRGs2Ntv/vBz0Q6QLJH3fK+fsWnCUutHNAQi2yA4OwIDAQABo4ICJTCCAiEwHwYDVR0jBBgwFoAU3r1esNaYPVZc1ckSKy7uVspCunowRgYIKwYBBQUHAQEEOjA4MDYGCCsGAQUFBzABhipodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2NhL29jc3AwDgYDVR0PAQH/BAQDAgTwMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB/BgNVHR8EeDB2MHSgPKA6hjhodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2lwYS9jcmwvTWFzdGVyQ1JMLmJpbqI0pDIwMDEOMAwGA1UECgwFaXBhY2ExHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAdBgNVHQ4EFgQUqhFargNcWnY/crbOldPRe751v2UwgeYGA1UdEQSB3jCB24ImaXBhLXN5bmNyZXBsLWthbmkuZGV2LmJsYWNraGF0cy5uZXQuYXWgUAYKKwYBBAGCNxQCA6BCDEBsZGFwL2lwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1QERFVi5CTEFDS0hBVFMuTkVULkFVoF8GBisGAQUCAqBVMFOgFhsUREVWLkJMQUNLSEFUUy5ORVQuQVWhOTA3oAMCAQGhMDAuGwRsZGFwGyZpcGEtc3luY3JlcGwta2FuaS5kZXYuYmxhY2toYXRzLm5ldC5hdTANBgkqhkiG9w0BAQsFAAOCAYEAO5YJykFv9SUy9UuEn8sF5lzghT+kJUEZr1Tzf9JArSDSE91j74428UmwgJjWa96G04/cDBg8vkivno8432mFnuLghn5oiIRthCVu125gWkZZ22MPranNYbNtoKPerqtRfEcQdxT9bg9TkX4F5xxuYZxt63KFQ4FFi7K8SKm28xnzddCVrq7ZL8/5Tk87rNdPL35FYS+uDBO8kFGIscdudPbSd64BWa5oRg97pAzDfR8EmSOiYD9PHJ7PgoilkKdfp1IsY4mYs5fJ2/U946/FvCXznmLgvqJf5dmt6JqFh3ctfiC28/c+LQydEacW7ud76wJdr/FCos3TI1zG8CI5vu0OFt8CZvZ6z9ZyH7UgSQl6avvXY+oEeFEruJ3tu2gP82/bXIzjs31IZKkN/g/TaD8xY5tpRAsfKfQ/8yKQvMtwl/ghE0/alYlHLBW4sXUX4lEkwZDwW5vQc6v86LapRfW/qvVrXItdpgJ79Z/jiYN9bB7MyUYis4rUBwU8ZrFX"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ac6003aa-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "ipa-syncrepl-kani.dev.blackhats.net.au"
+          ],
+          "fqdn": [
+            "ipa-syncrepl-kani.dev.blackhats.net.au"
+          ],
+          "ipaSshPubKey": [
+            "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL2s1FMFa4FwRDjqw8gbHgCpIaOvhQtBQZ9VcTAvpTHC/CIewmKgLYffnQklJOM9Npn2ShSOZwNpQYrwalVEeIA=",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHTGOifacjiocH68IwplT7LOecMPzIyvZxeR5u9v4tnc",
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDsXHlwhgSxhSN3eAlyWnqcD4pnrBDH3msyWfFM/jeQjz7GeZEjvGv41t4czZWEHTHsi4UeHAuV865eGYSBmCtdJZuO/IK69oT4wVgnp6ZJSzfAMeVerNzF+W4mnvpyEsRjydhDv3lkWdYW5E6cfoE/5363p0N6VKEZP5zNOomTHm4qveFU+MBqJaGCDjGpSfhnHpeVi99ZtURitA/azs+6Mdzu/IDUR3xHeNaWcfISqhOM3UhNi5R7wcCjYZxqOfa1cx/rGzMAuRFUM56J2JvCGY9r5bKQHYApejLSHGu6v1c4r14rdA9/EcA1W3atKbUjQxYL3IIkx+tQR6MGV2Vks9qjAQQKnQL2893zRYZuz7Hlwi6Z9/4p6bIWOxkQk9VJiJMjIIMmi1/fBn8z+DZu2OJ7kgFUkPpKCZ7mDpWWdkY9zd2JNOHpbyIDHRwH4GtWSudQ1kZHqLN2osrbLUsJjbevY7qy31EHY1RJoUL/f7igf/1HXlUyQ39vWyzT+Qs="
+          ],
+          "ipaUniqueID": [
+            "aeb18a36-3498-11ed-95c3-5254006b0418"
+          ],
+          "krbCanonicalName": [
+            "host/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AAK8hCJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastPwdChange": [
+            "20220915014948Z"
+          ],
+          "krbPrincipalKey": [
+            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogALjVV59CiovQ9czlBymqalSlY9UIcjjWSwbPj9vxwDRxc/0mQ0CDxqnPJjeu5aC2P8FiDw2ODF6cYoR1hWuRoAfse7UWW8ef/DBHoUUwQ6ADAgERoTwEOhAAJ7pUeI2zR6XMvyygR5/iP5KDYKtNnZyqNG6GWeP08ub440XP2f2d7N1JIS4SDbzevqzEIfMX7EYwR6FFMEOgAwIBE6E8BDoQAB2rw9U1hf0QntlzrjJ3f3iTqw91szfOZ87rgKSixBwfk/U1WXrN2OMVd15b+SsI2VQ0dFCBKzdKMFehVTBToAMCARShTARKIAAMOAEIC+bUW8fMp07LW5L/2VlK3HoXnoH48IHrp9ML68aLNxnNi5iJuqmWhFMO3sqCO6NCK9sizBWoUEcAKaU7bMq/3vCYxj0wR6FFMEOgAwIBGaE8BDoQAPOFfZmuqeSYyhuOdauIEqTY4l17K7rTxSQPauAZKZ1aoDmBmJzp1lD2wtzOzES+oJ9kPdmebpIlMFehVTBToAMCARqhTARKIAC3M5qXIO702h2Ry4QteGF81BcZQcnLQTAEbEfgGerhCyXCfgKxACK6SzLOUOCo6d4Tr37mVwvAKivMrTprhvWeJiBfkM9ObXQ"
+          ],
+          "krbPrincipalName": [
+            "host/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Host Password Policy,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "krbTicketFlags": [
+            "128"
+          ],
+          "managedBy": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "memberOf": [
+            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=ipaservers,cn=hostgroups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipaSshGroupOfPubKeys",
+            "ipahost",
+            "ipaobject",
+            "ipaservice",
+            "ipasshhost",
+            "krbprincipal",
+            "krbprincipalaux",
+            "krbticketpolicyaux",
+            "nshost",
+            "pkiuser",
+            "top"
+          ],
+          "serverHostName": [
+            "ipa-syncrepl-kani"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "ffd25150-3498-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "krbprincipalname=dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "ipaKrbPrincipalAlias": [
+            "dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "ipaUniqueID": [
+            "010aac04-3499-11ed-94f0-5254006b0418"
+          ],
+          "krbCanonicalName": [
+            "dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AAJHhSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastPwdChange": [
+            "20220915015207Z"
+          ],
+          "krbLoginFailedCount": [
+            "0"
+          ],
+          "krbPrincipalKey": [
+            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAOqe66hXnldEGz/s/2I89YygoskwmDCeiyIshuzMQCYRAYzvj/Za0hoaOGQ14WmmLiCU5sFlDGP+iNruTCTJWcbS2ceEhe3knDBHoUUwQ6ADAgERoTwEOhAAaqby3NxjVoP0NbbrerSWisui35G5NmTtMbf5LXirjYzRJEqOry551K7KRfOeINh5iQS7xupe+LowR6FFMEOgAwIBE6E8BDoQAKIln3mXSKY3I3pVpv0Nl7gJwSTMiMjuiTB5xU8EROjn/7hFVk7oelCcN3s2r9xhTlHS3MGVvPCqMFehVTBToAMCARShTARKIAD7caE8fup28Qo58twN/X344JGlpjii3iPIYEZ9D7+wb7jFhmhDnOtm+9dzT99zul0p8HvbIHcvRrP6aFmgV/KChGssKv8WRxQwR6FFMEOgAwIBGaE8BDoQAExsq/3MeNsYqGuuHK3hkFJhngOcjz8u3SqlpzLwTbol3/RSGi4Z0ajVqX1Oo26xxt3IQSduRZs+MFehVTBToAMCARqhTARKIAA/+X0NWyL8DTm8NimTtqt4qGDuIKnx666tpiao0avRHMdntqj+47nFT2mhS4j1FustPi5TDlmBm+QyaEqLrCRfNcSBIxxuq6c"
+          ],
+          "krbPrincipalName": [
+            "dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "krbTicketFlags": [
+            "128"
+          ],
+          "managedBy": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipakrbprincipal",
+            "ipaobject",
+            "ipaservice",
+            "krbTicketPolicyAux",
+            "krbprincipal",
+            "krbprincipalaux",
+            "pkiuser",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "02cd410c-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "krbprincipalname=HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "ipaKrbPrincipalAlias": [
+            "HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "ipaUniqueID": [
+            "0753f7aa-3499-11ed-be02-5254006b0418"
+          ],
+          "krbCanonicalName": [
+            "HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AAJRhSJjSFRUUC9pcGEtc3luY3JlcGwta2FuaS5kZXYuYmxhY2toYXRzLm5ldC5hdUBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastPwdChange": [
+            "20220915015217Z"
+          ],
+          "krbPrincipalKey": [
+            "MIIB1KADAgEBoQMCAQGiAwIBAaMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBBKPD5dWTdzSVRtP3EwU1hRoVUwU6ADAgEUoUwESiAAYwIymfpDp5vJdIyXzk479qv5VX6Mc6+nLly59bWI3EYVY2epAoeRO8T5KGZXG90WN36+fIMIvfe1gZSpplsdmJhh9/1LnDrIMGSgGzAZoAMCAQShEgQQKDouQW1hWH0pQzk8KClMJ6FFMEOgAwIBE6E8BDoQAFSkARWtl5FySsIwStmACSPGwm4Hq/r+M6vrQfOgw6V7Nwm4uX4dkgyyuPmQGj/yGLnjRo1T5UycMHSgGzAZoAMCAQShEgQQLEZHJitYR0h7akdxTWxHfKFVMFOgAwIBEqFMBEogAND/+/LRxdQZjoA/B6axDQMlV3DObQ+EBW+0mgbWfBZKwvbc7vKzlxLxfQViOgGOmQcqb5R1Xbw3Yg8OlFuhD2k0+5IiOtFUgzBkoBswGaADAgEEoRIEEFguXEBfNkQ8TmpfcjVYLT6hRTBDoAMCARGhPAQ6EACHcWgiZ3MkRqCO1cSiYVGDmtAEjWv/2rPS3Sg9qy8/UWJtvp2w2bRml80H7yM7e4JK+lQHhvlu8A"
+          ],
+          "krbPrincipalName": [
+            "HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "managedBy": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipakrbprincipal",
+            "ipaobject",
+            "ipaservice",
+            "krbprincipal",
+            "krbprincipalaux",
+            "krbticketpolicyaux",
+            "pkiuser",
+            "top"
+          ],
+          "userCertificate": [
+            "MIIFzzCCBDegAwIBAgIBCTANBgkqhkiG9w0BAQsFADA/MR0wGwYDVQQKDBRERVYuQkxBQ0tIQVRTLk5FVC5BVTEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDkxNTAxNTIxOFoXDTI0MDkxNTAxNTIxOFowUDEdMBsGA1UECgwUREVWLkJMQUNLSEFUUy5ORVQuQVUxLzAtBgNVBAMMJmlwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwheTBXcywPA3FMnikuqdrqIE8JkQRr+2s2nuRAnAhSPVL5wvo9cTWDHUxsHNjpCtlVigHfAdAH9/97VEUhhUWKeAF0On6HBUS8JDN+lLMKNgtKgtK43/6lIeTRXjIamgtjGI5uZzL50Y3dmL62pDnMtI0HfNdp6NE4STmUenvSJ3j5o3K33Vy9OxksIJzyIoqQJ28oYqB2kQh8GyKhc3oG6jHDYYN8GbZpg1wGiZHFtCtCrs0F9MmUdXyr5mOWaNjNVFUqJG603T9qwz9DiOGS8RSeDO9UP8ouiU3m0XRJoXAJCj/WmdQuLsr3mOKe/o6IQ7oDHjqvl48K8Ec6C2AQIDAQABo4ICQzCCAj8wHwYDVR0jBBgwFoAU3r1esNaYPVZc1ckSKy7uVspCunowRgYIKwYBBQUHAQEEOjA4MDYGCCsGAQUFBzABhipodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2NhL29jc3AwDgYDVR0PAQH/BAQDAgTwMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB/BgNVHR8EeDB2MHSgPKA6hjhodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2lwYS9jcmwvTWFzdGVyQ1JMLmJpbqI0pDIwMDEOMAwGA1UECgwFaXBhY2ExHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAdBgNVHQ4EFgQUBt9zuYl/V2blQ1BEqHE5NlvqBCEwggEDBgNVHREEgfswgfiCJmlwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1ghtpcGEtY2EuZGV2LmJsYWNraGF0cy5uZXQuYXWgUAYKKwYBBAGCNxQCA6BCDEBIVFRQL2lwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1QERFVi5CTEFDS0hBVFMuTkVULkFVoF8GBisGAQUCAqBVMFOgFhsUREVWLkJMQUNLSEFUUy5ORVQuQVWhOTA3oAMCAQGhMDAuGwRIVFRQGyZpcGEtc3luY3JlcGwta2FuaS5kZXYuYmxhY2toYXRzLm5ldC5hdTANBgkqhkiG9w0BAQsFAAOCAYEAtwCyLts3iTZEWuE83VoJqkTkzc04YvwVXPQamyu7IwbUGsrFZPxj9A1Binv9/ZtJw27P+LL8xFbCMMuvGV33XlDtdznV/511m+62QzYGXf8xKitxZiWupgwpm6/9yPrEoXTFp0fZqENFBbOgdIlXZTocctu/rNMlWN5prCEmaE132l0jG1+9y/qxQI7lWIIe7fHvV9GWmPATpf7YghzPyQbxRUNdgenzboJtcqxHqOmoOPDFFb2EzI+KbvE42UF3O/VUGppECFaKw2yJK3O/A2aa/6lhmgmP1U3783lw9nFVem5Se5Br0m4k3KTiv1vzjqSq7e2s0gblnhte8ZvoWz8GDxYin83c730muRhsbv/DBrbDiJCYzfftkgNKy+Ab4h0Z82SZ5MjGbyR9svTV8UQzIT3bKeIz1gLXHPDCYyJnXiU5rrCwSGtt5JAD3WdZCo+DO+g7PFpcfs9dhPaBbRiiOu0PFnqrlV5FNpPS1NJxJFgUoU1TH8CWeEQz2l5A"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a910-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Default Host Password Policy,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Default Host Password Policy"
+          ],
+          "krbMaxPwdLife": [
+            "0"
+          ],
+          "krbMinPwdLife": [
+            "0"
+          ],
+          "krbPwdFailureCountInterval": [
+            "0"
+          ],
+          "krbPwdHistoryLength": [
+            "0"
+          ],
+          "krbPwdLockoutDuration": [
+            "0"
+          ],
+          "krbPwdMaxFailure": [
+            "0"
+          ],
+          "krbPwdMinDiffChars": [
+            "0"
+          ],
+          "krbPwdMinLength": [
+            "0"
+          ],
+          "objectClass": [
+            "krbPwdPolicy",
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a911-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Default Service Password Policy"
+          ],
+          "krbMaxPwdLife": [
+            "0"
+          ],
+          "krbMinPwdLife": [
+            "0"
+          ],
+          "krbPwdFailureCountInterval": [
+            "0"
+          ],
+          "krbPwdHistoryLength": [
+            "0"
+          ],
+          "krbPwdLockoutDuration": [
+            "0"
+          ],
+          "krbPwdMaxFailure": [
+            "0"
+          ],
+          "krbPwdMinDiffChars": [
+            "0"
+          ],
+          "krbPwdMinLength": [
+            "0"
+          ],
+          "objectClass": [
+            "krbPwdPolicy",
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a915-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=cosTemplates,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "cosTemplates"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a916-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Default Password Policy,cn=cosTemplates,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Default Password Policy"
+          ],
+          "cosPriority": [
+            "10000000000"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Host Password Policy,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "cosTemplate",
+            "extensibleObject",
+            "krbContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a918-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=cosTemplates,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "cosTemplates"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a919-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Default Password Policy,cn=cosTemplates,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Default Password Policy"
+          ],
+          "cosPriority": [
+            "10000000000"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "cosTemplate",
+            "extensibleObject",
+            "krbContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a957-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=User Administrator,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "User Administrator"
+          ],
+          "description": [
+            "Responsible for creating Users and Groups"
+          ],
+          "memberOf": [
+            "cn=Group Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Manage subordinate ID,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Stage User Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Subordinate ID Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Stage User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add User to default group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Change User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Subordinate Ids,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage User Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage User SSH Public Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify External Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Preserved Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Stage User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify User RDN,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Preserve User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Preserved Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Radius Servers,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Stage User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Stage Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read UPG Definition,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read User Kerberos Login Attributes,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Stage User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Subordinate Ids,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove preserved User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Reset Preserved User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Undelete User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Unlock User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=User Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a958-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=IT Specialist,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "IT Specialist"
+          ],
+          "description": [
+            "IT Specialist"
+          ],
+          "memberOf": [
+            "cn=Automount Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Host Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Host Group Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Retrieve Certificates from the CA,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Revoke Certificate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Service Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Automount Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Automount Locations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Automount Maps,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Hostgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Hosts,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Service Delegations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Keytab Permissions,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host SSH Public Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Service Keytab Permissions,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Service Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Service Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Automount Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Automount Maps,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Hostgroup Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Hostgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Hosts,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Service Delegation Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Service Delegations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Automount Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Automount Locations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Automount Maps,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Hostgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Hosts,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Service Delegations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a959-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=IT Security Specialist,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "IT Security Specialist"
+          ],
+          "description": [
+            "IT Security Specialist"
+          ],
+          "memberOf": [
+            "cn=HBAC Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Netgroups Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Sudo Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add HBAC Rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add HBAC Service Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add HBAC Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Netgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Sudo Command Group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Sudo Command,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Sudo rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete HBAC Rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete HBAC Service Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete HBAC Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete Sudo Command Group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete Sudo Command,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete Sudo rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage HBAC Rule Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage HBAC Service Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Sudo Command Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify HBAC Rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Netgroup Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Netgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Sudo Command Group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Sudo Command,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Sudo rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Netgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a95a-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Security Architect,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Security Architect"
+          ],
+          "description": [
+            "Security Architect"
+          ],
+          "memberOf": [
+            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Delegation Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Password Policy Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Privileges,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add Roles,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Delete Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Privilege Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Privileges,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Role Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Modify Roles,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Privileges,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove Roles,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write IPA Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write IPA Configuration,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a95b-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Enrollment Administrator,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Enrollment Administrator"
+          ],
+          "description": [
+            "Enrollment Administrator responsible for client(host) enrollment"
+          ],
+          "memberOf": [
+            "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a965-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=trust admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "trust admins"
+          ],
+          "description": [
+            "Trusts administrators group"
+          ],
+          "ipaUniqueID": [
+            "0f233c48-3499-11ed-8e23-5254006b0418"
+          ],
+          "member": [
+            "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "ipaobject",
+            "ipausergroup",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a969-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=views,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "views"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a96d-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=subids,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "subids"
+          ],
+          "objectClass": [
+            "nsContainer",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "0c56a96e-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Subordinate ID Selfservice User,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Subordinate ID Selfservice User"
+          ],
+          "description": [
+            "User that can self-request subordiante ids"
+          ],
+          "memberOf": [
+            "cn=Self-service subordinate ID,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=Subordinate ID Selfservice Users,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "groupofnames",
+            "nestedgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "5d669e0f-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "krbprincipalname=DNS/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "ipaUniqueID": [
+            "5eef7106-3499-11ed-b9b6-5254006b0418"
+          ],
+          "krbCanonicalName": [
+            "DNS/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AALkhSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastPwdChange": [
+            "20220915015444Z"
+          ],
+          "krbLoginFailedCount": [
+            "0"
+          ],
+          "krbPrincipalKey": [
+            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAKadOfupjB5yb9MTZZqmM9CZoBJKpjByYaD66vmPQhiF0rncekqUZO/8ExZ+6Gasu1bIasBoAvjuNfYRNBAy0Zf7GrytjhJYKDBHoUUwQ6ADAgERoTwEOhAAgGBO1kFCX+Xum0dUbkOIhdP2T8Aj/nNpKDfo1+oRMYGJrDeTRBTSEsJZz9+tgWyD+gEY7jkrVZAwR6FFMEOgAwIBE6E8BDoQACR5EI6G6Zhkef34HovcuEZlpGtGfTZeoKASB/aDZrPhKpm+BjmnP0moUG1l3Ne+U4CbND3qz6K8MFehVTBToAMCARShTARKIADcrwredJSxyDMPxvInS1CtPNdGKy0cxOTb7p9oqqY5K9Aumm19H6P9MSIRC3q3s1irVhggZ9uPdfKMvHjzfj7o0gxO3r0w2VowR6FFMEOgAwIBGaE8BDoQAFU/tM7D+PBngTWJYD+g2FopzWjMLnjOsC4B2Bj5J/Z2rCKqqg/xBR0W6hFVjJ9L6gaXG3N8Dxk1MFehVTBToAMCARqhTARKIADkQ/J7BJhs0w6cCdKW/hS61eeJKwkNju/CCNBn/WA+93NlOmCgGNnipzkzGG8XiVJ/PbRQ/Lc9mwBYmhuZ606kwRvgSpZWFYM"
+          ],
+          "krbPrincipalName": [
+            "DNS/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "krbTicketFlags": [
+            "128"
+          ],
+          "managedBy": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "memberOf": [
+            "cn=DNS Servers,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage DNSSEC keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage DNSSEC metadata,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read DNS Servers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Update DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Write DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipaobject",
+            "ipaservice",
+            "krbTicketPolicyAux",
+            "krbprincipal",
+            "krbprincipalaux",
+            "pkiuser",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "5d669e18-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "krbprincipalname=ipa-dnskeysyncd/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "ipaUniqueID": [
+            "67bcb154-3499-11ed-b557-5254006b0418"
+          ],
+          "krbCanonicalName": [
+            "ipa-dnskeysyncd/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AALzhSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastPwdChange": [
+            "20220915015459Z"
+          ],
+          "krbLoginFailedCount": [
+            "0"
+          ],
+          "krbPrincipalKey": [
+            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAFa7Sp3bdrbaiQe70zCSQbMgcyCINfyrect5SVfT12CpqcEgQAIePmpXl27NiZkWHq15jl2TwWr2iEV9M5P/N8a/OXKsg8zd0zBHoUUwQ6ADAgERoTwEOhAAGCJuZzCbpGsjCHOn7WDxSvT+/+M69goL/8n6tU3pDWhg+kmFigJKAyvGAJ65znpDOYQOhrSm8cIwR6FFMEOgAwIBE6E8BDoQAA1H2x5/e0M7PZUFQz+FGC/wvoEnRBZSTss3KZrmxJ29KEK+0isSSsbMx8EzgNHlkqec5uva1aRQMFehVTBToAMCARShTARKIAAHLvDl7XzuhsPjx1BNt2MLkpvZCjqgGytapi+r76VG9pgjD67zdXvsEknn1LedR3jUzonDiXpWxGG5x+CZlXzNFYKu1bLVHOcwR6FFMEOgAwIBGaE8BDoQAJmC/mDbPNS7Pu09PPfOMyV3YvceWTncbNYGn2/PfyG3ixyBytUXgXpO39Fg47wwPvRaJjukhgT4MFehVTBToAMCARqhTARKIADEyjJA+Ovq57s/2SZL8P7pZ/W8YpkICp2Lhh+1QGq0qvfL0eBzGa+KIoofqnlkznYcbU5nzwol2esnSBTL7rbzgTqW4I+Neqo"
+          ],
+          "krbPrincipalName": [
+            "ipa-dnskeysyncd/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbPwdPolicyReference": [
+            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "krbTicketFlags": [
+            "128"
+          ],
+          "managedBy": [
+            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "memberOf": [
+            "cn=DNS Servers,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Add DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage DNSSEC keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Manage DNSSEC metadata,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Read DNS Servers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Remove DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Update DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+            "cn=System: Write DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipaobject",
+            "ipaservice",
+            "krbTicketPolicyAux",
+            "krbprincipal",
+            "krbprincipalaux",
+            "pkiuser",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "6a838c0b-3499-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=Default SMB Group,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Default SMB Group"
+          ],
+          "description": [
+            "Fallback group for primary group RID, do not add users to this group"
+          ],
+          "gidNumber": [
+            "8200001"
+          ],
+          "ipaNTSecurityIdentifier": [
+            "S-1-5-21-148961183-2750130983-218252910-1001"
+          ],
+          "ipaUniqueID": [
+            "6ac2d0ea-3499-11ed-8b34-5254006b0418"
+          ],
+          "objectClass": [
+            "ipantgroupattrs",
+            "ipaobject",
+            "posixgroup",
+            "top"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "babb8302-43a1-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "Test User"
+          ],
+          "displayName": [
+            "Test User"
+          ],
+          "gecos": [
+            "Test User"
+          ],
+          "gidNumber": [
+            "12345"
+          ],
+          "givenName": [
+            "Test"
+          ],
+          "homeDirectory": [
+            "/home/testuser"
+          ],
+          "initials": [
+            "TU"
+          ],
+          "ipaNTHash": [
+            "iEb36u6PsRetBr3YMLdYbA"
+          ],
+          "ipaNTSecurityIdentifier": [
+            "S-1-5-21-148961183-2750130983-218252910-1004"
+          ],
+          "ipaUniqueID": [
+            "d939d566-43a1-11ed-85aa-5254006b0418"
+          ],
+          "ipaUserAuthType": [
+            "otp",
+            "password"
+          ],
+          "krbCanonicalName": [
+            "testuser@DEV.BLACKHATS.NET.AU"
+          ],
+          "krbExtraData": [
+            "AAKuqj9jcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+          ],
+          "krbLastAdminUnlock": [
+            "20221007042726Z"
+          ],
+          "krbLastPwdChange": [
+            "20221007042726Z"
+          ],
+          "krbLoginFailedCount": [
+            "0"
+          ],
+          "krbPasswordExpiration": [
+            "20221007042726Z"
+          ],
+          "krbPrincipalKey": [
+            "MIIB1KADAgEBoQMCAQGiAwIBAqMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBAyd1FKPzBOfVwpMndBIUYzoVUwU6ADAgEUoUwESiAA08e/f13GWN0CXe7CQKbgKZi5huKImq5jD0FK304F3VqZDZcgH/vNK4jb4M5bliYSVTsnRJ7AHUWalPW1HDBd9KSLWFyoZMzkMGSgGzAZoAMCAQShEgQQV2Q/Z0d6RTplNmJnWiVGfKFFMEOgAwIBE6E8BDoQAOnA4dDmKA2oTh4hZnDf1/9ZVi24CQHpwUELHvAxjCE5WGI/X3AdTW/qoQ1hMijXZAfLrEILwu30MHSgGzAZoAMCAQShEgQQSWB1Xy05Wi4kb29jS005dqFVMFOgAwIBEqFMBEogAG/2TTXU4SlNkL2hnq528DrE6NPQVGYWu8q56UrxIqP3W+3Uyni93l3bKDbILoRl7+zpe6ten2dwV99MViDcuQ+1ZwekeME8xDBkoBswGaADAgEEoRIEEE4yL0ZcOGNzRFInXVs4VS+hRTBDoAMCARGhPAQ6EADdh6TBk9LTIBK/KhMLxeKATrQu9mk2y3GcmgvPU+HwKoEj3lWYJ4SuTc730mUb4KQsrS6+8qXilg"
+          ],
+          "krbPrincipalName": [
+            "testuser@DEV.BLACKHATS.NET.AU"
+          ],
+          "loginShell": [
+            "/bin/sh"
+          ],
+          "mail": [
+            "testuser@dev.blackhats.net.au"
+          ],
+          "memberOf": [
+            "cn=ipausers,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "mepManagedEntry": [
+            "cn=testuser,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "inetorgperson",
+            "inetuser",
+            "ipaSshGroupOfPubKeys",
+            "ipantuserattrs",
+            "ipaobject",
+            "ipasshuser",
+            "ipauserauthtypeclass",
+            "krbprincipalaux",
+            "krbticketpolicyaux",
+            "mepOriginEntry",
+            "organizationalperson",
+            "person",
+            "posixaccount",
+            "top"
+          ],
+          "sn": [
+            "User"
+          ],
+          "uid": [
+            "testuser"
+          ],
+          "uidNumber": [
+            "8200004"
+          ],
+          "userPassword": [
+            "{PBKDF2_SHA256}AAAIAEfAyPF34PDdETxzWnCQQN6Erz+TahCtmHixjbOPOb3skMmQzFCn5+18hevv/UHgvM1wUk7bZeKdxX6WJRLb5cEQR7rmv5HEX20pJl4tPwuW0uN15qX2pVEAwYbiKdw7NccxB0q1f5djc1NarmOYZoybpmmwclDug3WOa0+p0DkZlu5Q5gjX8V6DizlUjt38BV1itEGy16jU0rHFLxN4JrTXD9+j42Ie/6M+QvL+Tp35ToyMQFikCSN6D3nsvmWoM+4mKJTOjBtEXfK1zXjcuR8yXU2ajOhmcZP+LO1xIJGyPtJG1w5cjuK1/s4vn1UjtMayVzjiPisGxPinFmWVyI00mMKA2fVDuQOTnMER5grpDnMDUl1mAsZwKq3JXXq/1JJKY08KblhCmllo2dPforwAkkvzewN+c7Xp6W6DiHA8"
+          ]
+        }
+      }
+    },
+    {
+      "entry_uuid": "babb8306-43a1-11ed-a50d-919b4b1a5ec0",
+      "state": "Add",
+      "entry": {
+        "dn": "cn=testuser,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+        "attrs": {
+          "cn": [
+            "testuser"
+          ],
+          "description": [
+            "User private group for testuser"
+          ],
+          "gidNumber": [
+            "8200004"
+          ],
+          "ipaUniqueID": [
+            "d944a112-43a1-11ed-85aa-5254006b0418"
+          ],
+          "mepManagedBy": [
+            "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+          ],
+          "objectClass": [
+            "ipaobject",
+            "mepManagedEntry",
+            "posixgroup",
+            "top"
+          ]
+        }
+      }
+    }
+  ],
+  "delete_uuids": [],
+  "present_uuids": []
+}
+"#;

--- a/iam_migrations/freeipa/src/tests.rs
+++ b/iam_migrations/freeipa/src/tests.rs
@@ -1,9 +1,23 @@
+use crate::process_ipa_sync_result;
+use kanidm_proto::scim_v1::ScimSyncState;
+
 use ldap3_client::LdapSyncRepl;
 
 #[tokio::test]
 async fn test_ldap_to_scim() {
-    let _sync_request: LdapSyncRepl =
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let sync_request: LdapSyncRepl =
         serde_json::from_str(TEST_LDAP_SYNC_REPL_1).expect("failed to parse ldap sync");
+
+    let scim_sync_request = process_ipa_sync_result(ScimSyncState::Refresh, sync_request)
+        .await
+        .expect("failed to process ldap sync repl");
+
+    assert!(matches!(
+        scim_sync_request.from_state,
+        ScimSyncState::Refresh
+    ));
 
     // need to setup a fake ldap sync result.
 
@@ -12,1475 +26,398 @@ async fn test_ldap_to_scim() {
 
 const TEST_LDAP_SYNC_REPL_1: &str = r#"
 {
-  "cookie": "aXBhLXN5bmNyZXBsLWthbmkuZGV2LmJsYWNraGF0cy5uZXQuYXU6Mzg5I2NuPWRpcmVjdG9yeSBtYW5hZ2VyOmNuPWFjY291bnRzLGRjPWRldixkYz1ibGFja2hhdHMsZGM9bmV0LGRjPWF1OihvYmplY3RDbGFzcz0qKSM3OA",
-  "refresh_deletes": false,
-  "entries": [
-    {
-      "entry_uuid": "ac600325-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "accounts"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
+  "Success": {
+    "cookie": "aXBhLXN5bmNyZXBsLWthbmkuZGV2LmJsYWNraGF0cy5uZXQuYXU6Mzg5I2NuPWRpcmVjdG9yeSBtYW5hZ2VyOmRjPWRldixkYz1ibGFja2hhdHMsZGM9bmV0LGRjPWF1Oih8KCYob2JqZWN0Q2xhc3M9cGVyc29uKShvYmplY3RDbGFzcz1pcGFudHVzZXJhdHRycykob2JqZWN0Q2xhc3M9cG9zaXhhY2NvdW50KSkoJihvYmplY3RDbGFzcz1ncm91cG9mbmFtZXMpKG9iamVjdENsYXNzPWlwYXVzZXJncm91cCkoIShvYmplY3RDbGFzcz1tZXBtYW5hZ2VkZW50cnkpKSkoJihvYmplY3RDbGFzcz1pcGF0b2tlbikob2JqZWN0Q2xhc3M9aXBhdG9rZW50b3RwKSkpIzEwOQ",
+    "refresh_deletes": false,
+    "entries": [
+      {
+        "entry_uuid": "ac60034b-3498-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "Administrator"
+            ],
+            "gecos": [
+              "Administrator"
+            ],
+            "gidnumber": [
+              "8200000"
+            ],
+            "homedirectory": [
+              "/home/admin"
+            ],
+            "ipanthash": [
+              "CVBguEizG80swI8sftaknw"
+            ],
+            "ipantsecurityidentifier": [
+              "S-1-5-21-148961183-2750130983-218252910-500"
+            ],
+            "ipauniqueid": [
+              "ad15f644-3498-11ed-95c3-5254006b0418"
+            ],
+            "krbextradata": [
+              "AAL4hSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
+            ],
+            "krblastadminunlock": [
+              "20220915015504Z"
+            ],
+            "krblastfailedauth": [
+              "20221108050316Z"
+            ],
+            "krblastpwdchange": [
+              "20220915015504Z"
+            ],
+            "krbloginfailedcount": [
+              "0"
+            ],
+            "krbpasswordexpiration": [
+              "20221214015504Z"
+            ],
+            "krbprincipalkey": [
+              "MIIB1KADAgEBoQMCAQGiAwIBAaMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBBgeEMvRkhoVWphRX0iKXxCoVUwU6ADAgEUoUwESiAAuyt8szEUVLiWVjSTuUgbgCf8heFMeIhSmGTgJpwL50kddprbdeKuOYvyxepdAil/MqHs4qdqj54reDDqFW0T2bg1Iv9O1cZEMGSgGzAZoAMCAQShEgQQU2xOXT16V21hPFkzPClsJKFFMEOgAwIBE6E8BDoQALfdG+243xBQDt01+bFr46DcZnlHctoSyUQKw8I8FzvRE1LK9Ttl5qkkOHADpA7XSj1lQ2RFqBsSMHSgGzAZoAMCAQShEgQQay9XSC9tPDJJVjIwUDxFRKFVMFOgAwIBEqFMBEogADJjxICRFFzpOcsxMY3xVedF3IBd7qzsQJlSvShaeKwyhTBFI/wvVDtQq6ogWKlACUcAVk2N6p91VtRHHjxXVhKQvT0kt/KS7zBkoBswGaADAgEEoRIEEE5nNTh5SmgpZic0bDAmNUWhRTBDoAMCARGhPAQ6EAClGqBf9jZWixZo/evVMVH01NkI1VpR0fNrGyvtML78p5j6TAne5Nms/wj9BtVawuv+h+Gz1fjdfw"
+            ],
+            "krbprincipalname": [
+              "admin@DEV.BLACKHATS.NET.AU",
+              "root@DEV.BLACKHATS.NET.AU"
+            ],
+            "loginshell": [
+              "/bin/bash"
+            ],
+            "memberof": [
+              "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+              "cn=trust admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+            ],
+            "objectclass": [
+              "inetuser",
+              "ipantuserattrs",
+              "ipaobject",
+              "ipasshgroupofpubkeys",
+              "ipasshuser",
+              "krbprincipalaux",
+              "krbticketpolicyaux",
+              "person",
+              "posixaccount",
+              "top"
+            ],
+            "sn": [
+              "Administrator"
+            ],
+            "uid": [
+              "admin"
+            ],
+            "uidnumber": [
+              "8200000"
+            ],
+            "userpassword": [
+              "{PBKDF2_SHA256}AAAIAJ3EnyWJXp/ytIk6sqf1BbLO9fzObD3q5I4y2bRFfgAFVo6CaRAaZ7KPYzU6Y340VSUV4NGRRcBjeU8q+aoTOkuzQM91jl+xlCydiB0CjeIDZ0tGy4NmQUFzfg7+exsKhNk2MfUrHcaqfZBtT7Lkfei4Rk7810TQf3NlHIRO8K3egPQ8Ox52Upw1E5QGEKQmDOjrtLtOF5gbyFtR5wc0wUJfmMhd/g65GkqFIr5vbPan3kL3ZqMhh1rrj4ISi9Ui8P7E8GDicoJDPwPf6YD9D0dx6yk72GyiuYt6p2aGJWMY897xqgB+YMgPptiDPik22ExoBAoHeJNIzKjITc2ohLLn6RkCk4GcCwMVZmcxesl/T/OMeSkNvoOM1zy7ANsGbQeaLqpViJSV0xT5PJ6NoIKMU2pIP57Q17VAlYigtCPU"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "ac60034e-3498-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "cn=editors,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "editors"
+            ],
+            "description": [
+              "Limited admins who can edit other users"
+            ],
+            "gidnumber": [
+              "8200002"
+            ],
+            "ipantsecurityidentifier": [
+              "S-1-5-21-148961183-2750130983-218252910-1002"
+            ],
+            "ipauniqueid": [
+              "ad191e00-3498-11ed-b143-5254006b0418"
+            ],
+            "objectclass": [
+              "groupofnames",
+              "ipantgroupattrs",
+              "ipaobject",
+              "ipausergroup",
+              "nestedgroup",
+              "posixgroup",
+              "top"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "0c56a965-3499-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "cn=trust admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "trust admins"
+            ],
+            "description": [
+              "Trusts administrators group"
+            ],
+            "ipauniqueid": [
+              "0f233c48-3499-11ed-8e23-5254006b0418"
+            ],
+            "member": [
+              "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+            ],
+            "objectclass": [
+              "groupofnames",
+              "ipaobject",
+              "ipausergroup",
+              "nestedgroup",
+              "top"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "babb8302-43a1-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "Test User"
+            ],
+            "displayname": [
+              "Test User"
+            ],
+            "gecos": [
+              "Test User"
+            ],
+            "gidnumber": [
+              "12345"
+            ],
+            "givenname": [
+              "Test"
+            ],
+            "homedirectory": [
+              "/home/testuser"
+            ],
+            "initials": [
+              "TU"
+            ],
+            "ipanthash": [
+              "iEb36u6PsRetBr3YMLdYbA"
+            ],
+            "ipantsecurityidentifier": [
+              "S-1-5-21-148961183-2750130983-218252910-1004"
+            ],
+            "ipauniqueid": [
+              "d939d566-43a1-11ed-85aa-5254006b0418"
+            ],
+            "ipauserauthtype": [
+              "password"
+            ],
+            "krbcanonicalname": [
+              "testuser@DEV.BLACKHATS.NET.AU"
+            ],
+            "krbextradata": [
+              "AAL732ljdGVzdHVzZXJAREVWLkJMQUNLSEFUUy5ORVQuQVUA"
+            ],
+            "krblastadminunlock": [
+              "20221108044931Z"
+            ],
+            "krblastfailedauth": [
+              "20221108045207Z"
+            ],
+            "krblastpwdchange": [
+              "20221108045003Z"
+            ],
+            "krbloginfailedcount": [
+              "0"
+            ],
+            "krbpasswordexpiration": [
+              "20230206045003Z"
+            ],
+            "krbprincipalkey": [
+              "MIIB1KADAgEBoQMCAQGiAwIBBKMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBAhIyRjVSl7LkVCXCZqISkkoVUwU6ADAgEUoUwESiAAyMSJYrMnu6mUnDV3ls7arH782SiSi1+vSFosLoLogJZQHKAxUljESwhySlEn+tAEF3yEenvuigNNDtFS/cYMn4oQ1c/vH4tnMGSgGzAZoAMCAQShEgQQOGVcI0Q7YS53OCdxcmd6WaFFMEOgAwIBE6E8BDoQAG6TZ38sFh9gXirZsZcZEiFls92uUh1+Azz7DxrCpo0B8+he39ACvuwLIaxzfswHZE8/pQUFRiHeMHSgGzAZoAMCAQShEgQQOFpvIFxvRlFEVilZVkYhRaFVMFOgAwIBEqFMBEogANBXnuehcaBtCPIXvaGcUEXXkGxiHlDIBFhXeu6l6w0Nj2Cm8Fezun8ip+si3JuxZkaK7TlxccZQOpjxSRuwekeKrzTNp+vS7jBkoBswGaADAgEEoRIEEFZDXFBrSEZDO0kuX2BORyihRTBDoAMCARGhPAQ6EAChj/DZFH3h9pW31ipzT4PrtdDcR83qla52bf+bLDV6LFV6FvFqq3fBJnpiIwuD9rPBBuDut+1ncg"
+            ],
+            "krbprincipalname": [
+              "testuser@DEV.BLACKHATS.NET.AU"
+            ],
+            "loginshell": [
+              "/bin/sh"
+            ],
+            "mail": [
+              "testuser@dev.blackhats.net.au"
+            ],
+            "memberof": [
+              "cn=ipausers,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+            ],
+            "mepmanagedentry": [
+              "cn=testuser,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+            ],
+            "objectclass": [
+              "inetorgperson",
+              "inetuser",
+              "ipantuserattrs",
+              "ipaobject",
+              "ipasshgroupofpubkeys",
+              "ipasshuser",
+              "ipauserauthtypeclass",
+              "krbprincipalaux",
+              "krbticketpolicyaux",
+              "meporiginentry",
+              "organizationalperson",
+              "person",
+              "posixaccount",
+              "top"
+            ],
+            "sn": [
+              "User"
+            ],
+            "uid": [
+              "testuser"
+            ],
+            "uidnumber": [
+              "8200004"
+            ],
+            "userpassword": [
+              "{PBKDF2_SHA256}AAAIAOTKJTaS7zR1u0ar5vDHPzcd9FoDiQVYvpT/n19NpTQJKJfdugke9vwpYxaZk+SnR/WHi4oeKd1IyaVmAC+H5d4qUYcc74xLGoyaezCNy8HkKBz9Q/9MD/gvzUjWUTYjbnXAMjzVpAHhVtzAoPrZVoWgXWkhga+YDsqKnqG0g1UeMTgja2zYr0mrG6Y+w+VJP3nnbQ9q4vpb7MGIs8xgjse+nIWZC+mPrK4ZEjSeE9Tjj+0C6nFq1+xU6KZK8NOG8kuHyVeS87zddJApqLSb2p6X/ixobak1j8VzXFd9lxewMfY+gieoXtn47KCFsquWGlavY4ZqjHYu4+MuHDTN/s8E06O/DkLLxPPO4iSH1B6pIaVTMHxsybX7FRLTj/MOb2+oYwWZty8WJ+dRD7gDg0vdUJr/H8EzJkrdXhNyz7f+"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "f4dbef82-5f20-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "ipatokenuniqueid=380e27a4-438d-4c94-9dde-a3f6bc64ea1a,cn=otp,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "ipatokenotpalgorithm": [
+              "sha1"
+            ],
+            "ipatokenotpdigits": [
+              "6"
+            ],
+            "ipatokenotpkey": [
+              "hS/2a0DXBSKMJIlIcAJbBfCCZN0b8aTpoaJcj0RAAlV7QRQ"
+            ],
+            "ipatokenowner": [
+              "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
+            ],
+            "ipatokentotpclockoffset": [
+              "0"
+            ],
+            "ipatokentotptimestep": [
+              "30"
+            ],
+            "ipatokenuniqueid": [
+              "380e27a4-438d-4c94-9dde-a3f6bc64ea1a"
+            ],
+            "objectclass": [
+              "ipatoken",
+              "ipatokentotp",
+              "top"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "d547c581-5f26-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "cn=testgroup,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "testgroup"
+            ],
+            "description": [
+              "Test group"
+            ],
+            "ipauniqueid": [
+              "f1b96e6c-5f26-11ed-8cd2-5254006b0418"
+            ],
+            "objectclass": [
+              "groupofnames",
+              "ipaobject",
+              "ipausergroup",
+              "nestedgroup",
+              "top"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "d547c583-5f26-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "cn=testexternal,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "testexternal"
+            ],
+            "ipauniqueid": [
+              "f67fd292-5f26-11ed-a6d0-5254006b0418"
+            ],
+            "objectclass": [
+              "groupofnames",
+              "ipaexternalgroup",
+              "ipaobject",
+              "ipausergroup",
+              "nestedgroup",
+              "top"
+            ]
+          }
+        }
+      },
+      {
+        "entry_uuid": "f90b0b81-5f26-11ed-a50d-919b4b1a5ec0",
+        "state": "Add",
+        "entry": {
+          "dn": "cn=testposix,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
+          "attrs": {
+            "cn": [
+              "testposix"
+            ],
+            "gidnumber": [
+              "1234567"
+            ],
+            "ipauniqueid": [
+              "fb64973e-5f26-11ed-9cfe-5254006b0418"
+            ],
+            "objectclass": [
+              "groupofnames",
+              "ipaobject",
+              "ipausergroup",
+              "nestedgroup",
+              "posixgroup",
+              "top"
+            ]
+          }
         }
       }
-    },
-    {
-      "entry_uuid": "ac600326-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "users"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac600327-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "groups"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac600328-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "services"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac600329-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "computers"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60032a-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=hostgroups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "hostgroups"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60032b-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=ipservices,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "ipservices"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60034b-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Administrator"
-          ],
-          "gecos": [
-            "Administrator"
-          ],
-          "gidNumber": [
-            "8200000"
-          ],
-          "homeDirectory": [
-            "/home/admin"
-          ],
-          "ipaNTHash": [
-            "CVBguEizG80swI8sftaknw"
-          ],
-          "ipaNTSecurityIdentifier": [
-            "S-1-5-21-148961183-2750130983-218252910-500"
-          ],
-          "ipaUniqueID": [
-            "ad15f644-3498-11ed-95c3-5254006b0418"
-          ],
-          "krbExtraData": [
-            "AAL4hSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastAdminUnlock": [
-            "20220915015504Z"
-          ],
-          "krbLastFailedAuth": [
-            "20221007043105Z"
-          ],
-          "krbLastPwdChange": [
-            "20220915015504Z"
-          ],
-          "krbLoginFailedCount": [
-            "0"
-          ],
-          "krbPasswordExpiration": [
-            "20221214015504Z"
-          ],
-          "krbPrincipalKey": [
-            "MIIB1KADAgEBoQMCAQGiAwIBAaMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBBgeEMvRkhoVWphRX0iKXxCoVUwU6ADAgEUoUwESiAAuyt8szEUVLiWVjSTuUgbgCf8heFMeIhSmGTgJpwL50kddprbdeKuOYvyxepdAil/MqHs4qdqj54reDDqFW0T2bg1Iv9O1cZEMGSgGzAZoAMCAQShEgQQU2xOXT16V21hPFkzPClsJKFFMEOgAwIBE6E8BDoQALfdG+243xBQDt01+bFr46DcZnlHctoSyUQKw8I8FzvRE1LK9Ttl5qkkOHADpA7XSj1lQ2RFqBsSMHSgGzAZoAMCAQShEgQQay9XSC9tPDJJVjIwUDxFRKFVMFOgAwIBEqFMBEogADJjxICRFFzpOcsxMY3xVedF3IBd7qzsQJlSvShaeKwyhTBFI/wvVDtQq6ogWKlACUcAVk2N6p91VtRHHjxXVhKQvT0kt/KS7zBkoBswGaADAgEEoRIEEE5nNTh5SmgpZic0bDAmNUWhRTBDoAMCARGhPAQ6EAClGqBf9jZWixZo/evVMVH01NkI1VpR0fNrGyvtML78p5j6TAne5Nms/wj9BtVawuv+h+Gz1fjdfw"
-          ],
-          "krbPrincipalName": [
-            "admin@DEV.BLACKHATS.NET.AU",
-            "root@DEV.BLACKHATS.NET.AU"
-          ],
-          "loginShell": [
-            "/bin/bash"
-          ],
-          "memberOf": [
-            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=trust admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "inetuser",
-            "ipaNTUserAttrs",
-            "ipaSshGroupOfPubKeys",
-            "ipaobject",
-            "ipasshuser",
-            "krbprincipalaux",
-            "krbticketpolicyaux",
-            "person",
-            "posixaccount",
-            "top"
-          ],
-          "sn": [
-            "Administrator"
-          ],
-          "uid": [
-            "admin"
-          ],
-          "uidNumber": [
-            "8200000"
-          ],
-          "userPassword": [
-            "{PBKDF2_SHA256}AAAIAJ3EnyWJXp/ytIk6sqf1BbLO9fzObD3q5I4y2bRFfgAFVo6CaRAaZ7KPYzU6Y340VSUV4NGRRcBjeU8q+aoTOkuzQM91jl+xlCydiB0CjeIDZ0tGy4NmQUFzfg7+exsKhNk2MfUrHcaqfZBtT7Lkfei4Rk7810TQf3NlHIRO8K3egPQ8Ox52Upw1E5QGEKQmDOjrtLtOF5gbyFtR5wc0wUJfmMhd/g65GkqFIr5vbPan3kL3ZqMhh1rrj4ISi9Ui8P7E8GDicoJDPwPf6YD9D0dx6yk72GyiuYt6p2aGJWMY897xqgB+YMgPptiDPik22ExoBAoHeJNIzKjITc2ohLLn6RkCk4GcCwMVZmcxesl/T/OMeSkNvoOM1zy7ANsGbQeaLqpViJSV0xT5PJ6NoIKMU2pIP57Q17VAlYigtCPU"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60034c-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "admins"
-          ],
-          "description": [
-            "Account administrators group"
-          ],
-          "gidNumber": [
-            "8200000"
-          ],
-          "ipaNTSecurityIdentifier": [
-            "S-1-5-21-148961183-2750130983-218252910-512"
-          ],
-          "ipaUniqueID": [
-            "ad17b06a-3498-11ed-afaa-5254006b0418"
-          ],
-          "member": [
-            "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "memberOf": [
-            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "ipaNTGroupAttrs",
-            "ipaobject",
-            "ipausergroup",
-            "nestedGroup",
-            "posixgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60034d-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=ipausers,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "ipausers"
-          ],
-          "description": [
-            "Default group for all users"
-          ],
-          "ipaUniqueID": [
-            "ad18f36c-3498-11ed-8668-5254006b0418"
-          ],
-          "member": [
-            "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "ipaobject",
-            "ipausergroup",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60034e-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=editors,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "editors"
-          ],
-          "description": [
-            "Limited admins who can edit other users"
-          ],
-          "gidNumber": [
-            "8200002"
-          ],
-          "ipaNTSecurityIdentifier": [
-            "S-1-5-21-148961183-2750130983-218252910-1002"
-          ],
-          "ipaUniqueID": [
-            "ad191e00-3498-11ed-b143-5254006b0418"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "ipantgroupattrs",
-            "ipaobject",
-            "ipausergroup",
-            "nestedGroup",
-            "posixgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60034f-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=ipaservers,cn=hostgroups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "ipaservers"
-          ],
-          "description": [
-            "IPA server hosts"
-          ],
-          "ipaUniqueID": [
-            "ad196cd4-3498-11ed-b143-5254006b0418"
-          ],
-          "member": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "memberOf": [
-            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupOfNames",
-            "ipahostgroup",
-            "ipaobject",
-            "nestedGroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60035d-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=cosTemplates,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "cosTemplates"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac600368-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "roles"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac60036c-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=helpdesk,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "helpdesk"
-          ],
-          "description": [
-            "Helpdesk"
-          ],
-          "memberOf": [
-            "cn=Modify Group membership,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify Users and Reset passwords,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Change User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage User Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify External Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac6003a8-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "krbprincipalname=ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "ipaKrbPrincipalAlias": [
-            "ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "ipaUniqueID": [
-            "ae89dcfc-3498-11ed-bd3d-5254006b0418"
-          ],
-          "krbCanonicalName": [
-            "ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AAK8hCJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastPwdChange": [
-            "20220915014948Z"
-          ],
-          "krbLoginFailedCount": [
-            "0"
-          ],
-          "krbPrincipalKey": [
-            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAIt4+Fj03b3othVOnbkGcFJre/qKqofqp4Cesx6wkgLEnLLV5SDqtc/xhJuiqO4NvQgEdebViuxzA7bXMkMFIe1xCD+nVN8rczBHoUUwQ6ADAgERoTwEOhAAoAUnjH3biykn+eZWsiN9f6Xp6ygrYwKxLEOQqph766yNlX1Dfr+0pjYEqmmnf2jq/bRFQlIcJW8wR6FFMEOgAwIBE6E8BDoQAJDDCOlnFEs25wcosS7KQBwv2hEmxtIaBVVAGRc947sl0AavVW1xZ7meuTwpTJoylGdNSTCIQF9cMFehVTBToAMCARShTARKIACdaPkMQSiKQ3nVoihxLeQDyRJ4Bz0E+vtDWZHLRncmmVbtmzzhSeTNk9+9uZZAUbv/mmy3y/FdvfgkBo/2buwaI3WnMXMiI1kwR6FFMEOgAwIBGaE8BDoQABAuW5X9h0BFx6+AkoqzUF1vi0bL99KJBj2ufVf3GvQ4RatalbeYvQZRLGiA+f6T0Tck5f3d4d3VMFehVTBToAMCARqhTARKIACBBonLVHBKTlVDNCVK7iDwojO5Vhtm7XG5D4NeCiM5zhqoPlXTa/7XzEENLRFG/jMC20cKGWzy9Y6iD2uJEfWbCjbVQGnIxIg"
-          ],
-          "krbPrincipalName": [
-            "ldap/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "krbTicketFlags": [
-            "128"
-          ],
-          "managedBy": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "memberOf": [
-            "cn=replication managers,cn=sysaccounts,cn=etc,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipakrbprincipal",
-            "ipaobject",
-            "ipaservice",
-            "krbTicketPolicyAux",
-            "krbprincipal",
-            "krbprincipalaux",
-            "pkiuser",
-            "top"
-          ],
-          "userCertificate": [
-            "MIIFsTCCBBmgAwIBAgIBCDANBgkqhkiG9w0BAQsFADA/MR0wGwYDVQQKDBRERVYuQkxBQ0tIQVRTLk5FVC5BVTEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDkxNTAxNTE1OFoXDTI0MDkxNTAxNTE1OFowUDEdMBsGA1UECgwUREVWLkJMQUNLSEFUUy5ORVQuQVUxLzAtBgNVBAMMJmlwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1hu4DO2P6coC30ivQScItRA8TnliBr4Rf9vHcSMgFbJIUWD+VhfF5l42XXpAJU29kyaTWhMv0suC/youFQ0NKaVcuvUcPdd4bgcLjzHxNRMxUKXEuvffUzARV0KIdZoJQ1s8MT76mTgNmezJoqt8T+q0f5d/2J2jjEIbEC8V2igUR+YLHRahvRZZIYxZZ0hflZyUOtTiMa7sAhjGgbSPGp7QsErHTeoJ2J0R3EJWOvvGHkKgg69wSBZENEoyxlg/pk3aVXbFsIIkO5XooGE8b+EVm52xw9Uk0xDlWm0ZJuB6yRGs2Ntv/vBz0Q6QLJH3fK+fsWnCUutHNAQi2yA4OwIDAQABo4ICJTCCAiEwHwYDVR0jBBgwFoAU3r1esNaYPVZc1ckSKy7uVspCunowRgYIKwYBBQUHAQEEOjA4MDYGCCsGAQUFBzABhipodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2NhL29jc3AwDgYDVR0PAQH/BAQDAgTwMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB/BgNVHR8EeDB2MHSgPKA6hjhodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2lwYS9jcmwvTWFzdGVyQ1JMLmJpbqI0pDIwMDEOMAwGA1UECgwFaXBhY2ExHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAdBgNVHQ4EFgQUqhFargNcWnY/crbOldPRe751v2UwgeYGA1UdEQSB3jCB24ImaXBhLXN5bmNyZXBsLWthbmkuZGV2LmJsYWNraGF0cy5uZXQuYXWgUAYKKwYBBAGCNxQCA6BCDEBsZGFwL2lwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1QERFVi5CTEFDS0hBVFMuTkVULkFVoF8GBisGAQUCAqBVMFOgFhsUREVWLkJMQUNLSEFUUy5ORVQuQVWhOTA3oAMCAQGhMDAuGwRsZGFwGyZpcGEtc3luY3JlcGwta2FuaS5kZXYuYmxhY2toYXRzLm5ldC5hdTANBgkqhkiG9w0BAQsFAAOCAYEAO5YJykFv9SUy9UuEn8sF5lzghT+kJUEZr1Tzf9JArSDSE91j74428UmwgJjWa96G04/cDBg8vkivno8432mFnuLghn5oiIRthCVu125gWkZZ22MPranNYbNtoKPerqtRfEcQdxT9bg9TkX4F5xxuYZxt63KFQ4FFi7K8SKm28xnzddCVrq7ZL8/5Tk87rNdPL35FYS+uDBO8kFGIscdudPbSd64BWa5oRg97pAzDfR8EmSOiYD9PHJ7PgoilkKdfp1IsY4mYs5fJ2/U946/FvCXznmLgvqJf5dmt6JqFh3ctfiC28/c+LQydEacW7ud76wJdr/FCos3TI1zG8CI5vu0OFt8CZvZ6z9ZyH7UgSQl6avvXY+oEeFEruJ3tu2gP82/bXIzjs31IZKkN/g/TaD8xY5tpRAsfKfQ/8yKQvMtwl/ghE0/alYlHLBW4sXUX4lEkwZDwW5vQc6v86LapRfW/qvVrXItdpgJ79Z/jiYN9bB7MyUYis4rUBwU8ZrFX"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ac6003aa-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "ipa-syncrepl-kani.dev.blackhats.net.au"
-          ],
-          "fqdn": [
-            "ipa-syncrepl-kani.dev.blackhats.net.au"
-          ],
-          "ipaSshPubKey": [
-            "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL2s1FMFa4FwRDjqw8gbHgCpIaOvhQtBQZ9VcTAvpTHC/CIewmKgLYffnQklJOM9Npn2ShSOZwNpQYrwalVEeIA=",
-            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHTGOifacjiocH68IwplT7LOecMPzIyvZxeR5u9v4tnc",
-            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDsXHlwhgSxhSN3eAlyWnqcD4pnrBDH3msyWfFM/jeQjz7GeZEjvGv41t4czZWEHTHsi4UeHAuV865eGYSBmCtdJZuO/IK69oT4wVgnp6ZJSzfAMeVerNzF+W4mnvpyEsRjydhDv3lkWdYW5E6cfoE/5363p0N6VKEZP5zNOomTHm4qveFU+MBqJaGCDjGpSfhnHpeVi99ZtURitA/azs+6Mdzu/IDUR3xHeNaWcfISqhOM3UhNi5R7wcCjYZxqOfa1cx/rGzMAuRFUM56J2JvCGY9r5bKQHYApejLSHGu6v1c4r14rdA9/EcA1W3atKbUjQxYL3IIkx+tQR6MGV2Vks9qjAQQKnQL2893zRYZuz7Hlwi6Z9/4p6bIWOxkQk9VJiJMjIIMmi1/fBn8z+DZu2OJ7kgFUkPpKCZ7mDpWWdkY9zd2JNOHpbyIDHRwH4GtWSudQ1kZHqLN2osrbLUsJjbevY7qy31EHY1RJoUL/f7igf/1HXlUyQ39vWyzT+Qs="
-          ],
-          "ipaUniqueID": [
-            "aeb18a36-3498-11ed-95c3-5254006b0418"
-          ],
-          "krbCanonicalName": [
-            "host/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AAK8hCJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastPwdChange": [
-            "20220915014948Z"
-          ],
-          "krbPrincipalKey": [
-            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogALjVV59CiovQ9czlBymqalSlY9UIcjjWSwbPj9vxwDRxc/0mQ0CDxqnPJjeu5aC2P8FiDw2ODF6cYoR1hWuRoAfse7UWW8ef/DBHoUUwQ6ADAgERoTwEOhAAJ7pUeI2zR6XMvyygR5/iP5KDYKtNnZyqNG6GWeP08ub440XP2f2d7N1JIS4SDbzevqzEIfMX7EYwR6FFMEOgAwIBE6E8BDoQAB2rw9U1hf0QntlzrjJ3f3iTqw91szfOZ87rgKSixBwfk/U1WXrN2OMVd15b+SsI2VQ0dFCBKzdKMFehVTBToAMCARShTARKIAAMOAEIC+bUW8fMp07LW5L/2VlK3HoXnoH48IHrp9ML68aLNxnNi5iJuqmWhFMO3sqCO6NCK9sizBWoUEcAKaU7bMq/3vCYxj0wR6FFMEOgAwIBGaE8BDoQAPOFfZmuqeSYyhuOdauIEqTY4l17K7rTxSQPauAZKZ1aoDmBmJzp1lD2wtzOzES+oJ9kPdmebpIlMFehVTBToAMCARqhTARKIAC3M5qXIO702h2Ry4QteGF81BcZQcnLQTAEbEfgGerhCyXCfgKxACK6SzLOUOCo6d4Tr37mVwvAKivMrTprhvWeJiBfkM9ObXQ"
-          ],
-          "krbPrincipalName": [
-            "host/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Host Password Policy,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "krbTicketFlags": [
-            "128"
-          ],
-          "managedBy": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "memberOf": [
-            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=ipaservers,cn=hostgroups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipaSshGroupOfPubKeys",
-            "ipahost",
-            "ipaobject",
-            "ipaservice",
-            "ipasshhost",
-            "krbprincipal",
-            "krbprincipalaux",
-            "krbticketpolicyaux",
-            "nshost",
-            "pkiuser",
-            "top"
-          ],
-          "serverHostName": [
-            "ipa-syncrepl-kani"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "ffd25150-3498-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "krbprincipalname=dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "ipaKrbPrincipalAlias": [
-            "dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "ipaUniqueID": [
-            "010aac04-3499-11ed-94f0-5254006b0418"
-          ],
-          "krbCanonicalName": [
-            "dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AAJHhSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastPwdChange": [
-            "20220915015207Z"
-          ],
-          "krbLoginFailedCount": [
-            "0"
-          ],
-          "krbPrincipalKey": [
-            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAOqe66hXnldEGz/s/2I89YygoskwmDCeiyIshuzMQCYRAYzvj/Za0hoaOGQ14WmmLiCU5sFlDGP+iNruTCTJWcbS2ceEhe3knDBHoUUwQ6ADAgERoTwEOhAAaqby3NxjVoP0NbbrerSWisui35G5NmTtMbf5LXirjYzRJEqOry551K7KRfOeINh5iQS7xupe+LowR6FFMEOgAwIBE6E8BDoQAKIln3mXSKY3I3pVpv0Nl7gJwSTMiMjuiTB5xU8EROjn/7hFVk7oelCcN3s2r9xhTlHS3MGVvPCqMFehVTBToAMCARShTARKIAD7caE8fup28Qo58twN/X344JGlpjii3iPIYEZ9D7+wb7jFhmhDnOtm+9dzT99zul0p8HvbIHcvRrP6aFmgV/KChGssKv8WRxQwR6FFMEOgAwIBGaE8BDoQAExsq/3MeNsYqGuuHK3hkFJhngOcjz8u3SqlpzLwTbol3/RSGi4Z0ajVqX1Oo26xxt3IQSduRZs+MFehVTBToAMCARqhTARKIAA/+X0NWyL8DTm8NimTtqt4qGDuIKnx666tpiao0avRHMdntqj+47nFT2mhS4j1FustPi5TDlmBm+QyaEqLrCRfNcSBIxxuq6c"
-          ],
-          "krbPrincipalName": [
-            "dogtag/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "krbTicketFlags": [
-            "128"
-          ],
-          "managedBy": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipakrbprincipal",
-            "ipaobject",
-            "ipaservice",
-            "krbTicketPolicyAux",
-            "krbprincipal",
-            "krbprincipalaux",
-            "pkiuser",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "02cd410c-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "krbprincipalname=HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "ipaKrbPrincipalAlias": [
-            "HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "ipaUniqueID": [
-            "0753f7aa-3499-11ed-be02-5254006b0418"
-          ],
-          "krbCanonicalName": [
-            "HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AAJRhSJjSFRUUC9pcGEtc3luY3JlcGwta2FuaS5kZXYuYmxhY2toYXRzLm5ldC5hdUBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastPwdChange": [
-            "20220915015217Z"
-          ],
-          "krbPrincipalKey": [
-            "MIIB1KADAgEBoQMCAQGiAwIBAaMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBBKPD5dWTdzSVRtP3EwU1hRoVUwU6ADAgEUoUwESiAAYwIymfpDp5vJdIyXzk479qv5VX6Mc6+nLly59bWI3EYVY2epAoeRO8T5KGZXG90WN36+fIMIvfe1gZSpplsdmJhh9/1LnDrIMGSgGzAZoAMCAQShEgQQKDouQW1hWH0pQzk8KClMJ6FFMEOgAwIBE6E8BDoQAFSkARWtl5FySsIwStmACSPGwm4Hq/r+M6vrQfOgw6V7Nwm4uX4dkgyyuPmQGj/yGLnjRo1T5UycMHSgGzAZoAMCAQShEgQQLEZHJitYR0h7akdxTWxHfKFVMFOgAwIBEqFMBEogAND/+/LRxdQZjoA/B6axDQMlV3DObQ+EBW+0mgbWfBZKwvbc7vKzlxLxfQViOgGOmQcqb5R1Xbw3Yg8OlFuhD2k0+5IiOtFUgzBkoBswGaADAgEEoRIEEFguXEBfNkQ8TmpfcjVYLT6hRTBDoAMCARGhPAQ6EACHcWgiZ3MkRqCO1cSiYVGDmtAEjWv/2rPS3Sg9qy8/UWJtvp2w2bRml80H7yM7e4JK+lQHhvlu8A"
-          ],
-          "krbPrincipalName": [
-            "HTTP/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "managedBy": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipakrbprincipal",
-            "ipaobject",
-            "ipaservice",
-            "krbprincipal",
-            "krbprincipalaux",
-            "krbticketpolicyaux",
-            "pkiuser",
-            "top"
-          ],
-          "userCertificate": [
-            "MIIFzzCCBDegAwIBAgIBCTANBgkqhkiG9w0BAQsFADA/MR0wGwYDVQQKDBRERVYuQkxBQ0tIQVRTLk5FVC5BVTEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDkxNTAxNTIxOFoXDTI0MDkxNTAxNTIxOFowUDEdMBsGA1UECgwUREVWLkJMQUNLSEFUUy5ORVQuQVUxLzAtBgNVBAMMJmlwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwheTBXcywPA3FMnikuqdrqIE8JkQRr+2s2nuRAnAhSPVL5wvo9cTWDHUxsHNjpCtlVigHfAdAH9/97VEUhhUWKeAF0On6HBUS8JDN+lLMKNgtKgtK43/6lIeTRXjIamgtjGI5uZzL50Y3dmL62pDnMtI0HfNdp6NE4STmUenvSJ3j5o3K33Vy9OxksIJzyIoqQJ28oYqB2kQh8GyKhc3oG6jHDYYN8GbZpg1wGiZHFtCtCrs0F9MmUdXyr5mOWaNjNVFUqJG603T9qwz9DiOGS8RSeDO9UP8ouiU3m0XRJoXAJCj/WmdQuLsr3mOKe/o6IQ7oDHjqvl48K8Ec6C2AQIDAQABo4ICQzCCAj8wHwYDVR0jBBgwFoAU3r1esNaYPVZc1ckSKy7uVspCunowRgYIKwYBBQUHAQEEOjA4MDYGCCsGAQUFBzABhipodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2NhL29jc3AwDgYDVR0PAQH/BAQDAgTwMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB/BgNVHR8EeDB2MHSgPKA6hjhodHRwOi8vaXBhLWNhLmRldi5ibGFja2hhdHMubmV0LmF1L2lwYS9jcmwvTWFzdGVyQ1JMLmJpbqI0pDIwMDEOMAwGA1UECgwFaXBhY2ExHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAdBgNVHQ4EFgQUBt9zuYl/V2blQ1BEqHE5NlvqBCEwggEDBgNVHREEgfswgfiCJmlwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1ghtpcGEtY2EuZGV2LmJsYWNraGF0cy5uZXQuYXWgUAYKKwYBBAGCNxQCA6BCDEBIVFRQL2lwYS1zeW5jcmVwbC1rYW5pLmRldi5ibGFja2hhdHMubmV0LmF1QERFVi5CTEFDS0hBVFMuTkVULkFVoF8GBisGAQUCAqBVMFOgFhsUREVWLkJMQUNLSEFUUy5ORVQuQVWhOTA3oAMCAQGhMDAuGwRIVFRQGyZpcGEtc3luY3JlcGwta2FuaS5kZXYuYmxhY2toYXRzLm5ldC5hdTANBgkqhkiG9w0BAQsFAAOCAYEAtwCyLts3iTZEWuE83VoJqkTkzc04YvwVXPQamyu7IwbUGsrFZPxj9A1Binv9/ZtJw27P+LL8xFbCMMuvGV33XlDtdznV/511m+62QzYGXf8xKitxZiWupgwpm6/9yPrEoXTFp0fZqENFBbOgdIlXZTocctu/rNMlWN5prCEmaE132l0jG1+9y/qxQI7lWIIe7fHvV9GWmPATpf7YghzPyQbxRUNdgenzboJtcqxHqOmoOPDFFb2EzI+KbvE42UF3O/VUGppECFaKw2yJK3O/A2aa/6lhmgmP1U3783lw9nFVem5Se5Br0m4k3KTiv1vzjqSq7e2s0gblnhte8ZvoWz8GDxYin83c730muRhsbv/DBrbDiJCYzfftkgNKy+Ab4h0Z82SZ5MjGbyR9svTV8UQzIT3bKeIz1gLXHPDCYyJnXiU5rrCwSGtt5JAD3WdZCo+DO+g7PFpcfs9dhPaBbRiiOu0PFnqrlV5FNpPS1NJxJFgUoU1TH8CWeEQz2l5A"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a910-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Default Host Password Policy,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Default Host Password Policy"
-          ],
-          "krbMaxPwdLife": [
-            "0"
-          ],
-          "krbMinPwdLife": [
-            "0"
-          ],
-          "krbPwdFailureCountInterval": [
-            "0"
-          ],
-          "krbPwdHistoryLength": [
-            "0"
-          ],
-          "krbPwdLockoutDuration": [
-            "0"
-          ],
-          "krbPwdMaxFailure": [
-            "0"
-          ],
-          "krbPwdMinDiffChars": [
-            "0"
-          ],
-          "krbPwdMinLength": [
-            "0"
-          ],
-          "objectClass": [
-            "krbPwdPolicy",
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a911-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Default Service Password Policy"
-          ],
-          "krbMaxPwdLife": [
-            "0"
-          ],
-          "krbMinPwdLife": [
-            "0"
-          ],
-          "krbPwdFailureCountInterval": [
-            "0"
-          ],
-          "krbPwdHistoryLength": [
-            "0"
-          ],
-          "krbPwdLockoutDuration": [
-            "0"
-          ],
-          "krbPwdMaxFailure": [
-            "0"
-          ],
-          "krbPwdMinDiffChars": [
-            "0"
-          ],
-          "krbPwdMinLength": [
-            "0"
-          ],
-          "objectClass": [
-            "krbPwdPolicy",
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a915-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=cosTemplates,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "cosTemplates"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a916-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Default Password Policy,cn=cosTemplates,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Default Password Policy"
-          ],
-          "cosPriority": [
-            "10000000000"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Host Password Policy,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "cosTemplate",
-            "extensibleObject",
-            "krbContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a918-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=cosTemplates,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "cosTemplates"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a919-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Default Password Policy,cn=cosTemplates,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Default Password Policy"
-          ],
-          "cosPriority": [
-            "10000000000"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "cosTemplate",
-            "extensibleObject",
-            "krbContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a957-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=User Administrator,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "User Administrator"
-          ],
-          "description": [
-            "Responsible for creating Users and Groups"
-          ],
-          "memberOf": [
-            "cn=Group Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Manage subordinate ID,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Stage User Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Subordinate ID Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Stage User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add User to default group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Change User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Subordinate Ids,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage User Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage User Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage User SSH Public Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify External Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Preserved Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Stage User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify User RDN,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Preserve User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Preserved Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Radius Servers,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Stage User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Stage Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read UPG Definition,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read User Kerberos Login Attributes,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Stage User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Subordinate Ids,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Users,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove preserved User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Reset Preserved User password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Undelete User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Unlock User,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=User Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a958-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=IT Specialist,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "IT Specialist"
-          ],
-          "description": [
-            "IT Specialist"
-          ],
-          "memberOf": [
-            "cn=Automount Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Host Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Host Group Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Retrieve Certificates from the CA,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Revoke Certificate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Service Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Automount Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Automount Locations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Automount Maps,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Hostgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Hosts,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Service Delegations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Keytab Permissions,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host SSH Public Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Service Keytab Permissions,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Service Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Service Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Automount Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Automount Maps,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Hostgroup Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Hostgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Hosts,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Service Delegation Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Service Delegations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Automount Keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Automount Locations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Automount Maps,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Hostgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Hosts,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Service Delegations,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a959-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=IT Security Specialist,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "IT Security Specialist"
-          ],
-          "description": [
-            "IT Security Specialist"
-          ],
-          "memberOf": [
-            "cn=HBAC Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Netgroups Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Sudo Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add HBAC Rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add HBAC Service Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add HBAC Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Netgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Sudo Command Group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Sudo Command,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Sudo rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete HBAC Rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete HBAC Service Groups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete HBAC Services,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete Sudo Command Group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete Sudo Command,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete Sudo rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage HBAC Rule Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage HBAC Service Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Sudo Command Group Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify HBAC Rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Netgroup Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Netgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Sudo Command Group,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Sudo Command,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Sudo rule,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Netgroups,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a95a-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Security Architect,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Security Architect"
-          ],
-          "description": [
-            "Security Architect"
-          ],
-          "memberOf": [
-            "cn=Add Configuration Sub-Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Add Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Delegation Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Modify Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Password Policy Administrator,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read DNA Range,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read LDBM Database Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read PassSync Managers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Read Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Remove Replication Agreements,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Replication Administrators,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Privileges,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add Roles,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Delete Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Privilege Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Privileges,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Role Membership,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Modify Roles,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Group Password Policy costemplate,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read Group Password Policy,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Privileges,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove Roles,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write IPA Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write IPA Configuration,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Write Replication Changelog Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a95b-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Enrollment Administrator,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Enrollment Administrator"
-          ],
-          "description": [
-            "Enrollment Administrator responsible for client(host) enrollment"
-          ],
-          "memberOf": [
-            "cn=Host Enrollment,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add krbPrincipalName to a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Enroll a Host,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Certificates,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Enrollment Password,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Keytab,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage Host Principals,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a965-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=trust admins,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "trust admins"
-          ],
-          "description": [
-            "Trusts administrators group"
-          ],
-          "ipaUniqueID": [
-            "0f233c48-3499-11ed-8e23-5254006b0418"
-          ],
-          "member": [
-            "uid=admin,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "ipaobject",
-            "ipausergroup",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a969-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=views,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "views"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a96d-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=subids,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "subids"
-          ],
-          "objectClass": [
-            "nsContainer",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "0c56a96e-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Subordinate ID Selfservice User,cn=roles,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Subordinate ID Selfservice User"
-          ],
-          "description": [
-            "User that can self-request subordiante ids"
-          ],
-          "memberOf": [
-            "cn=Self-service subordinate ID,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=Subordinate ID Selfservice Users,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "groupofnames",
-            "nestedgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "5d669e0f-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "krbprincipalname=DNS/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "ipaUniqueID": [
-            "5eef7106-3499-11ed-b9b6-5254006b0418"
-          ],
-          "krbCanonicalName": [
-            "DNS/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AALkhSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastPwdChange": [
-            "20220915015444Z"
-          ],
-          "krbLoginFailedCount": [
-            "0"
-          ],
-          "krbPrincipalKey": [
-            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAKadOfupjB5yb9MTZZqmM9CZoBJKpjByYaD66vmPQhiF0rncekqUZO/8ExZ+6Gasu1bIasBoAvjuNfYRNBAy0Zf7GrytjhJYKDBHoUUwQ6ADAgERoTwEOhAAgGBO1kFCX+Xum0dUbkOIhdP2T8Aj/nNpKDfo1+oRMYGJrDeTRBTSEsJZz9+tgWyD+gEY7jkrVZAwR6FFMEOgAwIBE6E8BDoQACR5EI6G6Zhkef34HovcuEZlpGtGfTZeoKASB/aDZrPhKpm+BjmnP0moUG1l3Ne+U4CbND3qz6K8MFehVTBToAMCARShTARKIADcrwredJSxyDMPxvInS1CtPNdGKy0cxOTb7p9oqqY5K9Aumm19H6P9MSIRC3q3s1irVhggZ9uPdfKMvHjzfj7o0gxO3r0w2VowR6FFMEOgAwIBGaE8BDoQAFU/tM7D+PBngTWJYD+g2FopzWjMLnjOsC4B2Bj5J/Z2rCKqqg/xBR0W6hFVjJ9L6gaXG3N8Dxk1MFehVTBToAMCARqhTARKIADkQ/J7BJhs0w6cCdKW/hS61eeJKwkNju/CCNBn/WA+93NlOmCgGNnipzkzGG8XiVJ/PbRQ/Lc9mwBYmhuZ606kwRvgSpZWFYM"
-          ],
-          "krbPrincipalName": [
-            "DNS/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "krbTicketFlags": [
-            "128"
-          ],
-          "managedBy": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "memberOf": [
-            "cn=DNS Servers,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage DNSSEC keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage DNSSEC metadata,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read DNS Servers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Update DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Write DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipaobject",
-            "ipaservice",
-            "krbTicketPolicyAux",
-            "krbprincipal",
-            "krbprincipalaux",
-            "pkiuser",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "5d669e18-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "krbprincipalname=ipa-dnskeysyncd/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "ipaUniqueID": [
-            "67bcb154-3499-11ed-b557-5254006b0418"
-          ],
-          "krbCanonicalName": [
-            "ipa-dnskeysyncd/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AALzhSJjcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastPwdChange": [
-            "20220915015459Z"
-          ],
-          "krbLoginFailedCount": [
-            "0"
-          ],
-          "krbPrincipalKey": [
-            "MIICAqADAgEBoQMCAQGiAwIBAqMDAgEBpIIB6jCCAeYwV6FVMFOgAwIBEqFMBEogAFa7Sp3bdrbaiQe70zCSQbMgcyCINfyrect5SVfT12CpqcEgQAIePmpXl27NiZkWHq15jl2TwWr2iEV9M5P/N8a/OXKsg8zd0zBHoUUwQ6ADAgERoTwEOhAAGCJuZzCbpGsjCHOn7WDxSvT+/+M69goL/8n6tU3pDWhg+kmFigJKAyvGAJ65znpDOYQOhrSm8cIwR6FFMEOgAwIBE6E8BDoQAA1H2x5/e0M7PZUFQz+FGC/wvoEnRBZSTss3KZrmxJ29KEK+0isSSsbMx8EzgNHlkqec5uva1aRQMFehVTBToAMCARShTARKIAAHLvDl7XzuhsPjx1BNt2MLkpvZCjqgGytapi+r76VG9pgjD67zdXvsEknn1LedR3jUzonDiXpWxGG5x+CZlXzNFYKu1bLVHOcwR6FFMEOgAwIBGaE8BDoQAJmC/mDbPNS7Pu09PPfOMyV3YvceWTncbNYGn2/PfyG3ixyBytUXgXpO39Fg47wwPvRaJjukhgT4MFehVTBToAMCARqhTARKIADEyjJA+Ovq57s/2SZL8P7pZ/W8YpkICp2Lhh+1QGq0qvfL0eBzGa+KIoofqnlkznYcbU5nzwol2esnSBTL7rbzgTqW4I+Neqo"
-          ],
-          "krbPrincipalName": [
-            "ipa-dnskeysyncd/ipa-syncrepl-kani.dev.blackhats.net.au@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbPwdPolicyReference": [
-            "cn=Default Service Password Policy,cn=services,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "krbTicketFlags": [
-            "128"
-          ],
-          "managedBy": [
-            "fqdn=ipa-syncrepl-kani.dev.blackhats.net.au,cn=computers,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "memberOf": [
-            "cn=DNS Servers,cn=privileges,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Add DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage DNSSEC keys,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Manage DNSSEC metadata,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Read DNS Servers Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Remove DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Update DNS Entries,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au",
-            "cn=System: Write DNS Configuration,cn=permissions,cn=pbac,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipaobject",
-            "ipaservice",
-            "krbTicketPolicyAux",
-            "krbprincipal",
-            "krbprincipalaux",
-            "pkiuser",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "6a838c0b-3499-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=Default SMB Group,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Default SMB Group"
-          ],
-          "description": [
-            "Fallback group for primary group RID, do not add users to this group"
-          ],
-          "gidNumber": [
-            "8200001"
-          ],
-          "ipaNTSecurityIdentifier": [
-            "S-1-5-21-148961183-2750130983-218252910-1001"
-          ],
-          "ipaUniqueID": [
-            "6ac2d0ea-3499-11ed-8b34-5254006b0418"
-          ],
-          "objectClass": [
-            "ipantgroupattrs",
-            "ipaobject",
-            "posixgroup",
-            "top"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "babb8302-43a1-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "Test User"
-          ],
-          "displayName": [
-            "Test User"
-          ],
-          "gecos": [
-            "Test User"
-          ],
-          "gidNumber": [
-            "12345"
-          ],
-          "givenName": [
-            "Test"
-          ],
-          "homeDirectory": [
-            "/home/testuser"
-          ],
-          "initials": [
-            "TU"
-          ],
-          "ipaNTHash": [
-            "iEb36u6PsRetBr3YMLdYbA"
-          ],
-          "ipaNTSecurityIdentifier": [
-            "S-1-5-21-148961183-2750130983-218252910-1004"
-          ],
-          "ipaUniqueID": [
-            "d939d566-43a1-11ed-85aa-5254006b0418"
-          ],
-          "ipaUserAuthType": [
-            "otp",
-            "password"
-          ],
-          "krbCanonicalName": [
-            "testuser@DEV.BLACKHATS.NET.AU"
-          ],
-          "krbExtraData": [
-            "AAKuqj9jcm9vdC9hZG1pbkBERVYuQkxBQ0tIQVRTLk5FVC5BVQA"
-          ],
-          "krbLastAdminUnlock": [
-            "20221007042726Z"
-          ],
-          "krbLastPwdChange": [
-            "20221007042726Z"
-          ],
-          "krbLoginFailedCount": [
-            "0"
-          ],
-          "krbPasswordExpiration": [
-            "20221007042726Z"
-          ],
-          "krbPrincipalKey": [
-            "MIIB1KADAgEBoQMCAQGiAwIBAqMDAgEBpIIBvDCCAbgwdKAbMBmgAwIBBKESBBAyd1FKPzBOfVwpMndBIUYzoVUwU6ADAgEUoUwESiAA08e/f13GWN0CXe7CQKbgKZi5huKImq5jD0FK304F3VqZDZcgH/vNK4jb4M5bliYSVTsnRJ7AHUWalPW1HDBd9KSLWFyoZMzkMGSgGzAZoAMCAQShEgQQV2Q/Z0d6RTplNmJnWiVGfKFFMEOgAwIBE6E8BDoQAOnA4dDmKA2oTh4hZnDf1/9ZVi24CQHpwUELHvAxjCE5WGI/X3AdTW/qoQ1hMijXZAfLrEILwu30MHSgGzAZoAMCAQShEgQQSWB1Xy05Wi4kb29jS005dqFVMFOgAwIBEqFMBEogAG/2TTXU4SlNkL2hnq528DrE6NPQVGYWu8q56UrxIqP3W+3Uyni93l3bKDbILoRl7+zpe6ten2dwV99MViDcuQ+1ZwekeME8xDBkoBswGaADAgEEoRIEEE4yL0ZcOGNzRFInXVs4VS+hRTBDoAMCARGhPAQ6EADdh6TBk9LTIBK/KhMLxeKATrQu9mk2y3GcmgvPU+HwKoEj3lWYJ4SuTc730mUb4KQsrS6+8qXilg"
-          ],
-          "krbPrincipalName": [
-            "testuser@DEV.BLACKHATS.NET.AU"
-          ],
-          "loginShell": [
-            "/bin/sh"
-          ],
-          "mail": [
-            "testuser@dev.blackhats.net.au"
-          ],
-          "memberOf": [
-            "cn=ipausers,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "mepManagedEntry": [
-            "cn=testuser,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "inetorgperson",
-            "inetuser",
-            "ipaSshGroupOfPubKeys",
-            "ipantuserattrs",
-            "ipaobject",
-            "ipasshuser",
-            "ipauserauthtypeclass",
-            "krbprincipalaux",
-            "krbticketpolicyaux",
-            "mepOriginEntry",
-            "organizationalperson",
-            "person",
-            "posixaccount",
-            "top"
-          ],
-          "sn": [
-            "User"
-          ],
-          "uid": [
-            "testuser"
-          ],
-          "uidNumber": [
-            "8200004"
-          ],
-          "userPassword": [
-            "{PBKDF2_SHA256}AAAIAEfAyPF34PDdETxzWnCQQN6Erz+TahCtmHixjbOPOb3skMmQzFCn5+18hevv/UHgvM1wUk7bZeKdxX6WJRLb5cEQR7rmv5HEX20pJl4tPwuW0uN15qX2pVEAwYbiKdw7NccxB0q1f5djc1NarmOYZoybpmmwclDug3WOa0+p0DkZlu5Q5gjX8V6DizlUjt38BV1itEGy16jU0rHFLxN4JrTXD9+j42Ie/6M+QvL+Tp35ToyMQFikCSN6D3nsvmWoM+4mKJTOjBtEXfK1zXjcuR8yXU2ajOhmcZP+LO1xIJGyPtJG1w5cjuK1/s4vn1UjtMayVzjiPisGxPinFmWVyI00mMKA2fVDuQOTnMER5grpDnMDUl1mAsZwKq3JXXq/1JJKY08KblhCmllo2dPforwAkkvzewN+c7Xp6W6DiHA8"
-          ]
-        }
-      }
-    },
-    {
-      "entry_uuid": "babb8306-43a1-11ed-a50d-919b4b1a5ec0",
-      "state": "Add",
-      "entry": {
-        "dn": "cn=testuser,cn=groups,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au",
-        "attrs": {
-          "cn": [
-            "testuser"
-          ],
-          "description": [
-            "User private group for testuser"
-          ],
-          "gidNumber": [
-            "8200004"
-          ],
-          "ipaUniqueID": [
-            "d944a112-43a1-11ed-85aa-5254006b0418"
-          ],
-          "mepManagedBy": [
-            "uid=testuser,cn=users,cn=accounts,dc=dev,dc=blackhats,dc=net,dc=au"
-          ],
-          "objectClass": [
-            "ipaobject",
-            "mepManagedEntry",
-            "posixgroup",
-            "top"
-          ]
-        }
-      }
-    }
-  ],
-  "delete_uuids": [],
-  "present_uuids": []
+    ],
+    "delete_uuids": [],
+    "present_uuids": []
+  }
 }
 "#;

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -38,6 +38,7 @@ use webauthn_rs_proto::{
 };
 
 mod person;
+mod scim;
 mod service_account;
 mod sync_account;
 mod system;

--- a/kanidm_client/src/scim.rs
+++ b/kanidm_client/src/scim.rs
@@ -1,10 +1,16 @@
 use crate::{ClientError, KanidmClient};
-use kanidm_proto::scim_v1::ScimSyncState;
+use kanidm_proto::scim_v1::{ScimSyncRequest, ScimSyncState};
 
 impl KanidmClient {
     pub async fn scim_v1_sync_status(&self) -> Result<ScimSyncState, ClientError> {
         self.perform_get_request("/scim/v1/Sync").await
     }
 
-    // pub async fn scim_v1_sync_
+    pub async fn scim_v1_sync_update(
+        &self,
+        scim_sync_request: &ScimSyncRequest,
+    ) -> Result<(), ClientError> {
+        self.perform_post_request("/scim/v1/Sync", scim_sync_request)
+            .await
+    }
 }

--- a/kanidm_client/src/scim.rs
+++ b/kanidm_client/src/scim.rs
@@ -1,0 +1,9 @@
+use crate::{ClientError, KanidmClient};
+
+impl KanidmClient {
+    pub async fn scim_v1_sync_status(&self) -> Result<(), ClientError> {
+        self.perform_get_request("/scim/v1/Sync").await
+    }
+
+    // pub async fn scim_v1_sync_
+}

--- a/kanidm_client/src/scim.rs
+++ b/kanidm_client/src/scim.rs
@@ -1,7 +1,8 @@
 use crate::{ClientError, KanidmClient};
+use kanidm_proto::scim_v1::ScimSyncState;
 
 impl KanidmClient {
-    pub async fn scim_v1_sync_status(&self) -> Result<(), ClientError> {
+    pub async fn scim_v1_sync_status(&self) -> Result<ScimSyncState, ClientError> {
         self.perform_get_request("/scim/v1/Sync").await
     }
 

--- a/kanidm_client/src/sync_account.rs
+++ b/kanidm_client/src/sync_account.rs
@@ -31,4 +31,21 @@ impl KanidmClient {
         self.perform_post_request("/v1/sync_account", new_acct)
             .await
     }
+
+    pub async fn idm_sync_account_generate_token(
+        &self,
+        id: &str,
+        label: &str,
+    ) -> Result<String, ClientError> {
+        self.perform_post_request(
+            format!("/v1/sync_account/{}/_sync_token", id).as_str(),
+            label,
+        )
+        .await
+    }
+
+    pub async fn idm_sync_account_destroy_token(&self, id: &str) -> Result<(), ClientError> {
+        self.perform_delete_request(format!("/v1/sync_account/{}/_sync_token", id,).as_str())
+            .await
+    }
 }

--- a/kanidm_proto/Cargo.toml
+++ b/kanidm_proto/Cargo.toml
@@ -18,6 +18,7 @@ wasm = ["webauthn-rs-proto/wasm"]
 [dependencies]
 base32.workspace = true
 base64urlsafedata.workspace = true
+scim_proto.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 time = { workspace = true, features = ["serde", "std"] }

--- a/kanidm_proto/src/scim_v1.rs
+++ b/kanidm_proto/src/scim_v1.rs
@@ -1,9 +1,21 @@
 use base64urlsafedata::Base64UrlSafeData;
-
+use scim_proto::ScimEntry;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ScimSyncState {
     Initial,
     Active { cookie: Base64UrlSafeData },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ScimSyncRequest {
+    from_state: ScimSyncState,
+    to_state: ScimSyncState,
+
+    // How do I want to represent different entities to kani? Split by type? All in one?
+    entries: Vec<ScimEntry>,
+    // Delete uuids?
+    delete_uuids: Vec<Uuid>,
 }

--- a/kanidm_proto/src/scim_v1.rs
+++ b/kanidm_proto/src/scim_v1.rs
@@ -1,21 +1,155 @@
 use base64urlsafedata::Base64UrlSafeData;
-use scim_proto::ScimEntry;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use uuid::Uuid;
+
+pub use scim_proto::prelude::{ScimEntry, ScimError};
+use scim_proto::*;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ScimSyncState {
-    Initial,
+    Refresh,
     Active { cookie: Base64UrlSafeData },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ScimSyncRequest {
-    from_state: ScimSyncState,
-    to_state: ScimSyncState,
+    pub from_state: ScimSyncState,
+    pub to_state: ScimSyncState,
 
     // How do I want to represent different entities to kani? Split by type? All in one?
-    entries: Vec<ScimEntry>,
+    pub entries: Vec<ScimEntry>,
     // Delete uuids?
-    delete_uuids: Vec<Uuid>,
+    pub delete_uuids: Vec<Uuid>,
+}
+
+pub const SCIM_SCHEMA_SYNC_PERSON: &str = "urn:ietf:params:scim:schemas:kanidm:1.0:sync:person";
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(into = "ScimEntry")]
+pub struct ScimSyncPerson {
+    pub id: Uuid,
+    pub external_id: Option<String>,
+    pub user_name: String,
+    pub display_name: String,
+    pub gidnumber: Option<u32>,
+    pub homedirectory: Option<String>,
+    pub password_import: Option<String>,
+    pub login_shell: Option<String>,
+}
+
+/*
+impl TryFrom<ScimEntry> for ScimSyncPerson {
+    type Error = ScimError;
+
+    fn try_from(_value: ScimEntry) -> Result<Self, Self::Error> {
+        todo!();
+    }
+}
+*/
+
+impl Into<ScimEntry> for ScimSyncPerson {
+    fn into(self) -> ScimEntry {
+        let ScimSyncPerson {
+            id,
+            external_id,
+            user_name,
+            display_name,
+            gidnumber,
+            homedirectory,
+            password_import,
+            login_shell,
+        } = self;
+
+        let schemas = vec![SCIM_SCHEMA_SYNC_PERSON.to_string()];
+
+        let mut attrs = BTreeMap::default();
+
+        set_string!(attrs, "userName", user_name);
+        set_string!(attrs, "displayName", display_name);
+        set_option_u32!(attrs, "gidNumber", gidnumber);
+        set_option_string!(attrs, "homeDirectory", homedirectory);
+        set_option_string!(attrs, "passwordImport", password_import);
+        set_option_string!(attrs, "loginShell", login_shell);
+
+        ScimEntry {
+            schemas,
+            id,
+            external_id,
+            meta: None,
+            attrs,
+        }
+    }
+}
+
+pub const SCIM_SCHEMA_SYNC_GROUP: &str = "urn:ietf:params:scim:schemas:kanidm:1.0:sync:group";
+
+#[derive(Serialize, Debug, Clone)]
+pub struct ScimExternalMember {
+    pub external_id: String,
+}
+
+impl Into<ScimComplexAttr> for ScimExternalMember {
+    fn into(self) -> ScimComplexAttr {
+        let ScimExternalMember { external_id } = self;
+        let mut attrs = BTreeMap::default();
+
+        attrs.insert(
+            "external_id".to_string(),
+            ScimSimpleAttr::String(external_id),
+        );
+
+        ScimComplexAttr { attrs }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(into = "ScimEntry")]
+pub struct ScimSyncGroup {
+    pub id: Uuid,
+    pub external_id: Option<String>,
+    pub name: String,
+    pub description: Option<String>,
+    pub gidnumber: Option<u32>,
+    pub members: Vec<ScimExternalMember>,
+}
+
+/*
+impl TryFrom<ScimEntry> for ScimSyncPerson {
+    type Error = ScimError;
+
+    fn try_from(_value: ScimEntry) -> Result<Self, Self::Error> {
+        todo!();
+    }
+}
+*/
+
+impl Into<ScimEntry> for ScimSyncGroup {
+    fn into(self) -> ScimEntry {
+        let ScimSyncGroup {
+            id,
+            external_id,
+            name,
+            description,
+            gidnumber,
+            members,
+        } = self;
+
+        let schemas = vec![SCIM_SCHEMA_SYNC_GROUP.to_string()];
+
+        let mut attrs = BTreeMap::default();
+
+        set_string!(attrs, "name", name);
+        set_option_u32!(attrs, "gidNumber", gidnumber);
+        set_option_string!(attrs, "description", description);
+        set_multi_complex!(attrs, "members", members);
+
+        ScimEntry {
+            schemas,
+            id,
+            external_id,
+            meta: None,
+            attrs,
+        }
+    }
 }

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kanidm_tools"
 default-run = "kanidm"
 description = "Kanidm Client Tools"
-documentation = "https://docs.rs/kanidm_tools/latest/kanidm_tools/"
+documentation = "https://kanidm.github.io/kanidm/stable/"
 
 version.workspace = true
 authors.workspace = true

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -30,6 +30,7 @@ pub mod raw;
 pub mod recycle;
 pub mod serviceaccount;
 pub mod session;
+pub mod synch;
 
 impl SelfOpt {
     pub fn debug(&self) -> bool {
@@ -68,6 +69,7 @@ impl SystemOpt {
             SystemOpt::PwBadlist { commands } => commands.debug(),
             SystemOpt::Oauth2 { commands } => commands.debug(),
             SystemOpt::Domain { commands } => commands.debug(),
+            SystemOpt::Synch { commands } => commands.debug(),
         }
     }
 
@@ -76,6 +78,7 @@ impl SystemOpt {
             SystemOpt::PwBadlist { commands } => commands.exec().await,
             SystemOpt::Oauth2 { commands } => commands.exec().await,
             SystemOpt::Domain { commands } => commands.exec().await,
+            SystemOpt::Synch { commands } => commands.exec().await,
         }
     }
 }

--- a/kanidm_tools/src/cli/synch.rs
+++ b/kanidm_tools/src/cli/synch.rs
@@ -1,0 +1,68 @@
+use crate::SynchOpt;
+
+impl SynchOpt {
+    pub fn debug(&self) -> bool {
+        match self {
+            SynchOpt::List(copt) => copt.debug,
+            SynchOpt::Get(nopt) => nopt.copt.debug,
+            SynchOpt::Create { copt, .. }
+            | SynchOpt::GenerateToken { copt, .. }
+            | SynchOpt::DestroyToken { copt, .. } => copt.debug,
+        }
+    }
+
+    pub async fn exec(&self) {
+        match self {
+            SynchOpt::List(copt) => {
+                let client = copt.to_client().await;
+                match client.idm_sync_account_list().await {
+                    Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+            SynchOpt::Get(nopt) => {
+                let client = nopt.copt.to_client().await;
+                match client.idm_sync_account_get(nopt.name.as_str()).await {
+                    Ok(Some(e)) => println!("{}", e),
+                    Ok(None) => println!("No matching entries"),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+            SynchOpt::Create {
+                account_id,
+                copt,
+                description,
+            } => {
+                let client = copt.to_client().await;
+                match client
+                    .idm_sync_account_create(&account_id, description.as_deref())
+                    .await
+                {
+                    Ok(()) => println!("Success"),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+            SynchOpt::GenerateToken {
+                account_id,
+                label,
+                copt,
+            } => {
+                let client = copt.to_client().await;
+                match client
+                    .idm_sync_account_generate_token(&account_id, &label)
+                    .await
+                {
+                    Ok(token) => println!("token: {}", token),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+            SynchOpt::DestroyToken { account_id, copt } => {
+                let client = copt.to_client().await;
+                match client.idm_sync_account_destroy_token(&account_id).await {
+                    Ok(()) => println!("Success"),
+                    Err(e) => error!("Error -> {:?}", e),
+                }
+            }
+        }
+    }
+}

--- a/kanidm_tools/src/opt/kanidm.rs
+++ b/kanidm_tools/src/opt/kanidm.rs
@@ -733,6 +733,42 @@ pub enum DomainOpt {
 }
 
 #[derive(Debug, Subcommand)]
+pub enum SynchOpt {
+    #[clap(name = "list")]
+    /// List all configured IDM sync accounts
+    List(CommonOpt),
+    #[clap(name = "get")]
+    /// Display a selected IDM sync account
+    Get(Named),
+    /// Create a new IDM sync account
+    #[clap(name = "create")]
+    Create {
+        #[clap()]
+        account_id: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+        #[clap(name = "description")]
+        description: Option<String>,
+    },
+    #[clap(name = "generate-token")]
+    GenerateToken {
+        #[clap()]
+        account_id: String,
+        #[clap()]
+        label: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+    #[clap(name = "destroy-token")]
+    DestroyToken {
+        #[clap()]
+        account_id: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+}
+
+#[derive(Debug, Subcommand)]
 pub enum SystemOpt {
     #[clap(name = "pw-badlist")]
     /// Configure and manage the password badlist entry
@@ -752,6 +788,11 @@ pub enum SystemOpt {
         #[clap(subcommand)]
         commands: DomainOpt,
     },
+    #[clap(name = "sync", hide = true)]
+    Synch {
+        #[clap(subcommand)]
+        commands: SynchOpt,
+    }
 }
 
 #[derive(Debug, Subcommand)]

--- a/kanidm_unix_int/src/tasks_daemon.rs
+++ b/kanidm_unix_int/src/tasks_daemon.rs
@@ -11,8 +11,8 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 use std::ffi::CString;
-use std::os::unix::fs::symlink;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::time::Duration;
 use std::{fs, io};
@@ -81,7 +81,11 @@ fn chown(path: &Path, gid: u32) -> Result<(), String> {
     Ok(())
 }
 
-fn create_home_directory(info: &HomeDirectoryInfo, home_prefix: &str, use_etc_skel: bool) -> Result<(), String> {
+fn create_home_directory(
+    info: &HomeDirectoryInfo,
+    home_prefix: &str,
+    use_etc_skel: bool,
+) -> Result<(), String> {
     // Final sanity check to prevent certain classes of attacks.
     let name = info
         .name

--- a/kanidmd/core/src/actors/v1_read.rs
+++ b/kanidmd/core/src/actors/v1_read.rs
@@ -37,7 +37,7 @@ use kanidmd_lib::{
 // ===========================================================
 
 pub struct QueryServerReadV1 {
-    idms: Arc<IdmServer>,
+    pub(crate) idms: Arc<IdmServer>,
     ldap: Arc<LdapServer>,
 }
 

--- a/kanidmd/core/src/actors/v1_scim.rs
+++ b/kanidmd/core/src/actors/v1_scim.rs
@@ -4,7 +4,7 @@ use crate::{QueryServerReadV1, QueryServerWriteV1};
 use kanidmd_lib::idm::scim::{GenerateScimSyncTokenEvent, ScimSyncUpdateEvent};
 use kanidmd_lib::idm::server::IdmServerTransaction;
 
-use kanidm_proto::scim_v1::ScimSyncState;
+use kanidm_proto::scim_v1::{ScimSyncRequest, ScimSyncState};
 
 impl QueryServerWriteV1 {
     #[instrument(
@@ -88,7 +88,7 @@ impl QueryServerWriteV1 {
     pub async fn handle_scim_sync_apply(
         &self,
         bearer: Option<String>,
-        _changes: (),
+        changes: ScimSyncRequest,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
@@ -100,7 +100,7 @@ impl QueryServerWriteV1 {
         let sse = ScimSyncUpdateEvent { ident };
 
         idms_prox_write
-            .scim_sync_apply(&sse, ct)
+            .scim_sync_apply(&sse, &changes, ct)
             .and_then(|r| idms_prox_write.commit().map(|_| r))
     }
 }

--- a/kanidmd/core/src/actors/v1_scim.rs
+++ b/kanidmd/core/src/actors/v1_scim.rs
@@ -1,8 +1,10 @@
 use kanidmd_lib::prelude::*;
 
-use crate::QueryServerWriteV1;
-use kanidmd_lib::idm::scim::GenerateScimSyncTokenEvent;
+use crate::{QueryServerReadV1, QueryServerWriteV1};
+use kanidmd_lib::idm::scim::{GenerateScimSyncTokenEvent, ScimSyncUpdateEvent};
 use kanidmd_lib::idm::server::IdmServerTransaction;
+
+use kanidm_proto::scim_v1::ScimSyncState;
 
 impl QueryServerWriteV1 {
     #[instrument(
@@ -76,5 +78,49 @@ impl QueryServerWriteV1 {
         idms_prox_write
             .sync_account_destroy_token(&ident, target, ct)
             .and_then(|r| idms_prox_write.commit().map(|_| r))
+    }
+
+    #[instrument(
+        level = "info",
+        skip_all,
+        fields(uuid = ?eventid)
+    )]
+    pub async fn handle_scim_sync_apply(
+        &self,
+        bearer: Option<String>,
+        _changes: (),
+        eventid: Uuid,
+    ) -> Result<(), OperationError> {
+        let ct = duration_from_epoch_now();
+        let mut idms_prox_write = self.idms.proxy_write(ct).await;
+
+        let ident =
+            idms_prox_write.validate_and_parse_sync_token_to_ident(bearer.as_deref(), ct)?;
+
+        let sse = ScimSyncUpdateEvent { ident };
+
+        idms_prox_write
+            .scim_sync_apply(&sse, ct)
+            .and_then(|r| idms_prox_write.commit().map(|_| r))
+    }
+}
+
+impl QueryServerReadV1 {
+    #[instrument(
+        level = "info",
+        skip_all,
+        fields(uuid = ?eventid)
+    )]
+    pub async fn handle_scim_sync_status(
+        &self,
+        bearer: Option<String>,
+        eventid: Uuid,
+    ) -> Result<ScimSyncState, OperationError> {
+        let ct = duration_from_epoch_now();
+        let idms_prox_read = self.idms.proxy_read().await;
+
+        let ident = idms_prox_read.validate_and_parse_sync_token_to_ident(bearer.as_deref(), ct)?;
+
+        idms_prox_read.scim_sync_get_state(&ident)
     }
 }

--- a/kanidmd/core/src/https/mod.rs
+++ b/kanidmd/core/src/https/mod.rs
@@ -72,7 +72,7 @@ pub struct AppState {
 pub trait RequestExtensions {
     fn get_current_uat(&self) -> Option<String>;
 
-    fn get_auth_bearer(&self) -> Option<&str>;
+    fn get_auth_bearer(&self) -> Option<String>;
 
     fn get_current_auth_session_id(&self) -> Option<Uuid>;
 
@@ -84,7 +84,7 @@ pub trait RequestExtensions {
 }
 
 impl RequestExtensions for tide::Request<AppState> {
-    fn get_auth_bearer(&self) -> Option<&str> {
+    fn get_auth_bearer(&self) -> Option<String> {
         // Contact the QS to get it to validate wtf is up.
         // let kref = &self.state().bundy_handle;
         // self.session().get::<UserAuthToken>("uat")
@@ -97,6 +97,7 @@ impl RequestExtensions for tide::Request<AppState> {
                 // Turn it to a &str, and then check the prefix
                 h.as_str().strip_prefix("Bearer ")
             })
+            .map(str::to_string)
     }
 
     fn get_current_uat(&self) -> Option<String> {

--- a/kanidmd/core/src/https/v1_scim.rs
+++ b/kanidmd/core/src/https/v1_scim.rs
@@ -93,32 +93,36 @@ pub async fn sync_account_token_delete(req: tide::Request<AppState>) -> tide::Re
     to_tide_response(res, hvalue)
 }
 
-async fn scim_sync_post(_req: tide::Request<AppState>) -> tide::Result {
-    // let (eventid, hvalue) = req.new_eventid();
-    /*
-    let ApiTokenGenerate {
-        label,
-        expiry,
-        read_write,
-    } = req.body_json().await?;
-    */
+async fn scim_sync_post(mut req: tide::Request<AppState>) -> tide::Result {
+    let (eventid, hvalue) = req.new_eventid();
 
-    // We need to deserialise the body.
+    // Given the token, and a sync update, apply the changes if any
+    let bearer = req.get_auth_bearer();
 
-    Ok(tide::Response::new(500))
+    // Change this type later.
+    let changes: () = req.body_json().await?;
+
+    let res = req
+        .state()
+        .qe_w_ref
+        .handle_scim_sync_apply(bearer, changes, eventid)
+        .await;
+    to_tide_response(res, hvalue)
 }
 
-async fn scim_sync_get(_req: tide::Request<AppState>) -> tide::Result {
-    // let (eventid, hvalue) = req.new_eventid();
+async fn scim_sync_get(req: tide::Request<AppState>) -> tide::Result {
+    let (eventid, hvalue) = req.new_eventid();
 
-    // let bearer = req.get_auth_bearer();
+    // Given the token, what is it's connected sync state?
+    let bearer = req.get_auth_bearer();
+    trace!(?bearer);
 
-    // Given the token
-    // What is the connected sync session
-    // Issue it's current state (version) cookie.
-
-    // todo!();
-    Ok(tide::Response::new(500))
+    let res = req
+        .state()
+        .qe_r_ref
+        .handle_scim_sync_status(bearer, eventid)
+        .await;
+    to_tide_response(res, hvalue)
 }
 
 async fn scim_sink_get(req: tide::Request<AppState>) -> tide::Result {

--- a/kanidmd/core/src/https/v1_scim.rs
+++ b/kanidmd/core/src/https/v1_scim.rs
@@ -1,5 +1,6 @@
 use super::routemaps::{RouteMap, RouteMaps};
 use super::{to_tide_response, AppState, RequestExtensions};
+use kanidm_proto::scim_v1::ScimSyncRequest;
 use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidmd_lib::prelude::*;
 
@@ -100,7 +101,7 @@ async fn scim_sync_post(mut req: tide::Request<AppState>) -> tide::Result {
     let bearer = req.get_auth_bearer();
 
     // Change this type later.
-    let changes: () = req.body_json().await?;
+    let changes: ScimSyncRequest = req.body_json().await?;
 
     let res = req
         .state()

--- a/kanidmd/lib/src/constants/acp.rs
+++ b/kanidmd/lib/src/constants/acp.rs
@@ -1327,7 +1327,8 @@ pub const JSON_IDM_HP_ACP_SYNC_ACCOUNT_MANAGE_PRIV_V1: &str = r#"{
         ],
         "acp_modify_presentattr": [
             "name",
-            "description"
+            "description",
+            "sync_token_session"
         ],
         "acp_modify_class": [],
         "acp_create_attr": [

--- a/kanidmd/lib/src/entry.rs
+++ b/kanidmd/lib/src/entry.rs
@@ -1709,7 +1709,7 @@ impl Entry<EntryReduced, EntryCommitted> {
         // so they are all in "ldap forms" which makes our next stage a bit easier.
 
         // Stage 1 - transform our results to a map of kani attr -> ldap value.
-        let attr_map: Result<Map<&str, Vec<String>>, _> = self
+        let attr_map: Result<Map<&str, Vec<Vec<u8>>>, _> = self
             .attrs
             .iter()
             .map(|(k, vs)| {
@@ -1717,8 +1717,8 @@ impl Entry<EntryReduced, EntryCommitted> {
                     .map(|pvs| (k.as_str(), pvs))
             })
             .collect();
-
         let attr_map = attr_map?;
+
         // Stage 2 - transform and get all our attr - names out that we need to return.
         //                  ldap a, kani a
         let attr_names: Vec<(&str, &str)> = if all_attrs {
@@ -1748,7 +1748,7 @@ impl Entry<EntryReduced, EntryCommitted> {
                 match ldap_a {
                     "entrydn" => Some(LdapPartialAttribute {
                         atype: "entrydn".to_string(),
-                        vals: vec![dn.clone()],
+                        vals: vec![dn.as_bytes().to_vec()],
                     }),
                     _ => attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
                         atype: ldap_a.to_string(),

--- a/kanidmd/lib/src/idm/scim.rs
+++ b/kanidmd/lib/src/idm/scim.rs
@@ -306,7 +306,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
                 Some(b) => ScimSyncState::Active {
                     cookie: Base64UrlSafeData(b.to_vec()),
                 },
-                None => ScimSyncState::Initial,
+                None => ScimSyncState::Refresh,
             },
         )
     }
@@ -382,7 +382,7 @@ mod tests {
                 .expect("Failed to get current sync state");
             trace!(?sync_state);
 
-            assert!(matches!(sync_state, ScimSyncState::Initial));
+            assert!(matches!(sync_state, ScimSyncState::Refresh));
 
             drop(idms_prox_read);
 

--- a/kanidmd/lib/src/ldap.rs
+++ b/kanidmd/lib/src/ldap.rs
@@ -86,31 +86,31 @@ impl LdapServer {
             attributes: vec![
                 LdapPartialAttribute {
                     atype: "objectClass".to_string(),
-                    vals: vec!["top".to_string()],
+                    vals: vec!["top".as_bytes().to_vec()],
                 },
                 LdapPartialAttribute {
                     atype: "vendorName".to_string(),
-                    vals: vec!["Kanidm Project".to_string()],
+                    vals: vec!["Kanidm Project".as_bytes().to_vec()],
                 },
                 LdapPartialAttribute {
                     atype: "vendorVersion".to_string(),
-                    vals: vec!["kanidm_ldap_1.0.0".to_string()],
+                    vals: vec!["kanidm_ldap_1.0.0".as_bytes().to_vec()],
                 },
                 LdapPartialAttribute {
                     atype: "supportedLDAPVersion".to_string(),
-                    vals: vec!["3".to_string()],
+                    vals: vec!["3".as_bytes().to_vec()],
                 },
                 LdapPartialAttribute {
                     atype: "supportedExtension".to_string(),
-                    vals: vec!["1.3.6.1.4.1.4203.1.11.3".to_string()],
+                    vals: vec!["1.3.6.1.4.1.4203.1.11.3".as_bytes().to_vec()],
                 },
                 LdapPartialAttribute {
                     atype: "supportedFeatures".to_string(),
-                    vals: vec!["1.3.6.1.4.1.4203.1.5.1".to_string()],
+                    vals: vec!["1.3.6.1.4.1.4203.1.5.1".as_bytes().to_vec()],
                 },
                 LdapPartialAttribute {
                     atype: "defaultnamingcontext".to_string(),
-                    vals: vec![basedn.clone()],
+                    vals: vec![basedn.as_bytes().to_vec()],
                 },
             ],
         };
@@ -717,12 +717,12 @@ mod tests {
             let mut attrs = HashSet::new();
             for a in $e.attributes.iter() {
                 for v in a.vals.iter() {
-                    attrs.insert((a.atype.as_str(), v.as_str()));
+                    attrs.insert((a.atype.as_str(), v.as_slice()));
                 }
             };
             $(
                 assert!(attrs.contains(&(
-                    $item.0, $item.1
+                    $item.0, $item.1.as_bytes()
                 )));
             )*
 

--- a/kanidmd/lib/src/server.rs
+++ b/kanidmd/lib/src/server.rs
@@ -688,22 +688,26 @@ pub trait QueryServerTransaction<'a> {
         &self,
         value: &ValueSet,
         basedn: &str,
-    ) -> Result<Vec<String>, OperationError> {
+    ) -> Result<Vec<Vec<u8>>, OperationError> {
         if let Some(r_set) = value.as_refer_set() {
             let v: Result<Vec<_>, _> = r_set
                 .iter()
                 .copied()
                 .map(|ur| {
                     let rdn = self.uuid_to_rdn(ur)?;
-                    Ok(format!("{},{}", rdn, basedn))
+                    Ok(format!("{},{}", rdn, basedn).into_bytes())
                 })
                 .collect();
             v
         } else if let Some(k_set) = value.as_sshkey_map() {
-            let v: Vec<_> = k_set.values().cloned().collect();
+            let v: Vec<_> = k_set.values().cloned()
+                .map(|s| s.into_bytes())
+                .collect();
             Ok(v)
         } else {
-            let v: Vec<_> = value.to_proto_string_clone_iter().collect();
+            let v: Vec<_> = value.to_proto_string_clone_iter()
+                .map(|s| s.into_bytes())
+                .collect();
             Ok(v)
         }
     }

--- a/kanidmd/lib/src/server.rs
+++ b/kanidmd/lib/src/server.rs
@@ -700,12 +700,11 @@ pub trait QueryServerTransaction<'a> {
                 .collect();
             v
         } else if let Some(k_set) = value.as_sshkey_map() {
-            let v: Vec<_> = k_set.values().cloned()
-                .map(|s| s.into_bytes())
-                .collect();
+            let v: Vec<_> = k_set.values().cloned().map(|s| s.into_bytes()).collect();
             Ok(v)
         } else {
-            let v: Vec<_> = value.to_proto_string_clone_iter()
+            let v: Vec<_> = value
+                .to_proto_string_clone_iter()
                 .map(|s| s.into_bytes())
                 .collect();
             Ok(v)

--- a/orca/src/ds.rs
+++ b/orca/src/ds.rs
@@ -97,11 +97,11 @@ impl DirectoryServer {
                 attributes: vec![
                     LdapAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["top".to_string(), "organizationalUnit".to_string()],
+                        vals: vec!["top".as_bytes().into(), "organizationalUnit".as_bytes().into()],
                     },
                     LdapAttribute {
                         atype: "ou".to_string(),
-                        vals: vec!["people".to_string()],
+                        vals: vec!["people".as_bytes().into()],
                     },
                 ],
             };
@@ -121,11 +121,11 @@ impl DirectoryServer {
                 attributes: vec![
                     LdapAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["top".to_string(), "organizationalUnit".to_string()],
+                        vals: vec!["top".as_bytes().into(), "organizationalUnit".as_bytes().into()],
                     },
                     LdapAttribute {
                         atype: "ou".to_string(),
-                        vals: vec!["groups".to_string()],
+                        vals: vec!["groups".as_bytes().into()],
                     },
                 ],
             };
@@ -155,40 +155,40 @@ impl DirectoryServer {
                             LdapAttribute {
                                 atype: "objectClass".to_string(),
                                 vals: vec![
-                                    "top".to_string(),
-                                    "nsPerson".to_string(),
-                                    "nsAccount".to_string(),
-                                    "nsOrgPerson".to_string(),
-                                    "posixAccount".to_string(),
+                                    "top"          .as_bytes().into(),
+                                    "nsPerson"     .as_bytes().into(),
+                                    "nsAccount"    .as_bytes().into(),
+                                    "nsOrgPerson"  .as_bytes().into(),
+                                    "posixAccount" .as_bytes().into(),
                                 ],
                             },
                             LdapAttribute {
                                 atype: "cn".to_string(),
-                                vals: vec![a.uuid.to_string()],
+                                vals: vec![a.uuid.as_bytes().to_vec()],
                             },
                             LdapAttribute {
                                 atype: "uid".to_string(),
-                                vals: vec![a.name.clone()],
+                                vals: vec![a.name.as_bytes().into()],
                             },
                             LdapAttribute {
                                 atype: "displayName".to_string(),
-                                vals: vec![a.display_name.clone()],
+                                vals: vec![a.display_name.as_bytes().into()],
                             },
                             LdapAttribute {
                                 atype: "userPassword".to_string(),
-                                vals: vec![a.password.clone()],
+                                vals: vec![a.password.as_bytes().into()],
                             },
                             LdapAttribute {
                                 atype: "homeDirectory".to_string(),
-                                vals: vec![format!("/home/{}", a.uuid)],
+                                vals: vec![format!("/home/{}", a.uuid).as_bytes().into()],
                             },
                             LdapAttribute {
                                 atype: "uidNumber".to_string(),
-                                vals: vec!["1000".to_string()],
+                                vals: vec!["1000".as_bytes().into()],
                             },
                             LdapAttribute {
                                 atype: "gidNumber".to_string(),
-                                vals: vec!["1000".to_string()],
+                                vals: vec!["1000".as_bytes().into()],
                             },
                         ],
                     };
@@ -200,11 +200,11 @@ impl DirectoryServer {
                         attributes: vec![
                             LdapAttribute {
                                 atype: "objectClass".to_string(),
-                                vals: vec!["top".to_string(), "groupOfNames".to_string()],
+                                vals: vec!["top".as_bytes().into(), "groupOfNames".as_bytes().into()],
                             },
                             LdapAttribute {
                                 atype: "cn".to_string(),
-                                vals: vec![g.uuid.to_string(), g.name.clone()],
+                                vals: vec![g.uuid.as_bytes().to_vec(), g.name.as_bytes().into()],
                             },
                         ],
                     };
@@ -222,7 +222,7 @@ impl DirectoryServer {
             }
         }) {
             // List of dns
-            let vals: Vec<_> = g
+            let vals: Vec<Vec<u8>> = g
                 .members
                 .iter()
                 .map(|id| {
@@ -230,6 +230,7 @@ impl DirectoryServer {
                         .get(id)
                         .unwrap()
                         .get_ds_ldap_dn(&self.ldap.basedn)
+                        .as_bytes().into()
                 })
                 .collect();
 
@@ -270,11 +271,11 @@ impl DirectoryServer {
                 attributes: vec![
                     LdapAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["top".to_string(), "groupOfNames".to_string()],
+                        vals: vec!["top".as_bytes().into(), "groupOfNames".as_bytes().into()],
                     },
                     LdapAttribute {
                         atype: "cn".to_string(),
-                        vals: vec!["priv_account_manage".to_string()],
+                        vals: vec!["priv_account_manage".as_bytes().into()],
                     },
                 ],
             };
@@ -297,11 +298,11 @@ impl DirectoryServer {
                 attributes: vec![
                     LdapAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["top".to_string(), "groupOfNames".to_string()],
+                        vals: vec!["top".as_bytes().into(), "groupOfNames".as_bytes().into()],
                     },
                     LdapAttribute {
                         atype: "cn".to_string(),
-                        vals: vec!["priv_group_manage".to_string()],
+                        vals: vec!["priv_group_manage".as_bytes().into()],
                     },
                 ],
             };
@@ -317,14 +318,14 @@ impl DirectoryServer {
                         modification: LdapPartialAttribute {
                             atype: "aci".to_string(),
                             vals: vec![
-                                r#"(targetattr="dc || description || objectClass")(targetfilter="(objectClass=domain)")(version 3.0; acl "Enable anyone domain read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
+                                r#"(targetattr="dc || description || objectClass")(targetfilter="(objectClass=domain)")(version 3.0; acl "Enable anyone domain read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.as_bytes().into(),
 
-                                r#"(targetattr="ou || objectClass")(targetfilter="(objectClass=organizationalUnit)")(version 3.0; acl "Enable anyone ou read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
-                                r#"(targetattr="cn || member || gidNumber || nsUniqueId || description || objectClass")(targetfilter="(objectClass=groupOfNames)")(version 3.0; acl "Enable anyone group read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
-                                format!(r#"(targetattr="cn || member || gidNumber || description || objectClass")(targetfilter="(objectClass=groupOfNames)")(version 3.0; acl "Enable group_admin to manage groups"; allow (write,add, delete)(groupdn="ldap:///cn=priv_group_manage,{}");)"#, self.ldap.basedn),
-                                r#"(targetattr="objectClass || description || nsUniqueId || uid || displayName || loginShell || uidNumber || gidNumber || gecos || homeDirectory || cn || memberOf || mail || nsSshPublicKey || nsAccountLock || userCertificate")(targetfilter="(objectClass=posixaccount)")(version 3.0; acl "Enable anyone user read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.to_string(),
-                                r#"(targetattr="displayName || legalName || userPassword || nsSshPublicKey")(version 3.0; acl "Enable self partial modify"; allow (write)(userdn="ldap:///self");)"#.to_string(),
-                                format!(r#"(targetattr="uid || description || displayName || loginShell || uidNumber || gidNumber || gecos || homeDirectory || cn || memberOf || mail || legalName || telephoneNumber || mobile")(targetfilter="(&(objectClass=nsPerson)(objectClass=nsAccount))")(version 3.0; acl "Enable user admin create"; allow (write, add, delete, read)(groupdn="ldap:///cn=priv_account_manage,{}");)"#, self.ldap.basedn),
+                                r#"(targetattr="ou || objectClass")(targetfilter="(objectClass=organizationalUnit)")(version 3.0; acl "Enable anyone ou read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.as_bytes().into(),
+                                r#"(targetattr="cn || member || gidNumber || nsUniqueId || description || objectClass")(targetfilter="(objectClass=groupOfNames)")(version 3.0; acl "Enable anyone group read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.as_bytes().into(),
+                                format!(r#"(targetattr="cn || member || gidNumber || description || objectClass")(targetfilter="(objectClass=groupOfNames)")(version 3.0; acl "Enable group_admin to manage groups"; allow (write,add, delete)(groupdn="ldap:///cn=priv_group_manage,{}");)"#, self.ldap.basedn).as_bytes().into(),
+                                r#"(targetattr="objectClass || description || nsUniqueId || uid || displayName || loginShell || uidNumber || gidNumber || gecos || homeDirectory || cn || memberOf || mail || nsSshPublicKey || nsAccountLock || userCertificate")(targetfilter="(objectClass=posixaccount)")(version 3.0; acl "Enable anyone user read"; allow (read, search, compare)(userdn="ldap:///anyone");)"#.as_bytes().into(),
+                                r#"(targetattr="displayName || legalName || userPassword || nsSshPublicKey")(version 3.0; acl "Enable self partial modify"; allow (write)(userdn="ldap:///self");)"#.as_bytes().into(),
+                                format!(r#"(targetattr="uid || description || displayName || loginShell || uidNumber || gidNumber || gecos || homeDirectory || cn || memberOf || mail || legalName || telephoneNumber || mobile")(targetfilter="(&(objectClass=nsPerson)(objectClass=nsAccount))")(version 3.0; acl "Enable user admin create"; allow (write, add, delete, read)(groupdn="ldap:///cn=priv_account_manage,{}");)"#, self.ldap.basedn).as_bytes().into(),
                             ]
                         }
                     }
@@ -352,10 +353,10 @@ impl DirectoryServer {
                 == 0;
 
             if need_account {
-                priv_account.push(account.get_ds_ldap_dn(&self.ldap.basedn))
+                priv_account.push(account.get_ds_ldap_dn(&self.ldap.basedn).as_bytes().to_vec())
             }
             if need_group {
-                priv_group.push(account.get_ds_ldap_dn(&self.ldap.basedn))
+                priv_group.push(account.get_ds_ldap_dn(&self.ldap.basedn).as_bytes().to_vec())
             }
         }
 

--- a/orca/src/ds.rs
+++ b/orca/src/ds.rs
@@ -97,7 +97,10 @@ impl DirectoryServer {
                 attributes: vec![
                     LdapAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["top".as_bytes().into(), "organizationalUnit".as_bytes().into()],
+                        vals: vec![
+                            "top".as_bytes().into(),
+                            "organizationalUnit".as_bytes().into(),
+                        ],
                     },
                     LdapAttribute {
                         atype: "ou".to_string(),
@@ -121,7 +124,10 @@ impl DirectoryServer {
                 attributes: vec![
                     LdapAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["top".as_bytes().into(), "organizationalUnit".as_bytes().into()],
+                        vals: vec![
+                            "top".as_bytes().into(),
+                            "organizationalUnit".as_bytes().into(),
+                        ],
                     },
                     LdapAttribute {
                         atype: "ou".to_string(),
@@ -155,11 +161,11 @@ impl DirectoryServer {
                             LdapAttribute {
                                 atype: "objectClass".to_string(),
                                 vals: vec![
-                                    "top"          .as_bytes().into(),
-                                    "nsPerson"     .as_bytes().into(),
-                                    "nsAccount"    .as_bytes().into(),
-                                    "nsOrgPerson"  .as_bytes().into(),
-                                    "posixAccount" .as_bytes().into(),
+                                    "top".as_bytes().into(),
+                                    "nsPerson".as_bytes().into(),
+                                    "nsAccount".as_bytes().into(),
+                                    "nsOrgPerson".as_bytes().into(),
+                                    "posixAccount".as_bytes().into(),
                                 ],
                             },
                             LdapAttribute {
@@ -200,7 +206,10 @@ impl DirectoryServer {
                         attributes: vec![
                             LdapAttribute {
                                 atype: "objectClass".to_string(),
-                                vals: vec!["top".as_bytes().into(), "groupOfNames".as_bytes().into()],
+                                vals: vec![
+                                    "top".as_bytes().into(),
+                                    "groupOfNames".as_bytes().into(),
+                                ],
                             },
                             LdapAttribute {
                                 atype: "cn".to_string(),
@@ -230,7 +239,8 @@ impl DirectoryServer {
                         .get(id)
                         .unwrap()
                         .get_ds_ldap_dn(&self.ldap.basedn)
-                        .as_bytes().into()
+                        .as_bytes()
+                        .into()
                 })
                 .collect();
 
@@ -353,10 +363,20 @@ impl DirectoryServer {
                 == 0;
 
             if need_account {
-                priv_account.push(account.get_ds_ldap_dn(&self.ldap.basedn).as_bytes().to_vec())
+                priv_account.push(
+                    account
+                        .get_ds_ldap_dn(&self.ldap.basedn)
+                        .as_bytes()
+                        .to_vec(),
+                )
             }
             if need_group {
-                priv_group.push(account.get_ds_ldap_dn(&self.ldap.basedn).as_bytes().to_vec())
+                priv_group.push(
+                    account
+                        .get_ds_ldap_dn(&self.ldap.basedn)
+                        .as_bytes()
+                        .to_vec(),
+                )
             }
         }
 


### PR DESCRIPTION
Progress on #736, this adds the basic ipa sync repl driver which bridges to scim-sync. This adds scim commands to create sync accounts (currently hidden on the cli). This also adds the scim handlers and frameworks for testing this effectively. The actual "import" of entries is still not implemented however, and will be done in a follow up PR. There is some other cleanup I want to do first. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
