### PR TITLE
Fix ldap vattr search

### DIFF
--- a/kanidmd/lib/src/entry.rs
+++ b/kanidmd/lib/src/entry.rs
@@ -1774,14 +1774,20 @@ impl Entry<EntryReduced, EntryCommitted> {
                 .chain(
                     l_attrs
                         .iter()
-                        .map(|k| (k.as_str(), ldap_vattr_map(k.as_str()))),
+                        .map(|k| (
+                            k.as_str(),
+                            ldap_vattr_map(k.as_str()).unwrap_or(k.as_str())
+                        ))
                 )
                 .collect()
         } else {
             // Just get the requested ones.
             l_attrs
                 .iter()
-                .map(|k| (k.as_str(), ldap_vattr_map(k.as_str())))
+                .map(|k| (
+                    k.as_str(),
+                    ldap_vattr_map(k.as_str()).unwrap_or(k.as_str())
+                ))
                 .collect()
         };
 


### PR DESCRIPTION
Fixes #1301 - this allows specifying vattrs with a '*' search where both the vattr and all attrs will be returned. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
