### PR TITLE
Add signal trapping for a variety of signals

### DIFF
--- a/kanidmd/testkit-macros/src/entry.rs
+++ b/kanidmd/testkit-macros/src/entry.rs
@@ -43,8 +43,9 @@ fn parse_knobs(input: &syn::ItemFn) -> TokenStream {
         #header
         fn #test_driver() {
             let body = async {
-                let rsclient = kanidmd_testkit::setup_async_test().await;
-                #fn_name(rsclient).await
+                let (rsclient, mut core_handle) = kanidmd_testkit::setup_async_test().await;
+                #fn_name(rsclient).await;
+                core_handle.shutdown().await;
             };
             #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
             {

--- a/kanidmd/testkit/src/lib.rs
+++ b/kanidmd/testkit/src/lib.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicU16, Ordering};
 
 use kanidm_client::{KanidmClient, KanidmClientBuilder};
 use kanidmd_core::config::{Configuration, IntegrationTestConfig, ServerRole};
-use kanidmd_core::create_server_core;
+use kanidmd_core::{create_server_core, CoreHandle};
 use tokio::task;
 
 pub const ADMIN_TEST_USER: &str = "admin";
@@ -36,7 +36,7 @@ pub fn is_free_port(port: u16) -> bool {
 
 // allowed because the use of this function is behind a test gate
 #[allow(dead_code)]
-pub async fn setup_async_test() -> KanidmClient {
+pub async fn setup_async_test() -> (KanidmClient, CoreHandle) {
     let _ = sketching::test_init();
 
     let mut counter = 0;
@@ -71,7 +71,7 @@ pub async fn setup_async_test() -> KanidmClient {
     // config.log_level = Some(LogLevel::FullTrace as u32);
     config.threads = 1;
 
-    create_server_core(config, false)
+    let core_handle = create_server_core(config, false)
         .await
         .expect("failed to start server core");
     // We have to yield now to guarantee that the tide elements are setup.
@@ -85,5 +85,5 @@ pub async fn setup_async_test() -> KanidmClient {
 
     tracing::info!("Testkit server setup complete - {}", addr);
 
-    rsclient
+    (rsclient, core_handle)
 }

--- a/kanidmd_web_ui/src/views/mod.rs
+++ b/kanidmd_web_ui/src/views/mod.rs
@@ -357,7 +357,8 @@ impl ViewsApp {
             .expect_throw("failed to set header");
 
         let window = utils::window();
-        let resp_value = JsFuture::from(window.fetch_with_request(&request)).await
+        let resp_value = JsFuture::from(window.fetch_with_request(&request))
+            .await
             .map_err(|e| {
                 console::error!(&format!("fetch request failed {:?}", e));
                 e


### PR DESCRIPTION
Fixes #1221 - This adds proper trapping for a bunch of signal types. It also lays the ground work for SIGUSR1/2 and HUP actions.

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
