### PR TITLE
Windows-related build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,3 +240,15 @@ release/kanidm-unixd:
 		--bin kanidm_unixd_tasks \
 		--bin kanidm_cache_clear \
 		--bin kanidm_cache_invalidate
+
+
+# cert things
+
+.PHONY: cert/clean
+cert/clean: ## clean out the insecure cert bits
+cert/clean:
+	rm -f /tmp/kanidm/*.pem
+	rm -f /tmp/kanidm/*.cnf
+	rm -f /tmp/kanidm/*.csr
+	rm -f /tmp/kanidm/ca.txt*
+	rm -f /tmp/kanidm/ca.{cnf,srl,srl.old}

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -301,10 +301,7 @@ async fn main() {
                     if !config_test {
                         match sctx {
                             Ok(mut sctx) => {
-                                eprintln!("server started, sleeping for 5 seconds...");
-                                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                                 loop {
-
                                     #[cfg(target_family = "unix")]
                                     {
                                         tokio::select! {

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -293,11 +293,7 @@ async fn main() {
                         }
                     }
 
-                    #[cfg(debug_assertions)]
-                    trace!("Starting server core...");
                     let sctx = create_server_core(config, config_test).await;
-                    #[cfg(debug_assertions)]
-                    trace!("Done starting server core!");
                     if !config_test {
                         match sctx {
                             Ok(mut sctx) => {


### PR DESCRIPTION
It builds, but `kanidmd` stack-overflows on windows while running initialise_helper, something something DB-related-things, by the looks of it? 

It wasn't compiling at all before the PR changes, so I didn't make it *worse* 😃 

Relates to #1229 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes

```
PS C:\Users\yaleman\Projects\kanidm\kanidmd\daemon> cargo run --bin kanidmd server --config C:\Users\yaleman\AppData\Local\Temp\kanidm\server.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
     Running `C:\Users\yaleman\Projects\kanidm\target\debug\kanidmd.exe server --config C:\Users\yaleman\AppData\Local\Temp\kanidm\server.toml`
Running on windows, current username is: "yaleman"
Running in server mode ...
WARNING: permissions checks on windows aren't implemented, cannot check TLS Key at "C:/Users/yaleman/AppData/Local/Temp/kanidm/chain.pem" 
WARNING: permissions checks on windows aren't implemented, cannot check TLS Key at "C:/Users/yaleman/AppData/Local/Temp/kanidm/key.pem"   
00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Starting kanidm with configuration:  address: 127.0.0.1:8443, domain: localhost, 
ldap address: 127.0.0.1:3636, thread count: 16, dbpath: C:/Users/yaleman/AppData/Local/Temp/kanidm/kanidm.db, arcsize: AUTO, max request size: 262144b, secure cookies: true, trust X-Forwarded-For: false, with TLS: true, online_backup: enabled, role: write replica, integration mode: false, console output format: Text
Creating QS
Created QS
Helper starting

thread 'main' has overflowed its stack
error: process didn't exit successfully: `C:\Users\yaleman\Projects\kanidm\target\debug\kanidmd.exe server --config C:\Users\yaleman\AppData\Local\Temp\kanidm\server.toml` (exit code: 0xc00000fd, STATUS_STACK_OVERFLOW)
```