### PR TITLE
1355 docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,12 @@
 .git
 .github
 .gitignore
+.mypy_cache
 .vscode
 *.md
+**/__pycache__/**
+docs
+kanidmd/sampledata
 Makefile
 target
-docs
 test.db
-kanidmd/sampledata

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,6 @@ install-tools: ## install kanidm_tools in your local environment
 install-tools:
 	cd kanidm_tools && cargo install --path . --force
 
-.PHONY: prep
-prep:
-	cargo outdated -R
-	cargo audit
-
 .PHONY: codespell
 codespell:
 	codespell -c \
@@ -215,6 +210,11 @@ docs/pykanidm/serve:
 
 ########################################################################
 
+.PHONY: release/prep
+prep:
+	cargo outdated -R
+	cargo audit
+
 .PHONY: release/kanidm
 release/kanidm: ## Build the Kanidm CLI - ensure you include the environment variable KANIDM_BUILD_PROFILE
 	cargo build -p kanidm_tools --bin kanidm --release
@@ -240,7 +240,6 @@ release/kanidm-unixd:
 		--bin kanidm_unixd_tasks \
 		--bin kanidm_cache_clear \
 		--bin kanidm_cache_invalidate
-
 
 # cert things
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ buildx/kanidmd/x86_64_v3:
 		--build-arg "KANIDM_BUILD_PROFILE=container_x86_64_v3" \
 		--build-arg "KANIDM_FEATURES=" \
 		$(CONTAINER_BUILD_ARGS) .
-	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/server:$(IMAGE_VERSION)
 
 .PHONY: buildx/kanidmd
 buildx/kanidmd: ## Build multiarch kanidm server images and push to docker hub
@@ -36,7 +35,6 @@ buildx/kanidmd:
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
 		$(CONTAINER_BUILD_ARGS) .
-	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/server:$(IMAGE_VERSION)
 
 .PHONY: buildx/kanidm_tools
 buildx/kanidm_tools: ## Build multiarch kanidm tool images and push to docker hub
@@ -49,7 +47,6 @@ buildx/kanidm_tools:
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
 		$(CONTAINER_BUILD_ARGS) .
-	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/tools:$(IMAGE_VERSION)
 
 .PHONY: buildx/radiusd
 buildx/radiusd: ## Build multi-arch radius docker images and push to docker hub
@@ -57,10 +54,8 @@ buildx/radiusd:
 	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) \
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidm_rlm_python/Dockerfile \
+		--progress $(BUILDKIT_PROGRESS) \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) .
-		--progress $(BUILDKIT_PROGRESS) \
-		--progress $(BUILDKIT_PROGRESS) \
-	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/radius:$(IMAGE_VERSION)
 
 .PHONY: buildx
 buildx: buildx/kanidmd/x86_64_v3 buildx/kanidmd buildx/kanidm_tools buildx/radiusd

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ IMAGE_ARCH ?= "linux/amd64,linux/arm64"
 CONTAINER_BUILD_ARGS ?=
 MARKDOWN_FORMAT_ARGS ?= --options-line-width=100
 CONTAINER_TOOL ?= docker
+BUILDKIT_PROGRESS ?= plain
 
 BOOK_VERSION ?= master
 
@@ -18,6 +19,7 @@ buildx/kanidmd/x86_64_v3: ## build multiarch server images
 buildx/kanidmd/x86_64_v3: vendor
 	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) --pull --push --platform "linux/amd64/v3" \
 		-f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:x86_64_$(IMAGE_VERSION) \
+		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_x86_64_v3" \
 		--build-arg "KANIDM_FEATURES=" \
 		$(CONTAINER_BUILD_ARGS) .
@@ -30,6 +32,7 @@ buildx/kanidmd: vendor
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidmd/Dockerfile \
 		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION) \
+		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
 		$(CONTAINER_BUILD_ARGS) .
@@ -42,6 +45,7 @@ buildx/kanidm_tools: vendor
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidm_tools/Dockerfile \
 		-t $(IMAGE_BASE)/tools:$(IMAGE_VERSION) \
+		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
 		$(CONTAINER_BUILD_ARGS) .
@@ -54,6 +58,7 @@ buildx/radiusd:
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidm_rlm_python/Dockerfile \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) .
+		--progress $(BUILDKIT_PROGRESS) \
 	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/radius:$(IMAGE_VERSION)
 
 .PHONY: buildx

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 
 .PHONY: buildx/kanidmd/x86_64_v3
 buildx/kanidmd/x86_64_v3: ## build multiarch server images
-buildx/kanidmd/x86_64_v3: vendor
+buildx/kanidmd/x86_64_v3:
 	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) --pull --push --platform "linux/amd64/v3" \
 		-f kanidmd/Dockerfile -t $(IMAGE_BASE)/server:x86_64_$(IMAGE_VERSION) \
 		--progress $(BUILDKIT_PROGRESS) \
@@ -27,7 +27,7 @@ buildx/kanidmd/x86_64_v3: vendor
 
 .PHONY: buildx/kanidmd
 buildx/kanidmd: ## Build multiarch kanidm server images and push to docker hub
-buildx/kanidmd: vendor
+buildx/kanidmd:
 	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) \
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidmd/Dockerfile \
@@ -40,7 +40,7 @@ buildx/kanidmd: vendor
 
 .PHONY: buildx/kanidm_tools
 buildx/kanidm_tools: ## Build multiarch kanidm tool images and push to docker hub
-buildx/kanidm_tools: vendor
+buildx/kanidm_tools:
 	@$(CONTAINER_TOOL) buildx build $(CONTAINER_TOOL_ARGS) \
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidm_tools/Dockerfile \
@@ -58,6 +58,7 @@ buildx/radiusd:
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f kanidm_rlm_python/Dockerfile \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) .
+		--progress $(BUILDKIT_PROGRESS) \
 		--progress $(BUILDKIT_PROGRESS) \
 	@$(CONTAINER_TOOL) buildx imagetools $(CONTAINER_TOOL_ARGS) inspect $(IMAGE_BASE)/radius:$(IMAGE_VERSION)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,13 +16,13 @@ report it to our [issue tracker].
 
 ## 2023-02-01 - Kanidm 1.1.0-alpha11
 
-This is the eleventh alpha series release of the Kanidm Identity Management project. Alpha releases are
-to help get feedback and ideas from the community on how we can continue to make this project better
-for a future supported release.
+This is the eleventh alpha series release of the Kanidm Identity Management project. Alpha releases
+are to help get feedback and ideas from the community on how we can continue to make this project
+better for a future supported release.
 
-The project is shaping up very nicely, and a beta will be coming soon! The main reason we haven't done
-so yet is we haven't decided if we want to commit to the current API layout and freeze it yet. There
-are still things we want to change there. Otherwise the server is stable and reliable.
+The project is shaping up very nicely, and a beta will be coming soon! The main reason we haven't
+done so yet is we haven't decided if we want to commit to the current API layout and freeze it yet.
+There are still things we want to change there. Otherwise the server is stable and reliable.
 
 ### Release Highlights
 

--- a/kanidm_rlm_python/Dockerfile
+++ b/kanidm_rlm_python/Dockerfile
@@ -1,4 +1,14 @@
-FROM opensuse/tumbleweed:latest
+ARG BASE_IMAGE=opensuse/tumbleweed:latest
+FROM ${BASE_IMAGE} AS repos
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper mr -k repo-oss && \
+    zypper mr -k repo-non-oss && \
+    zypper mr -k repo-update && \
+    zypper dup -y
+
+# ======================
+FROM repos
 
 EXPOSE 1812 1813
 
@@ -28,29 +38,30 @@ COPY kanidm_rlm_python/sites-available/ /etc/raddb/sites-available/
 WORKDIR /etc/raddb
 
 # Enable the python and cache module.
-RUN ln -s /etc/raddb/mods-available/python3 /etc/raddb/mods-enabled/python3
-RUN ln -s /etc/raddb/sites-available/check-eap-tls /etc/raddb/sites-enabled/check-eap-tls
+RUN ln -s /etc/raddb/mods-available/python3 /etc/raddb/mods-enabled/python3 && \
+    ln -s /etc/raddb/sites-available/check-eap-tls /etc/raddb/sites-enabled/check-eap-tls
 
 # disable auth via methods we don't support!
-RUN rm /etc/raddb/mods-available/sql
-RUN rm /etc/raddb/mods-enabled/{passwd,totp}
+RUN rm /etc/raddb/mods-available/sql && \
+    rm /etc/raddb/mods-enabled/{passwd,totp}
 
 # Allows the radiusd user to write to the directory
-RUN chown -R radiusd: /etc/raddb
-RUN chmod 775 /etc/raddb/certs
-RUN chmod 640 /etc/raddb/clients.conf
+RUN chown -R radiusd: /etc/raddb && \
+    chmod 775 /etc/raddb/certs && \
+    chmod 640 /etc/raddb/clients.conf
 
 RUN mkdir -p /pkg/pykanidm/
 COPY pykanidm/ /pkg/pykanidm/
 
 # install the package and its dependencies
-RUN python3 -m pip install --no-cache-dir --no-warn-script-location /pkg/pykanidm
-# clean up after install
-RUN rm -rf /pkg/*
+RUN python3 -m pip install --no-cache-dir --no-warn-script-location /pkg/pykanidm && \
+    rm -rf /pkg/*
 
-USER radiusd
+COPY kanidm_rlm_python/radius_entrypoint.py /radius_entrypoint.py
+
 ENV LD_PRELOAD=/usr/lib64/libpython3.so
 ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
-COPY kanidm_rlm_python/radius_entrypoint.py /radius_entrypoint.py
+USER radiusd
+
 CMD [ "/usr/bin/python3", "/radius_entrypoint.py" ]

--- a/kanidm_rlm_python/Dockerfile
+++ b/kanidm_rlm_python/Dockerfile
@@ -3,7 +3,6 @@ FROM ${BASE_IMAGE} AS repos
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper mr -k repo-oss && \
-    zypper mr -k repo-non-oss && \
     zypper mr -k repo-update && \
     zypper dup -y
 

--- a/kanidm_rlm_python/Dockerfile
+++ b/kanidm_rlm_python/Dockerfile
@@ -2,9 +2,9 @@ ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper mr -k repo-oss && \
-    zypper mr -k repo-non-oss && \
-    zypper mr -k repo-update && \
+    zypper mr -k repo-oss; \
+    zypper mr -k repo-non-oss; \
+    zypper mr -k repo-update; \
     zypper dup -y
 
 # ======================

--- a/kanidm_rlm_python/Dockerfile
+++ b/kanidm_rlm_python/Dockerfile
@@ -2,9 +2,9 @@ ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper mr -k repo-oss; \
-    zypper mr -k repo-non-oss; \
-    zypper mr -k repo-update; \
+    zypper mr -k repo-oss && \
+    zypper mr -k repo-non-oss && \
+    zypper mr -k repo-update && \
     zypper dup -y
 
 # ======================

--- a/kanidm_rlm_python/Dockerfile
+++ b/kanidm_rlm_python/Dockerfile
@@ -4,7 +4,8 @@ EXPOSE 1812 1813
 
 # These all need to be on one line else the rpm cache ends
 # up in the layers.
-RUN zypper refresh --force && \
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
     freeradius-client \
     freeradius-server \
@@ -18,8 +19,7 @@ RUN zypper refresh --force && \
     iproute2 \
     iputils \
     openssl \
-    curl && \
-    zypper clean
+    curl
 
 ADD kanidm_rlm_python/mods-available/ /etc/raddb/mods-available/
 COPY kanidm_rlm_python/sites-available/ /etc/raddb/sites-available/

--- a/kanidm_tools/Dockerfile
+++ b/kanidm_tools/Dockerfile
@@ -1,8 +1,9 @@
 # This builds the kanidm CLI tools
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
-RUN zypper refresh --force
-RUN zypper dup -y
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper dup -y
 
 FROM repos AS builder
 ARG KANIDM_FEATURES
@@ -12,8 +13,10 @@ ARG KANIDM_BUILD_OPTIONS=""
 RUN echo Profile $KANIDM_BUILD_PROFILE
 RUN echo Features $KANIDM_FEATURES
 
-RUN zypper install -y --no-recommends \
-        rustup wasm-pack \
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper install -y --no-recommends \
+        cargo \
         clang \
         make automake autoconf \
         libopenssl-3-devel \
@@ -22,9 +25,6 @@ RUN zypper install -y --no-recommends \
         sqlite3-devel \
         rsync \
         mold
-
-RUN zypper clean -a
-RUN rustup default stable
 
 COPY . /usr/src/kanidm
 
@@ -38,7 +38,8 @@ ENV KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE:-container_generic}
 ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 
 # build the CLI
-RUN if [ -z "${KANIDM_FEATURES}" ]; then \
+RUN export CC="/usr/bin/clang"; \
+if [ -z "${KANIDM_FEATURES}" ]; then \
   cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
     --target-dir="/usr/src/kanidm/target/" \
     --release; \
@@ -61,8 +62,9 @@ RUN ls -al /usr/src/kanidm/target/release
 # == Construct the tools container
 FROM repos
 
-RUN zypper install -y timezone busybox-adduser openssl-3 && \
-    zypper clean -a
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper install -y timezone busybox-adduser openssl-3
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/

--- a/kanidm_tools/Dockerfile
+++ b/kanidm_tools/Dockerfile
@@ -33,14 +33,13 @@ RUN \
 
 COPY . /usr/src/kanidm
 
-RUN mkdir -p /usr/src/kanidm/.cargo
-RUN cp /usr/src/kanidm/cargo_vendor_config /usr/src/kanidm/.cargo/config.toml
-
 WORKDIR /usr/src/kanidm/
 
 # build the CLI
 RUN \
+--mount=type=cache,id=cargo,target=/cargo \
 --mount=type=cache,id=sccache,target=/sccache \
+export CARGO_HOME=/cargo; \
 export SCCACHE_DIR=/sccache; \
 export RUSTC_WRAPPER=/usr/bin/sccache; \
 export CC="/usr/bin/clang"; \

--- a/kanidm_tools/Dockerfile
+++ b/kanidm_tools/Dockerfile
@@ -3,6 +3,9 @@ ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper mr -k repo-oss && \
+    zypper mr -k repo-non-oss && \
+    zypper mr -k repo-update && \
     zypper dup -y
 
 FROM repos AS builder
@@ -10,12 +13,14 @@ ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE
 ARG KANIDM_BUILD_OPTIONS=""
 
-RUN echo Profile $KANIDM_BUILD_PROFILE
-RUN echo Features $KANIDM_FEATURES
+# Set the build profile
+ENV KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE:-container_generic}
+ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
+        sccache \
         cargo \
         clang \
         make automake autoconf \
@@ -33,34 +38,26 @@ RUN cp /usr/src/kanidm/cargo_vendor_config /usr/src/kanidm/.cargo/config.toml
 
 WORKDIR /usr/src/kanidm/
 
-# Set the build profile
-ENV KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE:-container_generic}
-ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
-
 # build the CLI
-RUN export CC="/usr/bin/clang"; \
-if [ -z "${KANIDM_FEATURES}" ]; then \
-  cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --release; \
-  cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --release; \
-else \
-  cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release; \
-  cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release; \
-fi
-
-RUN ls -al /usr/src/kanidm/target/release
+RUN \
+--mount=type=cache,id=sccache,target=/sccache \
+export SCCACHE_DIR=/sccache; \
+export RUSTC_WRAPPER=/usr/bin/sccache; \
+export CC="/usr/bin/clang"; \
+    cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release; \
+    cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release; \
+    sccache -s
 
 # == Construct the tools container
 FROM repos
+
+ENV RUST_BACKTRACE 1
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
@@ -70,10 +67,9 @@ COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/
 RUN chmod +x /sbin/kanidm
 RUN chmod +x /sbin/kanidm-ipa-sync
-ENV RUST_BACKTRACE 1
 
-RUN adduser -D -H kanidm
-RUN mkdir /etc/kanidm && \
+RUN adduser -D -H kanidm && \
+    mkdir /etc/kanidm && \
     touch /etc/kanidm/config
 
 USER kanidm

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -34,9 +34,6 @@ RUN \
 
 COPY . /usr/src/kanidm
 
-RUN mkdir -p /usr/src/kanidm/.cargo
-RUN cp /usr/src/kanidm/cargo_vendor_config /usr/src/kanidm/.cargo/config.toml
-
 # ======================
 
 # WORKDIR /usr/src/kanidm/kanidmd_web_ui
@@ -50,12 +47,13 @@ WORKDIR /usr/src/kanidm/kanidmd/daemon
 
 # Exports don't persist through RUN statements.
 RUN \
+--mount=type=cache,id=cargo,target=/cargo \
 --mount=type=cache,id=sccache,target=/sccache \
+export CARGO_HOME=/cargo; \
 export SCCACHE_DIR=/sccache; \
 export RUSTC_WRAPPER=/usr/bin/sccache; \
 export CC="/usr/bin/clang"; \
     cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
-        --locked --offline \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release; \

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -1,8 +1,9 @@
 # Build the main Kanidmd server
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
-RUN zypper refresh --force
-RUN zypper dup -y
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper dup -y
 
 # ======================
 FROM repos AS builder
@@ -13,8 +14,10 @@ ARG KANIDM_BUILD_OPTIONS=""
 RUN echo Profile $KANIDM_BUILD_PROFILE
 RUN echo Features $KANIDM_FEATURES
 
-RUN zypper install -y --no-recommends \
-        rustup \
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper install -y --no-recommends \
+        cargo \
         clang \
         make automake autoconf \
         libopenssl-3-devel pam-devel \
@@ -23,11 +26,6 @@ RUN zypper install -y --no-recommends \
         findutils \
         which \
         mold
-# wasm-pack \
-# lld
-
-RUN zypper clean -a
-RUN rustup default stable
 
 COPY . /usr/src/kanidm
 
@@ -70,12 +68,13 @@ RUN ls -al /usr/src/kanidm/target/release
 
 FROM repos
 
-RUN zypper install -y \
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper install -y \
         timezone \
         openssl-3 \
         sqlite3 \
         pam
-RUN zypper clean -a
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidmd /sbin/
 COPY --from=builder /usr/src/kanidm/kanidmd_web_ui/pkg /pkg

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -3,6 +3,9 @@ ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper mr -k repo-oss && \
+    zypper mr -k repo-non-oss && \
+    zypper mr -k repo-update && \
     zypper dup -y
 
 # ======================
@@ -11,12 +14,14 @@ ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE="container_generic"
 ARG KANIDM_BUILD_OPTIONS=""
 
-RUN echo Profile $KANIDM_BUILD_PROFILE
-RUN echo Features $KANIDM_FEATURES
+# Set the build profile
+ENV KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE:-container_generic}
+ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
+        sccache \
         cargo \
         clang \
         make automake autoconf \
@@ -43,26 +48,18 @@ RUN cp /usr/src/kanidm/cargo_vendor_config /usr/src/kanidm/.cargo/config.toml
 
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
-# Set the build profile
-ENV KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE:-container_generic}
-ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
-
 # Exports don't persist through RUN statements.
-RUN export CC="/usr/bin/clang"; \
-if [ -z "${KANIDM_FEATURES}" ]; then \
-  cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
-    --locked --offline \
-    --target-dir="/usr/src/kanidm/target/" \
-    --release; \
-else \
-  cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
-    --locked --offline \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release; \
-fi
-
-RUN ls -al /usr/src/kanidm/target/release
+RUN \
+--mount=type=cache,id=sccache,target=/sccache \
+export SCCACHE_DIR=/sccache; \
+export RUSTC_WRAPPER=/usr/bin/sccache; \
+export CC="/usr/bin/clang"; \
+    cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
+        --locked --offline \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release; \
+    sccache -s
 
 # ======================
 

--- a/kanidmd/lib/src/be/mod.rs
+++ b/kanidmd/lib/src/be/mod.rs
@@ -1714,9 +1714,9 @@ impl Backend {
         idxkeys: Vec<IdxKey>,
         vacuum: bool,
     ) -> Result<Self, OperationError> {
-        debug!("DB tickets -> {:?}", cfg.pool_size);
-        debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
-        debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+        info!("DB tickets -> {:?}", cfg.pool_size);
+        info!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
+        info!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
         // If in memory, reduce pool to 1
         if cfg.path.is_empty() {

--- a/profiles/container_generic.toml
+++ b/profiles/container_generic.toml
@@ -1,3 +1,3 @@
 web_ui_pkg_path = "/pkg"
-# Valid options are none, native, x86_64_v1, x86_64_v3
-cpu_flags = "none"
+# Don't set the cpu_flags to autodetect for this platform
+# cpu_flags = "none"

--- a/profiles/container_x86_64_v3.toml
+++ b/profiles/container_x86_64_v3.toml
@@ -1,3 +1,3 @@
 web_ui_pkg_path = "/pkg"
-# Valid options are none, native, x86_64, x86_64_v3
+# Define this to override the arch.
 cpu_flags = "x86_64_v3"

--- a/profiles/developer.toml
+++ b/profiles/developer.toml
@@ -1,3 +1,3 @@
 web_ui_pkg_path = "../../kanidmd_web_ui/pkg"
-# Valid options are none, native, x86_64, x86_64_v3
+# Set to native for developer machines.
 cpu_flags = "native"

--- a/profiles/release_suse_generic.toml
+++ b/profiles/release_suse_generic.toml
@@ -1,2 +1,3 @@
 web_ui_pkg_path = "/usr/share/kanidm/ui/pkg"
-cpu_flags = "none"
+# Don't set the value for autodetect
+# cpu_flags = "none"

--- a/profiles/release_suse_x86_64.toml
+++ b/profiles/release_suse_x86_64.toml
@@ -1,2 +1,0 @@
-web_ui_pkg_path = "/usr/share/kanidm/ui/pkg"
-cpu_flags = "x86_64_v1"

--- a/project_docs/RELEASE_CHECKLIST.md
+++ b/project_docs/RELEASE_CHECKLIST.md
@@ -47,8 +47,8 @@ cargo install cargo-outdated
 - [ ] git push origin 1.1.0-alpha.x
 - [ ] git push origin 1.1.0-alpha.x --tags
 
-- [ ] github -> create new release based on tag (not branch)
-      - use tag because then tools will get the tag + patches we apply.
+- [ ] github -> create new release based on tag (not branch) - use tag because then tools will get
+      the tag + patches we apply.
 
 ### Cargo publish
 


### PR DESCRIPTION
Fixes #1355 - This improves docker builds with a cache for metadata and packages, and removes steps that aren't needed. There is a bug in zypper which when resolved will improve things again. 

Oh and this cleans up profiles with cpu arches and arch features  :) 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
