### PR TITLE
Review oauth2 best practices document

### DIFF
--- a/kanidmd/core/src/https/oauth2.rs
+++ b/kanidmd/core/src/https/oauth2.rs
@@ -305,6 +305,8 @@ async fn oauth2_authorise(
             state,
             code,
         })) => {
+            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.11
+            // We could consider changing this to 303?
             let mut res = tide::Response::new(302);
 
             redirect_uri
@@ -411,6 +413,8 @@ async fn oauth2_authorise_permit(
             state,
             code,
         }) => {
+            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.11
+            // We could consider changing this to 303?
             let mut res = tide::Response::new(302);
             redirect_uri
                 .query_pairs_mut()


### PR DESCRIPTION
Fixes #1163 review oauth2 best practices. Mostly we did everything right due to careful design of the impl, and we actually are better than many impls. A single issue was found with the potential for http downgrade in redirects that was resolved. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
