### PR TITLE
20230128 protected to access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,8 @@ tokio-util = "^0.7.4"
 
 toml = "^0.5.11"
 touch = "^0.0.1"
-tracing = { version = "^0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
+# tracing = { version = "^0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
+tracing = { version = "^0.1.37" }
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter"] }
 
 # tracing-forest = { path = "/Users/william/development/tracing-forest/tracing-forest" }

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 .PHONY: buildx/kanidmd/x86_64_v3
 buildx/kanidmd/x86_64_v3: ## build multiarch server images
 buildx/kanidmd/x86_64_v3:
-	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) --pull --push --platform "linux/amd64" \
+	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) --pull --push --platform "linux/amd64/v3" \
 		-f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:x86_64_$(IMAGE_VERSION) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_x86_64_v3" \
 		--build-arg "KANIDM_FEATURES=" \

--- a/iam_migrations/freeipa/src/main.rs
+++ b/iam_migrations/freeipa/src/main.rs
@@ -721,17 +721,20 @@ fn ipa_to_scim_entry(
             // pw hash formats in 389-ds we don't support!
             .or_else(|| entry.remove_ava_single("userpassword"));
 
-        if !totp.is_empty() {
+        let totp_import = if !totp.is_empty() {
             if password_import.is_some() {
                 // If there are TOTP's, convert them to something sensible.
-                let totp_import = totp.iter().filter_map(ipa_to_totp).collect();
+                totp.iter().filter_map(ipa_to_totp).collect()
             } else {
                 warn!(
                     "Skipping totp for {} as password is not available to import.",
                     dn
                 );
+                Vec::default()
             }
-        }
+        } else {
+            Vec::default()
+        };
 
         let login_shell = entry.remove_ava_single("loginshell");
         let external_id = Some(entry.dn);

--- a/kanidm_unix_int/src/tasks_daemon.rs
+++ b/kanidm_unix_int/src/tasks_daemon.rs
@@ -87,10 +87,7 @@ fn create_home_directory(
     use_etc_skel: bool,
 ) -> Result<(), String> {
     // Final sanity check to prevent certain classes of attacks.
-    let name = info
-        .name
-        .trim_start_matches('.')
-        .replace(['/', '\\'], "");
+    let name = info.name.trim_start_matches('.').replace(['/', '\\'], "");
 
     let home_prefix_path = Path::new(home_prefix);
 
@@ -151,9 +148,7 @@ fn create_home_directory(
     for alias in info.aliases.iter() {
         // Sanity check the alias.
         // let alias = alias.replace(".", "").replace("/", "").replace("\\", "");
-        let alias = alias
-            .trim_start_matches('.')
-            .replace(['/', '\\'], "");
+        let alias = alias.trim_start_matches('.').replace(['/', '\\'], "");
         let alias_path_raw = format!("{}{}", home_prefix, alias);
         let alias_path = Path::new(&alias_path_raw);
 

--- a/kanidmd/core/src/https/middleware.rs
+++ b/kanidmd/core/src/https/middleware.rs
@@ -113,8 +113,6 @@ impl<State: Clone + Send + Sync + 'static> tide::Middleware<State> for StrictRes
 #[derive(Default)]
 struct StrictRequestMiddleware;
 
-
-
 #[async_trait::async_trait]
 impl<State: Clone + Send + Sync + 'static> tide::Middleware<State> for StrictRequestMiddleware {
     async fn handle(

--- a/kanidmd/core/src/https/routemaps.rs
+++ b/kanidmd/core/src/https/routemaps.rs
@@ -76,13 +76,10 @@ pub struct RouteInfo {
     pub method: http_types::Method,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[derive(Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct RouteMap {
     pub routelist: Vec<RouteInfo>,
 }
-
-
 
 impl RouteMap {
     // Serializes the object out to a pretty JSON blob

--- a/kanidmd/daemon/src/main.rs
+++ b/kanidmd/daemon/src/main.rs
@@ -505,9 +505,7 @@ async fn main() {
                     debug!("Request: {req:?}");
                     println!("OK")
                 }
-                KanidmdOpt::Version(_) => {
-                    
-                }
+                KanidmdOpt::Version(_) => {}
             }
         })
         .await;

--- a/kanidmd/lib/src/be/mod.rs
+++ b/kanidmd/lib/src/be/mod.rs
@@ -1998,9 +1998,7 @@ mod tests {
             let vr2 = unsafe { r2.into_sealed_committed() };
 
             // Modify single
-            assert!(be
-                .modify(&CID_ZERO, &[pre1], &[vr1.clone()])
-                .is_ok());
+            assert!(be.modify(&CID_ZERO, &[pre1], &[vr1.clone()]).is_ok());
             // Assert no other changes
             assert!(entry_attr_pres!(be, vr1, "desc"));
             assert!(!entry_attr_pres!(be, vr2, "desc"));
@@ -2064,19 +2062,13 @@ mod tests {
             // This sets up the RUV with the changes.
             let r1_ts = unsafe { r1.to_tombstone(CID_ONE.clone()).into_sealed_committed() };
 
-            assert!(be
-                .modify(&CID_ONE, &[r1], &[r1_ts.clone()])
-                .is_ok());
+            assert!(be.modify(&CID_ONE, &[r1], &[r1_ts.clone()]).is_ok());
 
             let r2_ts = unsafe { r2.to_tombstone(CID_TWO.clone()).into_sealed_committed() };
             let r3_ts = unsafe { r3.to_tombstone(CID_TWO.clone()).into_sealed_committed() };
 
             assert!(be
-                .modify(
-                    &CID_TWO,
-                    &[r2, r3],
-                    &[r2_ts.clone(), r3_ts.clone()]
-                )
+                .modify(&CID_TWO, &[r2, r3], &[r2_ts.clone(), r3_ts.clone()])
                 .is_ok());
 
             // The entry are now tombstones, but is still in the ruv. This is because we
@@ -2405,9 +2397,7 @@ mod tests {
 
             // == Now we reap_tombstones, and assert we removed the items.
             let e1_ts = unsafe { e1.to_tombstone(CID_ONE.clone()).into_sealed_committed() };
-            assert!(be
-                .modify(&CID_ONE, &[e1], &[e1_ts])
-                .is_ok());
+            assert!(be.modify(&CID_ONE, &[e1], &[e1_ts]).is_ok());
             be.reap_tombstones(&CID_TWO).unwrap();
 
             idl_state!(be, "name", IndexType::Equality, "william", Some(Vec::new()));
@@ -2453,9 +2443,7 @@ mod tests {
             e3.add_ava("uuid", Value::from("7b23c99d-c06b-4a9a-a958-3afa56383e1d"));
             let e3 = unsafe { e3.into_sealed_new() };
 
-            let mut rset = be
-                .create(&CID_ZERO, vec![e1, e2, e3])
-                .unwrap();
+            let mut rset = be.create(&CID_ZERO, vec![e1, e2, e3]).unwrap();
             rset.remove(1);
             let mut rset: Vec<_> = rset.into_iter().map(Arc::new).collect();
             let e1 = rset.pop().unwrap();
@@ -2464,13 +2452,7 @@ mod tests {
             // Now remove e1, e3.
             let e1_ts = unsafe { e1.to_tombstone(CID_ONE.clone()).into_sealed_committed() };
             let e3_ts = unsafe { e3.to_tombstone(CID_ONE.clone()).into_sealed_committed() };
-            assert!(be
-                .modify(
-                    &CID_ONE,
-                    &[e1, e3],
-                    &[e1_ts, e3_ts]
-                )
-                .is_ok());
+            assert!(be.modify(&CID_ONE, &[e1, e3], &[e1_ts, e3_ts]).is_ok());
             be.reap_tombstones(&CID_TWO).unwrap();
 
             idl_state!(be, "name", IndexType::Equality, "claire", Some(vec![2]));
@@ -2945,9 +2927,7 @@ mod tests {
             e3.add_ava("tb", Value::from("2"));
             let e3 = unsafe { e3.into_sealed_new() };
 
-            let _rset = be
-                .create(&CID_ZERO, vec![e1, e2, e3])
-                .unwrap();
+            let _rset = be.create(&CID_ZERO, vec![e1, e2, e3]).unwrap();
 
             // If the slopes haven't been generated yet, there are some hardcoded values
             // that we can use instead. They aren't generated until a first re-index.

--- a/kanidmd/lib/src/constants/schema.rs
+++ b/kanidmd/lib/src/constants/schema.rs
@@ -123,6 +123,9 @@ pub const JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &str = r#"
       "multivalue": [
         "false"
       ],
+      "sync_allowed": [
+        "true"
+      ],
       "attributename": [
         "primary_credential"
       ],

--- a/kanidmd/lib/src/credential/totp.rs
+++ b/kanidmd/lib/src/credential/totp.rs
@@ -367,12 +367,7 @@ mod tests {
     fn totp_allow_one_previous() {
         let key = vec![0x00, 0xaa, 0xbb, 0xcc];
         let secs = 1585369780;
-        let otp = Totp::new(
-            key,
-            TOTP_DEFAULT_STEP,
-            TotpAlgo::Sha512,
-            TotpDigits::Six,
-        );
+        let otp = Totp::new(key, TOTP_DEFAULT_STEP, TotpAlgo::Sha512, TotpDigits::Six);
         let d = Duration::from_secs(secs);
         // Step
         assert!(otp.verify(952181, &d));

--- a/kanidmd/lib/src/entry.rs
+++ b/kanidmd/lib/src/entry.rs
@@ -559,9 +559,7 @@ impl Entry<EntryInit, EntryNew> {
         let cid = Cid::new_zero();
         self.set_last_changed(cid.clone());
         let eclog = EntryChangelog::new_without_schema(cid, self.attrs.clone());
-        let uuid = self
-            .get_uuid()
-            .unwrap_or_else(Uuid::new_v4);
+        let uuid = self.get_uuid().unwrap_or_else(Uuid::new_v4);
         Entry {
             valid: EntrySealed { uuid, eclog },
             state: EntryCommitted { id: 0 },
@@ -950,9 +948,7 @@ impl Entry<EntryInvalid, EntryNew> {
 
     #[cfg(test)]
     pub unsafe fn into_sealed_committed(self) -> Entry<EntrySealed, EntryCommitted> {
-        let uuid = self
-            .get_uuid()
-            .unwrap_or_else(Uuid::new_v4);
+        let uuid = self.get_uuid().unwrap_or_else(Uuid::new_v4);
         Entry {
             valid: EntrySealed {
                 uuid,
@@ -983,9 +979,7 @@ impl Entry<EntryInvalid, EntryNew> {
 
     #[cfg(test)]
     pub unsafe fn into_valid_committed(self) -> Entry<EntryValid, EntryCommitted> {
-        let uuid = self
-            .get_uuid()
-            .unwrap_or_else(Uuid::new_v4);
+        let uuid = self.get_uuid().unwrap_or_else(Uuid::new_v4);
         Entry {
             valid: EntryValid {
                 cid: self.valid.cid,
@@ -1001,9 +995,7 @@ impl Entry<EntryInvalid, EntryNew> {
 impl Entry<EntryInvalid, EntryCommitted> {
     #[cfg(test)]
     pub unsafe fn into_sealed_committed(self) -> Entry<EntrySealed, EntryCommitted> {
-        let uuid = self
-            .get_uuid()
-            .unwrap_or_else(Uuid::new_v4);
+        let uuid = self.get_uuid().unwrap_or_else(Uuid::new_v4);
         Entry {
             valid: EntrySealed {
                 uuid,
@@ -1895,6 +1887,11 @@ impl<VALID, STATE> Entry<VALID, STATE> {
     #[inline(always)]
     pub fn get_ava_as_iutf8_iter(&self, attr: &str) -> Option<impl Iterator<Item = &str>> {
         self.attrs.get(attr).and_then(|vs| vs.as_iutf8_iter())
+    }
+
+    #[inline(always)]
+    pub fn get_ava_as_iutf8(&self, attr: &str) -> Option<&BTreeSet<String>> {
+        self.attrs.get(attr).and_then(|vs| vs.as_iutf8_set())
     }
 
     #[inline(always)]

--- a/kanidmd/lib/src/plugins/cred_import.rs
+++ b/kanidmd/lib/src/plugins/cred_import.rs
@@ -93,7 +93,8 @@ impl CredImport {
                 }
             };
 
-            // TOTP IMPORT
+            // TOTP IMPORT - Must be subsequent to password import to allow primary cred to
+            // be created.
             if let Some(vs) = e.pop_ava("totp_import") {
                 // Get the map.
                 let totps = vs.as_totp_map().ok_or_else(|| {

--- a/kanidmd/lib/src/plugins/cred_import.rs
+++ b/kanidmd/lib/src/plugins/cred_import.rs
@@ -75,7 +75,6 @@ impl CredImport {
                 // does the entry have a primary cred?
                 match e.get_ava_single_credential("primary_credential") {
                     Some(c) => {
-                        // This is the major diff to create, we can update in place!
                         let c = c.update_password(pw);
                         e.set_ava(
                             "primary_credential",

--- a/kanidmd/lib/src/plugins/protected.rs
+++ b/kanidmd/lib/src/plugins/protected.rs
@@ -57,7 +57,6 @@ impl Plugin for Protected {
                 || cand.attribute_equality("class", &PVCLASS_TOMBSTONE)
                 || cand.attribute_equality("class", &PVCLASS_RECYCLED)
                 || cand.attribute_equality("class", &PVCLASS_DYNGROUP)
-            // || cand.attribute_equality("class", &PVCLASS_SYNC_OBJECT)
             {
                 Err(OperationError::SystemProtectedObject)
             } else {
@@ -247,7 +246,6 @@ impl Plugin for Protected {
                 || cand.attribute_equality("class", &PVCLASS_TOMBSTONE)
                 || cand.attribute_equality("class", &PVCLASS_RECYCLED)
                 || cand.attribute_equality("class", &PVCLASS_DYNGROUP)
-                || cand.attribute_equality("class", &PVCLASS_SYNC_OBJECT)
             {
                 Err(OperationError::SystemProtectedObject)
             } else {

--- a/kanidmd/lib/src/plugins/protected.rs
+++ b/kanidmd/lib/src/plugins/protected.rs
@@ -57,7 +57,7 @@ impl Plugin for Protected {
                 || cand.attribute_equality("class", &PVCLASS_TOMBSTONE)
                 || cand.attribute_equality("class", &PVCLASS_RECYCLED)
                 || cand.attribute_equality("class", &PVCLASS_DYNGROUP)
-                || cand.attribute_equality("class", &PVCLASS_SYNC_OBJECT)
+            // || cand.attribute_equality("class", &PVCLASS_SYNC_OBJECT)
             {
                 Err(OperationError::SystemProtectedObject)
             } else {

--- a/kanidmd/lib/src/plugins/protected.rs
+++ b/kanidmd/lib/src/plugins/protected.rs
@@ -102,8 +102,6 @@ impl Plugin for Protected {
             if cand.attribute_equality("class", &PVCLASS_TOMBSTONE)
                 || cand.attribute_equality("class", &PVCLASS_RECYCLED)
                 || cand.attribute_equality("class", &PVCLASS_DYNGROUP)
-                // Temporary until I move this into access.rs
-                || cand.attribute_equality("class", &PVCLASS_SYNC_OBJECT)
             {
                 Err(OperationError::SystemProtectedObject)
             } else {
@@ -182,8 +180,6 @@ impl Plugin for Protected {
             if cand.attribute_equality("class", &PVCLASS_TOMBSTONE)
                 || cand.attribute_equality("class", &PVCLASS_RECYCLED)
                 || cand.attribute_equality("class", &PVCLASS_DYNGROUP)
-                // Temporary until I move this into access.rs
-                || cand.attribute_equality("class", &PVCLASS_SYNC_OBJECT)
             {
                 Err(OperationError::SystemProtectedObject)
             } else {

--- a/kanidmd/lib/src/server/access/mod.rs
+++ b/kanidmd/lib/src/server/access/mod.rs
@@ -233,7 +233,7 @@ pub trait AccessControlsTransaction<'a> {
             .collect();
 
         if allowed_entries.is_empty() {
-            security_access!("denied ❌");
+            security_access!("denied ❌ - no entries were released");
         } else {
             security_access!("allowed {} entries ✅", allowed_entries.len());
         }
@@ -488,7 +488,7 @@ pub trait AccessControlsTransaction<'a> {
         if r {
             security_access!("allowed ✅");
         } else {
-            security_access!("denied ❌");
+            security_access!("denied ❌ - modifications may not proceed");
         }
         Ok(r)
     }
@@ -621,7 +621,7 @@ pub trait AccessControlsTransaction<'a> {
         if r {
             security_access!("allowed ✅");
         } else {
-            security_access!("denied ❌");
+            security_access!("denied ❌ - modifications may not proceed");
         }
         Ok(r)
     }
@@ -674,7 +674,7 @@ pub trait AccessControlsTransaction<'a> {
         if r {
             security_access!("allowed ✅");
         } else {
-            security_access!("denied ❌");
+            security_access!("denied ❌ - create may not proceed");
         }
 
         Ok(r)
@@ -737,7 +737,7 @@ pub trait AccessControlsTransaction<'a> {
         if r {
             security_access!("allowed ✅");
         } else {
-            security_access!("denied ❌");
+            security_access!("denied ❌ - delete may not proceed");
         }
         Ok(r)
     }

--- a/kanidmd/lib/src/server/access/profiles.rs
+++ b/kanidmd/lib/src/server/access/profiles.rs
@@ -56,10 +56,7 @@ impl AccessControlSearch {
                 receiver: Some(receiver),
                 targetscope,
             },
-            attrs: attrs
-                .split_whitespace()
-                .map(AttrString::from)
-                .collect(),
+            attrs: attrs.split_whitespace().map(AttrString::from).collect(),
         }
     }
 }
@@ -222,18 +219,9 @@ impl AccessControlModify {
                 receiver: Some(receiver),
                 targetscope,
             },
-            classes: classes
-                .split_whitespace()
-                .map(AttrString::from)
-                .collect(),
-            presattrs: presattrs
-                .split_whitespace()
-                .map(AttrString::from)
-                .collect(),
-            remattrs: remattrs
-                .split_whitespace()
-                .map(AttrString::from)
-                .collect(),
+            classes: classes.split_whitespace().map(AttrString::from).collect(),
+            presattrs: presattrs.split_whitespace().map(AttrString::from).collect(),
+            remattrs: remattrs.split_whitespace().map(AttrString::from).collect(),
         }
     }
 }

--- a/kanidmd/lib/src/server/mod.rs
+++ b/kanidmd/lib/src/server/mod.rs
@@ -1585,10 +1585,7 @@ mod tests {
         assert!(r3 == Ok(Value::Refer(uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930"))));
 
         // test attr reference already resolved.
-        let r4 = server_txn.clone_value(
-            "member",
-            "cc8e95b4-c24f-4d68-ba54-8bed76f63930",
-        );
+        let r4 = server_txn.clone_value("member", "cc8e95b4-c24f-4d68-ba54-8bed76f63930");
 
         debug!("{:?}", r4);
         assert!(r4 == Ok(Value::Refer(uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930"))));

--- a/kanidmd/lib/src/server/recycle.rs
+++ b/kanidmd/lib/src/server/recycle.rs
@@ -811,13 +811,11 @@ mod tests {
             )
         };
         assert!(server_txn.revive_recycled(&rev3).is_ok());
-        assert!(
-            !check_entry_has_mo(
-                &mut server_txn,
-                "u3",
-                "36048117-e479-45ed-aeb5-611e8d83d5b1"
-            )
-        );
+        assert!(!check_entry_has_mo(
+            &mut server_txn,
+            "u3",
+            "36048117-e479-45ed-aeb5-611e8d83d5b1"
+        ));
 
         // Revive u4, should NOT have the MO.
         let rev4a = unsafe {
@@ -827,13 +825,11 @@ mod tests {
             )
         };
         assert!(server_txn.revive_recycled(&rev4a).is_ok());
-        assert!(
-            !check_entry_has_mo(
-                &mut server_txn,
-                "u4",
-                "d5c59ac6-c533-4b00-989f-d0e183f07bab"
-            )
-        );
+        assert!(!check_entry_has_mo(
+            &mut server_txn,
+            "u4",
+            "d5c59ac6-c533-4b00-989f-d0e183f07bab"
+        ));
 
         // Now revive g4, should allow MO onto u4.
         let rev4b = unsafe {
@@ -843,13 +839,11 @@ mod tests {
             )
         };
         assert!(server_txn.revive_recycled(&rev4b).is_ok());
-        assert!(
-            !check_entry_has_mo(
-                &mut server_txn,
-                "u4",
-                "d5c59ac6-c533-4b00-989f-d0e183f07bab"
-            )
-        );
+        assert!(!check_entry_has_mo(
+            &mut server_txn,
+            "u4",
+            "d5c59ac6-c533-4b00-989f-d0e183f07bab"
+        ));
 
         assert!(server_txn.commit().is_ok());
     }

--- a/kanidmd/testkit/tests/default_entries.rs
+++ b/kanidmd/testkit/tests/default_entries.rs
@@ -219,12 +219,7 @@ async fn login_account_via_admin(rsclient: &KanidmClient, id: &str) {
     login_account(rsclient, id).await
 }
 
-async fn test_read_attrs(
-    rsclient: &KanidmClient,
-    id: &str,
-    attrs: &[&str],
-    is_readable: bool,
-) {
+async fn test_read_attrs(rsclient: &KanidmClient, id: &str, attrs: &[&str], is_readable: bool) {
     println!("Test read to {}, is readable: {}", id, is_readable);
     let rset = rsclient
         .search(Filter::Eq("name".to_string(), id.to_string()))
@@ -246,12 +241,7 @@ async fn test_read_attrs(
     }
 }
 
-async fn test_write_attrs(
-    rsclient: &KanidmClient,
-    id: &str,
-    attrs: &[&str],
-    is_writeable: bool,
-) {
+async fn test_write_attrs(rsclient: &KanidmClient, id: &str, attrs: &[&str], is_writeable: bool) {
     println!("Test write to {}, is writeable: {}", id, is_writeable);
     for attr in attrs.iter() {
         println!("Writing to {}", attr);
@@ -260,11 +250,7 @@ async fn test_write_attrs(
     }
 }
 
-async fn test_modify_group(
-    rsclient: &KanidmClient,
-    group_names: &[&str],
-    is_modificable: bool,
-) {
+async fn test_modify_group(rsclient: &KanidmClient, group_names: &[&str], is_modificable: bool) {
     // need user test created to be added as test part
     for group in group_names.iter() {
         println!("Testing group: {}", group);


### PR DESCRIPTION
This cleans up some of the user experience for sync users, and starts to move some of the protected code into access. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
