### PR TITLE
Start to add reauth capabilities

### DIFF
--- a/kanidm_book/src/developers/designs/elevated_priv_mode.md
+++ b/kanidm_book/src/developers/designs/elevated_priv_mode.md
@@ -18,15 +18,15 @@ For us to implement this will require some changes to how we manage sessions.
 - CHANGE: service-accounts require a hard/short session expiry limit and always have elevated permissions
 - CHANGE: persons require no session expiry and must request elevation for privs.
 
-- ISSUE: Sessions currently are recorded identically between service-accounts, persons, and api tokens
-- CHANGE: Change the session storage types to have unique session types for these
-
-- ISSUE: Sessions currently indicate both read-write types as the same access scope type.
+- ISSUE: Sessions currently indicate all read-write types as the same access scope type.
 - CHANGE: Split sessions to show rwalways, rwcapable, rwactive
+
+- ISSUE: Sessions currently are recorded identically between service-accounts, persons, and api tokens
+- CHANGE: Change the session storage types to have unique session types for these ✅
 
 - ISSUE: Access Scope types are confused by api session using the same types.
 - CHANGE: Use access scope only as the end result of current effective permission calculation and
-  not as a method to convert to anything else.
+  not as a method to convert to anything else. ✅
 
 
     AccessScope {
@@ -77,12 +77,13 @@ For us to implement this will require some changes to how we manage sessions.
 
 - CHANGE: Session with PrivCapable indicates that re-auth can be performed.
 - CHANGE: Improve how Uat/Api Token scopes become Access Scopes
-- CHANGE: Remove all AccessScope into other types.
+- CHANGE: Remove all AccessScope into other types. ✅
 
 ## Session Re-Authentication
 
 - Must be performed by the same credential that issued the session originally
   - This is now stored in the session metadata itself.
+  - Does it need to be in the cred-id?
 
 - CHANGE: Store the cred id in UAT so that a replica can process the operation in a replication sync failure?
   - This would rely on re-writing the session.
@@ -133,8 +134,8 @@ For us to implement this will require some changes to how we manage sessions.
 
 ## TODO:
 
-1. Remove the ident-only access scope, it's useless!
-1. Split tokens to have a dedicated session type seperate to uat sessions.
+1. Remove the ident-only access scope, it's useless! ✅
+1. Split tokens to have a dedicated session type separate to uat sessions. ✅
 1. Change uat session access scope recording to match service-account vs person intent.
 1. Change UAT session issuance to have the uat purpose reflect the readwrite or readwrite-capable nature of the session, based on *auth-type* that was used.
 1. Based on auth-type, limit or unlimit expiry to match the intent of the session.

--- a/kanidm_book/src/developers/designs/elevated_priv_mode.md
+++ b/kanidm_book/src/developers/designs/elevated_priv_mode.md
@@ -1,0 +1,142 @@
+# Elevation of Privilege Inside User Sessions
+
+To improve user experience, we need to allow long lived sessions in browsers. This is especially
+important as a single sign on system, users tend to be associated 1 to 1 with devices, and by
+having longer lived sessions, they have a smoother experience.
+
+However, we also don't want user sessions to have unbound write permissions for the entire (possibly
+unlimited) duration of their session.
+
+Prior art for this is github, which has unbounded sessions on machines and requests a
+re-authentication when a modifying or sensitive action is to occur.
+
+For us to implement this will require some changes to how we manage sessions.
+
+## Session Issuance
+
+- ISSUE: Sessions are issued identically for service-accounts and persons
+- CHANGE: service-accounts require a hard/short session expiry limit and always have elevated permissions
+- CHANGE: persons require no session expiry and must request elevation for privs.
+
+- ISSUE: Sessions currently are recorded identically between service-accounts, persons, and api tokens
+- CHANGE: Change the session storage types to have unique session types for these
+
+- ISSUE: Sessions currently indicate both read-write types as the same access scope type.
+- CHANGE: Split sessions to show rwalways, rwcapable, rwactive
+
+- ISSUE: Access Scope types are confused by api session using the same types.
+- CHANGE: Use access scope only as the end result of current effective permission calculation and
+  not as a method to convert to anything else.
+
+
+    AccessScope {
+        ReadOnly,
+        ReadWrite,
+        Synchronise
+    }
+
+    // Bound by token expiry
+    ApiTokenScope {
+        ReadOnly,
+        ReadWrite,
+        Synchronise
+    }
+
+    UatTokenScope {
+        ReadOnly,
+        // Want to avoid "read write" here to prevent dev confusion.
+        PrivilegeCapable,
+        PrivilegeActive { expiry },
+        ReadWrite,
+    }
+
+    SessionScope {
+        Ro,
+        RwAlways,
+        PrivCapable,
+    }
+
+    ApiTokenScope {
+        RO
+        RW
+        Sync
+    }
+
+
+    AuthSession
+      if service account
+        rw always, bound expiry
+
+      if person
+        priv cap, unbound exp
+           - Should we have a "trust the machine flag" to limit exp though?
+           - can we do other types of cryptographic session binding?
+
+
+## Session Validation
+
+- CHANGE: Session with PrivCapable indicates that re-auth can be performed.
+- CHANGE: Improve how Uat/Api Token scopes become Access Scopes
+- CHANGE: Remove all AccessScope into other types.
+
+## Session Re-Authentication
+
+- Must be performed by the same credential that issued the session originally
+  - This is now stored in the session metadata itself.
+
+- CHANGE: Store the cred id in UAT so that a replica can process the operation in a replication sync failure?
+  - This would rely on re-writing the session.
+- CHANGE: Should we record in the session when priv-escalations are performed?
+
+## Misc
+
+- CHANGE: Compact/shrink UAT size if possible.
+
+## Diagram
+
+
+                                                                                                        Set                                               
+                                                                             ┌───────────────────────PrivActive────────────────────┐                      
+                                                                             │                         + Exp                       │                      
+                                                                             │                                                     │                      
+                                  ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐        │                      .───────────.         ┌────────────────┐              
+                                                                             │   ┌────────────────▶( If Priv Cap )───────▶│Re-Auth-Allowed │              
+                                  │                                 │        │   │                  `───────────'         └────────────────┘              
+                                       DB Content                    ┌ ─ ─ ─ ┼ ─ ┼ ─ ─ ─ ─ ─ ─ ─ ─                                                        
+    ┌───────────────────┐         │                                 │    JWT │   │                │                                                       
+    │                   │                                            │       ▼   │                                                                        
+    │    AuthSession    │         │         ┌──────────────┐        │    ┌──────────────┐         │                                                       
+    │                   │                   │SessionScope  │         │   │UatScope      │                                                                 
+    │  Service Account  │         │         │- RO          │        │    │- RO          │         │                                                       
+    │     -> RWAlways   │──────────────────▶│- RW          │─────────┼──▶│- RW          │──────────────────────────┐                                      
+    │                   │         │         │- PrivCapable │        │    │- PrivCapable │         │                │                                      
+    │      Person       │                   └──────────────┘         │   │- PrivActive  │                          │                                      
+    │     -> PrivCap    │         │                                 │    └──────────────┘         │                │                                      
+    │                   │                                            │                                             │                                      
+    └───────────────────┘         │                                 │                             │                ▼                                      
+                                                                     │                                     ┌──────────────┐                               
+                                  │                                 │                             │        │AccessScope   │              ┌───────────────┐
+                                                                     │                                     │- RO          │              │               │
+                                  │                                 │                             │        │- RW          │───────────▶  │Access Controls│
+                                                                     │                                     │- Sync        │              │               │
+     ┌───────────────────┐        │       ┌─────────────────┐       │     ┌──────────────┐        │        └──────────────┘              └───────────────┘
+     │                   │                │ApiSessionScope  │        │    │ApiTokenScope │                         ▲                                      
+     │ Create API Token  │        │       │- RO             │       │     │- RO          │        │                │                                      
+     │                   │───────────────▶│- RW             │────────┼───▶│- RW          │─────────────────────────┘                                      
+     │Access Based On Req│        │       │- Sync           │       │     │- Sync        │        │                                                       
+     │                   │                └─────────────────┘        │    │              │                                                                
+     └───────────────────┘        │                                 │     └──────────────┘        │                                                       
+                                                                     │                                                                                    
+                                  │                                 │                             │                                                       
+                                   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─                                                        
+
+
+## TODO:
+
+1. Remove the ident-only access scope, it's useless!
+1. Split tokens to have a dedicated session type seperate to uat sessions.
+1. Change uat session access scope recording to match service-account vs person intent.
+1. Change UAT session issuance to have the uat purpose reflect the readwrite or readwrite-capable nature of the session, based on *auth-type* that was used.
+1. Based on auth-type, limit or unlimit expiry to match the intent of the session.
+
+

--- a/kanidm_book/src/developers/designs/elevated_priv_mode.md
+++ b/kanidm_book/src/developers/designs/elevated_priv_mode.md
@@ -1,8 +1,8 @@
 # Elevation of Privilege Inside User Sessions
 
 To improve user experience, we need to allow long lived sessions in browsers. This is especially
-important as a single sign on system, users tend to be associated 1 to 1 with devices, and by
-having longer lived sessions, they have a smoother experience.
+important as a single sign on system, users tend to be associated 1 to 1 with devices, and by having
+longer lived sessions, they have a smoother experience.
 
 However, we also don't want user sessions to have unbound write permissions for the entire (possibly
 unlimited) duration of their session.
@@ -15,63 +15,38 @@ For us to implement this will require some changes to how we manage sessions.
 ## Session Issuance
 
 - ISSUE: Sessions are issued identically for service-accounts and persons
-- CHANGE: service-accounts require a hard/short session expiry limit and always have elevated permissions
+- CHANGE: service-accounts require a hard/short session expiry limit and always have elevated
+  permissions
 - CHANGE: persons require no session expiry and must request elevation for privs.
 
 - ISSUE: Sessions currently indicate all read-write types as the same access scope type.
 - CHANGE: Split sessions to show rwalways, rwcapable, rwactive
 
-- ISSUE: Sessions currently are recorded identically between service-accounts, persons, and api tokens
+- ISSUE: Sessions currently are recorded identically between service-accounts, persons, and api
+  tokens
 - CHANGE: Change the session storage types to have unique session types for these ✅
 
 - ISSUE: Access Scope types are confused by api session using the same types.
 - CHANGE: Use access scope only as the end result of current effective permission calculation and
   not as a method to convert to anything else. ✅
 
+  AccessScope { ReadOnly, ReadWrite, Synchronise }
 
-    AccessScope {
-        ReadOnly,
-        ReadWrite,
-        Synchronise
-    }
+  // Bound by token expiry ApiTokenScope { ReadOnly, ReadWrite, Synchronise }
 
-    // Bound by token expiry
-    ApiTokenScope {
-        ReadOnly,
-        ReadWrite,
-        Synchronise
-    }
+  UatTokenScope { ReadOnly, // Want to avoid "read write" here to prevent dev confusion.
+  PrivilegeCapable, PrivilegeActive { expiry }, ReadWrite, }
 
-    UatTokenScope {
-        ReadOnly,
-        // Want to avoid "read write" here to prevent dev confusion.
-        PrivilegeCapable,
-        PrivilegeActive { expiry },
-        ReadWrite,
-    }
+  SessionScope { Ro, RwAlways, PrivCapable, }
 
-    SessionScope {
-        Ro,
-        RwAlways,
-        PrivCapable,
-    }
+  ApiTokenScope { RO RW Sync }
 
-    ApiTokenScope {
-        RO
-        RW
-        Sync
-    }
-
-
-    AuthSession
-      if service account
-        rw always, bound expiry
+  AuthSession if service account rw always, bound expiry
 
       if person
         priv cap, unbound exp
            - Should we have a "trust the machine flag" to limit exp though?
            - can we do other types of cryptographic session binding?
-
 
 ## Session Validation
 
@@ -85,7 +60,8 @@ For us to implement this will require some changes to how we manage sessions.
   - This is now stored in the session metadata itself.
   - Does it need to be in the cred-id?
 
-- CHANGE: Store the cred id in UAT so that a replica can process the operation in a replication sync failure?
+- CHANGE: Store the cred id in UAT so that a replica can process the operation in a replication sync
+  failure?
   - This would rely on re-writing the session.
 - CHANGE: Should we record in the session when priv-escalations are performed?
 
@@ -94,7 +70,6 @@ For us to implement this will require some changes to how we manage sessions.
 - CHANGE: Compact/shrink UAT size if possible.
 
 ## Diagram
-
 
                                                                                                         Set                                               
                                                                              ┌───────────────────────PrivActive────────────────────┐                      
@@ -129,15 +104,13 @@ For us to implement this will require some changes to how we manage sessions.
      └───────────────────┘        │                                 │     └──────────────┘        │                                                       
                                                                      │                                                                                    
                                   │                                 │                             │                                                       
-                                   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─                                                        
-
+                                   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
 
 ## TODO:
 
 1. Remove the ident-only access scope, it's useless! ✅
 1. Split tokens to have a dedicated session type separate to uat sessions. ✅
 1. Change uat session access scope recording to match service-account vs person intent.
-1. Change UAT session issuance to have the uat purpose reflect the readwrite or readwrite-capable nature of the session, based on *auth-type* that was used.
+1. Change UAT session issuance to have the uat purpose reflect the readwrite or readwrite-capable
+   nature of the session, based on _auth-type_ that was used.
 1. Based on auth-type, limit or unlimit expiry to match the intent of the session.
-
-

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -360,6 +360,7 @@ impl FromStr for UiHint {
 pub enum UatPurposeStatus {
     ReadOnly,
     ReadWrite,
+    PrivilegeCapable,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -387,6 +388,7 @@ impl fmt::Display for UatStatus {
         match &self.purpose {
             UatPurposeStatus::ReadOnly => writeln!(f, "purpose: read only")?,
             UatPurposeStatus::ReadWrite => writeln!(f, "purpose: read write")?,
+            UatPurposeStatus::PrivilegeCapable => writeln!(f, "purpose: privilege capable")?,
         }
         Ok(())
     }

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -358,7 +358,6 @@ impl FromStr for UiHint {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum UatPurposeStatus {
-    IdentityOnly,
     ReadOnly,
     ReadWrite,
 }
@@ -386,7 +385,6 @@ impl fmt::Display for UatStatus {
         }
         writeln!(f, "issued_at: {}", self.issued_at)?;
         match &self.purpose {
-            UatPurposeStatus::IdentityOnly => writeln!(f, "purpose: identity only")?,
             UatPurposeStatus::ReadOnly => writeln!(f, "purpose: read only")?,
             UatPurposeStatus::ReadWrite => writeln!(f, "purpose: read write")?,
         }
@@ -397,7 +395,6 @@ impl fmt::Display for UatStatus {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum UatPurpose {
-    IdentityOnly,
     ReadOnly,
     ReadWrite {
         /// If none, there is no expiry, and this is always rw. If there is
@@ -446,7 +443,6 @@ impl fmt::Display for UserAuthToken {
             writeln!(f, "expiry: -")?;
         }
         match &self.purpose {
-            UatPurpose::IdentityOnly => writeln!(f, "purpose: identity only")?,
             UatPurpose::ReadOnly => writeln!(f, "purpose: read only")?,
             UatPurpose::ReadWrite {
                 expiry: Some(expiry),

--- a/kanidmd/lib/src/be/dbvalue.rs
+++ b/kanidmd/lib/src/be/dbvalue.rs
@@ -663,6 +663,7 @@ impl DbValueSetV2 {
             DbValueSetV2::DeviceKey(set) => set.len(),
             DbValueSetV2::TrustedDeviceEnrollment(set) => set.len(),
             DbValueSetV2::Session(set) => set.len(),
+            DbValueSetV2::ApiToken(set) => set.len(),
             DbValueSetV2::Oauth2Session(set) => set.len(),
             DbValueSetV2::JwsKeyEs256(set) => set.len(),
             DbValueSetV2::JwsKeyRs256(set) => set.len(),

--- a/kanidmd/lib/src/be/dbvalue.rs
+++ b/kanidmd/lib/src/be/dbvalue.rs
@@ -391,6 +391,8 @@ pub enum DbValueAccessScopeV1 {
     ReadOnly,
     #[serde(rename = "w")]
     ReadWrite,
+    #[serde(rename = "p")]
+    PrivilegeCapable,
     #[serde(rename = "s")]
     Synchronise,
 }
@@ -436,6 +438,35 @@ pub enum DbValueSession {
         cred_id: Uuid,
         #[serde(rename = "s", default)]
         scope: DbValueAccessScopeV1,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub enum DbValueApiTokenScopeV1 {
+    #[serde(rename = "r")]
+    #[default]
+    ReadOnly,
+    #[serde(rename = "w")]
+    ReadWrite,
+    #[serde(rename = "s")]
+    Synchronise,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DbValueApiToken {
+    V1 {
+        #[serde(rename = "u")]
+        refer: Uuid,
+        #[serde(rename = "l")]
+        label: String,
+        #[serde(rename = "e")]
+        expiry: Option<String>,
+        #[serde(rename = "i")]
+        issued_at: String,
+        #[serde(rename = "b")]
+        issued_by: DbValueIdentityId,
+        #[serde(rename = "s", default)]
+        scope: DbValueApiTokenScopeV1,
     },
 }
 
@@ -594,6 +625,8 @@ pub enum DbValueSetV2 {
     UiHint(Vec<u16>),
     #[serde(rename = "TO")]
     TotpSecret(Vec<(String, DbTotpV1)>),
+    #[serde(rename = "AT")]
+    ApiToken(Vec<DbValueApiToken>),
 }
 
 impl DbValueSetV2 {

--- a/kanidmd/lib/src/constants/entries.rs
+++ b/kanidmd/lib/src/constants/entries.rs
@@ -565,7 +565,7 @@ pub const JSON_SYSTEM_INFO_V1: &str = r#"{
         "class": ["object", "system_info", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
         "description": ["System (local) info and metadata object."],
-        "version": ["11"]
+        "version": ["12"]
     }
 }"#;
 

--- a/kanidmd/lib/src/constants/schema.rs
+++ b/kanidmd/lib/src/constants/schema.rs
@@ -1233,7 +1233,7 @@ pub const JSON_SCHEMA_ATTR_API_TOKEN_SESSION: &str = r#"{
         "api_token_session"
       ],
       "syntax": [
-        "SESSION"
+        "APITOKEN"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000111"
@@ -1326,7 +1326,7 @@ pub const JSON_SCHEMA_ATTR_SYNC_TOKEN_SESSION: &str = r#"{
         "sync_token_session"
       ],
       "syntax": [
-        "SESSION"
+        "APITOKEN"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000115"

--- a/kanidmd/lib/src/entry.rs
+++ b/kanidmd/lib/src/entry.rs
@@ -58,7 +58,7 @@ use crate::repl::entry::EntryChangeState;
 
 use crate::schema::{SchemaAttribute, SchemaClass, SchemaTransaction};
 use crate::value::{
-    IndexType, IntentTokenState, Oauth2Session, PartialValue, Session, SyntaxType, Value,
+    IndexType, IntentTokenState, Oauth2Session, PartialValue, Session, SyntaxType, Value, ApiToken
 };
 use crate::valueset::{self, ValueSet};
 
@@ -1959,6 +1959,14 @@ impl<VALID, STATE> Entry<VALID, STATE> {
         attr: &str,
     ) -> Option<&std::collections::BTreeMap<Uuid, Session>> {
         self.attrs.get(attr).and_then(|vs| vs.as_session_map())
+    }
+
+    #[inline(always)]
+    pub fn get_ava_as_apitoken_map(
+        &self,
+        attr: &str,
+    ) -> Option<&std::collections::BTreeMap<Uuid, ApiToken>> {
+        self.attrs.get(attr).and_then(|vs| vs.as_apitoken_map())
     }
 
     #[inline(always)]

--- a/kanidmd/lib/src/entry.rs
+++ b/kanidmd/lib/src/entry.rs
@@ -58,7 +58,7 @@ use crate::repl::entry::EntryChangeState;
 
 use crate::schema::{SchemaAttribute, SchemaClass, SchemaTransaction};
 use crate::value::{
-    IndexType, IntentTokenState, Oauth2Session, PartialValue, Session, SyntaxType, Value, ApiToken
+    ApiToken, IndexType, IntentTokenState, Oauth2Session, PartialValue, Session, SyntaxType, Value,
 };
 use crate::valueset::{self, ValueSet};
 

--- a/kanidmd/lib/src/idm/account.rs
+++ b/kanidmd/lib/src/idm/account.rs
@@ -209,7 +209,9 @@ impl Account {
         // TODO: Apply policy to this expiry time.
         let expiry = expiry_secs
             .map(|offset| OffsetDateTime::unix_epoch() + ct + Duration::from_secs(offset));
+
         let issued_at = OffsetDateTime::unix_epoch() + ct;
+
         // TODO: Apply priv expiry, and what type of token this is (ident, ro, rw).
         let purpose = UatPurpose::ReadWrite { expiry };
 

--- a/kanidmd/lib/src/idm/authsession.rs
+++ b/kanidmd/lib/src/idm/authsession.rs
@@ -856,6 +856,10 @@ impl AuthSession {
                         let session_id = Uuid::new_v4();
                         let issue = self.issue;
 
+                        // We need to actually work this out better, and then
+                        // pass it to to_userauthtoken
+                        let scope = ();
+
                         security_info!(
                             "Issuing {:?} session {} for {} {}",
                             issue,
@@ -901,7 +905,7 @@ impl AuthSession {
                                     expiry: uat.expiry,
                                     issued_at: uat.issued_at,
                                     issued_by: IdentityId::User(self.account.uuid),
-                                    scope: (&uat.purpose).into(),
+                                    scope,
                                 }))
                                 .map_err(|_| {
                                     admin_error!("unable to queue failing authentication as the session will not validate ... ");

--- a/kanidmd/lib/src/idm/authsession.rs
+++ b/kanidmd/lib/src/idm/authsession.rs
@@ -858,7 +858,7 @@ impl AuthSession {
 
                         // We need to actually work this out better, and then
                         // pass it to to_userauthtoken
-                        let scope = ();
+                        let scope = SessionScope::ReadWrite;
 
                         security_info!(
                             "Issuing {:?} session {} for {} {}",

--- a/kanidmd/lib/src/idm/credupdatesession.rs
+++ b/kanidmd/lib/src/idm/credupdatesession.rs
@@ -148,7 +148,7 @@ impl CredentialUpdateSession {
     }
 }
 
-enum MfaRegStateStatus {
+pub enum MfaRegStateStatus {
     // Nothing in progress.
     None,
     TotpCheck(TotpSecret),
@@ -183,6 +183,16 @@ pub struct CredentialUpdateSessionStatus {
     passkeys: Vec<PasskeyDetail>,
     // Any info the client needs about mfareg state.
     mfaregstate: MfaRegStateStatus,
+}
+
+impl CredentialUpdateSessionStatus {
+    pub fn can_commit(&self) -> bool {
+        self.can_commit
+    }
+
+    pub fn mfaregstate(&self) -> &MfaRegStateStatus {
+        &self.mfaregstate
+    }
 }
 
 // We allow Into here because CUStatus is foreign so it's impossible for us to implement From
@@ -2017,7 +2027,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
         let (cust, _) = setup_test_session(idms, ct).await;
 
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction_async().await;
         // The session exists
         let c_status = cutxn.credential_update_status(&cust, ct);
         assert!(c_status.is_ok());

--- a/kanidmd/lib/src/idm/delayed.rs
+++ b/kanidmd/lib/src/idm/delayed.rs
@@ -70,7 +70,7 @@ pub struct AuthSessionRecord {
     pub expiry: Option<OffsetDateTime>,
     pub issued_at: OffsetDateTime,
     pub issued_by: IdentityId,
-    pub scope: AccessScope,
+    pub scope: SessionScope,
 }
 
 #[derive(Debug)]

--- a/kanidmd/lib/src/idm/mod.rs
+++ b/kanidmd/lib/src/idm/mod.rs
@@ -13,6 +13,7 @@ pub mod group;
 pub mod ldap;
 pub mod oauth2;
 pub mod radius;
+pub mod reauth;
 pub mod scim;
 pub mod server;
 pub mod serviceaccount;

--- a/kanidmd/lib/src/idm/reauth.rs
+++ b/kanidmd/lib/src/idm/reauth.rs
@@ -1,0 +1,233 @@
+use crate::prelude::*;
+
+use crate::idm::event::AuthResult;
+use crate::idm::server::IdmServerAuthTransaction;
+
+#[derive(Debug)]
+pub struct ReauthEvent {
+    // pub ident: Option<Identity>,
+    // pub step: AuthEventStep,
+    // pub sessionid: Option<Uuid>,
+}
+
+impl<'a> IdmServerAuthTransaction<'a> {
+    pub async fn reauth(
+        &mut self,
+        _ae: &ReauthEvent,
+        _ct: Duration,
+    ) -> Result<AuthResult, OperationError> {
+        todo!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::idm::credupdatesession::{InitCredentialUpdateEvent, MfaRegStateStatus};
+    use crate::idm::delayed::DelayedAction;
+    use crate::idm::event::{AuthEvent, AuthResult};
+    use crate::idm::server::IdmServerTransaction;
+    use crate::idm::AuthState;
+    use crate::prelude::*;
+
+    use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech};
+
+    use uuid::uuid;
+
+    use webauthn_authenticator_rs::softpasskey::SoftPasskey;
+    use webauthn_authenticator_rs::WebauthnAuthenticator;
+
+    const TESTPERSON_UUID: Uuid = uuid!("cf231fea-1a8f-4410-a520-fd9b1a379c86");
+
+    async fn setup_testaccount(idms: &IdmServer, ct: Duration) {
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+
+        let e2 = entry_init!(
+            ("class", Value::new_class("object")),
+            ("class", Value::new_class("account")),
+            ("class", Value::new_class("person")),
+            ("name", Value::new_iname("testperson")),
+            ("uuid", Value::Uuid(TESTPERSON_UUID)),
+            ("description", Value::new_utf8s("testperson")),
+            ("displayname", Value::new_utf8s("testperson"))
+        );
+
+        let cr = idms_prox_write.qs_write.internal_create(vec![e2]);
+        assert!(cr.is_ok());
+        assert!(idms_prox_write.commit().is_ok());
+    }
+
+    async fn setup_testaccount_passkey(
+        idms: &IdmServer,
+        ct: Duration,
+    ) -> WebauthnAuthenticator<SoftPasskey> {
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        let testperson = idms_prox_write
+            .qs_write
+            .internal_search_uuid(TESTPERSON_UUID)
+            .expect("failed");
+        let (cust, _c_status) = idms_prox_write
+            .init_credential_update(
+                &InitCredentialUpdateEvent::new_impersonate_entry(testperson),
+                ct,
+            )
+            .expect("Failed to begin credential update.");
+        idms_prox_write.commit().expect("Failed to commit txn");
+
+        // Update session is setup.
+
+        let cutxn = idms.cred_update_transaction();
+        let origin = cutxn.get_origin().clone();
+
+        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());
+
+        let c_status = cutxn
+            .credential_passkey_init(&cust, ct)
+            .expect("Failed to initiate passkey registration");
+
+        let passkey_chal = match c_status.mfaregstate() {
+            MfaRegStateStatus::Passkey(c) => Some(c),
+            _ => None,
+        }
+        .expect("Unable to access passkey challenge, invalid state");
+
+        let passkey_resp = wa
+            .do_registration(origin.clone(), passkey_chal.clone())
+            .expect("Failed to create soft passkey");
+
+        // Finish the registration
+        let label = "softtoken".to_string();
+        let c_status = cutxn
+            .credential_passkey_finish(&cust, ct, label, &passkey_resp)
+            .expect("Failed to initiate passkey registration");
+
+        assert!(c_status.can_commit());
+
+        drop(cutxn);
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+
+        idms_prox_write
+            .commit_credential_update(&cust, ct)
+            .expect("Failed to commit credential update.");
+
+        idms_prox_write.commit().expect("Failed to commit txn");
+
+        wa
+    }
+
+    async fn auth_passkey(
+        idms: &IdmServer,
+        ct: Duration,
+        wa: &mut WebauthnAuthenticator<SoftPasskey>,
+        idms_delayed: &mut IdmServerDelayed,
+    ) -> Option<String> {
+        let mut idms_auth = idms.auth();
+        let origin = idms_auth.get_origin().clone();
+
+        let auth_init = AuthEvent::named_init("testperson");
+
+        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let ar = r1.unwrap();
+        let AuthResult {
+            sessionid,
+            state,
+            delay: _,
+        } = ar;
+
+        if !matches!(state, AuthState::Choose(_)) {
+            debug!("Can't proceed - {:?}", state);
+            return None;
+        };
+
+        let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Passkey);
+
+        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let ar = r2.unwrap();
+        let AuthResult {
+            sessionid,
+            state,
+            delay: _,
+        } = ar;
+
+        trace!(?state);
+
+        let rcr = match state {
+            AuthState::Continue(mut allowed) => match allowed.pop() {
+                Some(AuthAllowed::Passkey(rcr)) => rcr,
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
+        };
+
+        trace!(?rcr);
+
+        let resp = wa
+            .do_authentication(origin, rcr)
+            .expect("failed to use softtoken to authenticate");
+
+        let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
+
+        let r3 = idms_auth.auth(&passkey_step, ct).await;
+        debug!("r3 ==> {:?}", r3);
+        idms_auth.commit().expect("Must not fail");
+
+        match r3 {
+            Ok(AuthResult {
+                sessionid: _,
+                state: AuthState::Success(token, AuthIssueSession::Token),
+                delay: _,
+            }) => {
+                // Process the webauthn update
+                let da = idms_delayed.try_recv().expect("invalid");
+                assert!(matches!(da, DelayedAction::WebauthnCounterIncrement(_)));
+                let r = idms.delayed_action(ct, da).await;
+                assert!(r.is_ok());
+
+                // Process the auth session
+                let da = idms_delayed.try_recv().expect("invalid");
+                assert!(matches!(da, DelayedAction::AuthSessionRecord(_)));
+                // We have to actually write this one else the following tests
+                // won't work!
+                let r = idms.delayed_action(ct, da).await;
+                assert!(r.is_ok());
+
+                Some(token)
+            }
+            _ => None,
+        }
+    }
+
+    async fn token_to_ident(idms: &IdmServer, ct: Duration, token: Option<&str>) -> Identity {
+        let mut idms_prox_read = idms.proxy_read().await;
+
+        idms_prox_read
+            .validate_and_parse_token_to_ident(token, ct)
+            .expect("Invalid UAT")
+    }
+
+    #[idm_test]
+    async fn test_idm_reauth_passkey(idms: &IdmServer, idms_delayed: &mut IdmServerDelayed) {
+        let ct = duration_from_epoch_now();
+
+        // Setup the test account
+        setup_testaccount(idms, ct).await;
+        let mut passkey = setup_testaccount_passkey(idms, ct).await;
+
+        // Do an initial auth.
+        let token = auth_passkey(idms, ct, &mut passkey, idms_delayed)
+            .await
+            .expect("failed to authenticate with passkey");
+
+        // Token_str to uat
+        let ident = token_to_ident(idms, ct, Some(token.as_str())).await;
+
+        // Check that the rw entitlement is not present, and that re-auth is allowed.
+        // assert!(matches!(ident.access_scope(), AccessScope::ReadOnly));
+        assert!(matches!(ident.access_scope(), AccessScope::ReadWrite));
+
+        // Assert the session is rw capable though.
+
+        // Do a re-auth
+
+        // They now have the entitlement.
+    }
+}

--- a/kanidmd/lib/src/idm/scim.rs
+++ b/kanidmd/lib/src/idm/scim.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::credential::totp::{Totp, TotpAlgo, TotpDigits};
 use crate::idm::server::{IdmServerProxyReadTransaction, IdmServerProxyWriteTransaction};
 use crate::prelude::*;
-use crate::value::Session;
+use crate::value::ApiToken;
 
 use crate::schema::{SchemaClass, SchemaTransaction};
 
@@ -21,7 +21,7 @@ use crate::schema::{SchemaClass, SchemaTransaction};
 pub(crate) struct SyncAccount {
     pub name: String,
     pub uuid: Uuid,
-    pub sync_tokens: BTreeMap<Uuid, Session>,
+    pub sync_tokens: BTreeMap<Uuid, ApiToken>,
     pub jws_key: JwsSigner,
 }
 
@@ -49,7 +49,7 @@ macro_rules! try_from_entry {
             ))?;
 
         let sync_tokens = $value
-            .get_ava_as_session_map("sync_token_session")
+            .get_ava_as_apitoken_map("sync_token_session")
             .cloned()
             .unwrap_or_default();
 
@@ -146,11 +146,12 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         let session_id = Uuid::new_v4();
         let issued_at = time::OffsetDateTime::unix_epoch() + ct;
 
-        let purpose = ApiTokenPurpose::Synchronise;
+        let scope = ApiTokenScope::Synchronise;
+        let purpose = scope.try_into()?;
 
-        let session = Value::Session(
+        let session = Value::ApiToken(
             session_id,
-            Session {
+            ApiToken {
                 label: gte.label.clone(),
                 expiry: None,
                 // Need the other inner bits?
@@ -158,11 +159,9 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
                 issued_at,
                 // Who actually created this?
                 issued_by: gte.ident.get_event_origin_id(),
-                // random id
-                cred_id: Uuid::new_v4(),
                 // What is the access scope of this session? This is
                 // for auditing purposes.
-                scope: (&purpose).into(),
+                scope
             },
         );
 
@@ -1550,7 +1549,7 @@ mod tests {
                 .expect("Missing attribute: jws_es256_private_key");
 
             let sync_tokens = sync_entry
-                .get_ava_as_session_map("sync_token_session")
+                .get_ava_as_apitoken_map("sync_token_session")
                 .cloned()
                 .unwrap_or_default();
 

--- a/kanidmd/lib/src/idm/scim.rs
+++ b/kanidmd/lib/src/idm/scim.rs
@@ -83,7 +83,7 @@ impl SyncAccount {
 
         // Get the sessions. There are no gracewindows on sync, we are much stricter.
         let session_present = entry
-            .get_ava_as_session_map("sync_token_session")
+            .get_ava_as_apitoken_map("sync_token_session")
             .map(|session_map| session_map.get(&sst.token_id).is_some())
             .unwrap_or(false);
 
@@ -161,7 +161,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
                 issued_by: gte.ident.get_event_origin_id(),
                 // What is the access scope of this session? This is
                 // for auditing purposes.
-                scope
+                scope,
             },
         );
 

--- a/kanidmd/lib/src/idm/scim.rs
+++ b/kanidmd/lib/src/idm/scim.rs
@@ -544,7 +544,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         };
 
         match sse.ident.access_scope() {
-            AccessScope::IdentityOnly | AccessScope::ReadOnly | AccessScope::ReadWrite => {
+            AccessScope::ReadOnly | AccessScope::ReadWrite => {
                 warn!("Ident access scope is not synchronise");
                 return Err(OperationError::AccessDenied);
             }
@@ -1347,7 +1347,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         };
 
         match ident.access_scope() {
-            AccessScope::IdentityOnly | AccessScope::ReadOnly | AccessScope::ReadWrite => {
+            AccessScope::ReadOnly | AccessScope::ReadWrite => {
                 warn!("Ident access scope is not synchronise");
                 return Err(OperationError::AccessDenied);
             }

--- a/kanidmd/lib/src/idm/server.rs
+++ b/kanidmd/lib/src/idm/server.rs
@@ -3696,7 +3696,7 @@ mod tests {
                     expiry: Some(OffsetDateTime::unix_epoch() + expiry_a),
                     issued_at: OffsetDateTime::unix_epoch() + ct,
                     issued_by: IdentityId::User(UUID_ADMIN),
-                    scope: AccessScope::ReadOnly,
+                    scope: SessionScope::ReadOnly,
                 });
                 // Persist it.
                 let r = task::block_on(idms.delayed_action(ct, da));
@@ -3731,7 +3731,7 @@ mod tests {
                     expiry: Some(OffsetDateTime::unix_epoch() + expiry_b),
                     issued_at: OffsetDateTime::unix_epoch() + ct,
                     issued_by: IdentityId::User(UUID_ADMIN),
-                    scope: AccessScope::ReadOnly,
+                    scope: SessionScope::ReadOnly,
                 });
                 // Persist it.
                 let r = task::block_on(idms.delayed_action(expiry_a, da));

--- a/kanidmd/lib/src/idm/server.rs
+++ b/kanidmd/lib/src/idm/server.rs
@@ -670,7 +670,6 @@ pub trait IdmServerTransaction<'a> {
         // ✅  Session is valid! Start to setup for it to be used.
 
         let scope = match uat.purpose {
-            UatPurpose::IdentityOnly => AccessScope::IdentityOnly,
             UatPurpose::ReadOnly => AccessScope::ReadOnly,
             UatPurpose::ReadWrite { expiry: None } => AccessScope::ReadWrite,
             UatPurpose::ReadWrite {
@@ -3697,7 +3696,7 @@ mod tests {
                     expiry: Some(OffsetDateTime::unix_epoch() + expiry_a),
                     issued_at: OffsetDateTime::unix_epoch() + ct,
                     issued_by: IdentityId::User(UUID_ADMIN),
-                    scope: AccessScope::IdentityOnly,
+                    scope: AccessScope::ReadOnly,
                 });
                 // Persist it.
                 let r = task::block_on(idms.delayed_action(ct, da));
@@ -3732,7 +3731,7 @@ mod tests {
                     expiry: Some(OffsetDateTime::unix_epoch() + expiry_b),
                     issued_at: OffsetDateTime::unix_epoch() + ct,
                     issued_by: IdentityId::User(UUID_ADMIN),
-                    scope: AccessScope::IdentityOnly,
+                    scope: AccessScope::ReadOnly,
                 });
                 // Persist it.
                 let r = task::block_on(idms.delayed_action(expiry_a, da));

--- a/kanidmd/lib/src/idm/server.rs
+++ b/kanidmd/lib/src/idm/server.rs
@@ -898,6 +898,11 @@ impl<'a> IdmServerAuthTransaction<'a> {
         session_read.contains_key(&sessionid)
     }
 
+    pub fn get_origin(&self) -> &Url {
+        #[allow(clippy::unwrap_used)]
+        self.webauthn.get_allowed_origins().get(0).unwrap()
+    }
+
     #[instrument(level = "trace", skip(self))]
     pub async fn expire_auth_sessions(&mut self, ct: Duration) {
         // ct is current time - sub the timeout. and then split.

--- a/kanidmd/lib/src/lib.rs
+++ b/kanidmd/lib/src/lib.rs
@@ -89,7 +89,9 @@ pub mod prelude {
         QueryServerWriteTransaction,
     };
     pub use crate::utils::duration_from_epoch_now;
-    pub use crate::value::{IndexType, PartialValue, SyntaxType, Value, SessionScope, ApiTokenScope};
+    pub use crate::value::{
+        ApiTokenScope, IndexType, PartialValue, SessionScope, SyntaxType, Value,
+    };
     pub use crate::valueset::{
         ValueSet, ValueSetBool, ValueSetCid, ValueSetIndex, ValueSetIutf8, ValueSetRefer,
         ValueSetSecret, ValueSetSpn, ValueSetSyntax, ValueSetT, ValueSetUint32, ValueSetUtf8,

--- a/kanidmd/lib/src/lib.rs
+++ b/kanidmd/lib/src/lib.rs
@@ -89,7 +89,7 @@ pub mod prelude {
         QueryServerWriteTransaction,
     };
     pub use crate::utils::duration_from_epoch_now;
-    pub use crate::value::{IndexType, PartialValue, SyntaxType, Value};
+    pub use crate::value::{IndexType, PartialValue, SyntaxType, Value, SessionScope, ApiTokenScope};
     pub use crate::valueset::{
         ValueSet, ValueSetBool, ValueSetCid, ValueSetIndex, ValueSetIutf8, ValueSetRefer,
         ValueSetSecret, ValueSetSpn, ValueSetSyntax, ValueSetT, ValueSetUint32, ValueSetUtf8,

--- a/kanidmd/lib/src/plugins/refint.rs
+++ b/kanidmd/lib/src/plugins/refint.rs
@@ -834,7 +834,7 @@ mod tests {
         let pv_parent_id = PartialValue::Refer(parent);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::IdentityOnly;
+        let scope = AccessScope::ReadOnly;
 
         // Mod the user
         let modlist = modlist!([

--- a/kanidmd/lib/src/plugins/refint.rs
+++ b/kanidmd/lib/src/plugins/refint.rs
@@ -834,7 +834,7 @@ mod tests {
         let pv_parent_id = PartialValue::Refer(parent);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::ReadOnly;
+        let scope = SessionScope::ReadOnly;
 
         // Mod the user
         let modlist = modlist!([

--- a/kanidmd/lib/src/plugins/session.rs
+++ b/kanidmd/lib/src/plugins/session.rs
@@ -198,7 +198,7 @@ mod tests {
         let expiry = Some(exp_curtime_odt);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::IdentityOnly;
+        let scope = AccessScope::ReadOnly;
 
         let session = Value::Session(
             session_id,
@@ -316,7 +316,7 @@ mod tests {
         let expiry = Some(exp_curtime_odt);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::IdentityOnly;
+        let scope = AccessScope::ReadOnly;
 
         // Mod the user
         let modlist = modlist!([
@@ -453,7 +453,7 @@ mod tests {
         let pv_parent_id = PartialValue::Refer(parent);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::IdentityOnly;
+        let scope = AccessScope::ReadOnly;
 
         // Mod the user
         let modlist = modlist!([
@@ -666,7 +666,7 @@ mod tests {
         let expiry = None;
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::IdentityOnly;
+        let scope = AccessScope::ReadOnly;
 
         let session = Value::Session(
             session_id,

--- a/kanidmd/lib/src/plugins/session.rs
+++ b/kanidmd/lib/src/plugins/session.rs
@@ -198,7 +198,7 @@ mod tests {
         let expiry = Some(exp_curtime_odt);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::ReadOnly;
+        let scope = SessionScope::ReadOnly;
 
         let session = Value::Session(
             session_id,
@@ -316,7 +316,7 @@ mod tests {
         let expiry = Some(exp_curtime_odt);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::ReadOnly;
+        let scope = SessionScope::ReadOnly;
 
         // Mod the user
         let modlist = modlist!([
@@ -453,7 +453,7 @@ mod tests {
         let pv_parent_id = PartialValue::Refer(parent);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::ReadOnly;
+        let scope = SessionScope::ReadOnly;
 
         // Mod the user
         let modlist = modlist!([
@@ -666,7 +666,7 @@ mod tests {
         let expiry = None;
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
-        let scope = AccessScope::ReadOnly;
+        let scope = SessionScope::ReadOnly;
 
         let session = Value::Session(
             session_id,

--- a/kanidmd/lib/src/repl/proto.rs
+++ b/kanidmd/lib/src/repl/proto.rs
@@ -217,7 +217,6 @@ pub struct ReplOauth2SessionV1 {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
 pub enum ReplAccessScopeV1 {
-    IdentityOnly,
     #[default]
     ReadOnly,
     ReadWrite,

--- a/kanidmd/lib/src/repl/proto.rs
+++ b/kanidmd/lib/src/repl/proto.rs
@@ -216,7 +216,16 @@ pub struct ReplOauth2SessionV1 {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
-pub enum ReplAccessScopeV1 {
+pub enum ReplSessionScopeV1 {
+    #[default]
+    ReadOnly,
+    ReadWrite,
+    PrivilegeCapable,
+    Synchronise,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
+pub enum ReplApiTokenScopeV1 {
     #[default]
     ReadOnly,
     ReadWrite,
@@ -238,7 +247,17 @@ pub struct ReplSessionV1 {
     pub issued_at: String,
     pub issued_by: ReplIdentityIdV1,
     pub cred_id: Uuid,
-    pub scope: ReplAccessScopeV1,
+    pub scope: ReplSessionScopeV1,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ReplApiTokenV1 {
+    pub refer: Uuid,
+    pub label: String,
+    pub expiry: Option<String>,
+    pub issued_at: String,
+    pub issued_by: ReplIdentityIdV1,
+    pub scope: ReplApiTokenScopeV1,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -342,6 +361,9 @@ pub enum ReplAttrV1 {
     },
     Session {
         set: Vec<ReplSessionV1>,
+    },
+    ApiToken {
+        set: Vec<ReplApiTokenV1>,
     },
     TotpSecret {
         set: Vec<(String, ReplTotpV1)>,

--- a/kanidmd/lib/src/schema.rs
+++ b/kanidmd/lib/src/schema.rs
@@ -205,6 +205,7 @@ impl SchemaAttribute {
             SyntaxType::DeviceKey => matches!(v, PartialValue::DeviceKey(_)),
             // Allow refer types.
             SyntaxType::Session => matches!(v, PartialValue::Refer(_)),
+            SyntaxType::ApiToken => matches!(v, PartialValue::Refer(_)),
             SyntaxType::Oauth2Session => matches!(v, PartialValue::Refer(_)),
             // These are just insensitive string lookups on the hex-ified kid.
             SyntaxType::JwsKeyEs256 => matches!(v, PartialValue::Iutf8(_)),
@@ -255,6 +256,7 @@ impl SchemaAttribute {
                 SyntaxType::Passkey => matches!(v, Value::Passkey(_, _, _)),
                 SyntaxType::DeviceKey => matches!(v, Value::DeviceKey(_, _, _)),
                 SyntaxType::Session => matches!(v, Value::Session(_, _)),
+                SyntaxType::ApiToken => matches!(v, Value::ApiToken(_, _)),
                 SyntaxType::Oauth2Session => matches!(v, Value::Oauth2Session(_, _)),
                 SyntaxType::JwsKeyEs256 => matches!(v, Value::JwsKeyEs256(_)),
                 SyntaxType::JwsKeyRs256 => matches!(v, Value::JwsKeyRs256(_)),

--- a/kanidmd/lib/src/server/access/create.rs
+++ b/kanidmd/lib/src/server/access/create.rs
@@ -66,7 +66,7 @@ fn create_filter_entry<'a>(
     info!(event = %ident, "Access check for create event");
 
     match ident.access_scope() {
-        AccessScope::IdentityOnly | AccessScope::ReadOnly | AccessScope::Synchronise => {
+        AccessScope::ReadOnly | AccessScope::Synchronise => {
             security_access!("denied ❌ - identity access scope is not permitted to create");
             return IResult::Denied;
         }

--- a/kanidmd/lib/src/server/access/delete.rs
+++ b/kanidmd/lib/src/server/access/delete.rs
@@ -65,7 +65,7 @@ fn delete_filter_entry<'a>(
     info!(event = %ident, "Access check for delete event");
 
     match ident.access_scope() {
-        AccessScope::IdentityOnly | AccessScope::ReadOnly | AccessScope::Synchronise => {
+        AccessScope::ReadOnly | AccessScope::Synchronise => {
             security_access!("denied ❌ - identity access scope is not permitted to delete");
             return IResult::Denied;
         }

--- a/kanidmd/lib/src/server/access/mod.rs
+++ b/kanidmd/lib/src/server/access/mod.rs
@@ -1629,16 +1629,8 @@ mod tests {
         let ev1 = unsafe { E_TESTPERSON_1.clone().into_sealed_committed() };
 
         let ex_some = vec![Arc::new(ev1.clone())];
-        let ex_none = vec![];
 
         let r_set = vec![Arc::new(ev1)];
-
-        let se_io = unsafe {
-            SearchEvent::new_impersonate_identity(
-                Identity::from_impersonate_entry_identityonly(E_TEST_ACCOUNT_1.clone()),
-                filter_all!(f_pres("name")),
-            )
-        };
 
         let se_ro = unsafe {
             SearchEvent::new_impersonate_identity(
@@ -1669,8 +1661,6 @@ mod tests {
         };
 
         // Check the admin search event
-        test_acp_search!(&se_io, vec![acp.clone()], r_set.clone(), ex_none);
-
         test_acp_search!(&se_ro, vec![acp.clone()], r_set.clone(), ex_some);
 
         test_acp_search!(&se_rw, vec![acp], r_set, ex_some);
@@ -1687,14 +1677,6 @@ mod tests {
         let exv1 = unsafe { E_TESTPERSON_1_REDUCED.clone().into_sealed_committed() };
 
         let ex_anon_some = vec![exv1];
-        let ex_anon_none: Vec<EntrySealedCommitted> = vec![];
-
-        let se_anon_io = unsafe {
-            SearchEvent::new_impersonate_identity(
-                Identity::from_impersonate_entry_identityonly(E_TEST_ACCOUNT_1.clone()),
-                filter_all!(f_pres("name")),
-            )
-        };
 
         let se_anon_ro = unsafe {
             SearchEvent::new_impersonate_identity(
@@ -1718,8 +1700,6 @@ mod tests {
         };
 
         // Finally test it!
-        test_acp_search_reduce!(&se_anon_io, vec![acp.clone()], r_set.clone(), ex_anon_none);
-
         test_acp_search_reduce!(&se_anon_ro, vec![acp], r_set, ex_anon_some);
     }
 
@@ -1970,15 +1950,6 @@ mod tests {
         let r_set = vec![Arc::new(ev1)];
 
         // Name present
-        let me_pres_io = unsafe {
-            ModifyEvent::new_impersonate_identity(
-                Identity::from_impersonate_entry_identityonly(E_TEST_ACCOUNT_1.clone()),
-                filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
-                modlist!([m_pres("name", &Value::new_iname("value"))]),
-            )
-        };
-
-        // Name present
         let me_pres_ro = unsafe {
             ModifyEvent::new_impersonate_identity(
                 Identity::from_impersonate_entry_readonly(E_TEST_ACCOUNT_1.clone()),
@@ -2012,8 +1983,6 @@ mod tests {
                 "account",
             )
         };
-
-        test_acp_modify!(&me_pres_io, vec![acp_allow.clone()], &r_set, false);
 
         test_acp_modify!(&me_pres_ro, vec![acp_allow.clone()], &r_set, false);
 
@@ -2140,11 +2109,6 @@ mod tests {
 
         let admin = E_TEST_ACCOUNT_1.clone();
 
-        let ce_admin_io = CreateEvent::new_impersonate_identity(
-            Identity::from_impersonate_entry_identityonly(admin.clone()),
-            vec![],
-        );
-
         let ce_admin_ro = CreateEvent::new_impersonate_identity(
             Identity::from_impersonate_entry_readonly(admin.clone()),
             vec![],
@@ -2170,8 +2134,6 @@ mod tests {
                 "class name uuid",
             )
         };
-
-        test_acp_create!(&ce_admin_io, vec![acp.clone()], &r1_set, false);
 
         test_acp_create!(&ce_admin_ro, vec![acp.clone()], &r1_set, false);
 
@@ -2244,11 +2206,6 @@ mod tests {
 
         let admin = E_TEST_ACCOUNT_1.clone();
 
-        let de_admin_io = DeleteEvent::new_impersonate_identity(
-            Identity::from_impersonate_entry_identityonly(admin.clone()),
-            filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
-        );
-
         let de_admin_ro = DeleteEvent::new_impersonate_identity(
             Identity::from_impersonate_entry_readonly(admin.clone()),
             filter_all!(f_eq("name", PartialValue::new_iname("testperson1"))),
@@ -2269,8 +2226,6 @@ mod tests {
                 filter_valid!(f_eq("name", PartialValue::new_iname("testperson1"))),
             )
         };
-
-        test_acp_delete!(&de_admin_io, vec![acp.clone()], &r_set, false);
 
         test_acp_delete!(&de_admin_ro, vec![acp.clone()], &r_set, false);
 

--- a/kanidmd/lib/src/server/access/modify.rs
+++ b/kanidmd/lib/src/server/access/modify.rs
@@ -149,7 +149,7 @@ fn modify_ident_test<'a>(ident: &Identity) -> AccessResult<'a> {
     info!(event = %ident, "Access check for modify event");
 
     match ident.access_scope() {
-        AccessScope::IdentityOnly | AccessScope::ReadOnly | AccessScope::Synchronise => {
+        AccessScope::ReadOnly | AccessScope::Synchronise => {
             security_access!("denied ❌ - identity access scope is not permitted to modify");
             return AccessResult::Denied;
         }

--- a/kanidmd/lib/src/server/access/search.rs
+++ b/kanidmd/lib/src/server/access/search.rs
@@ -82,7 +82,7 @@ fn search_filter_entry<'a>(
     info!(event = %ident, "Access check for search (filter) event");
 
     match ident.access_scope() {
-        AccessScope::IdentityOnly | AccessScope::Synchronise => {
+        AccessScope::Synchronise => {
             security_access!("denied ❌ - identity access scope is not permitted to search");
             return AccessResult::Denied;
         }

--- a/kanidmd/lib/src/server/identity.rs
+++ b/kanidmd/lib/src/server/identity.rs
@@ -9,7 +9,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 use uuid::uuid;
 
-use kanidm_proto::v1::{ApiTokenPurpose, UatPurpose, UatPurposeStatus};
+use kanidm_proto::v1::{ApiTokenPurpose, UatPurpose};
 
 use serde::{Deserialize, Serialize};
 
@@ -42,35 +42,11 @@ impl From<&ApiTokenPurpose> for AccessScope {
     }
 }
 
-impl TryInto<ApiTokenPurpose> for AccessScope {
-    type Error = OperationError;
-
-    fn try_into(self: AccessScope) -> Result<ApiTokenPurpose, OperationError> {
-        match self {
-            AccessScope::ReadOnly => Ok(ApiTokenPurpose::ReadOnly),
-            AccessScope::ReadWrite => Ok(ApiTokenPurpose::ReadWrite),
-            AccessScope::Synchronise => Ok(ApiTokenPurpose::Synchronise),
-        }
-    }
-}
-
 impl From<&UatPurpose> for AccessScope {
     fn from(purpose: &UatPurpose) -> Self {
         match purpose {
             UatPurpose::ReadOnly => AccessScope::ReadOnly,
             UatPurpose::ReadWrite { .. } => AccessScope::ReadWrite,
-        }
-    }
-}
-
-impl TryInto<UatPurposeStatus> for AccessScope {
-    type Error = OperationError;
-
-    fn try_into(self: AccessScope) -> Result<UatPurposeStatus, OperationError> {
-        match self {
-            AccessScope::ReadOnly => Ok(UatPurposeStatus::ReadOnly),
-            AccessScope::ReadWrite => Ok(UatPurposeStatus::ReadWrite),
-            AccessScope::Synchronise => Err(OperationError::InvalidEntryState),
         }
     }
 }

--- a/kanidmd/lib/src/server/identity.rs
+++ b/kanidmd/lib/src/server/identity.rs
@@ -17,7 +17,6 @@ use crate::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessScope {
-    IdentityOnly,
     ReadOnly,
     ReadWrite,
     Synchronise,
@@ -26,7 +25,6 @@ pub enum AccessScope {
 impl std::fmt::Display for AccessScope {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            AccessScope::IdentityOnly => write!(f, "identity only"),
             AccessScope::ReadOnly => write!(f, "read only"),
             AccessScope::ReadWrite => write!(f, "read write"),
             AccessScope::Synchronise => write!(f, "synchronise"),
@@ -52,7 +50,6 @@ impl TryInto<ApiTokenPurpose> for AccessScope {
             AccessScope::ReadOnly => Ok(ApiTokenPurpose::ReadOnly),
             AccessScope::ReadWrite => Ok(ApiTokenPurpose::ReadWrite),
             AccessScope::Synchronise => Ok(ApiTokenPurpose::Synchronise),
-            AccessScope::IdentityOnly => Err(OperationError::InvalidEntryState),
         }
     }
 }
@@ -60,7 +57,6 @@ impl TryInto<ApiTokenPurpose> for AccessScope {
 impl From<&UatPurpose> for AccessScope {
     fn from(purpose: &UatPurpose) -> Self {
         match purpose {
-            UatPurpose::IdentityOnly => AccessScope::IdentityOnly,
             UatPurpose::ReadOnly => AccessScope::ReadOnly,
             UatPurpose::ReadWrite { .. } => AccessScope::ReadWrite,
         }
@@ -74,7 +70,6 @@ impl TryInto<UatPurposeStatus> for AccessScope {
         match self {
             AccessScope::ReadOnly => Ok(UatPurposeStatus::ReadOnly),
             AccessScope::ReadWrite => Ok(UatPurposeStatus::ReadWrite),
-            AccessScope::IdentityOnly => Ok(UatPurposeStatus::IdentityOnly),
             AccessScope::Synchronise => Err(OperationError::InvalidEntryState),
         }
     }
@@ -156,18 +151,6 @@ impl Identity {
             origin: IdentType::Internal,
             session_id: uuid!("00000000-0000-0000-0000-000000000000"),
             scope: AccessScope::ReadWrite,
-            limits: Limits::unlimited(),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn from_impersonate_entry_identityonly(
-        entry: Arc<Entry<EntrySealed, EntryCommitted>>,
-    ) -> Self {
-        Identity {
-            origin: IdentType::User(IdentUser { entry }),
-            session_id: uuid!("00000000-0000-0000-0000-000000000000"),
-            scope: AccessScope::IdentityOnly,
             limits: Limits::unlimited(),
         }
     }

--- a/kanidmd/lib/src/server/migrations.rs
+++ b/kanidmd/lib/src/server/migrations.rs
@@ -343,13 +343,13 @@ impl<'a> QueryServerWriteTransaction<'a> {
     #[instrument(level = "debug", skip_all)]
     pub fn migrate_11_to_12(&mut self) -> Result<(), OperationError> {
         admin_warn!("starting 11 to 12 migration.");
-            // sync_token_session
+        // sync_token_session
         let filter = filter!(f_or!([
             f_pres("api_token_session"),
             f_pres("sync_token_session"),
         ]));
 
-        let mut mod_candidates = self.internal_search_writeable(filter).map_err(|e| {
+        let mut mod_candidates = self.internal_search_writeable(&filter).map_err(|e| {
             admin_error!(err = ?e, "migrate_11_to_12 internal search failure");
             e
         })?;
@@ -362,45 +362,37 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
         // First, filter based on if any credentials present actually are the legacy
         // webauthn type.
-        let (
-            pre_candidates,
-            candidates
-        ) = mod_candidates
-            .into_iter()
-            .map(|(pre, mut ent)| {
 
-                if let Some(api_token_session) = ent.pop_ava("api_token_session") {
-                    let api_token_session = api_token_session.migrate_session_to_apitoken()
+        for (_, ent) in mod_candidates.iter_mut() {
+            if let Some(api_token_session) = ent.pop_ava("api_token_session") {
+                let api_token_session =
+                    api_token_session
+                        .migrate_session_to_apitoken()
                         .map_err(|e| {
                             error!("Failed to covert api_token_session from session -> apitoken");
                             e
                         })?;
 
-                    ent.set_ava_set(
-                        "api_token_session",
-                        api_token_session);
-                }
+                ent.set_ava_set("api_token_session", api_token_session);
+            }
 
-                if let Some(sync_token_session) = ent.pop_ava("sync_token_session") {
-                    let sync_token_session = sync_token_session.migrate_session_to_apitoken()
+            if let Some(sync_token_session) = ent.pop_ava("sync_token_session") {
+                let sync_token_session =
+                    sync_token_session
+                        .migrate_session_to_apitoken()
                         .map_err(|e| {
                             error!("Failed to covert sync_token_session from session -> apitoken");
                             e
                         })?;
 
-                    ent.set_ava_set(
-                        "sync_token_session",
-                        api_token_session);
-                }
+                ent.set_ava_set("sync_token_session", sync_token_session);
+            }
+        }
 
-                (pre, ent)
-            })
-            .unzip();
+        let (pre_candidates, candidates) = mod_candidates.into_iter().unzip();
 
         // Apply the batch mod.
-        self.internal_apply_writable(
-            pre_candidates, candidates
-        )
+        self.internal_apply_writable(pre_candidates, candidates)
     }
 
     #[instrument(level = "info", skip_all)]

--- a/kanidmd/lib/src/server/migrations.rs
+++ b/kanidmd/lib/src/server/migrations.rs
@@ -344,46 +344,63 @@ impl<'a> QueryServerWriteTransaction<'a> {
     pub fn migrate_11_to_12(&mut self) -> Result<(), OperationError> {
         admin_warn!("starting 11 to 12 migration.");
             // sync_token_session
-        let filter = filter!(f_pres("api_token_session"));
+        let filter = filter!(f_or!([
+            f_pres("api_token_session"),
+            f_pres("sync_token_session"),
+        ]));
 
-        let pre_candidates = self.internal_search(filter).map_err(|e| {
+        let mut mod_candidates = self.internal_search_writeable(filter).map_err(|e| {
             admin_error!(err = ?e, "migrate_11_to_12 internal search failure");
             e
         })?;
 
-        /*
-        // First, filter based on if any credentials present actually are the legacy
-        // webauthn type.
-        let modset: Vec<_> = pre_candidates
-            .into_iter()
-            .filter_map(|ent| {
-                ent.get_ava_single_credential("primary_credential")
-                    .and_then(|cred| cred.passkey_ref().ok())
-                    .map(|pk_map| {
-                        let modlist = pk_map
-                            .iter()
-                            .map(|(t, k)| {
-                                Modify::Present(
-                                    "passkeys".into(),
-                                    Value::Passkey(Uuid::new_v4(), t.clone(), k.clone()),
-                                )
-                            })
-                            .chain(std::iter::once(m_purge("primary_credential")))
-                            .collect();
-                        (ent.get_uuid(), ModifyList::new_list(modlist))
-                    })
-            })
-            .collect();
-        */
-
         // If there is nothing, we don't need to do anything.
-        if modset.is_empty() {
+        if mod_candidates.is_empty() {
             admin_info!("migrate_11_to_12 no entries to migrate, complete");
             return Ok(());
         }
 
+        // First, filter based on if any credentials present actually are the legacy
+        // webauthn type.
+        let (
+            pre_candidates,
+            candidates
+        ) = mod_candidates
+            .into_iter()
+            .map(|(pre, mut ent)| {
+
+                if let Some(api_token_session) = ent.pop_ava("api_token_session") {
+                    let api_token_session = api_token_session.migrate_session_to_apitoken()
+                        .map_err(|e| {
+                            error!("Failed to covert api_token_session from session -> apitoken");
+                            e
+                        })?;
+
+                    ent.set_ava_set(
+                        "api_token_session",
+                        api_token_session);
+                }
+
+                if let Some(sync_token_session) = ent.pop_ava("sync_token_session") {
+                    let sync_token_session = sync_token_session.migrate_session_to_apitoken()
+                        .map_err(|e| {
+                            error!("Failed to covert sync_token_session from session -> apitoken");
+                            e
+                        })?;
+
+                    ent.set_ava_set(
+                        "sync_token_session",
+                        api_token_session);
+                }
+
+                (pre, ent)
+            })
+            .unzip();
+
         // Apply the batch mod.
-        self.internal_batch_modify(modset.into_iter())
+        self.internal_apply_writable(
+            pre_candidates, candidates
+        )
     }
 
     #[instrument(level = "info", skip_all)]

--- a/kanidmd/lib/src/server/migrations.rs
+++ b/kanidmd/lib/src/server/migrations.rs
@@ -343,7 +343,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
     #[instrument(level = "debug", skip_all)]
     pub fn migrate_11_to_12(&mut self) -> Result<(), OperationError> {
         admin_warn!("starting 11 to 12 migration.");
-        // sync_token_session
+            // sync_token_session
         let filter = filter!(f_or!([
             f_pres("api_token_session"),
             f_pres("sync_token_session"),
@@ -365,34 +365,41 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
         for (_, ent) in mod_candidates.iter_mut() {
             if let Some(api_token_session) = ent.pop_ava("api_token_session") {
-                let api_token_session =
-                    api_token_session
-                        .migrate_session_to_apitoken()
-                        .map_err(|e| {
-                            error!("Failed to covert api_token_session from session -> apitoken");
-                            e
-                        })?;
+                let api_token_session = api_token_session.migrate_session_to_apitoken()
+                    .map_err(|e| {
+                        error!("Failed to convert api_token_session from session -> apitoken");
+                        e
+                    })?;
 
-                ent.set_ava_set("api_token_session", api_token_session);
+                ent.set_ava_set(
+                    "api_token_session",
+                    api_token_session);
             }
 
             if let Some(sync_token_session) = ent.pop_ava("sync_token_session") {
-                let sync_token_session =
-                    sync_token_session
-                        .migrate_session_to_apitoken()
-                        .map_err(|e| {
-                            error!("Failed to covert sync_token_session from session -> apitoken");
-                            e
-                        })?;
+                let sync_token_session = sync_token_session.migrate_session_to_apitoken()
+                    .map_err(|e| {
+                        error!("Failed to convert sync_token_session from session -> apitoken");
+                        e
+                    })?;
 
-                ent.set_ava_set("sync_token_session", sync_token_session);
+                ent.set_ava_set(
+                    "sync_token_session",
+                    sync_token_session);
             }
-        }
+        };
 
-        let (pre_candidates, candidates) = mod_candidates.into_iter().unzip();
+        let (
+            pre_candidates,
+            candidates
+        ) = mod_candidates
+            .into_iter()
+            .unzip();
 
         // Apply the batch mod.
-        self.internal_apply_writable(pre_candidates, candidates)
+        self.internal_apply_writable(
+            pre_candidates, candidates
+        )
     }
 
     #[instrument(level = "info", skip_all)]

--- a/kanidmd/lib/src/server/mod.rs
+++ b/kanidmd/lib/src/server/mod.rs
@@ -497,6 +497,7 @@ pub trait QueryServerTransaction<'a> {
                     SyntaxType::Passkey => Err(OperationError::InvalidAttribute("Passkey Values can not be supplied through modification".to_string())),
                     SyntaxType::DeviceKey => Err(OperationError::InvalidAttribute("DeviceKey Values can not be supplied through modification".to_string())),
                     SyntaxType::Session => Err(OperationError::InvalidAttribute("Session Values can not be supplied through modification".to_string())),
+                    SyntaxType::ApiToken => Err(OperationError::InvalidAttribute("ApiToken Values can not be supplied through modification".to_string())),
                     SyntaxType::JwsKeyEs256 => Err(OperationError::InvalidAttribute("JwsKeyEs256 Values can not be supplied through modification".to_string())),
                     SyntaxType::JwsKeyRs256 => Err(OperationError::InvalidAttribute("JwsKeyRs256 Values can not be supplied through modification".to_string())),
                     SyntaxType::Oauth2Session => Err(OperationError::InvalidAttribute("Oauth2Session Values can not be supplied through modification".to_string())),
@@ -551,6 +552,7 @@ pub trait QueryServerTransaction<'a> {
                     SyntaxType::ReferenceUuid
                     | SyntaxType::OauthScopeMap
                     | SyntaxType::Session
+                    | SyntaxType::ApiToken
                     | SyntaxType::Oauth2Session => {
                         let un = self.name_to_uuid(value).unwrap_or(UUID_DOES_NOT_EXIST);
                         Ok(PartialValue::Refer(un))

--- a/kanidmd/lib/src/value.rs
+++ b/kanidmd/lib/src/value.rs
@@ -13,10 +13,10 @@ use std::time::Duration;
 
 use compact_jwt::JwsSigner;
 use hashbrown::HashSet;
-use kanidm_proto::v1::Filter as ProtoFilter;
-use kanidm_proto::v1::UiHint;
-use kanidm_proto::v1::UatPurposeStatus;
 use kanidm_proto::v1::ApiTokenPurpose;
+use kanidm_proto::v1::Filter as ProtoFilter;
+use kanidm_proto::v1::UatPurposeStatus;
+use kanidm_proto::v1::UiHint;
 use num_enum::TryFromPrimitive;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -334,8 +334,6 @@ pub enum PartialValue {
     Passkey(Uuid),
     DeviceKey(Uuid),
     TrustedDeviceEnrollment(Uuid),
-    Session(Uuid),
-    ApiToken(Uuid),
     // The label, if any.
 }
 
@@ -706,8 +704,6 @@ impl PartialValue {
             PartialValue::PhoneNumber(a) => a.to_string(),
             PartialValue::IntentToken(u) => u.clone(),
             PartialValue::TrustedDeviceEnrollment(u) => u.as_hyphenated().to_string(),
-            PartialValue::Session(u) => u.as_hyphenated().to_string(),
-            PartialValue::ApiToken(u) => u.as_hyphenated().to_string(),
             PartialValue::UiHint(u) => (*u as u16).to_string(),
         }
     }

--- a/kanidmd/lib/src/valueset/mod.rs
+++ b/kanidmd/lib/src/valueset/mod.rs
@@ -126,6 +126,11 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
         Ok(None)
     }
 
+    fn migrate_session_to_apitoken(&self) -> Result<ValueSet, OperationError> {
+        debug_assert!(false);
+        Err(OperationError::InvalidValueState)
+    }
+
     fn get_ssh_tag(&self, _tag: &str) -> Option<&str> {
         None
     }

--- a/kanidmd/lib/src/valueset/mod.rs
+++ b/kanidmd/lib/src/valueset/mod.rs
@@ -16,7 +16,7 @@ use crate::credential::{totp::Totp, Credential};
 use crate::prelude::*;
 use crate::repl::{cid::Cid, proto::ReplAttrV1};
 use crate::schema::SchemaAttribute;
-use crate::value::{Address, IntentTokenState, Oauth2Session, Session, ApiToken};
+use crate::value::{Address, ApiToken, IntentTokenState, Oauth2Session, Session};
 
 mod address;
 mod binary;
@@ -59,7 +59,7 @@ pub use self::nsuniqueid::ValueSetNsUniqueId;
 pub use self::oauth::{ValueSetOauthScope, ValueSetOauthScopeMap};
 pub use self::restricted::ValueSetRestricted;
 pub use self::secret::ValueSetSecret;
-pub use self::session::{ValueSetOauth2Session, ValueSetSession, ValueSetApiToken};
+pub use self::session::{ValueSetApiToken, ValueSetOauth2Session, ValueSetSession};
 pub use self::spn::ValueSetSpn;
 pub use self::ssh::ValueSetSshKey;
 pub use self::syntax::ValueSetSyntax;
@@ -585,6 +585,7 @@ pub fn from_result_value_iter(
         | Value::TotpSecret(_, _)
         | Value::TrustedDeviceEnrollment(_)
         | Value::Session(_, _)
+        | Value::ApiToken(_, _)
         | Value::Oauth2Session(_, _)
         | Value::JwsKeyEs256(_)
         | Value::JwsKeyRs256(_) => {

--- a/kanidmd/lib/src/valueset/mod.rs
+++ b/kanidmd/lib/src/valueset/mod.rs
@@ -16,7 +16,7 @@ use crate::credential::{totp::Totp, Credential};
 use crate::prelude::*;
 use crate::repl::{cid::Cid, proto::ReplAttrV1};
 use crate::schema::SchemaAttribute;
-use crate::value::{Address, IntentTokenState, Oauth2Session, Session};
+use crate::value::{Address, IntentTokenState, Oauth2Session, Session, ApiToken};
 
 mod address;
 mod binary;
@@ -59,7 +59,7 @@ pub use self::nsuniqueid::ValueSetNsUniqueId;
 pub use self::oauth::{ValueSetOauthScope, ValueSetOauthScopeMap};
 pub use self::restricted::ValueSetRestricted;
 pub use self::secret::ValueSetSecret;
-pub use self::session::{ValueSetOauth2Session, ValueSetSession};
+pub use self::session::{ValueSetOauth2Session, ValueSetSession, ValueSetApiToken};
 pub use self::spn::ValueSetSpn;
 pub use self::ssh::ValueSetSshKey;
 pub use self::syntax::ValueSetSyntax;
@@ -483,6 +483,11 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
         None
     }
 
+    fn as_apitoken_map(&self) -> Option<&BTreeMap<Uuid, ApiToken>> {
+        debug_assert!(false);
+        None
+    }
+
     fn as_oauth2session_map(&self) -> Option<&BTreeMap<Uuid, Oauth2Session>> {
         debug_assert!(false);
         None
@@ -631,6 +636,7 @@ pub fn from_value_iter(mut iter: impl Iterator<Item = Value>) -> Result<ValueSet
         Value::JwsKeyEs256(k) => ValueSetJwsKeyEs256::new(k),
         Value::JwsKeyRs256(k) => ValueSetJwsKeyRs256::new(k),
         Value::Session(u, m) => ValueSetSession::new(u, m),
+        Value::ApiToken(u, m) => ValueSetApiToken::new(u, m),
         Value::Oauth2Session(u, m) => ValueSetOauth2Session::new(u, m),
         Value::UiHint(u) => ValueSetUiHint::new(u),
         Value::TotpSecret(l, t) => ValueSetTotpSecret::new(l, t),
@@ -677,6 +683,7 @@ pub fn from_db_valueset_v2(dbvs: DbValueSetV2) -> Result<ValueSet, OperationErro
         DbValueSetV2::Passkey(set) => ValueSetPasskey::from_dbvs2(set),
         DbValueSetV2::DeviceKey(set) => ValueSetDeviceKey::from_dbvs2(set),
         DbValueSetV2::Session(set) => ValueSetSession::from_dbvs2(set),
+        DbValueSetV2::ApiToken(set) => ValueSetApiToken::from_dbvs2(set),
         DbValueSetV2::Oauth2Session(set) => ValueSetOauth2Session::from_dbvs2(set),
         DbValueSetV2::JwsKeyEs256(set) => ValueSetJwsKeyEs256::from_dbvs2(&set),
         DbValueSetV2::JwsKeyRs256(set) => ValueSetJwsKeyEs256::from_dbvs2(&set),
@@ -726,6 +733,7 @@ pub fn from_repl_v1(rv1: &ReplAttrV1) -> Result<ValueSet, OperationError> {
         ReplAttrV1::OauthScopeMap { set } => ValueSetOauthScopeMap::from_repl_v1(set),
         ReplAttrV1::Oauth2Session { set } => ValueSetOauth2Session::from_repl_v1(set),
         ReplAttrV1::Session { set } => ValueSetSession::from_repl_v1(set),
+        ReplAttrV1::ApiToken { set } => ValueSetApiToken::from_repl_v1(set),
         ReplAttrV1::TotpSecret { set } => ValueSetTotpSecret::from_repl_v1(set),
     }
 }

--- a/kanidmd/lib/src/valueset/session.rs
+++ b/kanidmd/lib/src/valueset/session.rs
@@ -40,7 +40,7 @@ impl ValueSetSession {
                         // MISTAKE - Skip due to lack of credential id
                         // Don't actually skip, generate a random cred id. Session cleanup will
                         // trim sessions on users, but if we skip blazenly we invalidate every api
-                        // token ever issued. OPPS!
+                        // token ever issued. OOPS!
                         DbValueSession::V1 {
                             refer,
                             label,


### PR DESCRIPTION
Relates #1115 start of adding reauth capabilities and tests, but currently I ran into a bit of a design wall about how to handle different credential/auth types here so I need to step back and think through how to approach this. I think I'll need to do some tech debt cleanups first before I can complete this. Currently I'm okay to merge this little bit though because it's a test only and the reauth features aren't exposed to the world yet. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [x] design document included (if relevant)
