### PR TITLE
WIP: Webauthn-transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,34 +378,6 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "authenticator-ctap2-2021"
-version = "0.3.2-dev.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06c690e5e2800f70c0cf8773a9fe7680d66e719dae9b4cabedd13ef4885d056"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "cfg-if",
- "core-foundation",
- "devd-rs",
- "libc",
- "libudev",
- "log",
- "memoffset 0.6.5",
- "nom",
- "openssl",
- "openssl-sys",
- "rand 0.8.5",
- "runloop",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_json",
- "sha2 0.10.7",
  "winapi",
 ]
 
@@ -550,6 +544,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.1.3"
+dependencies = [
+ "base64 0.21.2",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "base64urlsafedata"
@@ -886,7 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f9032b96a89dd79ffc5f62523d5351ebb40680cbdfc4029393b511b9e971aa"
 dependencies = [
  "base64 0.13.1",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "openssl",
  "serde",
@@ -1309,16 +1312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "devd-rs"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9313f104b590510b46fc01c0a324fc76505c13871454d3c48490468d04c8d395"
-dependencies = [
- "libc",
- "nom",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1545,29 @@ dependencies = [
  "getrandom 0.2.10",
  "openssl",
  "zeroize",
+]
+
+[[package]]
+name = "fido-hid-rs"
+version = "0.5.0-dev"
+dependencies = [
+ "async-trait",
+ "bindgen",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "futures",
+ "lazy_static",
+ "libc",
+ "mach2",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "udev",
+ "windows 0.41.0",
 ]
 
 [[package]]
@@ -2443,7 +2459,7 @@ dependencies = [
 name = "kanidm-ipa-sync"
 version = "1.1.0-beta.13-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "clap",
  "clap_complete",
@@ -2467,7 +2483,7 @@ dependencies = [
 name = "kanidm-ldap-sync"
 version = "1.1.0-beta.13-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "clap",
  "clap_complete",
@@ -2510,7 +2526,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "base64 0.21.2",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "kanidm_proto",
  "openssl",
@@ -2535,7 +2551,7 @@ name = "kanidm_proto"
 version = "1.1.0-beta.13-dev"
 dependencies = [
  "base32",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "last-git-commit",
  "num_enum",
  "scim_proto",
@@ -2558,6 +2574,7 @@ dependencies = [
  "clap_complete",
  "compact_jwt",
  "dialoguer",
+ "futures",
  "futures-concurrency",
  "kanidm_client",
  "kanidm_proto",
@@ -2581,7 +2598,7 @@ dependencies = [
 name = "kanidm_unix_int"
 version = "1.1.0-beta.13-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "clap",
  "clap_complete",
@@ -2662,7 +2679,7 @@ version = "1.1.0-beta.13-dev"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "compact_jwt",
  "concread",
  "criterion",
@@ -2836,7 +2853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "471c4b5d674dbfe41fd479ec0b9435fd765bc838347c5625d2d2f2229a36b104"
 dependencies = [
  "base64 0.13.1",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "ldap3_proto",
  "openssl",
@@ -2932,16 +2949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libudev"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea626d3bdf40a1c5aee3bcd4f40826970cae8d80a8fec934c82a63840094dcfe"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,9 +3077,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -3136,6 +3152,20 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3538,6 +3568,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.7.0"
+source = "git+https://github.com/bluetech/pcsc-rust.git?rev=13e24649be96989cdffb7e73ca3a994b9534ddff#13e24649be96989cdffb7e73ca3a994b9534ddff"
+dependencies = [
+ "bitflags 1.3.2",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.2.0"
+source = "git+https://github.com/bluetech/pcsc-rust.git?rev=13e24649be96989cdffb7e73ca3a994b9534ddff#13e24649be96989cdffb7e73ca3a994b9534ddff"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -4121,12 +4168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "runloop"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d79b4b604167921892e84afbbaad9d5ad74e091bf6c511d9dbfb0593f09fabd"
-
-[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,7 +4283,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e53f2c444b72dd7410aa1cdc3c0942349262e84364dc7968dc7402525ea2ca"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "peg",
  "serde",
  "serde_json",
@@ -4384,16 +4425,6 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -5020,6 +5051,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5266,6 +5298,17 @@ name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
+name = "udev"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
+dependencies = [
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "unicase"
@@ -5534,32 +5577,41 @@ dependencies = [
 
 [[package]]
 name = "webauthn-authenticator-rs"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603b8602cae2d6c3706b6195765ff582389494d10c442d84a1de2ed5a25679ef"
+version = "0.5.0-dev"
 dependencies = [
- "authenticator-ctap2-2021",
- "base64urlsafedata",
+ "async-stream",
+ "async-trait",
+ "base64urlsafedata 0.1.3",
+ "bitflags 1.3.2",
+ "fido-hid-rs",
+ "futures",
+ "hex",
  "nom",
+ "num-derive",
+ "num-traits",
  "openssl",
+ "pcsc",
  "rpassword 5.0.1",
  "serde",
+ "serde_bytes",
  "serde_cbor_2",
  "serde_json",
+ "tokio",
+ "tokio-stream",
  "tracing",
+ "unicode-normalization",
  "url",
  "uuid",
+ "webauthn-rs-core",
  "webauthn-rs-proto",
  "windows 0.41.0",
 ]
 
 [[package]]
 name = "webauthn-rs"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db00711c712414e93b019c4596315085792215bc2ac2d5872f9e8913b0a6316"
+version = "0.5.0-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3",
  "serde",
  "tracing",
  "url",
@@ -5569,12 +5621,10 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294c78c83f12153a51e1cf1e6970b5da1397645dada39033a9c3173a8fc4fc2b"
+version = "0.5.0-dev"
 dependencies = [
- "base64 0.13.1",
- "base64urlsafedata",
+ "base64 0.21.2",
+ "base64urlsafedata 0.1.3",
  "compact_jwt",
  "der-parser",
  "nom",
@@ -5593,11 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24e638361a63ba5c0a0be6a60229490fcdf33740ed63df5bb6bdb627b52a138"
+version = "0.5.0-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3",
  "js-sys",
  "serde",
  "serde-wasm-bindgen 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,14 +162,14 @@ wasm-bindgen = "^0.2.86"
 wasm-bindgen-futures = "^0.4.30"
 wasm-bindgen-test = "0.3.35"
 
-webauthn-authenticator-rs = "0.4.8"
-webauthn-rs = "0.4.8"
-webauthn-rs-core = "0.4.8"
-webauthn-rs-proto = "0.4.8"
-# webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs" }
-# webauthn-rs = { path = "../webauthn-rs/webauthn-rs" }
-# webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
-# webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
+# webauthn-authenticator-rs = "0.5.0"
+# webauthn-rs = "0.5.0"
+# webauthn-rs-core = "0.5.0"
+# webauthn-rs-proto = "0.5.0"
+webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs" }
+webauthn-rs = { path = "../webauthn-rs/webauthn-rs" }
+webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
+webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
 web-sys = "^0.3.62"
 whoami = "^1.4.1"
 walkdir = "2"

--- a/server/lib/Cargo.toml
+++ b/server/lib/Cargo.toml
@@ -81,7 +81,7 @@ users = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
-webauthn-authenticator-rs = { workspace = true }
+webauthn-authenticator-rs = { workspace = true, features = ["softpasskey"] }
 
 futures = { workspace = true }
 kanidmd_lib_macros = { workspace = true }

--- a/server/lib/src/be/dbvalue.rs
+++ b/server/lib/src/be/dbvalue.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
-    DeviceKey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
+    AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
 };
 use webauthn_rs_core::proto::{COSEKey, UserVerificationPolicy};
 

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -40,7 +40,7 @@ use smartstring::alias::String as AttrString;
 use time::OffsetDateTime;
 use tracing::trace;
 use uuid::Uuid;
-use webauthn_rs::prelude::{DeviceKey as DeviceKeyV4, Passkey as PasskeyV4};
+use webauthn_rs::prelude::{AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4};
 
 use crate::be::dbentry::{DbEntry, DbEntryV2, DbEntryVers};
 use crate::be::dbvalue::DbValueSetV2;

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -7,7 +7,7 @@ use kanidm_proto::v1::{
 use time::OffsetDateTime;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
-    AuthenticationResult, CredentialID, DeviceKey as DeviceKeyV4, Passkey as PasskeyV4,
+    AuthenticationResult, CredentialID, AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4,
 };
 
 use crate::constants::UUID_ANONYMOUS;

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -12,7 +12,7 @@ use kanidm_proto::v1::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use webauthn_rs::prelude::{
-    CreationChallengeResponse, DeviceKey as DeviceKeyV4, Passkey as PasskeyV4, PasskeyRegistration,
+    CreationChallengeResponse, AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4, PasskeyRegistration,
     RegisterPublicKeyCredential,
 };
 

--- a/server/lib/src/repl/proto.rs
+++ b/server/lib/src/repl/proto.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 use webauthn_rs::prelude::{
-    DeviceKey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
+    AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
 };
 
 // Re-export this for our own usage.

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -21,7 +21,7 @@ use sshkeys::PublicKey as SshPublicKey;
 use time::OffsetDateTime;
 use url::Url;
 use uuid::Uuid;
-use webauthn_rs::prelude::{DeviceKey as DeviceKeyV4, Passkey as PasskeyV4};
+use webauthn_rs::prelude::{AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4};
 
 use kanidm_proto::v1::ApiTokenPurpose;
 use kanidm_proto::v1::Filter as ProtoFilter;

--- a/server/lib/src/valueset/cred.rs
+++ b/server/lib/src/valueset/cred.rs
@@ -1,7 +1,7 @@
 use std::collections::btree_map::Entry as BTreeEntry;
 use std::collections::BTreeMap;
 
-use webauthn_rs::prelude::{DeviceKey as DeviceKeyV4, Passkey as PasskeyV4};
+use webauthn_rs::prelude::{AttestedResidentKey as DeviceKeyV4, Passkey as PasskeyV4};
 
 use crate::be::dbvalue::{
     DbValueCredV1, DbValueDeviceKeyV1, DbValueIntentTokenStateV1, DbValuePasskeyV1,

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -6,7 +6,7 @@ use hashbrown::HashSet;
 use smolset::SmolSet;
 use time::OffsetDateTime;
 // use std::fmt::Debug;
-use webauthn_rs::prelude::DeviceKey as DeviceKeyV4;
+use webauthn_rs::prelude::AttestedResidentKey as DeviceKeyV4;
 use webauthn_rs::prelude::Passkey as PasskeyV4;
 
 use kanidm_proto::v1::Filter as ProtoFilter;

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -29,9 +29,6 @@ doc = false
 name = "kanidm_ssh_authorizedkeys_direct"
 path = "src/ssh_authorizedkeys.rs"
 
-[features]
-webauthn-transport = ["webauthn-authenticator-rs/usb", "webauthn-authenticator-rs/nfc"]
-
 [dependencies]
 async-recursion = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
@@ -60,10 +57,9 @@ clap_complete = { workspace=true }
 uuid = { workspace=true }
 url = { workspace = true }
 
-[target."cfg(target_os = \"windows\")".dependencies.webauthn-authenticator-rs]
-workspace = true
-features = ["win10"]
+[target."cfg(target_os = \"windows\")".dependencies]
+webauthn-authenticator-rs = { workspace = true, features = ["win10"] }
 
-[target."cfg(not(any(target_os = \"windows\")))".dependencies.webauthn-authenticator-rs]
-workspace = true
-features = ["u2fhid"]
+[target."cfg(not(target_os = \"windows\"))".dependencies]
+futures.workspace = true
+webauthn-authenticator-rs = { workspace = true, features = ["nfc", "usb", "ui-cli"] }

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -29,6 +29,9 @@ doc = false
 name = "kanidm_ssh_authorizedkeys_direct"
 path = "src/ssh_authorizedkeys.rs"
 
+[features]
+webauthn-transport = ["webauthn-authenticator-rs/usb", "webauthn-authenticator-rs/nfc"]
+
 [dependencies]
 async-recursion = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -902,7 +902,7 @@ async fn passkey_enroll_prompt(session_token: &CUSessionToken, client: &KanidmCl
     };
 
     // Setup and connect to the webauthn handler ...
-    let mut wa = get_authenticator();
+    let mut wa = get_authenticator().await;
 
     eprintln!("Your authenticator will now flash for you to interact with.");
     eprintln!("You may be asked to enter the PIN for your device.");

--- a/tools/cli/src/cli/session.rs
+++ b/tools/cli/src/cli/session.rs
@@ -199,7 +199,7 @@ async fn do_passkey(
     client: &mut KanidmClient,
     pkr: RequestChallengeResponse,
 ) -> Result<AuthResponse, ClientError> {
-    let mut wa = get_authenticator();
+    let mut wa = get_authenticator().await;
     println!("Your authenticator will now flash for you to interact with it.");
     let auth = wa
         .do_authentication(client.get_origin().clone(), pkr)
@@ -216,7 +216,7 @@ async fn do_securitykey(
     client: &mut KanidmClient,
     pkr: RequestChallengeResponse,
 ) -> Result<AuthResponse, ClientError> {
-    let mut wa = get_authenticator();
+    let mut wa = get_authenticator().await;
     println!("Your authenticator will now flash for you to interact with it.");
     let auth = wa
         .do_authentication(client.get_origin().clone(), pkr)

--- a/tools/cli/src/cli/webauthn/mod.rs
+++ b/tools/cli/src/cli/webauthn/mod.rs
@@ -1,11 +1,16 @@
-#[cfg(not(any(target_os = "windows")))]
+#[cfg(not(any(target_os = "windows", feature = "webauthn-transport")))]
 mod mozilla;
-#[cfg(not(any(target_os = "windows")))]
+#[cfg(not(any(target_os = "windows", feature = "webauthn-transport")))]
 use mozilla::get_authenticator_backend;
 
-#[cfg(target_os = "windows")]
+#[cfg(feature = "webauthn-transport")]
+mod transport;
+#[cfg(feature = "webauthn-transport")]
+use transport::get_authenticator_backend;
+
+#[cfg(all(not(feature = "webauthn-transport"), target_os = "windows"))]
 mod win10;
-#[cfg(target_os = "windows")]
+#[cfg(all(not(feature = "webauthn-transport"), target_os = "windows"))]
 use win10::get_authenticator_backend;
 
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};

--- a/tools/cli/src/cli/webauthn/mod.rs
+++ b/tools/cli/src/cli/webauthn/mod.rs
@@ -1,17 +1,7 @@
-#[cfg(not(any(target_os = "windows", feature = "webauthn-transport")))]
-mod mozilla;
-#[cfg(not(any(target_os = "windows", feature = "webauthn-transport")))]
-use mozilla::get_authenticator_backend;
-
-#[cfg(feature = "webauthn-transport")]
-mod transport;
-#[cfg(feature = "webauthn-transport")]
-use transport::get_authenticator_backend;
-
-#[cfg(all(not(feature = "webauthn-transport"), target_os = "windows"))]
-mod win10;
-#[cfg(all(not(feature = "webauthn-transport"), target_os = "windows"))]
-use win10::get_authenticator_backend;
+#[cfg_attr(target_os = "windows", path = "win10.rs")]
+#[cfg_attr(not(target_os = "windows"), path = "transport.rs")]
+mod backend;
+use backend::get_authenticator_backend;
 
 use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 
@@ -22,10 +12,11 @@ use webauthn_authenticator_rs::{AuthenticatorBackend, WebauthnAuthenticator};
 ///
 ///   This supports BLE, NFC and USB tokens.
 ///
-/// * On other platforms, this uses Mozilla's `authenticator-rs`.
+/// * On other platforms, this uses `webauthn-authenticator-rs`' `AnyTransport`.
 ///
-///   This only supports USB tokens, and doesn't work on Windows systems which
-///   have the platform WebAuthn API available.
-pub(crate) fn get_authenticator() -> WebauthnAuthenticator<impl AuthenticatorBackend> {
-    WebauthnAuthenticator::new(get_authenticator_backend())
+///   In the default configuration, this supports NFC and USB tokens, but
+///   doesn't work on Windows systems which have the platform WebAuthn API
+///   available.
+pub(crate) async fn get_authenticator() -> WebauthnAuthenticator<impl AuthenticatorBackend> {
+    WebauthnAuthenticator::new(get_authenticator_backend().await)
 }

--- a/tools/cli/src/cli/webauthn/mozilla.rs
+++ b/tools/cli/src/cli/webauthn/mozilla.rs
@@ -1,5 +1,0 @@
-use webauthn_authenticator_rs::u2fhid::U2FHid;
-
-pub fn get_authenticator_backend() -> U2FHid {
-    U2FHid::new()
-}

--- a/tools/cli/src/cli/webauthn/transport.rs
+++ b/tools/cli/src/cli/webauthn/transport.rs
@@ -1,12 +1,36 @@
+use futures::StreamExt;
 use webauthn_authenticator_rs::{
     ctap2::CtapAuthenticator,
-    transport::{AnyToken, AnyTransport, Transport},
+    transport::{AnyToken, AnyTransport, Transport, TokenEvent},
     ui::Cli,
 };
 
 static CLI: Cli = Cli {};
 
-pub fn get_authenticator_backend() -> CtapAuthenticator<'static, AnyToken, Cli> {
-    let mut t = AnyTransport::new().unwrap();
-    t.connect_one(&CLI).unwrap()
+pub async fn get_authenticator_backend() -> CtapAuthenticator<'static, AnyToken, Cli> {
+    let t = AnyTransport::new().await.unwrap();
+    match t.watch().await {
+        Ok(mut tokens) => {
+            while let Some(event) = tokens.next().await {
+                match event {
+                    TokenEvent::Added(token) => {
+                        let auth = CtapAuthenticator::new(token, &CLI).await;
+
+                        if let Some(auth) = auth {
+                            return auth;
+                        }
+                    }
+
+                    TokenEvent::EnumerationComplete => {
+                        info!("device enumeration completed without detecting a FIDO2 authenticator, connect one to authenticate!");
+                    }
+
+                    TokenEvent::Removed(_) => {}
+                }
+            }
+        }
+        Err(e) => panic!("Error: {e:?}"),
+    }
+
+    panic!("No authenticators available!");
 }

--- a/tools/cli/src/cli/webauthn/transport.rs
+++ b/tools/cli/src/cli/webauthn/transport.rs
@@ -1,0 +1,12 @@
+use webauthn_authenticator_rs::{
+    ctap2::CtapAuthenticator,
+    transport::{AnyToken, AnyTransport, Transport},
+    ui::Cli,
+};
+
+static CLI: Cli = Cli {};
+
+pub fn get_authenticator_backend() -> CtapAuthenticator<'static, AnyToken, Cli> {
+    let mut t = AnyTransport::new().unwrap();
+    t.connect_one(&CLI).unwrap()
+}

--- a/tools/cli/src/cli/webauthn/win10.rs
+++ b/tools/cli/src/cli/webauthn/win10.rs
@@ -1,5 +1,5 @@
 use webauthn_authenticator_rs::win10::Win10;
 
-pub fn get_authenticator_backend() -> Win10 {
+pub async fn get_authenticator_backend() -> Win10 {
     Default::default()
 }


### PR DESCRIPTION
Draft, don't merge yet, needs https://github.com/kanidm/webauthn-rs/pull/215; this PR is on top of #1203 

This uses the `CtapAuthenticator` implementation in `webauthn-authenticator-rs`.  You'll ned to switch to my `transport-auth` branch (https://github.com/kanidm/webauthn-rs/pull/215) to get that working.

Then you can use it with `--features webauthn-transport` (which should disable using `mozilla` and `win10`).

Notes:

* I don't know what features `webauthn-authenticator-rs` is built with with `webauthn-transport` enabled – ideally this should disable both `mozilla` and `win10`, but Cargo may not offer enough control yet.

* This could have a better name...

Fixes #

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
