### PR TITLE
fix(make): improve help output and solve warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BOOK_VERSION ?= master
 
 .DEFAULT: help
 help:
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##/\n\t/'
+	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 buildx/kanidmd/x86_64_v3: ## build multiarch server images
 buildx/kanidmd/x86_64_v3:


### PR DESCRIPTION
Change `make help` output from:

```
fgrep: warning: fgrep is obsolescent; using grep -F
fgrep: warning: fgrep is obsolescent; using grep -F
buildx/kanidmd/x86_64_v3:
         build multiarch server images
buildx/kanidmd:
         Build multiarch kanidm server images and push to docker hub
buildx/kanidm_tools:
         Build multiarch kanidm tool images and push to docker hub
buildx/radiusd:
         Build multi-arch radius docker images and push to docker hub
build/kanidmd:
         Build the kanidmd docker image locally
build/radiusd:
         Build the radiusd docker image locally
test/kanidmd:
         Run cargo test in docker
test/radiusd:
         Run a test radius server
install-tools:
         install tools in local environment
test/pykanidm:
         run the test suite (mypy/pylint/pytest) for the kanidm python module

        ######################################################################
doc:
         Build the rust documentation locally
book:
         Build the Kanidm book
docs/pykanidm/build:
         Build the mkdocs
docs/pykanidm/serve:
         Run the local mkdocs server

        ######################################################################
release/kanidm:
         Build the Kanidm CLI - ensure you include the environment variable KANIDM_BUILD_PROFILE
release/kanidmd:
         Build the Kanidm daemon - ensure you include the environment variable KANIDM_BUILD_PROFILE
release/kanidm-ssh:
         Build the Kanidm SSH tools - ensure you include the environment variable KANIDM_BUILD_PROFILE
release/kanidm-unixd:
         Build the Kanidm UNIX tools - ensure you include the environment variable KANIDM_BUILD_PROFILE
```

to:

```
book                 Build the Kanidm book
build/kanidmd        Build the kanidmd docker image locally
build/radiusd        Build the radiusd docker image locally
buildx/kanidmd       Build multiarch kanidm server images and push to docker hub
buildx/kanidmd/x86_64_v3 build multiarch server images
buildx/kanidm_tools  Build multiarch kanidm tool images and push to docker hub
buildx/radiusd       Build multi-arch radius docker images and push to docker hub
doc                  Build the rust documentation locally
docs/pykanidm/build  Build the mkdocs
docs/pykanidm/serve  Run the local mkdocs server
install-tools        install tools in local environment
release/kanidm       Build the Kanidm CLI - ensure you include the environment variable KANIDM_BUILD_PROFILE
release/kanidmd      Build the Kanidm daemon - ensure you include the environment variable KANIDM_BUILD_PROFILE
release/kanidm-ssh   Build the Kanidm SSH tools - ensure you include the environment variable KANIDM_BUILD_PROFILE
release/kanidm-unixd Build the Kanidm UNIX tools - ensure you include the environment variable KANIDM_BUILD_PROFILE
test/kanidmd         Run cargo test in docker
test/pykanidm        run the test suite (mypy/pylint/pytest) for the kanidm python module
test/radiusd         Run a test radius server
```