### PR TITLE
Add ability to bind with token as a dn

### DIFF
--- a/kanidmd_web_ui/src/views/mod.rs
+++ b/kanidmd_web_ui/src/views/mod.rs
@@ -357,7 +357,8 @@ impl ViewsApp {
             .expect_throw("failed to set header");
 
         let window = utils::window();
-        let resp_value = JsFuture::from(window.fetch_with_request(&request)).await
+        let resp_value = JsFuture::from(window.fetch_with_request(&request))
+            .await
             .map_err(|e| {
                 console::error!(&format!("fetch request failed {:?}", e));
                 e


### PR DESCRIPTION
Fixes #1208 - add an extra syntax to allow tokens in the binddn with the syntax "token=APITOKEN". We still allow the anonymous bind dn + token syntax as well. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
