### PR TITLE
Allow multiple backends to run in parallel for repl tests

### DIFF
--- a/kanidmd/lib-macros/src/entry.rs
+++ b/kanidmd/lib-macros/src/entry.rs
@@ -98,6 +98,100 @@ pub(crate) fn qs_test(_args: &TokenStream, item: TokenStream, with_init: bool) -
     result.into()
 }
 
+pub(crate) fn qs_pair_test(_args: &TokenStream, item: TokenStream, with_init: bool) -> TokenStream {
+    let input: syn::ItemFn = match syn::parse(item.clone()) {
+        Ok(it) => it,
+        Err(e) => return token_stream_with_error(item, e),
+    };
+
+    if let Some(attr) = input.attrs.iter().find(|attr| attr.path.is_ident("test")) {
+        let msg = "second test attribute is supplied";
+        return token_stream_with_error(item, syn::Error::new_spanned(attr, msg));
+    };
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the `async` keyword is missing from the function declaration";
+        return token_stream_with_error(item, syn::Error::new_spanned(input.sig.fn_token, msg));
+    }
+
+    // If type mismatch occurs, the current rustc points to the last statement.
+    let (last_stmt_start_span, _last_stmt_end_span) = {
+        let mut last_stmt = input
+            .block
+            .stmts
+            .last()
+            .map(ToTokens::into_token_stream)
+            .unwrap_or_default()
+            .into_iter();
+        // `Span` on stable Rust has a limitation that only points to the first
+        // token, not the whole tokens. We can work around this limitation by
+        // using the first/last span of the tokens like
+        // `syn::Error::new_spanned` does.
+        let start = last_stmt.next().map_or_else(Span::call_site, |t| t.span());
+        let end = last_stmt.last().map_or(start, |t| t.span());
+        (start, end)
+    };
+
+    let rt = quote_spanned! {last_stmt_start_span=>
+        tokio::runtime::Builder::new_current_thread()
+    };
+
+    let header = quote! {
+        #[::core::prelude::v1::test]
+    };
+
+    let init = if with_init {
+        quote! {
+            server_a.initialise_helper(duration_from_epoch_now())
+                .await
+                .expect("init_a failed!");
+            server_b.initialise_helper(duration_from_epoch_now())
+                .await
+                .expect("init_b failed!");
+        }
+    } else {
+        quote! {}
+    };
+
+    let test_fn = &input.sig.ident;
+    let test_driver = Ident::new(&format!("qs_{}", test_fn), input.sig.span());
+
+    // Effectively we are just injecting a real test function around this which we will
+    // call.
+
+    let result = quote! {
+        #input
+
+        #header
+        fn #test_driver() {
+            let body = async {
+                let (server_a, server_b) = crate::testkit::setup_pair_test().await;
+
+                #init
+
+                #test_fn(&server_a, &server_b).await;
+
+                // Any needed teardown?
+                // Make sure there are no errors.
+                let verifications_a = server_a.verify().await;
+                let verifications_b = server_b.verify().await;
+                trace!("Verification result: {:?}, {:?}", verifications_a, verifications_b);
+                assert!(verifications_a.len() + verifications_b.len() == 0);
+            };
+            #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
+            {
+                return #rt
+                    .enable_all()
+                    .build()
+                    .expect("Failed building the Runtime")
+                    .block_on(body);
+            }
+        }
+    };
+
+    result.into()
+}
+
 pub(crate) fn idm_test(_args: &TokenStream, item: TokenStream) -> TokenStream {
     let input: syn::ItemFn = match syn::parse(item.clone()) {
         Ok(it) => it,

--- a/kanidmd/lib-macros/src/lib.rs
+++ b/kanidmd/lib-macros/src/lib.rs
@@ -23,6 +23,11 @@ pub fn qs_test(args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn qs_pair_test(args: TokenStream, item: TokenStream) -> TokenStream {
+    entry::qs_pair_test(&args, item, true)
+}
+
+#[proc_macro_attribute]
 pub fn qs_test_no_init(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::qs_test(&args, item, false)
 }

--- a/kanidmd/lib/src/macros.rs
+++ b/kanidmd/lib/src/macros.rs
@@ -9,8 +9,8 @@ macro_rules! setup_test {
             let schema_txn = schema_outer.write_blocking();
             schema_txn.reload_idxmeta()
         };
-        let be =
-            Backend::new(BackendConfig::new_test(), idxmeta, false).expect("Failed to init BE");
+        let be = Backend::new(BackendConfig::new_test("main"), idxmeta, false)
+            .expect("Failed to init BE");
 
         let qs = QueryServer::new(be, schema_outer, "example.com".to_string());
         async_std::task::block_on(qs.initialise_helper(duration_from_epoch_now()))
@@ -30,8 +30,8 @@ macro_rules! setup_test {
             let schema_txn = schema_outer.write();
             schema_txn.reload_idxmeta()
         };
-        let be =
-            Backend::new(BackendConfig::new_test(), idxmeta, false).expect("Failed to init BE");
+        let be = Backend::new(BackendConfig::new_test("main"), idxmeta, false)
+            .expect("Failed to init BE");
 
         let qs = QueryServer::new(be, schema_outer, "example.com".to_string());
         async_std::task::block_on(qs.initialise_helper(duration_from_epoch_now()))

--- a/kanidmd/lib/src/repl/tests.rs
+++ b/kanidmd/lib/src/repl/tests.rs
@@ -1,0 +1,7 @@
+use crate::prelude::*;
+
+#[tokio::test]
+async fn multiple_qs_setup() {
+    assert!(true);
+}
+

--- a/kanidmd/lib/src/testkit.rs
+++ b/kanidmd/lib/src/testkit.rs
@@ -14,10 +14,46 @@ pub async fn setup_test() -> QueryServer {
         let schema_txn = schema_outer.write();
         schema_txn.reload_idxmeta()
     };
-    let be = Backend::new(BackendConfig::new_test(), idxmeta, false).expect("Failed to init BE");
+    let be =
+        Backend::new(BackendConfig::new_test("main"), idxmeta, false).expect("Failed to init BE");
 
     // Init is called via the proc macro
     QueryServer::new(be, schema_outer, "example.com".to_string())
+}
+
+#[allow(clippy::expect_used)]
+pub async fn setup_pair_test() -> (QueryServer, QueryServer) {
+    sketching::test_init();
+
+    let qs_a = {
+        // Create an in memory BE
+        let schema_outer = Schema::new().expect("Failed to init schema");
+        let idxmeta = {
+            let schema_txn = schema_outer.write();
+            schema_txn.reload_idxmeta()
+        };
+        let be = Backend::new(BackendConfig::new_test("db_a"), idxmeta, false)
+            .expect("Failed to init BE");
+
+        // Init is called via the proc macro
+        QueryServer::new(be, schema_outer, "example.com".to_string())
+    };
+
+    let qs_b = {
+        // Create an in memory BE
+        let schema_outer = Schema::new().expect("Failed to init schema");
+        let idxmeta = {
+            let schema_txn = schema_outer.write();
+            schema_txn.reload_idxmeta()
+        };
+        let be = Backend::new(BackendConfig::new_test("db_b"), idxmeta, false)
+            .expect("Failed to init BE");
+
+        // Init is called via the proc macro
+        QueryServer::new(be, schema_outer, "example.com".to_string())
+    };
+
+    (qs_a, qs_b)
 }
 
 #[allow(clippy::expect_used)]


### PR DESCRIPTION
Relates #68 - support running two instances at the same time in a single test. This will allow us to perform replication testing within the standard cargo-test runs. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
