### PR TITLE
Abstract webauthn backends, and use Windows API on Windows

### DIFF
--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -44,10 +44,17 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
 url = { workspace = true, features = ["serde"] }
 uuid.workspace = true
-webauthn-authenticator-rs = { workspace = true, features = ["u2fhid"] }
 zxcvbn.workspace = true
 
 [build-dependencies]
 clap = { workspace = true, features = ["derive"] }
 clap_complete.workspace = true
 uuid.workspace = true
+
+[target."cfg(target_os = \"windows\")".dependencies.webauthn-authenticator-rs]
+workspace = true
+features = ["win10"]
+
+[target."cfg(not(any(target_os = \"windows\")))".dependencies.webauthn-authenticator-rs]
+workspace = true
+features = ["u2fhid"]

--- a/kanidm_tools/src/cli/lib.rs
+++ b/kanidm_tools/src/cli/lib.rs
@@ -31,6 +31,7 @@ pub mod recycle;
 pub mod serviceaccount;
 pub mod session;
 pub mod synch;
+mod webauthn;
 
 impl SelfOpt {
     pub fn debug(&self) -> bool {

--- a/kanidm_tools/src/cli/person.rs
+++ b/kanidm_tools/src/cli/person.rs
@@ -13,9 +13,8 @@ use qrcode::QrCode;
 use time::OffsetDateTime;
 use url::Url;
 use uuid::Uuid;
-use webauthn_authenticator_rs::u2fhid::U2FHid;
-use webauthn_authenticator_rs::WebauthnAuthenticator;
 
+use crate::webauthn::get_authenticator;
 use crate::{
     password_prompt, AccountCredential, AccountRadius, AccountSsh, AccountUserAuthToken,
     AccountValidity, PersonOpt, PersonPosix,
@@ -836,7 +835,7 @@ async fn passkey_enroll_prompt(session_token: &CUSessionToken, client: &KanidmCl
     };
 
     // Setup and connect to the webauthn handler ...
-    let mut wa = WebauthnAuthenticator::new(U2FHid::new());
+    let mut wa = get_authenticator();
 
     eprintln!("Your authenticator will now flash for you to interact with.");
     eprintln!("You may be asked to enter the PIN for your device.");

--- a/kanidm_tools/src/cli/session.rs
+++ b/kanidm_tools/src/cli/session.rs
@@ -12,10 +12,9 @@ use kanidm_proto::v1::{AuthAllowed, AuthResponse, AuthState, UserAuthToken};
 #[cfg(target_family = "unix")]
 use libc::umask;
 use webauthn_authenticator_rs::prelude::RequestChallengeResponse;
-use webauthn_authenticator_rs::u2fhid::U2FHid;
-use webauthn_authenticator_rs::WebauthnAuthenticator;
 
 use crate::common::prompt_for_username_get_username;
+use crate::webauthn::get_authenticator;
 use crate::{LoginOpt, LogoutOpt, SessionOpt};
 
 static TOKEN_DIR: &str = "~/.cache";
@@ -196,7 +195,7 @@ impl LoginOpt {
         client: &mut KanidmClient,
         pkr: RequestChallengeResponse,
     ) -> Result<AuthResponse, ClientError> {
-        let mut wa = WebauthnAuthenticator::new(U2FHid::new());
+        let mut wa = get_authenticator();
         println!("Your authenticator will now flash for you to interact with it.");
         let auth = wa
             .do_authentication(client.get_origin().clone(), pkr)
@@ -213,7 +212,7 @@ impl LoginOpt {
         client: &mut KanidmClient,
         pkr: RequestChallengeResponse,
     ) -> Result<AuthResponse, ClientError> {
-        let mut wa = WebauthnAuthenticator::new(U2FHid::new());
+        let mut wa = get_authenticator();
         println!("Your authenticator will now flash for you to interact with it.");
         let auth = wa
             .do_authentication(client.get_origin().clone(), pkr)

--- a/kanidm_tools/src/cli/webauthn/mod.rs
+++ b/kanidm_tools/src/cli/webauthn/mod.rs
@@ -1,0 +1,26 @@
+#[cfg(not(any(target_os = "windows")))]
+mod mozilla;
+#[cfg(not(any(target_os = "windows")))]
+use mozilla::get_authenticator_backend;
+
+#[cfg(target_os = "windows")]
+mod win10;
+#[cfg(target_os = "windows")]
+use win10::get_authenticator_backend;
+
+use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
+
+/// Gets a [WebauthnAuthenticator] with an appropriate backend for the current platform:
+///
+/// * On Windows, this uses the platform WebAuthn API, available on Windows 10
+///   build 1903 and later.
+///
+///   This supports BLE, NFC and USB tokens.
+///
+/// * On other platforms, this uses Mozilla's `authenticator-rs`.
+///
+///   This only supports USB tokens, and doesn't work on Windows systems which
+///   have the platform WebAuthn API available.
+pub(crate) fn get_authenticator() -> WebauthnAuthenticator<impl AuthenticatorBackend> {
+    WebauthnAuthenticator::new(get_authenticator_backend())
+}

--- a/kanidm_tools/src/cli/webauthn/mozilla.rs
+++ b/kanidm_tools/src/cli/webauthn/mozilla.rs
@@ -1,0 +1,5 @@
+use webauthn_authenticator_rs::u2fhid::U2FHid;
+
+pub fn get_authenticator_backend() -> U2FHid {
+    U2FHid::new()
+}

--- a/kanidm_tools/src/cli/webauthn/win10.rs
+++ b/kanidm_tools/src/cli/webauthn/win10.rs
@@ -1,0 +1,5 @@
+use webauthn_authenticator_rs::win10::Win10;
+
+pub fn get_authenticator_backend() -> Win10 {
+    Default::default()
+}


### PR DESCRIPTION
Windows blocks direct access to WebAuthn tokens in Windows 10 build 1903 and later, and `webauthn-authenticator-rs` supports that API... so we should use it. :)

Tested on `aarch64-pc-windows-msvc` and `x86_64-pc-windows-msvc`; also works over MSTSC.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] ~~book chapter included (if relevant)~~
- [ ] ~~design document included (if relevant)~~
