### PR TITLE
fix(oauth2): use the short name in the userinfo

### DIFF
--- a/kanidmd_web_ui/src/oauth2.rs
+++ b/kanidmd_web_ui/src/oauth2.rs
@@ -244,7 +244,7 @@ impl Component for Oauth2App {
                 };
             }
         };
-        console::debug!(format!("{query:?}", ));
+        console::debug!(format!("{query:?}",));
 
         // In the query, if this is openid there MAY be a hint
         // as to the users name.


### PR DESCRIPTION
This implements #1023 for the userinfo endpoint, which was an oversight in #1043. I've also added a testcase to verify this behavior


- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

