### PR TITLE
feat(oauth2): add support for a 'groups' claim

### DIFF
--- a/kanidmd/lib/src/idm/account.rs
+++ b/kanidmd/lib/src/idm/account.rs
@@ -156,7 +156,7 @@ impl Account {
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn try_from_entry_ro(
         value: &Entry<EntrySealed, EntryCommitted>,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Self, OperationError> {
         let groups = Group::try_from_account_entry_ro(value, qs)?;
         try_from_entry!(value, groups)

--- a/kanidmd/lib/src/idm/group.rs
+++ b/kanidmd/lib/src/idm/group.rs
@@ -85,7 +85,7 @@ impl Group {
 
     pub fn try_from_account_entry_ro(
         value: &Entry<EntrySealed, EntryCommitted>,
-        qs: &mut QueryServerReadTransaction,
+        qs: &QueryServerReadTransaction,
     ) -> Result<Vec<Self>, OperationError> {
         try_from_account_e!(value, qs)
     }


### PR DESCRIPTION
Adds support for a 'groups' claim. If supplied, it will add the UUID of the accounts groups to the id_token and userinfo endpoint.

Since we had a lot of duplicate logic between token exchange and userinfo, I also refactored out the common parts.

As discussed in the chat, I'll also add a toggle for the resource server to only provide this information in the userinfo endpoint and not the ID token, just wanted to submit this already to get some early feedback if this change is going in the right direction

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes