### PR TITLE
Update release docs to prevent forgetting a release step

### DIFF
--- a/project_docs/RELEASE_CHECKLIST.md
+++ b/project_docs/RELEASE_CHECKLIST.md
@@ -47,6 +47,9 @@ cargo install cargo-outdated
 - [ ] git push origin 1.1.0-alpha.x
 - [ ] git push origin 1.1.0-alpha.x --tags
 
+- [ ] github -> create new release based on tag (not branch)
+      - use tag because then tools will get the tag + patches we apply.
+
 ### Cargo publish
 
 - [ ] publish `kanidm_proto`


### PR DESCRIPTION
Forgot a step in the release process.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
