### PR TITLE
1399 some async cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,6 @@ dependencies = [
  "blocking",
  "futures-lite",
  "once_cell",
- "tokio",
 ]
 
 [[package]]
@@ -2410,7 +2409,6 @@ dependencies = [
 name = "kanidmd_lib"
 version = "1.1.0-alpha.12-dev"
 dependencies = [
- "async-std",
  "async-trait",
  "base64 0.13.1",
  "base64urlsafedata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ homepage = "https://github.com/kanidm/kanidm/"
 repository = "https://github.com/kanidm/kanidm/"
 
 [workspace.dependencies]
-async-std = { version = "^1.12.0", features = ["tokio1"] }
 async-trait = "^0.1.62"
 base32 = "^0.4.0"
 base64 = "^0.13.1"

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -117,7 +117,7 @@ impl QueryServerReadV1 {
         // the credentials provided is sufficient to say if someone is
         // "authenticated" or not.
         let ct = duration_from_epoch_now();
-        let mut idm_auth = self.idms.auth_async().await;
+        let mut idm_auth = self.idms.auth().await;
         security_info!(?sessionid, ?req, "Begin auth event");
 
         // Destructure it.
@@ -840,7 +840,7 @@ impl QueryServerReadV1 {
         eventid: Uuid,
     ) -> Result<Option<UnixUserToken>, OperationError> {
         let ct = duration_from_epoch_now();
-        let mut idm_auth = self.idms.auth_async().await;
+        let mut idm_auth = self.idms.auth().await;
         // resolve the id
         let ident = idm_auth
             .validate_and_parse_token_to_ident(uat.as_deref(), ct)

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -980,7 +980,7 @@ impl QueryServerReadV1 {
         eventid: Uuid,
     ) -> Result<CUStatus, OperationError> {
         let ct = duration_from_epoch_now();
-        let idms_cred_update = self.idms.cred_update_transaction_async().await;
+        let idms_cred_update = self.idms.cred_update_transaction().await;
         let session_token = CredentialUpdateSessionToken {
             token_enc: session_token.token,
         };
@@ -1009,7 +1009,7 @@ impl QueryServerReadV1 {
         eventid: Uuid,
     ) -> Result<CUStatus, OperationError> {
         let ct = duration_from_epoch_now();
-        let idms_cred_update = self.idms.cred_update_transaction_async().await;
+        let idms_cred_update = self.idms.cred_update_transaction().await;
         let session_token = CredentialUpdateSessionToken {
             token_enc: session_token.token,
         };

--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -696,7 +696,7 @@ pub async fn create_server_core(
         None => {}
     }
 
-    let ldap = match LdapServer::new(&idms) {
+    let ldap = match LdapServer::new(&idms).await {
         Ok(l) => l,
         Err(e) => {
             error!("Unable to start LdapServer -> {:?}", e);

--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -119,7 +119,7 @@ async fn setup_qs_idms(
 
     // We generate a SINGLE idms only!
 
-    let (idms, idms_delayed) = IdmServer::new(query_server.clone(), &config.origin)?;
+    let (idms, idms_delayed) = IdmServer::new(query_server.clone(), &config.origin).await?;
 
     Ok((query_server, idms, idms_delayed))
 }

--- a/server/lib/Cargo.toml
+++ b/server/lib/Cargo.toml
@@ -20,7 +20,6 @@ name = "scaling_10k"
 harness = false
 
 [dependencies]
-async-std.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 base64urlsafedata.workspace = true

--- a/server/lib/src/be/idl_sqlite.rs
+++ b/server/lib/src/be/idl_sqlite.rs
@@ -1552,7 +1552,6 @@ impl IdlSqlite {
     pub fn read(&self) -> IdlSqliteReadTransaction {
         // When we make this async, this will allow us to backoff
         // when we miss-grabbing from the conn-pool.
-        // async_std::task::yield_now().await
         #[allow(clippy::expect_used)]
         let conn = self
             .pool

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -1037,7 +1037,7 @@ mod tests {
 
         let webauthn = create_webauthn();
 
-        let anon_account = entry_str_to_account!(JSON_ANONYMOUS_V1);
+        let anon_account = entry_to_account!(E_ANONYMOUS_V1.clone());
 
         let (session, state) = AuthSession::new(
             anon_account,
@@ -1107,7 +1107,7 @@ mod tests {
         sketching::test_init();
         let webauthn = create_webauthn();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1.clone());
         // manually load in a cred
         let p = CryptoPolicy::minimum();
         let cred = Credential::new_password_only(&p, "test_password").unwrap();
@@ -1166,7 +1166,7 @@ mod tests {
         let jws_signer = create_jwt_signer();
         let webauthn = create_webauthn();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1.clone());
         // manually load in a cred
         let p = CryptoPolicy::minimum();
         let cred = Credential::new_password_only(&p, "list@no3IBTyqHu$bad").unwrap();
@@ -1258,7 +1258,7 @@ mod tests {
         let webauthn = create_webauthn();
         let jws_signer = create_jwt_signer();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1);
 
         // Setup a fake time stamp for consistency.
         let ts = Duration::from_secs(12345);
@@ -1418,7 +1418,7 @@ mod tests {
         let webauthn = create_webauthn();
         let jws_signer = create_jwt_signer();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1);
 
         // Setup a fake time stamp for consistency.
         let ts = Duration::from_secs(12345);
@@ -1582,7 +1582,7 @@ mod tests {
         let (async_tx, mut async_rx) = unbounded();
         let ts = duration_from_epoch_now();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1.clone());
 
         let (webauthn, mut wa, wan_cred) = setup_webauthn_passkey(account.name.as_str());
         let jws_signer = create_jwt_signer();
@@ -1719,7 +1719,7 @@ mod tests {
         let (async_tx, mut async_rx) = unbounded();
         let ts = duration_from_epoch_now();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1);
 
         let (webauthn, mut wa, wan_cred) = setup_webauthn_securitykey(account.name.as_str());
         let jws_signer = create_jwt_signer();
@@ -1896,7 +1896,7 @@ mod tests {
         let (async_tx, mut async_rx) = unbounded();
         let ts = duration_from_epoch_now();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1);
 
         let (webauthn, mut wa, wan_cred) = setup_webauthn_securitykey(account.name.as_str());
         let jws_signer = create_jwt_signer();
@@ -2145,7 +2145,7 @@ mod tests {
         let jws_signer = create_jwt_signer();
         let webauthn = create_webauthn();
         // create the ent
-        let mut account = entry_str_to_account!(JSON_ADMIN_V1);
+        let mut account = entry_to_account!(E_ADMIN_V1);
 
         // Setup a fake time stamp for consistency.
         let ts = Duration::from_secs(12345);

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -2027,7 +2027,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
         let (cust, _) = setup_test_session(idms, ct).await;
 
-        let cutxn = idms.cred_update_transaction_async().await;
+        let cutxn = idms.cred_update_transaction().await;
         // The session exists
         let c_status = cutxn.credential_update_status(&cust, ct);
         assert!(c_status.is_ok());
@@ -2037,7 +2037,7 @@ mod tests {
         let (_cust, _) =
             renew_test_session(idms, ct + MAXIMUM_CRED_UPDATE_TTL + Duration::from_secs(1)).await;
 
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Now fake going back in time .... allows the tokne to decrypt, but the session
         // is gone anyway!
@@ -2057,7 +2057,7 @@ mod tests {
 
         let (cust, _) = setup_test_session(idms, ct).await;
 
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Get the credential status - this should tell
         // us the details of the credentials, as well as
@@ -2088,7 +2088,7 @@ mod tests {
 
         // Test deleting the pw
         let (cust, _) = renew_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         let c_status = cutxn
             .credential_update_status(&cust, ct)
@@ -2125,7 +2125,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Setup the PW
         let c_status = cutxn
@@ -2188,7 +2188,7 @@ mod tests {
 
         // If we remove TOTP, show it reverts back.
         let (cust, _) = renew_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         let c_status = cutxn
             .credential_primary_remove_totp(&cust, ct, "totp")
@@ -2219,7 +2219,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Setup the PW
         let c_status = cutxn
@@ -2293,7 +2293,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Setup the PW
         let _c_status = cutxn
@@ -2369,7 +2369,7 @@ mod tests {
 
         // Renew to start the next steps
         let (cust, _) = renew_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Only 7 codes left.
         let c_status = cutxn
@@ -2430,7 +2430,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         // Setup the PW
         let c_status = cutxn
@@ -2482,7 +2482,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
         let origin = cutxn.get_origin().clone();
 
         // Create a soft passkey
@@ -2538,7 +2538,7 @@ mod tests {
 
         // Now test removing the token
         let (cust, _) = renew_test_session(idms, ct).await;
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
 
         trace!(?c_status);
         assert!(c_status.primary.is_none());

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -1741,7 +1741,7 @@ mod tests {
         pw: &str,
         ct: Duration,
     ) -> Option<String> {
-        let mut idms_auth = idms.auth();
+        let mut idms_auth = idms.auth().await;
 
         let auth_init = AuthEvent::named_init("testperson");
 
@@ -1800,7 +1800,7 @@ mod tests {
         token: &Totp,
         ct: Duration,
     ) -> Option<String> {
-        let mut idms_auth = idms.auth();
+        let mut idms_auth = idms.auth().await;
 
         let auth_init = AuthEvent::named_init("testperson");
 
@@ -1873,7 +1873,7 @@ mod tests {
         code: &str,
         ct: Duration,
     ) -> Option<String> {
-        let mut idms_auth = idms.auth();
+        let mut idms_auth = idms.auth().await;
 
         let auth_init = AuthEvent::named_init("testperson");
 
@@ -1948,7 +1948,7 @@ mod tests {
         origin: Url,
         ct: Duration,
     ) -> Option<String> {
-        let mut idms_auth = idms.auth();
+        let mut idms_auth = idms.auth().await;
 
         let auth_init = AuthEvent::named_init("testperson");
 

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -603,7 +603,6 @@ mod tests {
     use crate::prelude::*;
     use std::str::FromStr;
 
-    use async_std::task;
     use compact_jwt::{Jws, JwsUnverified};
     use hashbrown::HashSet;
     use kanidm_proto::v1::ApiToken;
@@ -616,152 +615,160 @@ mod tests {
 
     const TEST_PASSWORD: &str = "ntaoeuntnaoeuhraohuercahu😍";
 
-    #[test]
-    fn test_ldap_simple_bind() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, _idms_delayed: &IdmServerDelayed| {
-                let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+    #[idm_test]
+    async fn test_ldap_simple_bind(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
+        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
 
-                let mut idms_prox_write =
-                    task::block_on(idms.proxy_write(duration_from_epoch_now()));
-                // make the admin a valid posix account
-                let me_posix = unsafe {
-                    ModifyEvent::new_internal_invalid(
-                        filter!(f_eq("name", PartialValue::new_iname("admin"))),
-                        ModifyList::new_list(vec![
-                            Modify::Present(
-                                AttrString::from("class"),
-                                Value::new_class("posixaccount"),
-                            ),
-                            Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
-                        ]),
-                    )
-                };
-                assert!(idms_prox_write.qs_write.modify(&me_posix).is_ok());
+        let mut idms_prox_write = idms.proxy_write(duration_from_epoch_now()).await;
+        // make the admin a valid posix account
+        let me_posix = unsafe {
+            ModifyEvent::new_internal_invalid(
+                filter!(f_eq("name", PartialValue::new_iname("admin"))),
+                ModifyList::new_list(vec![
+                    Modify::Present(AttrString::from("class"), Value::new_class("posixaccount")),
+                    Modify::Present(AttrString::from("gidnumber"), Value::new_uint32(2001)),
+                ]),
+            )
+        };
+        assert!(idms_prox_write.qs_write.modify(&me_posix).is_ok());
 
-                let pce = UnixPasswordChangeEvent::new_internal(UUID_ADMIN, TEST_PASSWORD);
+        let pce = UnixPasswordChangeEvent::new_internal(UUID_ADMIN, TEST_PASSWORD);
 
-                assert!(idms_prox_write.set_unix_account_password(&pce).is_ok());
-                assert!(idms_prox_write.commit().is_ok());
+        assert!(idms_prox_write.set_unix_account_password(&pce).is_ok());
+        assert!(idms_prox_write.commit().is_ok());
 
-                let anon_t = task::block_on(ldaps.do_bind(idms, "", ""))
-                    .unwrap()
-                    .unwrap();
-                assert!(anon_t.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
-                assert!(
-                    task::block_on(ldaps.do_bind(idms, "", "test")).unwrap_err()
-                        == OperationError::NotAuthenticated
-                );
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        assert!(anon_t.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
+        assert!(
+            ldaps.do_bind(idms, "", "test").await.unwrap_err() == OperationError::NotAuthenticated
+        );
 
-                // Now test the admin and various DN's
-                let admin_t = task::block_on(ldaps.do_bind(idms, "admin", TEST_PASSWORD))
-                    .unwrap()
-                    .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t =
-                    task::block_on(ldaps.do_bind(idms, "admin@example.com", TEST_PASSWORD))
-                        .unwrap()
-                        .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(idms, STR_UUID_ADMIN, TEST_PASSWORD))
-                    .unwrap()
-                    .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(
-                    idms,
-                    "name=admin,dc=example,dc=com",
-                    TEST_PASSWORD,
-                ))
-                .unwrap()
-                .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(
-                    idms,
-                    "spn=admin@example.com,dc=example,dc=com",
-                    TEST_PASSWORD,
-                ))
-                .unwrap()
-                .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(
-                    idms,
-                    format!("uuid={STR_UUID_ADMIN},dc=example,dc=com").as_str(),
-                    TEST_PASSWORD,
-                ))
-                .unwrap()
-                .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        // Now test the admin and various DN's
+        let admin_t = ldaps
+            .do_bind(idms, "admin", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, "admin@example.com", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, STR_UUID_ADMIN, TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, "name=admin,dc=example,dc=com", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(
+                idms,
+                "spn=admin@example.com,dc=example,dc=com",
+                TEST_PASSWORD,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(
+                idms,
+                format!("uuid={STR_UUID_ADMIN},dc=example,dc=com").as_str(),
+                TEST_PASSWORD,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
 
-                let admin_t = task::block_on(ldaps.do_bind(idms, "name=admin", TEST_PASSWORD))
-                    .unwrap()
-                    .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t =
-                    task::block_on(ldaps.do_bind(idms, "spn=admin@example.com", TEST_PASSWORD))
-                        .unwrap()
-                        .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(
-                    idms,
-                    format!("uuid={STR_UUID_ADMIN}").as_str(),
-                    TEST_PASSWORD,
-                ))
-                .unwrap()
-                .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, "name=admin", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, "spn=admin@example.com", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(
+                idms,
+                format!("uuid={STR_UUID_ADMIN}").as_str(),
+                TEST_PASSWORD,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
 
-                let admin_t =
-                    task::block_on(ldaps.do_bind(idms, "admin,dc=example,dc=com", TEST_PASSWORD))
-                        .unwrap()
-                        .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(
-                    idms,
-                    "admin@example.com,dc=example,dc=com",
-                    TEST_PASSWORD,
-                ))
-                .unwrap()
-                .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
-                let admin_t = task::block_on(ldaps.do_bind(
-                    idms,
-                    format!("{STR_UUID_ADMIN},dc=example,dc=com").as_str(),
-                    TEST_PASSWORD,
-                ))
-                .unwrap()
-                .unwrap();
-                assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, "admin,dc=example,dc=com", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(idms, "admin@example.com,dc=example,dc=com", TEST_PASSWORD)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
+        let admin_t = ldaps
+            .do_bind(
+                idms,
+                format!("{STR_UUID_ADMIN},dc=example,dc=com").as_str(),
+                TEST_PASSWORD,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(admin_t.effective_session == LdapSession::UnixBind(UUID_ADMIN));
 
-                // Bad password, check last to prevent softlocking of the admin account.
-                assert!(task::block_on(ldaps.do_bind(idms, "admin", "test"))
-                    .unwrap()
-                    .is_none());
+        // Bad password, check last to prevent softlocking of the admin account.
+        assert!(ldaps
+            .do_bind(idms, "admin", "test")
+            .await
+            .unwrap()
+            .is_none());
 
-                // Non-existent and invalid DNs
-                assert!(task::block_on(ldaps.do_bind(
-                    idms,
-                    "spn=admin@example.com,dc=clownshoes,dc=example,dc=com",
-                    TEST_PASSWORD
-                ))
-                .is_err());
-                assert!(task::block_on(ldaps.do_bind(
-                    idms,
-                    "spn=claire@example.com,dc=example,dc=com",
-                    TEST_PASSWORD
-                ))
-                .is_err());
-                assert!(
-                    task::block_on(ldaps.do_bind(idms, ",dc=example,dc=com", TEST_PASSWORD))
-                        .is_err()
-                );
-                assert!(
-                    task::block_on(ldaps.do_bind(idms, "dc=example,dc=com", TEST_PASSWORD))
-                        .is_err()
-                );
+        // Non-existent and invalid DNs
+        assert!(ldaps
+            .do_bind(
+                idms,
+                "spn=admin@example.com,dc=clownshoes,dc=example,dc=com",
+                TEST_PASSWORD
+            )
+            .await
+            .is_err());
+        assert!(ldaps
+            .do_bind(
+                idms,
+                "spn=claire@example.com,dc=example,dc=com",
+                TEST_PASSWORD
+            )
+            .await
+            .is_err());
+        assert!(ldaps
+            .do_bind(idms, ",dc=example,dc=com", TEST_PASSWORD)
+            .await
+            .is_err());
+        assert!(ldaps
+            .do_bind(idms, "dc=example,dc=com", TEST_PASSWORD)
+            .await
+            .is_err());
 
-                assert!(task::block_on(ldaps.do_bind(idms, "claire", "test")).is_err());
-            }
-        )
+        assert!(ldaps.do_bind(idms, "claire", "test").await.is_err());
     }
 
     macro_rules! assert_entry_contains {
@@ -789,384 +796,370 @@ mod tests {
         }};
     }
 
-    #[test]
-    fn test_ldap_virtual_attribute_generation() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, _idms_delayed: &IdmServerDelayed| {
-                let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+    #[idm_test]
+    async fn test_ldap_virtual_attribute_generation(
+        idms: &IdmServer,
+        _idms_delayed: &IdmServerDelayed,
+    ) {
+        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
 
-                let ssh_ed25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP william@amethyst";
+        let ssh_ed25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP william@amethyst";
 
-                // Setup a user we want to check.
-                {
-                    let e1 = entry_init!(
-                        ("class", Value::new_class("object")),
-                        ("class", Value::new_class("person")),
-                        ("class", Value::new_class("account")),
-                        ("class", Value::new_class("posixaccount")),
-                        ("name", Value::new_iname("testperson1")),
-                        (
-                            "uuid",
-                            Value::Uuid(uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930"))
-                        ),
-                        ("description", Value::new_utf8s("testperson1")),
-                        ("displayname", Value::new_utf8s("testperson1")),
-                        ("gidnumber", Value::new_uint32(12345678)),
-                        ("loginshell", Value::new_iutf8("/bin/zsh")),
-                        ("ssh_publickey", Value::new_sshkey_str("test", ssh_ed25519))
-                    );
+        // Setup a user we want to check.
+        {
+            let e1 = entry_init!(
+                ("class", Value::new_class("object")),
+                ("class", Value::new_class("person")),
+                ("class", Value::new_class("account")),
+                ("class", Value::new_class("posixaccount")),
+                ("name", Value::new_iname("testperson1")),
+                (
+                    "uuid",
+                    Value::Uuid(uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930"))
+                ),
+                ("description", Value::new_utf8s("testperson1")),
+                ("displayname", Value::new_utf8s("testperson1")),
+                ("gidnumber", Value::new_uint32(12345678)),
+                ("loginshell", Value::new_iutf8("/bin/zsh")),
+                ("ssh_publickey", Value::new_sshkey_str("test", ssh_ed25519))
+            );
 
-                    let mut server_txn =
-                        task::block_on(idms.proxy_write(duration_from_epoch_now()));
-                    let ce = CreateEvent::new_internal(vec![e1]);
-                    assert!(server_txn
-                        .qs_write
-                        .create(&ce)
-                        .and_then(|_| server_txn.commit())
-                        .is_ok());
-                }
+            let mut server_txn = idms.proxy_write(duration_from_epoch_now()).await;
+            let ce = CreateEvent::new_internal(vec![e1]);
+            assert!(server_txn
+                .qs_write
+                .create(&ce)
+                .and_then(|_| server_txn.commit())
+                .is_ok());
+        }
 
-                // Setup the anonymous login.
-                let anon_t = task::block_on(ldaps.do_bind(idms, "", ""))
-                    .unwrap()
-                    .unwrap();
-                assert!(anon_t.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
+        // Setup the anonymous login.
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        assert!(anon_t.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
 
-                // Check that when we request *, we get default list.
-                let sr = SearchRequest {
-                    msgid: 1,
-                    base: "dc=example,dc=com".to_string(),
-                    scope: LdapSearchScope::Subtree,
-                    filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
-                    attrs: vec!["*".to_string()],
-                };
-                let r1 = task::block_on(ldaps.do_search(idms, &sr, &anon_t)).unwrap();
+        // Check that when we request *, we get default list.
+        let sr = SearchRequest {
+            msgid: 1,
+            base: "dc=example,dc=com".to_string(),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
+            attrs: vec!["*".to_string()],
+        };
+        let r1 = ldaps.do_search(idms, &sr, &anon_t).await.unwrap();
 
-                // The result, and the ldap proto success msg.
-                assert!(r1.len() == 2);
-                match &r1[0].op {
-                    LdapOp::SearchResultEntry(lsre) => {
-                        assert_entry_contains!(
-                            lsre,
-                            "spn=testperson1@example.com,dc=example,dc=com",
-                            ("class", "object"),
-                            ("class", "person"),
-                            ("class", "account"),
-                            ("class", "posixaccount"),
-                            ("displayname", "testperson1"),
-                            ("name", "testperson1"),
-                            ("gidnumber", "12345678"),
-                            ("loginshell", "/bin/zsh"),
-                            ("ssh_publickey", ssh_ed25519),
-                            ("uuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930")
-                        );
-                    }
-                    _ => assert!(false),
-                };
-
-                // Check that when we request +, we get all attrs and the vattrs
-                let sr = SearchRequest {
-                    msgid: 1,
-                    base: "dc=example,dc=com".to_string(),
-                    scope: LdapSearchScope::Subtree,
-                    filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
-                    attrs: vec!["+".to_string()],
-                };
-                let r1 = task::block_on(ldaps.do_search(idms, &sr, &anon_t)).unwrap();
-
-                // The result, and the ldap proto success msg.
-                assert!(r1.len() == 2);
-                match &r1[0].op {
-                    LdapOp::SearchResultEntry(lsre) => {
-                        assert_entry_contains!(
-                            lsre,
-                            "spn=testperson1@example.com,dc=example,dc=com",
-                            ("objectclass", "object"),
-                            ("objectclass", "person"),
-                            ("objectclass", "account"),
-                            ("objectclass", "posixaccount"),
-                            ("displayname", "testperson1"),
-                            ("name", "testperson1"),
-                            ("gidnumber", "12345678"),
-                            ("loginshell", "/bin/zsh"),
-                            ("ssh_publickey", ssh_ed25519),
-                            ("entryuuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930"),
-                            ("entrydn", "spn=testperson1@example.com,dc=example,dc=com"),
-                            ("uidnumber", "12345678"),
-                            ("cn", "testperson1"),
-                            ("keys", ssh_ed25519)
-                        );
-                    }
-                    _ => assert!(false),
-                };
-
-                // Check that when we request an attr by name, we get all of them correctly.
-                let sr = SearchRequest {
-                    msgid: 1,
-                    base: "dc=example,dc=com".to_string(),
-                    scope: LdapSearchScope::Subtree,
-                    filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
-                    attrs: vec![
-                        "name".to_string(),
-                        "entrydn".to_string(),
-                        "keys".to_string(),
-                        "uidnumber".to_string(),
-                    ],
-                };
-                let r1 = task::block_on(ldaps.do_search(idms, &sr, &anon_t)).unwrap();
-
-                // The result, and the ldap proto success msg.
-                assert!(r1.len() == 2);
-                match &r1[0].op {
-                    LdapOp::SearchResultEntry(lsre) => {
-                        assert_entry_contains!(
-                            lsre,
-                            "spn=testperson1@example.com,dc=example,dc=com",
-                            ("name", "testperson1"),
-                            ("entrydn", "spn=testperson1@example.com,dc=example,dc=com"),
-                            ("uidnumber", "12345678"),
-                            ("keys", ssh_ed25519)
-                        );
-                    }
-                    _ => assert!(false),
-                };
+        // The result, and the ldap proto success msg.
+        assert!(r1.len() == 2);
+        match &r1[0].op {
+            LdapOp::SearchResultEntry(lsre) => {
+                assert_entry_contains!(
+                    lsre,
+                    "spn=testperson1@example.com,dc=example,dc=com",
+                    ("class", "object"),
+                    ("class", "person"),
+                    ("class", "account"),
+                    ("class", "posixaccount"),
+                    ("displayname", "testperson1"),
+                    ("name", "testperson1"),
+                    ("gidnumber", "12345678"),
+                    ("loginshell", "/bin/zsh"),
+                    ("ssh_publickey", ssh_ed25519),
+                    ("uuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930")
+                );
             }
-        )
+            _ => assert!(false),
+        };
+
+        // Check that when we request +, we get all attrs and the vattrs
+        let sr = SearchRequest {
+            msgid: 1,
+            base: "dc=example,dc=com".to_string(),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
+            attrs: vec!["+".to_string()],
+        };
+        let r1 = ldaps.do_search(idms, &sr, &anon_t).await.unwrap();
+
+        // The result, and the ldap proto success msg.
+        assert!(r1.len() == 2);
+        match &r1[0].op {
+            LdapOp::SearchResultEntry(lsre) => {
+                assert_entry_contains!(
+                    lsre,
+                    "spn=testperson1@example.com,dc=example,dc=com",
+                    ("objectclass", "object"),
+                    ("objectclass", "person"),
+                    ("objectclass", "account"),
+                    ("objectclass", "posixaccount"),
+                    ("displayname", "testperson1"),
+                    ("name", "testperson1"),
+                    ("gidnumber", "12345678"),
+                    ("loginshell", "/bin/zsh"),
+                    ("ssh_publickey", ssh_ed25519),
+                    ("entryuuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930"),
+                    ("entrydn", "spn=testperson1@example.com,dc=example,dc=com"),
+                    ("uidnumber", "12345678"),
+                    ("cn", "testperson1"),
+                    ("keys", ssh_ed25519)
+                );
+            }
+            _ => assert!(false),
+        };
+
+        // Check that when we request an attr by name, we get all of them correctly.
+        let sr = SearchRequest {
+            msgid: 1,
+            base: "dc=example,dc=com".to_string(),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
+            attrs: vec![
+                "name".to_string(),
+                "entrydn".to_string(),
+                "keys".to_string(),
+                "uidnumber".to_string(),
+            ],
+        };
+        let r1 = ldaps.do_search(idms, &sr, &anon_t).await.unwrap();
+
+        // The result, and the ldap proto success msg.
+        assert!(r1.len() == 2);
+        match &r1[0].op {
+            LdapOp::SearchResultEntry(lsre) => {
+                assert_entry_contains!(
+                    lsre,
+                    "spn=testperson1@example.com,dc=example,dc=com",
+                    ("name", "testperson1"),
+                    ("entrydn", "spn=testperson1@example.com,dc=example,dc=com"),
+                    ("uidnumber", "12345678"),
+                    ("keys", ssh_ed25519)
+                );
+            }
+            _ => assert!(false),
+        };
     }
 
-    #[test]
-    fn test_ldap_token_privilege_granting() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, _idms_delayed: &IdmServerDelayed| {
-                // Setup the ldap server
-                let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+    #[idm_test]
+    async fn test_ldap_token_privilege_granting(
+        idms: &IdmServer,
+        _idms_delayed: &IdmServerDelayed,
+    ) {
+        // Setup the ldap server
+        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
 
-                // Prebuild the search req we'll be using this test.
-                let sr = SearchRequest {
-                    msgid: 1,
-                    base: "dc=example,dc=com".to_string(),
-                    scope: LdapSearchScope::Subtree,
-                    filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
-                    attrs: vec![
-                        "name".to_string(),
-                        "mail".to_string(),
-                        "mail;primary".to_string(),
-                        "mail;alternative".to_string(),
-                        "emailprimary".to_string(),
-                        "emailalternative".to_string(),
-                    ],
-                };
+        // Prebuild the search req we'll be using this test.
+        let sr = SearchRequest {
+            msgid: 1,
+            base: "dc=example,dc=com".to_string(),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
+            attrs: vec![
+                "name".to_string(),
+                "mail".to_string(),
+                "mail;primary".to_string(),
+                "mail;alternative".to_string(),
+                "emailprimary".to_string(),
+                "emailalternative".to_string(),
+            ],
+        };
 
-                let sa_uuid = uuid::uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930");
+        let sa_uuid = uuid::uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930");
 
-                // Configure the user account that will have the tokens issued.
-                // Should be a SERVICE account.
-                let apitoken = {
-                    // Create a service account,
+        // Configure the user account that will have the tokens issued.
+        // Should be a SERVICE account.
+        let apitoken = {
+            // Create a service account,
 
-                    let e1 = entry_init!(
-                        ("class", Value::new_class("object")),
-                        ("class", Value::new_class("service_account")),
-                        ("class", Value::new_class("account")),
-                        ("uuid", Value::Uuid(sa_uuid)),
-                        ("name", Value::new_iname("service_permission_test")),
-                        ("displayname", Value::new_utf8s("service_permission_test"))
-                    );
+            let e1 = entry_init!(
+                ("class", Value::new_class("object")),
+                ("class", Value::new_class("service_account")),
+                ("class", Value::new_class("account")),
+                ("uuid", Value::Uuid(sa_uuid)),
+                ("name", Value::new_iname("service_permission_test")),
+                ("displayname", Value::new_utf8s("service_permission_test"))
+            );
 
-                    // Setup a person with an email
-                    let e2 = entry_init!(
-                        ("class", Value::new_class("object")),
-                        ("class", Value::new_class("person")),
-                        ("class", Value::new_class("account")),
-                        ("class", Value::new_class("posixaccount")),
-                        ("name", Value::new_iname("testperson1")),
-                        (
-                            "mail",
-                            Value::EmailAddress("testperson1@example.com".to_string(), true)
-                        ),
-                        (
-                            "mail",
-                            Value::EmailAddress(
-                                "testperson1.alternative@example.com".to_string(),
-                                false
-                            )
-                        ),
-                        ("description", Value::new_utf8s("testperson1")),
-                        ("displayname", Value::new_utf8s("testperson1")),
-                        ("gidnumber", Value::new_uint32(12345678)),
-                        ("loginshell", Value::new_iutf8("/bin/zsh"))
-                    );
+            // Setup a person with an email
+            let e2 = entry_init!(
+                ("class", Value::new_class("object")),
+                ("class", Value::new_class("person")),
+                ("class", Value::new_class("account")),
+                ("class", Value::new_class("posixaccount")),
+                ("name", Value::new_iname("testperson1")),
+                (
+                    "mail",
+                    Value::EmailAddress("testperson1@example.com".to_string(), true)
+                ),
+                (
+                    "mail",
+                    Value::EmailAddress("testperson1.alternative@example.com".to_string(), false)
+                ),
+                ("description", Value::new_utf8s("testperson1")),
+                ("displayname", Value::new_utf8s("testperson1")),
+                ("gidnumber", Value::new_uint32(12345678)),
+                ("loginshell", Value::new_iutf8("/bin/zsh"))
+            );
 
-                    // Setup an access control for the service account to view mail attrs.
+            // Setup an access control for the service account to view mail attrs.
 
-                    let ct = duration_from_epoch_now();
+            let ct = duration_from_epoch_now();
 
-                    let mut server_txn = task::block_on(idms.proxy_write(ct));
-                    let ce = CreateEvent::new_internal(vec![e1, e2]);
-                    assert!(server_txn.qs_write.create(&ce).is_ok());
+            let mut server_txn = idms.proxy_write(ct).await;
+            let ce = CreateEvent::new_internal(vec![e1, e2]);
+            assert!(server_txn.qs_write.create(&ce).is_ok());
 
-                    // idm_people_read_priv
-                    let me = unsafe {
-                        ModifyEvent::new_internal_invalid(
-                            filter!(f_eq(
-                                "name",
-                                PartialValue::new_iname("idm_people_read_priv")
-                            )),
-                            ModifyList::new_list(vec![Modify::Present(
-                                AttrString::from("member"),
-                                Value::Refer(sa_uuid),
-                            )]),
-                        )
-                    };
-                    assert!(server_txn.qs_write.modify(&me).is_ok());
+            // idm_people_read_priv
+            let me = unsafe {
+                ModifyEvent::new_internal_invalid(
+                    filter!(f_eq(
+                        "name",
+                        PartialValue::new_iname("idm_people_read_priv")
+                    )),
+                    ModifyList::new_list(vec![Modify::Present(
+                        AttrString::from("member"),
+                        Value::Refer(sa_uuid),
+                    )]),
+                )
+            };
+            assert!(server_txn.qs_write.modify(&me).is_ok());
 
-                    // Issue a token
-                    // make it purpose = ldap <- currently purpose isn't supported,
-                    // it's an idea for future.
-                    let gte = GenerateApiTokenEvent::new_internal(sa_uuid, "TestToken", None);
+            // Issue a token
+            // make it purpose = ldap <- currently purpose isn't supported,
+            // it's an idea for future.
+            let gte = GenerateApiTokenEvent::new_internal(sa_uuid, "TestToken", None);
 
-                    let apitoken = server_txn
-                        .service_account_generate_api_token(&gte, ct)
-                        .expect("Failed to create new apitoken");
+            let apitoken = server_txn
+                .service_account_generate_api_token(&gte, ct)
+                .expect("Failed to create new apitoken");
 
-                    assert!(server_txn.commit().is_ok());
+            assert!(server_txn.commit().is_ok());
 
-                    apitoken
-                };
+            apitoken
+        };
 
-                // assert the token fails on non-ldap events token-xchg <- currently
-                // we don't have purpose so this isn't tested.
+        // assert the token fails on non-ldap events token-xchg <- currently
+        // we don't have purpose so this isn't tested.
 
-                // Bind with anonymous, search and show mail attr isn't accessible.
-                let anon_lbt = task::block_on(ldaps.do_bind(idms, "", ""))
-                    .unwrap()
-                    .unwrap();
-                assert!(anon_lbt.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
+        // Bind with anonymous, search and show mail attr isn't accessible.
+        let anon_lbt = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        assert!(anon_lbt.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
 
-                let r1 = task::block_on(ldaps.do_search(idms, &sr, &anon_lbt)).unwrap();
-                assert!(r1.len() == 2);
-                match &r1[0].op {
-                    LdapOp::SearchResultEntry(lsre) => {
-                        assert_entry_contains!(
-                            lsre,
-                            "spn=testperson1@example.com,dc=example,dc=com",
-                            ("name", "testperson1")
-                        );
-                    }
-                    _ => assert!(false),
-                };
-
-                // Inspect the token to get its uuid out.
-                let apitoken_unverified =
-                    JwsUnverified::from_str(&apitoken).expect("Failed to parse apitoken");
-
-                let apitoken_inner: Jws<ApiToken> = apitoken_unverified
-                    .validate_embeded()
-                    .expect("Embedded jwk not found");
-
-                let apitoken_inner = apitoken_inner.into_inner();
-
-                // Bind using the token as a DN
-                let sa_lbt = task::block_on(ldaps.do_bind(idms, "dn=token", &apitoken))
-                    .unwrap()
-                    .unwrap();
-                assert!(sa_lbt.effective_session == LdapSession::ApiToken(apitoken_inner.clone()));
-
-                // Bind using the token as a pw
-                let sa_lbt = task::block_on(ldaps.do_bind(idms, "", &apitoken))
-                    .unwrap()
-                    .unwrap();
-                assert!(sa_lbt.effective_session == LdapSession::ApiToken(apitoken_inner));
-
-                // Search and retrieve mail that's now accessible.
-                let r1 = task::block_on(ldaps.do_search(idms, &sr, &sa_lbt)).unwrap();
-                assert!(r1.len() == 2);
-                match &r1[0].op {
-                    LdapOp::SearchResultEntry(lsre) => {
-                        assert_entry_contains!(
-                            lsre,
-                            "spn=testperson1@example.com,dc=example,dc=com",
-                            ("name", "testperson1"),
-                            ("mail", "testperson1@example.com"),
-                            ("mail", "testperson1.alternative@example.com"),
-                            ("mail;primary", "testperson1@example.com"),
-                            ("mail;alternative", "testperson1.alternative@example.com"),
-                            ("emailprimary", "testperson1@example.com"),
-                            ("emailalternative", "testperson1.alternative@example.com")
-                        );
-                    }
-                    _ => assert!(false),
-                };
+        let r1 = ldaps.do_search(idms, &sr, &anon_lbt).await.unwrap();
+        assert!(r1.len() == 2);
+        match &r1[0].op {
+            LdapOp::SearchResultEntry(lsre) => {
+                assert_entry_contains!(
+                    lsre,
+                    "spn=testperson1@example.com,dc=example,dc=com",
+                    ("name", "testperson1")
+                );
             }
-        )
+            _ => assert!(false),
+        };
+
+        // Inspect the token to get its uuid out.
+        let apitoken_unverified =
+            JwsUnverified::from_str(&apitoken).expect("Failed to parse apitoken");
+
+        let apitoken_inner: Jws<ApiToken> = apitoken_unverified
+            .validate_embeded()
+            .expect("Embedded jwk not found");
+
+        let apitoken_inner = apitoken_inner.into_inner();
+
+        // Bind using the token as a DN
+        let sa_lbt = ldaps
+            .do_bind(idms, "dn=token", &apitoken)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(sa_lbt.effective_session == LdapSession::ApiToken(apitoken_inner.clone()));
+
+        // Bind using the token as a pw
+        let sa_lbt = ldaps.do_bind(idms, "", &apitoken).await.unwrap().unwrap();
+        assert!(sa_lbt.effective_session == LdapSession::ApiToken(apitoken_inner));
+
+        // Search and retrieve mail that's now accessible.
+        let r1 = ldaps.do_search(idms, &sr, &sa_lbt).await.unwrap();
+        assert!(r1.len() == 2);
+        match &r1[0].op {
+            LdapOp::SearchResultEntry(lsre) => {
+                assert_entry_contains!(
+                    lsre,
+                    "spn=testperson1@example.com,dc=example,dc=com",
+                    ("name", "testperson1"),
+                    ("mail", "testperson1@example.com"),
+                    ("mail", "testperson1.alternative@example.com"),
+                    ("mail;primary", "testperson1@example.com"),
+                    ("mail;alternative", "testperson1.alternative@example.com"),
+                    ("emailprimary", "testperson1@example.com"),
+                    ("emailalternative", "testperson1.alternative@example.com")
+                );
+            }
+            _ => assert!(false),
+        };
     }
 
-    #[test]
-    fn test_ldap_virtual_attribute_with_all_attr_search() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, _idms_delayed: &IdmServerDelayed| {
-                let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+    #[idm_test]
+    async fn test_ldap_virtual_attribute_with_all_attr_search(
+        idms: &IdmServer,
+        _idms_delayed: &IdmServerDelayed,
+    ) {
+        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
 
-                let acct_uuid = uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930");
+        let acct_uuid = uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930");
 
-                // Setup a user we want to check.
-                {
-                    let e1 = entry_init!(
-                        ("class", Value::new_class("person")),
-                        ("class", Value::new_class("account")),
-                        ("name", Value::new_iname("testperson1")),
-                        ("uuid", Value::Uuid(acct_uuid)),
-                        ("description", Value::new_utf8s("testperson1")),
-                        ("displayname", Value::new_utf8s("testperson1"))
-                    );
+        // Setup a user we want to check.
+        {
+            let e1 = entry_init!(
+                ("class", Value::new_class("person")),
+                ("class", Value::new_class("account")),
+                ("name", Value::new_iname("testperson1")),
+                ("uuid", Value::Uuid(acct_uuid)),
+                ("description", Value::new_utf8s("testperson1")),
+                ("displayname", Value::new_utf8s("testperson1"))
+            );
 
-                    let mut server_txn =
-                        task::block_on(idms.proxy_write(duration_from_epoch_now()));
-                    assert!(server_txn
-                        .qs_write
-                        .internal_create(vec![e1])
-                        .and_then(|_| server_txn.commit())
-                        .is_ok());
-                }
+            let mut server_txn = idms.proxy_write(duration_from_epoch_now()).await;
+            assert!(server_txn
+                .qs_write
+                .internal_create(vec![e1])
+                .and_then(|_| server_txn.commit())
+                .is_ok());
+        }
 
-                // Setup the anonymous login.
-                let anon_t = task::block_on(ldaps.do_bind(idms, "", ""))
-                    .unwrap()
-                    .unwrap();
-                assert!(anon_t.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
+        // Setup the anonymous login.
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        assert!(anon_t.effective_session == LdapSession::UnixBind(UUID_ANONYMOUS));
 
-                // Check that when we request a virtual attr by name *and* all_attrs we get all the requested values.
-                let sr = SearchRequest {
-                    msgid: 1,
-                    base: "dc=example,dc=com".to_string(),
-                    scope: LdapSearchScope::Subtree,
-                    filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
-                    attrs: vec![
-                        "*".to_string(),
-                        // Already being returned
-                        "name".to_string(),
-                        // This is a virtual attribute
-                        "entryuuid".to_string(),
-                    ],
-                };
-                let r1 = task::block_on(ldaps.do_search(idms, &sr, &anon_t)).unwrap();
+        // Check that when we request a virtual attr by name *and* all_attrs we get all the requested values.
+        let sr = SearchRequest {
+            msgid: 1,
+            base: "dc=example,dc=com".to_string(),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Equality("name".to_string(), "testperson1".to_string()),
+            attrs: vec![
+                "*".to_string(),
+                // Already being returned
+                "name".to_string(),
+                // This is a virtual attribute
+                "entryuuid".to_string(),
+            ],
+        };
+        let r1 = ldaps.do_search(idms, &sr, &anon_t).await.unwrap();
 
-                // The result, and the ldap proto success msg.
-                assert!(r1.len() == 2);
-                match &r1[0].op {
-                    LdapOp::SearchResultEntry(lsre) => {
-                        assert_entry_contains!(
-                            lsre,
-                            "spn=testperson1@example.com,dc=example,dc=com",
-                            ("name", "testperson1"),
-                            ("displayname", "testperson1"),
-                            ("uuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930"),
-                            ("entryuuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930")
-                        );
-                    }
-                    _ => assert!(false),
-                };
+        // The result, and the ldap proto success msg.
+        assert!(r1.len() == 2);
+        match &r1[0].op {
+            LdapOp::SearchResultEntry(lsre) => {
+                assert_entry_contains!(
+                    lsre,
+                    "spn=testperson1@example.com,dc=example,dc=com",
+                    ("name", "testperson1"),
+                    ("displayname", "testperson1"),
+                    ("uuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930"),
+                    ("entryuuid", "cc8e95b4-c24f-4d68-ba54-8bed76f63930")
+                );
             }
-        )
+            _ => assert!(false),
+        };
     }
 }

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -4,7 +4,6 @@
 use std::collections::BTreeSet;
 use std::iter;
 
-use async_std::task;
 use kanidm_proto::v1::{ApiToken, OperationError, UserAuthToken};
 use ldap3_proto::simple::*;
 use regex::Regex;
@@ -59,9 +58,9 @@ pub struct LdapServer {
 }
 
 impl LdapServer {
-    pub fn new(idms: &IdmServer) -> Result<Self, OperationError> {
+    pub async fn new(idms: &IdmServer) -> Result<Self, OperationError> {
         // let ct = duration_from_epoch_now();
-        let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
         // This is the rootdse path.
         // get the domain_info item
         let domain_entry = idms_prox_read
@@ -617,7 +616,7 @@ mod tests {
 
     #[idm_test]
     async fn test_ldap_simple_bind(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
-        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+        let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
         let mut idms_prox_write = idms.proxy_write(duration_from_epoch_now()).await;
         // make the admin a valid posix account
@@ -801,7 +800,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &IdmServerDelayed,
     ) {
-        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+        let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
         let ssh_ed25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP william@amethyst";
 
@@ -943,7 +942,7 @@ mod tests {
         _idms_delayed: &IdmServerDelayed,
     ) {
         // Setup the ldap server
-        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+        let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
         // Prebuild the search req we'll be using this test.
         let sr = SearchRequest {
@@ -1103,7 +1102,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &IdmServerDelayed,
     ) {
-        let ldaps = LdapServer::new(idms).expect("failed to start ldap");
+        let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
         let acct_uuid = uuid!("cc8e95b4-c24f-4d68-ba54-8bed76f63930");
 

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -378,7 +378,7 @@ impl LdapServer {
         );
         let ct = duration_from_epoch_now();
 
-        let mut idm_auth = idms.auth_async().await;
+        let mut idm_auth = idms.auth().await;
 
         let target_uuid: Uuid = if dn.is_empty() {
             if pw.is_empty() {

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -1822,7 +1822,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -1847,7 +1847,7 @@ mod tests {
             .expect("Failed to perform oauth2 token exchange");
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(_)) => {}
             _ => assert!(false),
         }
@@ -2154,7 +2154,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -2319,7 +2319,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -2337,7 +2337,7 @@ mod tests {
             .expect("Unable to exchange for oauth2 token");
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(_)) => {}
             _ => assert!(false),
         }
@@ -2423,7 +2423,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -2443,7 +2443,7 @@ mod tests {
         drop(idms_prox_read);
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(osr)) => {
                 // Process it to ensure the record exists.
                 let mut idms_prox_write = idms.proxy_write(ct).await;
@@ -2585,7 +2585,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -2608,7 +2608,7 @@ mod tests {
         let mut idms_prox_write = idms.proxy_write(ct).await;
 
         // Assert that the session creation was submitted
-        let session_id = match idms_delayed.async_rx.blocking_recv() {
+        let session_id = match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(osr)) => {
                 assert!(idms_prox_write.process_oauth2sessionrecord(&osr).is_ok());
                 osr.session_id
@@ -2920,7 +2920,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -2941,7 +2941,7 @@ mod tests {
             .expect("Failed to perform oauth2 token exchange");
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(_)) => {}
             _ => assert!(false),
         }
@@ -3052,7 +3052,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -3073,7 +3073,7 @@ mod tests {
             .expect("Failed to perform oauth2 token exchange");
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(_)) => {}
             _ => assert!(false),
         }
@@ -3145,7 +3145,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -3166,7 +3166,7 @@ mod tests {
             .expect("Failed to perform oauth2 token exchange");
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(_)) => {}
             _ => assert!(false),
         }
@@ -3314,7 +3314,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -3335,7 +3335,7 @@ mod tests {
             .expect("Failed to perform oauth2 token exchange");
 
         // Assert that the session creation was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2SessionRecord(_)) => {}
             _ => assert!(false),
         }
@@ -3395,7 +3395,7 @@ mod tests {
         drop(idms_prox_read);
 
         // Assert that the consent was submitted
-        let o2cg = match idms_delayed.async_rx.blocking_recv() {
+        let o2cg = match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(o2cg)) => o2cg,
             _ => unreachable!(),
         };
@@ -3606,7 +3606,7 @@ mod tests {
         drop(idms_prox_read);
 
         // Assert that the consent was submitted
-        let o2cg = match idms_delayed.async_rx.blocking_recv() {
+        let o2cg = match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(o2cg)) => o2cg,
             _ => unreachable!(),
         };
@@ -3711,7 +3711,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }
@@ -3804,7 +3804,7 @@ mod tests {
             .expect("Failed to perform oauth2 permit");
 
         // Assert that the consent was submitted
-        match idms_delayed.async_rx.blocking_recv() {
+        match idms_delayed.async_rx.recv().await {
             Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
             _ => assert!(false),
         }

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -1631,8 +1631,6 @@ mod tests {
     use crate::idm::server::{IdmServer, IdmServerTransaction};
     use crate::prelude::*;
 
-    use async_std::task;
-
     const TEST_CURRENT_TIME: u64 = 6000;
     const UAT_EXPIRE: u64 = 5;
     const TOKEN_EXPIRE: u64 = 900;
@@ -1678,14 +1676,14 @@ mod tests {
     }
 
     // setup an oauth2 instance.
-    fn setup_oauth2_resource_server(
+    async fn setup_oauth2_resource_server(
         idms: &IdmServer,
         ct: Duration,
         enable_pkce: bool,
         enable_legacy_crypto: bool,
         prefer_short_username: bool,
     ) -> (String, UserAuthToken, Identity, Uuid) {
-        let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+        let mut idms_prox_write = idms.proxy_write(ct).await;
 
         let uuid = Uuid::new_v4();
 
@@ -1766,12 +1764,12 @@ mod tests {
         (secret, uat, ident, uuid)
     }
 
-    fn setup_idm_admin(
+    async fn setup_idm_admin(
         idms: &IdmServer,
         ct: Duration,
         authtype: AuthType,
     ) -> (UserAuthToken, Identity) {
-        let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+        let mut idms_prox_write = idms.proxy_write(ct).await;
         let account = idms_prox_write
             .target_to_account(UUID_IDM_ADMIN)
             .expect("account must exist");
@@ -1788,1945 +1786,1864 @@ mod tests {
         (uat, ident)
     }
 
-    #[test]
-    fn test_idm_oauth2_basic_function() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_basic_function(idms: &IdmServer, idms_delayed: &mut IdmServerDelayed) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // Get an ident/uat for now.
+        // Get an ident/uat for now.
 
-                // == Setup the authorisation request
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        // == Setup the authorisation request
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                // Should be in the consent phase;
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
-
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
-
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // Check we are reflecting the CSRF properly.
-                assert!(permit_success.state == "123");
-
-                // == Submit the token exchange code.
-
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: Some("test_resource_server".to_string()),
-                    client_secret: Some(secret),
-                    // From the first step.
-                    code_verifier,
-                };
-
-                let token_response = idms_prox_read
-                    .check_oauth2_token_exchange(None, &token_req, ct)
-                    .expect("Failed to perform oauth2 token exchange");
-
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // 🎉 We got a token! In the future we can then check introspection from this point.
-                assert!(token_response.token_type == "bearer");
-            }
-        )
-    }
-
-    #[test]
-    fn test_idm_oauth2_invalid_authorisation_requests() {
-        run_idm_test!(|_qs: &QueryServer,
-                       idms: &IdmServer,
-                       _idms_delayed: &mut IdmServerDelayed| {
-            // Test invalid oauth2 authorisation states/requests.
-            let ct = Duration::from_secs(TEST_CURRENT_TIME);
-            let (_secret, uat, ident, _) =
-                setup_oauth2_resource_server(idms, ct, true, false, false);
-
-            let (anon_uat, anon_ident) = setup_idm_admin(idms, ct, AuthType::Anonymous);
-            let (idm_admin_uat, idm_admin_ident) = setup_idm_admin(idms, ct, AuthType::PasswordMfa);
-
-            // Need a uat from a user not in the group. Probs anonymous.
-            let idms_prox_read = task::block_on(idms.proxy_read());
-
-            let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-
-            let pkce_request = Some(PkceRequest {
-                code_challenge: Base64UrlSafeData(code_challenge),
-                code_challenge_method: CodeChallengeMethod::S256,
-            });
-
-            //  * response type != code.
-            let auth_req = AuthorisationRequest {
-                response_type: "NOTCODE".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request: pkce_request.clone(),
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "openid".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::UnsupportedResponseType
-            );
-
-            // * No pkce in pkce enforced mode.
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request: None,
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "openid".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::InvalidRequest
-            );
-
-            //  * invalid rs name
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "NOT A REAL RESOURCE SERVER".to_string(),
-                state: "123".to_string(),
-                pkce_request: pkce_request.clone(),
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "openid".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::InvalidClientId
-            );
-
-            //  * mis match origin in the redirect.
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request: pkce_request.clone(),
-                redirect_uri: Url::parse("https://totes.not.sus.org/oauth2/result").unwrap(),
-                scope: "openid".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::InvalidOrigin
-            );
-
-            // Requested scope is not available
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request: pkce_request.clone(),
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "invalid_scope read".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::AccessDenied
-            );
-
-            // Not a member of the group.
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request: pkce_request.clone(),
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "read openid".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&idm_admin_ident, &idm_admin_uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::AccessDenied
-            );
-
-            // Deny Anonymous auth methods
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request,
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "read openid".to_string(),
-                nonce: None,
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
-
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorisation(&anon_ident, &anon_uat, &auth_req, ct)
-                    .unwrap_err()
-                    == Oauth2Error::AccessDenied
-            );
-        })
-    }
-
-    #[test]
-    fn test_idm_oauth2_invalid_authorisation_permit_requests() {
-        run_idm_test!(|_qs: &QueryServer,
-                       idms: &IdmServer,
-                       _idms_delayed: &mut IdmServerDelayed| {
-            // Test invalid oauth2 authorisation states/requests.
-            let ct = Duration::from_secs(TEST_CURRENT_TIME);
-            let (_secret, uat, ident, _) =
-                setup_oauth2_resource_server(idms, ct, true, false, false);
-
-            let (uat2, ident2) = {
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                let account = idms_prox_write
-                    .target_to_account(UUID_IDM_ADMIN)
-                    .expect("account must exist");
-                let session_id = uuid::Uuid::new_v4();
-                let uat2 = account
-                    .to_userauthtoken(
-                        session_id,
-                        ct,
-                        AuthType::PasswordMfa,
-                        Some(AUTH_SESSION_EXPIRY),
-                    )
-                    .expect("Unable to create uat");
-                let ident2 = idms_prox_write
-                    .process_uat_to_identity(&uat2, ct)
-                    .expect("Unable to process uat");
-                (uat2, ident2)
-            };
-
-            let idms_prox_read = task::block_on(idms.proxy_read());
-
-            let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-
-            let consent_request = good_authorisation_request!(
-                idms_prox_read,
-                &ident,
-                &uat,
-                ct,
-                code_challenge,
-                "openid".to_string()
-            );
-
-            let consent_token = if let AuthoriseResponse::ConsentRequested {
-                consent_token, ..
-            } = consent_request
-            {
+        // Should be in the consent phase;
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
                 consent_token
             } else {
                 unreachable!();
             };
 
-            // Invalid permits
-            //  * expired token, aka past ttl.
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_permit(
-                        &ident,
-                        &uat,
-                        &consent_token,
-                        ct + Duration::from_secs(TOKEN_EXPIRE),
-                    )
-                    .unwrap_err()
-                    == OperationError::CryptographyError
-            );
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-            //  * incorrect ident
-            // We get another uat, but for a different user, and we'll introduce these
-            // inconsistently to cause confusion.
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_permit(&ident2, &uat, &consent_token, ct,)
-                    .unwrap_err()
-                    == OperationError::InvalidSessionState
-            );
+        // Check we are reflecting the CSRF properly.
+        assert!(permit_success.state == "123");
 
-            //  * incorrect session id
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat2, &consent_token, ct,)
-                    .unwrap_err()
-                    == OperationError::InvalidSessionState
-            );
-        })
+        // == Submit the token exchange code.
+
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: Some("test_resource_server".to_string()),
+            client_secret: Some(secret),
+            // From the first step.
+            code_verifier,
+        };
+
+        let token_response = idms_prox_read
+            .check_oauth2_token_exchange(None, &token_req, ct)
+            .expect("Failed to perform oauth2 token exchange");
+
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(_)) => {}
+            _ => assert!(false),
+        }
+
+        // 🎉 We got a token! In the future we can then check introspection from this point.
+        assert!(token_response.token_type == "bearer");
     }
 
-    #[test]
-    fn test_idm_oauth2_invalid_token_exchange_requests() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, mut uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_invalid_authorisation_requests(
+        idms: &IdmServer,
+        _idms_delayed: &mut IdmServerDelayed,
+    ) {
+        // Test invalid oauth2 authorisation states/requests.
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-                // ⚠️  We set the uat expiry time to 5 seconds from TEST_CURRENT_TIME. This
-                // allows all our other tests to pass, but it means when we specifically put the
-                // clock forward a fraction, the fernet tokens are still valid, but the uat
-                // is not.
-                // IE
-                //   |---------------------|------------------|
-                //   TEST_CURRENT_TIME     UAT_EXPIRE         TOKEN_EXPIRE
-                //
-                // This lets us check a variety of time based cases.
-                uat.expiry = Some(
-                    time::OffsetDateTime::unix_epoch()
-                        + Duration::from_secs(TEST_CURRENT_TIME + UAT_EXPIRE - 1),
-                );
+        let (anon_uat, anon_ident) = setup_idm_admin(idms, ct, AuthType::Anonymous).await;
+        let (idm_admin_uat, idm_admin_ident) =
+            setup_idm_admin(idms, ct, AuthType::PasswordMfa).await;
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        // Need a uat from a user not in the group. Probs anonymous.
+        let idms_prox_read = idms.proxy_read().await;
 
-                // == Setup the authorisation request
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        let pkce_request = Some(PkceRequest {
+            code_challenge: Base64UrlSafeData(code_challenge),
+            code_challenge_method: CodeChallengeMethod::S256,
+        });
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        //  * response type != code.
+        let auth_req = AuthorisationRequest {
+            response_type: "NOTCODE".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: pkce_request.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::UnsupportedResponseType
+        );
 
-                // == Submit the token exchange code.
+        // * No pkce in pkce enforced mode.
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: None,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                // Invalid token exchange
-                //  * invalid client_authz (not base64)
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code.clone(),
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    // From the first step.
-                    code_verifier: code_verifier.clone(),
-                };
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidRequest
+        );
 
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(Some("not base64"), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::AuthenticationRequired
-                );
+        //  * invalid rs name
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "NOT A REAL RESOURCE SERVER".to_string(),
+            state: "123".to_string(),
+            pkce_request: pkce_request.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                //  * doesn't have :
-                let client_authz = Some(base64::encode(format!("test_resource_server {secret}")));
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::AuthenticationRequired
-                );
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidClientId
+        );
 
-                //  * invalid client_id
-                let client_authz = Some(base64::encode(format!("NOT A REAL SERVER:{secret}")));
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::AuthenticationRequired
-                );
+        //  * mis match origin in the redirect.
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: pkce_request.clone(),
+            redirect_uri: Url::parse("https://totes.not.sus.org/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                //  * valid client_id, but invalid secret
-                let client_authz = Some(base64::encode("test_resource_server:12345"));
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::AuthenticationRequired
-                );
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidOrigin
+        );
 
-                // ✅ Now the valid client_authz is in place.
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
-                //  * expired exchange code (took too long)
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(
-                            client_authz.as_deref(),
-                            &token_req,
-                            ct + Duration::from_secs(TOKEN_EXPIRE)
-                        )
-                        .unwrap_err()
-                        == Oauth2Error::InvalidRequest
-                );
+        // Requested scope is not available
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: pkce_request.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "invalid_scope read".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                //  * Uat has expired!
-                // NOTE: This is setup EARLY in the test, by manipulation of the UAT expiry.
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(
-                            client_authz.as_deref(),
-                            &token_req,
-                            ct + Duration::from_secs(UAT_EXPIRE)
-                        )
-                        .unwrap_err()
-                        == Oauth2Error::AccessDenied
-                );
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AccessDenied
+        );
 
-                //  * incorrect grant_type
-                let token_req = AccessTokenRequest {
-                    grant_type: "INCORRECT GRANT TYPE".to_string(),
-                    code: permit_success.code.clone(),
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    code_verifier: code_verifier.clone(),
-                };
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::InvalidRequest
-                );
+        // Not a member of the group.
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: pkce_request.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "read openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                //  * Incorrect redirect uri
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code.clone(),
-                    redirect_uri: Url::parse("https://totes.not.sus.org/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    code_verifier,
-                };
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::InvalidOrigin
-                );
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&idm_admin_ident, &idm_admin_uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AccessDenied
+        );
 
-                //  * code verifier incorrect
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    code_verifier: Some("12345".to_string()),
-                };
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::InvalidRequest
-                );
-            }
-        )
+        // Deny Anonymous auth methods
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "read openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
+
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&anon_ident, &anon_uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AccessDenied
+        );
     }
 
-    #[test]
-    fn test_idm_oauth2_token_introspect() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+    #[idm_test]
+    async fn test_idm_oauth2_invalid_authorisation_permit_requests(
+        idms: &IdmServer,
+        _idms_delayed: &mut IdmServerDelayed,
+    ) {
+        // Test invalid oauth2 authorisation states/requests.
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let (uat2, ident2) = {
+            let mut idms_prox_write = idms.proxy_write(ct).await;
+            let account = idms_prox_write
+                .target_to_account(UUID_IDM_ADMIN)
+                .expect("account must exist");
+            let session_id = uuid::Uuid::new_v4();
+            let uat2 = account
+                .to_userauthtoken(
+                    session_id,
+                    ct,
+                    AuthType::PasswordMfa,
+                    Some(AUTH_SESSION_EXPIRY),
+                )
+                .expect("Unable to create uat");
+            let ident2 = idms_prox_write
+                .process_uat_to_identity(&uat2, ct)
+                .expect("Unable to process uat");
+            (uat2, ident2)
+        };
 
-                // == Setup the authorisation request
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
+        let idms_prox_read = idms.proxy_read().await;
+
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
+
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
+
+        // Invalid permits
+        //  * expired token, aka past ttl.
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_permit(
                     &ident,
                     &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+                    &consent_token,
+                    ct + Duration::from_secs(TOKEN_EXPIRE),
+                )
+                .unwrap_err()
+                == OperationError::CryptographyError
+        );
 
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        //  * incorrect ident
+        // We get another uat, but for a different user, and we'll introduce these
+        // inconsistently to cause confusion.
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_permit(&ident2, &uat, &consent_token, ct,)
+                .unwrap_err()
+                == OperationError::InvalidSessionState
+        );
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
-
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    code_verifier,
-                };
-                let oauth2_token = idms_prox_read
-                    .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                    .expect("Unable to exchange for oauth2 token");
-
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // Okay, now we have the token, we can check it works with introspect.
-                let intr_request = AccessTokenIntrospectRequest {
-                    token: oauth2_token.access_token,
-                    token_type_hint: None,
-                };
-                let intr_response = idms_prox_read
-                    .check_oauth2_token_introspect(
-                        client_authz.as_deref().unwrap(),
-                        &intr_request,
-                        ct,
-                    )
-                    .expect("Failed to inspect token");
-
-                eprintln!("👉  {intr_response:?}");
-                assert!(intr_response.active);
-                assert!(intr_response.scope.as_deref() == Some("openid supplement"));
-                assert!(intr_response.client_id.as_deref() == Some("test_resource_server"));
-                assert!(intr_response.username.as_deref() == Some("admin@example.com"));
-                assert!(intr_response.token_type.as_deref() == Some("access_token"));
-                assert!(intr_response.iat == Some(ct.as_secs() as i64));
-                assert!(intr_response.nbf == Some(ct.as_secs() as i64));
-
-                drop(idms_prox_read);
-                // start a write,
-
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                // Expire the account, should cause introspect to return inactive.
-                let v_expire =
-                    Value::new_datetime_epoch(Duration::from_secs(TEST_CURRENT_TIME - 1));
-                let me_inv_m = unsafe {
-                    ModifyEvent::new_internal_invalid(
-                        filter!(f_eq("name", PartialValue::new_iname("admin"))),
-                        ModifyList::new_list(vec![Modify::Present(
-                            AttrString::from("account_expire"),
-                            v_expire,
-                        )]),
-                    )
-                };
-                // go!
-                assert!(idms_prox_write.qs_write.modify(&me_inv_m).is_ok());
-                assert!(idms_prox_write.commit().is_ok());
-
-                // start a new read
-                // check again.
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-                let intr_response = idms_prox_read
-                    .check_oauth2_token_introspect(&client_authz.unwrap(), &intr_request, ct)
-                    .expect("Failed to inspect token");
-
-                assert!(!intr_response.active);
-            }
-        )
+        //  * incorrect session id
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_permit(&ident, &uat2, &consent_token, ct,)
+                .unwrap_err()
+                == OperationError::InvalidSessionState
+        );
     }
 
-    #[test]
-    fn test_idm_oauth2_token_revoke() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                // First, setup to get a token.
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+    #[idm_test]
+    async fn test_idm_oauth2_invalid_token_exchange_requests(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, mut uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        // ⚠️  We set the uat expiry time to 5 seconds from TEST_CURRENT_TIME. This
+        // allows all our other tests to pass, but it means when we specifically put the
+        // clock forward a fraction, the fernet tokens are still valid, but the uat
+        // is not.
+        // IE
+        //   |---------------------|------------------|
+        //   TEST_CURRENT_TIME     UAT_EXPIRE         TOKEN_EXPIRE
+        //
+        // This lets us check a variety of time based cases.
+        uat.expiry = Some(
+            time::OffsetDateTime::unix_epoch()
+                + Duration::from_secs(TEST_CURRENT_TIME + UAT_EXPIRE - 1),
+        );
 
-                // == Setup the authorisation request
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        // == Setup the authorisation request
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    code_verifier,
-                };
-                let oauth2_token = idms_prox_read
-                    .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                    .expect("Unable to exchange for oauth2 token");
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-                drop(idms_prox_read);
+        // == Submit the token exchange code.
 
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(osr)) => {
-                        // Process it to ensure the record exists.
-                        let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+        // Invalid token exchange
+        //  * invalid client_authz (not base64)
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            // From the first step.
+            code_verifier: code_verifier.clone(),
+        };
 
-                        assert!(idms_prox_write.process_oauth2sessionrecord(&osr).is_ok());
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(Some("not base64"), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AuthenticationRequired
+        );
 
-                        assert!(idms_prox_write.commit().is_ok());
-                    }
-                    _ => assert!(false),
-                }
+        //  * doesn't have :
+        let client_authz = Some(base64::encode(format!("test_resource_server {secret}")));
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AuthenticationRequired
+        );
 
-                // Okay, now we have the token, we can check behaviours with the revoke interface.
+        //  * invalid client_id
+        let client_authz = Some(base64::encode(format!("NOT A REAL SERVER:{secret}")));
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AuthenticationRequired
+        );
 
-                // First, assert it is valid, similar to the introspect api.
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-                let intr_request = AccessTokenIntrospectRequest {
-                    token: oauth2_token.access_token.clone(),
-                    token_type_hint: None,
-                };
-                let intr_response = idms_prox_read
-                    .check_oauth2_token_introspect(
-                        client_authz.as_deref().unwrap(),
-                        &intr_request,
-                        ct,
-                    )
-                    .expect("Failed to inspect token");
-                eprintln!("👉  {intr_response:?}");
-                assert!(intr_response.active);
-                drop(idms_prox_read);
+        //  * valid client_id, but invalid secret
+        let client_authz = Some(base64::encode("test_resource_server:12345"));
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::AuthenticationRequired
+        );
 
-                // First, the revoke needs basic auth. Provide incorrect auth, and we fail.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+        // ✅ Now the valid client_authz is in place.
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+        //  * expired exchange code (took too long)
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(
+                    client_authz.as_deref(),
+                    &token_req,
+                    ct + Duration::from_secs(TOKEN_EXPIRE)
+                )
+                .unwrap_err()
+                == Oauth2Error::InvalidRequest
+        );
 
-                let bad_client_authz = Some(base64::encode("test_resource_server:12345"));
-                let revoke_request = TokenRevokeRequest {
-                    token: oauth2_token.access_token.clone(),
-                    token_type_hint: None,
-                };
-                let e = idms_prox_write
-                    .oauth2_token_revoke(bad_client_authz.as_deref().unwrap(), &revoke_request, ct)
-                    .unwrap_err();
-                assert!(matches!(e, Oauth2Error::AuthenticationRequired));
-                assert!(idms_prox_write.commit().is_ok());
+        //  * Uat has expired!
+        // NOTE: This is setup EARLY in the test, by manipulation of the UAT expiry.
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(
+                    client_authz.as_deref(),
+                    &token_req,
+                    ct + Duration::from_secs(UAT_EXPIRE)
+                )
+                .unwrap_err()
+                == Oauth2Error::AccessDenied
+        );
 
-                // Now submit a non-existent/invalid token. Does not affect our tokens validity.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                let revoke_request = TokenRevokeRequest {
-                    token: "this is an invalid token, nothing will happen!".to_string(),
-                    token_type_hint: None,
-                };
-                let e = idms_prox_write
-                    .oauth2_token_revoke(client_authz.as_deref().unwrap(), &revoke_request, ct)
-                    .unwrap_err();
-                assert!(matches!(e, Oauth2Error::InvalidRequest));
-                assert!(idms_prox_write.commit().is_ok());
+        //  * incorrect grant_type
+        let token_req = AccessTokenRequest {
+            grant_type: "INCORRECT GRANT TYPE".to_string(),
+            code: permit_success.code.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            code_verifier: code_verifier.clone(),
+        };
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidRequest
+        );
 
-                // Check our token is still valid.
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-                let intr_response = idms_prox_read
-                    .check_oauth2_token_introspect(
-                        client_authz.as_deref().unwrap(),
-                        &intr_request,
-                        ct,
-                    )
-                    .expect("Failed to inspect token");
-                assert!(intr_response.active);
-                drop(idms_prox_read);
+        //  * Incorrect redirect uri
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code.clone(),
+            redirect_uri: Url::parse("https://totes.not.sus.org/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            code_verifier,
+        };
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidOrigin
+        );
 
-                // Finally revoke it.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                let revoke_request = TokenRevokeRequest {
-                    token: oauth2_token.access_token.clone(),
-                    token_type_hint: None,
-                };
-                assert!(idms_prox_write
-                    .oauth2_token_revoke(client_authz.as_deref().unwrap(), &revoke_request, ct,)
-                    .is_ok());
-                assert!(idms_prox_write.commit().is_ok());
-
-                // Check it is still valid - this is because we are still in the GRACE window.
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-                let intr_response = idms_prox_read
-                    .check_oauth2_token_introspect(
-                        client_authz.as_deref().unwrap(),
-                        &intr_request,
-                        ct,
-                    )
-                    .expect("Failed to inspect token");
-
-                assert!(intr_response.active);
-                drop(idms_prox_read);
-
-                // Check after the grace window, it will be invalid.
-                let ct = ct + GRACE_WINDOW;
-
-                // Assert it is now invalid.
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-                let intr_response = idms_prox_read
-                    .check_oauth2_token_introspect(
-                        client_authz.as_deref().unwrap(),
-                        &intr_request,
-                        ct,
-                    )
-                    .expect("Failed to inspect token");
-
-                assert!(!intr_response.active);
-                drop(idms_prox_read);
-
-                // A second invalidation of the token "does nothing".
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                let revoke_request = TokenRevokeRequest {
-                    token: oauth2_token.access_token,
-                    token_type_hint: None,
-                };
-                assert!(idms_prox_write
-                    .oauth2_token_revoke(client_authz.as_deref().unwrap(), &revoke_request, ct,)
-                    .is_ok());
-                assert!(idms_prox_write.commit().is_ok());
-            }
-        )
+        //  * code verifier incorrect
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            code_verifier: Some("12345".to_string()),
+        };
+        assert!(
+            idms_prox_read
+                .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidRequest
+        );
     }
 
-    #[test]
-    fn test_idm_oauth2_session_cleanup_post_rs_delete() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                // First, setup to get a token.
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+    #[idm_test]
+    async fn test_idm_oauth2_token_introspect(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // == Setup the authorisation request
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        // == Setup the authorisation request
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    code_verifier,
-                };
-                let _oauth2_token = idms_prox_read
-                    .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                    .expect("Unable to exchange for oauth2 token");
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            code_verifier,
+        };
+        let oauth2_token = idms_prox_read
+            .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+            .expect("Unable to exchange for oauth2 token");
 
-                drop(idms_prox_read);
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(_)) => {}
+            _ => assert!(false),
+        }
 
+        // Okay, now we have the token, we can check it works with introspect.
+        let intr_request = AccessTokenIntrospectRequest {
+            token: oauth2_token.access_token,
+            token_type_hint: None,
+        };
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+
+        eprintln!("👉  {intr_response:?}");
+        assert!(intr_response.active);
+        assert!(intr_response.scope.as_deref() == Some("openid supplement"));
+        assert!(intr_response.client_id.as_deref() == Some("test_resource_server"));
+        assert!(intr_response.username.as_deref() == Some("admin@example.com"));
+        assert!(intr_response.token_type.as_deref() == Some("access_token"));
+        assert!(intr_response.iat == Some(ct.as_secs() as i64));
+        assert!(intr_response.nbf == Some(ct.as_secs() as i64));
+
+        drop(idms_prox_read);
+        // start a write,
+
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        // Expire the account, should cause introspect to return inactive.
+        let v_expire = Value::new_datetime_epoch(Duration::from_secs(TEST_CURRENT_TIME - 1));
+        let me_inv_m = unsafe {
+            ModifyEvent::new_internal_invalid(
+                filter!(f_eq("name", PartialValue::new_iname("admin"))),
+                ModifyList::new_list(vec![Modify::Present(
+                    AttrString::from("account_expire"),
+                    v_expire,
+                )]),
+            )
+        };
+        // go!
+        assert!(idms_prox_write.qs_write.modify(&me_inv_m).is_ok());
+        assert!(idms_prox_write.commit().is_ok());
+
+        // start a new read
+        // check again.
+        let mut idms_prox_read = idms.proxy_read().await;
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(&client_authz.unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+
+        assert!(!intr_response.active);
+    }
+
+    #[idm_test]
+    async fn test_idm_oauth2_token_revoke(idms: &IdmServer, idms_delayed: &mut IdmServerDelayed) {
+        // First, setup to get a token.
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+
+        let mut idms_prox_read = idms.proxy_read().await;
+
+        // == Setup the authorisation request
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
+
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
+
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
+
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
+
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            code_verifier,
+        };
+        let oauth2_token = idms_prox_read
+            .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+            .expect("Unable to exchange for oauth2 token");
+
+        drop(idms_prox_read);
+
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(osr)) => {
                 // Process it to ensure the record exists.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+                let mut idms_prox_write = idms.proxy_write(ct).await;
 
-                // Assert that the session creation was submitted
-                let session_id = match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(osr)) => {
-                        assert!(idms_prox_write.process_oauth2sessionrecord(&osr).is_ok());
-                        osr.session_id
-                    }
-                    _ => {
-                        unreachable!();
-                    }
-                };
-
-                // Check it is now there
-                let entry = idms_prox_write
-                    .qs_write
-                    .internal_search_uuid(UUID_ADMIN)
-                    .expect("failed");
-                let valid = entry
-                    .get_ava_as_oauth2session_map("oauth2_session")
-                    .map(|map| map.get(&session_id).is_some())
-                    .unwrap_or(false);
-                assert!(valid);
-
-                // Delete the resource server.
-
-                let de = unsafe {
-                    DeleteEvent::new_internal_invalid(filter!(f_eq(
-                        "oauth2_rs_name",
-                        PartialValue::new_iname("test_resource_server")
-                    )))
-                };
-
-                assert!(idms_prox_write.qs_write.delete(&de).is_ok());
-
-                // Assert the session is gone. This is cleaned up as an artifact of the referential
-                // integrity plugin.
-                let entry = idms_prox_write
-                    .qs_write
-                    .internal_search_uuid(UUID_ADMIN)
-                    .expect("failed");
-                let valid = entry
-                    .get_ava_as_oauth2session_map("oauth2_session")
-                    .map(|map| map.get(&session_id).is_some())
-                    .unwrap_or(false);
-                assert!(!valid);
+                assert!(idms_prox_write.process_oauth2sessionrecord(&osr).is_ok());
 
                 assert!(idms_prox_write.commit().is_ok());
             }
-        )
+            _ => assert!(false),
+        }
+
+        // Okay, now we have the token, we can check behaviours with the revoke interface.
+
+        // First, assert it is valid, similar to the introspect api.
+        let mut idms_prox_read = idms.proxy_read().await;
+        let intr_request = AccessTokenIntrospectRequest {
+            token: oauth2_token.access_token.clone(),
+            token_type_hint: None,
+        };
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+        eprintln!("👉  {intr_response:?}");
+        assert!(intr_response.active);
+        drop(idms_prox_read);
+
+        // First, the revoke needs basic auth. Provide incorrect auth, and we fail.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+
+        let bad_client_authz = Some(base64::encode("test_resource_server:12345"));
+        let revoke_request = TokenRevokeRequest {
+            token: oauth2_token.access_token.clone(),
+            token_type_hint: None,
+        };
+        let e = idms_prox_write
+            .oauth2_token_revoke(bad_client_authz.as_deref().unwrap(), &revoke_request, ct)
+            .unwrap_err();
+        assert!(matches!(e, Oauth2Error::AuthenticationRequired));
+        assert!(idms_prox_write.commit().is_ok());
+
+        // Now submit a non-existent/invalid token. Does not affect our tokens validity.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        let revoke_request = TokenRevokeRequest {
+            token: "this is an invalid token, nothing will happen!".to_string(),
+            token_type_hint: None,
+        };
+        let e = idms_prox_write
+            .oauth2_token_revoke(client_authz.as_deref().unwrap(), &revoke_request, ct)
+            .unwrap_err();
+        assert!(matches!(e, Oauth2Error::InvalidRequest));
+        assert!(idms_prox_write.commit().is_ok());
+
+        // Check our token is still valid.
+        let mut idms_prox_read = idms.proxy_read().await;
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+        assert!(intr_response.active);
+        drop(idms_prox_read);
+
+        // Finally revoke it.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        let revoke_request = TokenRevokeRequest {
+            token: oauth2_token.access_token.clone(),
+            token_type_hint: None,
+        };
+        assert!(idms_prox_write
+            .oauth2_token_revoke(client_authz.as_deref().unwrap(), &revoke_request, ct,)
+            .is_ok());
+        assert!(idms_prox_write.commit().is_ok());
+
+        // Check it is still valid - this is because we are still in the GRACE window.
+        let mut idms_prox_read = idms.proxy_read().await;
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+
+        assert!(intr_response.active);
+        drop(idms_prox_read);
+
+        // Check after the grace window, it will be invalid.
+        let ct = ct + GRACE_WINDOW;
+
+        // Assert it is now invalid.
+        let mut idms_prox_read = idms.proxy_read().await;
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+
+        assert!(!intr_response.active);
+        drop(idms_prox_read);
+
+        // A second invalidation of the token "does nothing".
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        let revoke_request = TokenRevokeRequest {
+            token: oauth2_token.access_token,
+            token_type_hint: None,
+        };
+        assert!(idms_prox_write
+            .oauth2_token_revoke(client_authz.as_deref().unwrap(), &revoke_request, ct,)
+            .is_ok());
+        assert!(idms_prox_write.commit().is_ok());
     }
 
-    #[test]
-    fn test_idm_oauth2_authorisation_reject() {
-        run_idm_test!(|_qs: &QueryServer,
-                       idms: &IdmServer,
-                       _idms_delayed: &mut IdmServerDelayed| {
-            let ct = Duration::from_secs(TEST_CURRENT_TIME);
-            let (_secret, uat, ident, _) =
-                setup_oauth2_resource_server(idms, ct, true, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_session_cleanup_post_rs_delete(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        // First, setup to get a token.
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
 
-            let (uat2, ident2) = {
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                let account = idms_prox_write
-                    .target_to_account(UUID_IDM_ADMIN)
-                    .expect("account must exist");
-                let session_id = uuid::Uuid::new_v4();
-                let uat2 = account
-                    .to_userauthtoken(
-                        session_id,
-                        ct,
-                        AuthType::PasswordMfa,
-                        Some(AUTH_SESSION_EXPIRY),
-                    )
-                    .expect("Unable to create uat");
-                let ident2 = idms_prox_write
-                    .process_uat_to_identity(&uat2, ct)
-                    .expect("Unable to process uat");
-                (uat2, ident2)
-            };
+        let mut idms_prox_read = idms.proxy_read().await;
 
-            let idms_prox_read = task::block_on(idms.proxy_read());
-            let redirect_uri = Url::parse("https://demo.example.com/oauth2/result").unwrap();
-            let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        // == Setup the authorisation request
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-            // Check reject behaviour
-            let consent_request = good_authorisation_request!(
-                idms_prox_read,
-                &ident,
-                &uat,
-                ct,
-                code_challenge,
-                "openid".to_string()
-            );
-
-            let consent_token = if let AuthoriseResponse::ConsentRequested {
-                consent_token, ..
-            } = consent_request
-            {
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
                 consent_token
             } else {
                 unreachable!();
             };
 
-            let reject_success = idms_prox_read
-                .check_oauth2_authorise_reject(&ident, &uat, &consent_token, ct)
-                .expect("Failed to perform oauth2 reject");
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-            assert!(reject_success == redirect_uri);
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-            // Too much time past to reject
-            let past_ct = Duration::from_secs(TEST_CURRENT_TIME + 301);
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_reject(&ident, &uat, &consent_token, past_ct)
-                    .unwrap_err()
-                    == OperationError::CryptographyError
-            );
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            code_verifier,
+        };
+        let _oauth2_token = idms_prox_read
+            .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+            .expect("Unable to exchange for oauth2 token");
 
-            // Invalid consent token
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_reject(&ident, &uat, "not a token", ct)
-                    .unwrap_err()
-                    == OperationError::CryptographyError
-            );
+        drop(idms_prox_read);
 
-            // Wrong UAT
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_reject(&ident, &uat2, &consent_token, ct)
-                    .unwrap_err()
-                    == OperationError::InvalidSessionState
-            );
-            // Wrong ident
-            assert!(
-                idms_prox_read
-                    .check_oauth2_authorise_reject(&ident2, &uat, &consent_token, ct)
-                    .unwrap_err()
-                    == OperationError::InvalidSessionState
-            );
-        })
+        // Process it to ensure the record exists.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+
+        // Assert that the session creation was submitted
+        let session_id = match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(osr)) => {
+                assert!(idms_prox_write.process_oauth2sessionrecord(&osr).is_ok());
+                osr.session_id
+            }
+            _ => {
+                unreachable!();
+            }
+        };
+
+        // Check it is now there
+        let entry = idms_prox_write
+            .qs_write
+            .internal_search_uuid(UUID_ADMIN)
+            .expect("failed");
+        let valid = entry
+            .get_ava_as_oauth2session_map("oauth2_session")
+            .map(|map| map.get(&session_id).is_some())
+            .unwrap_or(false);
+        assert!(valid);
+
+        // Delete the resource server.
+
+        let de = unsafe {
+            DeleteEvent::new_internal_invalid(filter!(f_eq(
+                "oauth2_rs_name",
+                PartialValue::new_iname("test_resource_server")
+            )))
+        };
+
+        assert!(idms_prox_write.qs_write.delete(&de).is_ok());
+
+        // Assert the session is gone. This is cleaned up as an artifact of the referential
+        // integrity plugin.
+        let entry = idms_prox_write
+            .qs_write
+            .internal_search_uuid(UUID_ADMIN)
+            .expect("failed");
+        let valid = entry
+            .get_ava_as_oauth2session_map("oauth2_session")
+            .map(|map| map.get(&session_id).is_some())
+            .unwrap_or(false);
+        assert!(!valid);
+
+        assert!(idms_prox_write.commit().is_ok());
     }
 
-    #[test]
-    fn test_idm_oauth2_openid_discovery() {
-        run_idm_test!(|_qs: &QueryServer,
-                       idms: &IdmServer,
-                       _idms_delayed: &mut IdmServerDelayed| {
-            let ct = Duration::from_secs(TEST_CURRENT_TIME);
-            let (_secret, _uat, _ident, _) =
-                setup_oauth2_resource_server(idms, ct, true, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_authorisation_reject(
+        idms: &IdmServer,
+        _idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-            let idms_prox_read = task::block_on(idms.proxy_read());
+        let (uat2, ident2) = {
+            let mut idms_prox_write = idms.proxy_write(ct).await;
+            let account = idms_prox_write
+                .target_to_account(UUID_IDM_ADMIN)
+                .expect("account must exist");
+            let session_id = uuid::Uuid::new_v4();
+            let uat2 = account
+                .to_userauthtoken(
+                    session_id,
+                    ct,
+                    AuthType::PasswordMfa,
+                    Some(AUTH_SESSION_EXPIRY),
+                )
+                .expect("Unable to create uat");
+            let ident2 = idms_prox_write
+                .process_uat_to_identity(&uat2, ct)
+                .expect("Unable to process uat");
+            (uat2, ident2)
+        };
 
-            // check the discovery end point works as we expect
-            assert!(
-                idms_prox_read
-                    .oauth2_openid_discovery("nosuchclient")
-                    .unwrap_err()
-                    == OperationError::NoMatchingEntries
-            );
+        let idms_prox_read = idms.proxy_read().await;
+        let redirect_uri = Url::parse("https://demo.example.com/oauth2/result").unwrap();
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-            assert!(
-                idms_prox_read
-                    .oauth2_openid_publickey("nosuchclient")
-                    .unwrap_err()
-                    == OperationError::NoMatchingEntries
-            );
+        // Check reject behaviour
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-            let discovery = idms_prox_read
-                .oauth2_openid_discovery("test_resource_server")
-                .expect("Failed to get discovery");
-
-            let mut jwkset = idms_prox_read
-                .oauth2_openid_publickey("test_resource_server")
-                .expect("Failed to get public key");
-
-            let jwk = jwkset.keys.pop().expect("no such jwk");
-
-            match jwk {
-                Jwk::EC { alg, use_, kid, .. } => {
-                    match (
-                        alg.unwrap(),
-                        &discovery.id_token_signing_alg_values_supported[0],
-                    ) {
-                        (JwaAlg::ES256, IdTokenSignAlg::ES256) => {}
-                        _ => panic!(),
-                    };
-                    assert!(use_.unwrap() == JwkUse::Sig);
-                    assert!(kid.is_some())
-                }
-                _ => panic!(),
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
             };
 
-            assert!(
-                discovery.issuer
-                    == Url::parse("https://idm.example.com/oauth2/openid/test_resource_server")
-                        .unwrap()
-            );
+        let reject_success = idms_prox_read
+            .check_oauth2_authorise_reject(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 reject");
 
-            assert!(
-                discovery.authorization_endpoint
-                    == Url::parse("https://idm.example.com/ui/oauth2").unwrap()
-            );
+        assert!(reject_success == redirect_uri);
 
-            assert!(
-                discovery.token_endpoint
-                    == Url::parse("https://idm.example.com/oauth2/token").unwrap()
-            );
+        // Too much time past to reject
+        let past_ct = Duration::from_secs(TEST_CURRENT_TIME + 301);
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_reject(&ident, &uat, &consent_token, past_ct)
+                .unwrap_err()
+                == OperationError::CryptographyError
+        );
 
-            assert!(
-                discovery.userinfo_endpoint
-                    == Some(
-                        Url::parse(
-                            "https://idm.example.com/oauth2/openid/test_resource_server/userinfo"
-                        )
-                        .unwrap()
-                    )
-            );
+        // Invalid consent token
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_reject(&ident, &uat, "not a token", ct)
+                .unwrap_err()
+                == OperationError::CryptographyError
+        );
 
-            assert!(
-                discovery.jwks_uri
-                    == Url::parse(
-                        "https://idm.example.com/oauth2/openid/test_resource_server/public_key.jwk"
+        // Wrong UAT
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_reject(&ident, &uat2, &consent_token, ct)
+                .unwrap_err()
+                == OperationError::InvalidSessionState
+        );
+        // Wrong ident
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorise_reject(&ident2, &uat, &consent_token, ct)
+                .unwrap_err()
+                == OperationError::InvalidSessionState
+        );
+    }
+
+    #[idm_test]
+    async fn test_idm_oauth2_openid_discovery(
+        idms: &IdmServer,
+        _idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, _uat, _ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
+
+        let idms_prox_read = idms.proxy_read().await;
+
+        // check the discovery end point works as we expect
+        assert!(
+            idms_prox_read
+                .oauth2_openid_discovery("nosuchclient")
+                .unwrap_err()
+                == OperationError::NoMatchingEntries
+        );
+
+        assert!(
+            idms_prox_read
+                .oauth2_openid_publickey("nosuchclient")
+                .unwrap_err()
+                == OperationError::NoMatchingEntries
+        );
+
+        let discovery = idms_prox_read
+            .oauth2_openid_discovery("test_resource_server")
+            .expect("Failed to get discovery");
+
+        let mut jwkset = idms_prox_read
+            .oauth2_openid_publickey("test_resource_server")
+            .expect("Failed to get public key");
+
+        let jwk = jwkset.keys.pop().expect("no such jwk");
+
+        match jwk {
+            Jwk::EC { alg, use_, kid, .. } => {
+                match (
+                    alg.unwrap(),
+                    &discovery.id_token_signing_alg_values_supported[0],
+                ) {
+                    (JwaAlg::ES256, IdTokenSignAlg::ES256) => {}
+                    _ => panic!(),
+                };
+                assert!(use_.unwrap() == JwkUse::Sig);
+                assert!(kid.is_some())
+            }
+            _ => panic!(),
+        };
+
+        assert!(
+            discovery.issuer
+                == Url::parse("https://idm.example.com/oauth2/openid/test_resource_server")
+                    .unwrap()
+        );
+
+        assert!(
+            discovery.authorization_endpoint
+                == Url::parse("https://idm.example.com/ui/oauth2").unwrap()
+        );
+
+        assert!(
+            discovery.token_endpoint == Url::parse("https://idm.example.com/oauth2/token").unwrap()
+        );
+
+        assert!(
+            discovery.userinfo_endpoint
+                == Some(
+                    Url::parse(
+                        "https://idm.example.com/oauth2/openid/test_resource_server/userinfo"
                     )
                     .unwrap()
-            );
+                )
+        );
 
-            eprintln!("{:?}", discovery.scopes_supported);
-            assert!(
-                discovery.scopes_supported
-                    == Some(vec![
-                        "groups".to_string(),
-                        "openid".to_string(),
-                        "supplement".to_string(),
-                    ])
-            );
+        assert!(
+            discovery.jwks_uri
+                == Url::parse(
+                    "https://idm.example.com/oauth2/openid/test_resource_server/public_key.jwk"
+                )
+                .unwrap()
+        );
 
-            assert!(discovery.response_types_supported == vec![ResponseType::Code]);
-            assert!(discovery.response_modes_supported == vec![ResponseMode::Query]);
-            assert!(discovery.grant_types_supported == vec![GrantType::AuthorisationCode]);
-            assert!(discovery.subject_types_supported == vec![SubjectType::Public]);
-            assert!(discovery.id_token_signing_alg_values_supported == vec![IdTokenSignAlg::ES256]);
-            assert!(discovery.userinfo_signing_alg_values_supported.is_none());
-            assert!(
-                discovery.token_endpoint_auth_methods_supported
-                    == vec![
-                        TokenEndpointAuthMethod::ClientSecretBasic,
-                        TokenEndpointAuthMethod::ClientSecretPost
-                    ]
-            );
-            assert!(discovery.display_values_supported == Some(vec![DisplayValue::Page]));
-            assert!(discovery.claim_types_supported == vec![ClaimType::Normal]);
-            assert!(discovery.claims_supported.is_none());
-            assert!(discovery.service_documentation.is_some());
+        eprintln!("{:?}", discovery.scopes_supported);
+        assert!(
+            discovery.scopes_supported
+                == Some(vec![
+                    "groups".to_string(),
+                    "openid".to_string(),
+                    "supplement".to_string(),
+                ])
+        );
 
-            assert!(discovery.registration_endpoint.is_none());
-            assert!(discovery.acr_values_supported.is_none());
-            assert!(discovery.id_token_encryption_alg_values_supported.is_none());
-            assert!(discovery.id_token_encryption_enc_values_supported.is_none());
-            assert!(discovery.userinfo_encryption_alg_values_supported.is_none());
-            assert!(discovery.userinfo_encryption_enc_values_supported.is_none());
-            assert!(discovery
-                .request_object_signing_alg_values_supported
-                .is_none());
-            assert!(discovery
-                .request_object_encryption_alg_values_supported
-                .is_none());
-            assert!(discovery
-                .request_object_encryption_enc_values_supported
-                .is_none());
-            assert!(discovery
-                .token_endpoint_auth_signing_alg_values_supported
-                .is_none());
-            assert!(discovery.claims_locales_supported.is_none());
-            assert!(discovery.ui_locales_supported.is_none());
-            assert!(discovery.op_policy_uri.is_none());
-            assert!(discovery.op_tos_uri.is_none());
-            assert!(!discovery.claims_parameter_supported);
-            assert!(!discovery.request_uri_parameter_supported);
-            assert!(!discovery.require_request_uri_registration);
-            assert!(discovery.request_parameter_supported);
-        })
+        assert!(discovery.response_types_supported == vec![ResponseType::Code]);
+        assert!(discovery.response_modes_supported == vec![ResponseMode::Query]);
+        assert!(discovery.grant_types_supported == vec![GrantType::AuthorisationCode]);
+        assert!(discovery.subject_types_supported == vec![SubjectType::Public]);
+        assert!(discovery.id_token_signing_alg_values_supported == vec![IdTokenSignAlg::ES256]);
+        assert!(discovery.userinfo_signing_alg_values_supported.is_none());
+        assert!(
+            discovery.token_endpoint_auth_methods_supported
+                == vec![
+                    TokenEndpointAuthMethod::ClientSecretBasic,
+                    TokenEndpointAuthMethod::ClientSecretPost
+                ]
+        );
+        assert!(discovery.display_values_supported == Some(vec![DisplayValue::Page]));
+        assert!(discovery.claim_types_supported == vec![ClaimType::Normal]);
+        assert!(discovery.claims_supported.is_none());
+        assert!(discovery.service_documentation.is_some());
+
+        assert!(discovery.registration_endpoint.is_none());
+        assert!(discovery.acr_values_supported.is_none());
+        assert!(discovery.id_token_encryption_alg_values_supported.is_none());
+        assert!(discovery.id_token_encryption_enc_values_supported.is_none());
+        assert!(discovery.userinfo_encryption_alg_values_supported.is_none());
+        assert!(discovery.userinfo_encryption_enc_values_supported.is_none());
+        assert!(discovery
+            .request_object_signing_alg_values_supported
+            .is_none());
+        assert!(discovery
+            .request_object_encryption_alg_values_supported
+            .is_none());
+        assert!(discovery
+            .request_object_encryption_enc_values_supported
+            .is_none());
+        assert!(discovery
+            .token_endpoint_auth_signing_alg_values_supported
+            .is_none());
+        assert!(discovery.claims_locales_supported.is_none());
+        assert!(discovery.ui_locales_supported.is_none());
+        assert!(discovery.op_policy_uri.is_none());
+        assert!(discovery.op_tos_uri.is_none());
+        assert!(!discovery.claims_parameter_supported);
+        assert!(!discovery.request_uri_parameter_supported);
+        assert!(!discovery.require_request_uri_registration);
+        assert!(discovery.request_parameter_supported);
     }
 
-    #[test]
-    fn test_idm_oauth2_openid_extensions() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+    #[idm_test]
+    async fn test_idm_oauth2_openid_extensions(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-                // == Submit the token exchange code.
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    // From the first step.
-                    code_verifier,
-                };
+        // == Submit the token exchange code.
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            // From the first step.
+            code_verifier,
+        };
 
-                let token_response = idms_prox_read
-                    .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                    .expect("Failed to perform oauth2 token exchange");
+        let token_response = idms_prox_read
+            .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+            .expect("Failed to perform oauth2 token exchange");
 
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(_)) => {}
-                    _ => assert!(false),
-                }
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(_)) => {}
+            _ => assert!(false),
+        }
 
-                // 🎉 We got a token!
-                assert!(token_response.token_type == "bearer");
+        // 🎉 We got a token!
+        assert!(token_response.token_type == "bearer");
 
-                let id_token = token_response.id_token.expect("No id_token in response!");
-                let access_token = token_response.access_token;
+        let id_token = token_response.id_token.expect("No id_token in response!");
+        let access_token = token_response.access_token;
 
-                let mut jwkset = idms_prox_read
-                    .oauth2_openid_publickey("test_resource_server")
-                    .expect("Failed to get public key");
-                let public_jwk = jwkset.keys.pop().expect("no such jwk");
+        let mut jwkset = idms_prox_read
+            .oauth2_openid_publickey("test_resource_server")
+            .expect("Failed to get public key");
+        let public_jwk = jwkset.keys.pop().expect("no such jwk");
 
-                let jws_validator =
-                    JwsValidator::try_from(&public_jwk).expect("failed to build validator");
+        let jws_validator = JwsValidator::try_from(&public_jwk).expect("failed to build validator");
 
-                let oidc_unverified =
-                    OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
+        let oidc_unverified =
+            OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
 
-                let iat = ct.as_secs() as i64;
+        let iat = ct.as_secs() as i64;
 
-                let oidc = oidc_unverified
-                    .validate(&jws_validator, iat)
-                    .expect("Failed to verify oidc");
+        let oidc = oidc_unverified
+            .validate(&jws_validator, iat)
+            .expect("Failed to verify oidc");
 
-                // Are the id_token values what we expect?
-                assert!(
-                    oidc.iss
-                        == Url::parse("https://idm.example.com/oauth2/openid/test_resource_server")
-                            .unwrap()
-                );
-                assert!(oidc.sub == OidcSubject::U(UUID_ADMIN));
-                assert!(oidc.aud == "test_resource_server");
-                assert!(oidc.iat == iat);
-                assert!(oidc.nbf == Some(iat));
-                assert!(oidc.exp == iat + (AUTH_SESSION_EXPIRY as i64));
-                assert!(oidc.auth_time.is_none());
-                // Is nonce correctly passed through?
-                assert!(oidc.nonce == Some("abcdef".to_string()));
-                assert!(oidc.at_hash.is_none());
-                assert!(oidc.acr.is_none());
-                assert!(oidc.amr == Some(vec!["passwordmfa".to_string()]));
-                assert!(oidc.azp == Some("test_resource_server".to_string()));
-                assert!(oidc.jti.is_none());
-                assert!(oidc.s_claims.name == Some("System Administrator".to_string()));
-                assert!(oidc.s_claims.preferred_username == Some("admin@example.com".to_string()));
-                assert!(
-                    oidc.s_claims.scopes == vec!["openid".to_string(), "supplement".to_string()]
-                );
-                assert!(oidc.claims.is_empty());
-                // Does our access token work with the userinfo endpoint?
-                // Do the id_token details line up to the userinfo?
-                let userinfo = idms_prox_read
-                    .oauth2_openid_userinfo("test_resource_server", &access_token, ct)
-                    .expect("failed to get userinfo");
-
-                assert!(oidc.iss == userinfo.iss);
-                assert!(oidc.sub == userinfo.sub);
-                assert!(oidc.aud == userinfo.aud);
-                assert!(oidc.iat == userinfo.iat);
-                assert!(oidc.nbf == userinfo.nbf);
-                assert!(oidc.exp == userinfo.exp);
-                assert!(userinfo.auth_time.is_none());
-                assert!(userinfo.nonce.is_none());
-                assert!(userinfo.at_hash.is_none());
-                assert!(userinfo.acr.is_none());
-                assert!(oidc.amr == userinfo.amr);
-                assert!(oidc.azp == userinfo.azp);
-                assert!(userinfo.jti.is_none());
-                assert!(oidc.s_claims == userinfo.s_claims);
-                assert!(userinfo.claims.is_empty());
-            }
-        )
-    }
-
-    #[test]
-    fn test_idm_oauth2_openid_short_username() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                // we run the same test as test_idm_oauth2_openid_extensions()
-                // but change the preferred_username setting on the RS
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, true);
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
-
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
-
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
-
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
-
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // == Submit the token exchange code.
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    // From the first step.
-                    code_verifier,
-                };
-
-                let token_response = idms_prox_read
-                    .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                    .expect("Failed to perform oauth2 token exchange");
-
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(_)) => {}
-                    _ => assert!(false),
-                }
-
-                let id_token = token_response.id_token.expect("No id_token in response!");
-                let access_token = token_response.access_token;
-
-                let mut jwkset = idms_prox_read
-                    .oauth2_openid_publickey("test_resource_server")
-                    .expect("Failed to get public key");
-                let public_jwk = jwkset.keys.pop().expect("no such jwk");
-
-                let jws_validator =
-                    JwsValidator::try_from(&public_jwk).expect("failed to build validator");
-
-                let oidc_unverified =
-                    OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
-
-                let iat = ct.as_secs() as i64;
-
-                let oidc = oidc_unverified
-                    .validate(&jws_validator, iat)
-                    .expect("Failed to verify oidc");
-
-                // Do we have the short username in the token claims?
-                assert!(oidc.s_claims.preferred_username == Some("admin".to_string()));
-                // Do the id_token details line up to the userinfo?
-                let userinfo = idms_prox_read
-                    .oauth2_openid_userinfo("test_resource_server", &access_token, ct)
-                    .expect("failed to get userinfo");
-
-                assert!(oidc.s_claims == userinfo.s_claims);
-            }
-        )
-    }
-
-    #[test]
-    fn test_idm_oauth2_openid_group_claims() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                // we run the same test as test_idm_oauth2_openid_extensions()
-                // but change the preferred_username setting on the RS
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, true);
-                let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
-
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid groups".to_string()
-                );
-
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
-
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
-
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // == Submit the token exchange code.
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: None,
-                    client_secret: None,
-                    // From the first step.
-                    code_verifier,
-                };
-
-                let token_response = idms_prox_read
-                    .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
-                    .expect("Failed to perform oauth2 token exchange");
-
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(_)) => {}
-                    _ => assert!(false),
-                }
-
-                let id_token = token_response.id_token.expect("No id_token in response!");
-                let access_token = token_response.access_token;
-
-                let mut jwkset = idms_prox_read
-                    .oauth2_openid_publickey("test_resource_server")
-                    .expect("Failed to get public key");
-                let public_jwk = jwkset.keys.pop().expect("no such jwk");
-
-                let jws_validator =
-                    JwsValidator::try_from(&public_jwk).expect("failed to build validator");
-
-                let oidc_unverified =
-                    OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
-
-                let iat = ct.as_secs() as i64;
-
-                let oidc = oidc_unverified
-                    .validate(&jws_validator, iat)
-                    .expect("Failed to verify oidc");
-
-                // does our id_token contain the expected groups?
-                assert!(oidc.claims.contains_key(&"groups".to_string()));
-
-                assert!(oidc
-                    .claims
-                    .get(&"groups".to_string())
-                    .expect("unable to find key")
-                    .as_array()
+        // Are the id_token values what we expect?
+        assert!(
+            oidc.iss
+                == Url::parse("https://idm.example.com/oauth2/openid/test_resource_server")
                     .unwrap()
-                    .contains(&serde_json::json!(STR_UUID_IDM_ALL_ACCOUNTS)));
+        );
+        assert!(oidc.sub == OidcSubject::U(UUID_ADMIN));
+        assert!(oidc.aud == "test_resource_server");
+        assert!(oidc.iat == iat);
+        assert!(oidc.nbf == Some(iat));
+        assert!(oidc.exp == iat + (AUTH_SESSION_EXPIRY as i64));
+        assert!(oidc.auth_time.is_none());
+        // Is nonce correctly passed through?
+        assert!(oidc.nonce == Some("abcdef".to_string()));
+        assert!(oidc.at_hash.is_none());
+        assert!(oidc.acr.is_none());
+        assert!(oidc.amr == Some(vec!["passwordmfa".to_string()]));
+        assert!(oidc.azp == Some("test_resource_server".to_string()));
+        assert!(oidc.jti.is_none());
+        assert!(oidc.s_claims.name == Some("System Administrator".to_string()));
+        assert!(oidc.s_claims.preferred_username == Some("admin@example.com".to_string()));
+        assert!(oidc.s_claims.scopes == vec!["openid".to_string(), "supplement".to_string()]);
+        assert!(oidc.claims.is_empty());
+        // Does our access token work with the userinfo endpoint?
+        // Do the id_token details line up to the userinfo?
+        let userinfo = idms_prox_read
+            .oauth2_openid_userinfo("test_resource_server", &access_token, ct)
+            .expect("failed to get userinfo");
 
-                // Do the id_token details line up to the userinfo?
-                let userinfo = idms_prox_read
-                    .oauth2_openid_userinfo("test_resource_server", &access_token, ct)
-                    .expect("failed to get userinfo");
+        assert!(oidc.iss == userinfo.iss);
+        assert!(oidc.sub == userinfo.sub);
+        assert!(oidc.aud == userinfo.aud);
+        assert!(oidc.iat == userinfo.iat);
+        assert!(oidc.nbf == userinfo.nbf);
+        assert!(oidc.exp == userinfo.exp);
+        assert!(userinfo.auth_time.is_none());
+        assert!(userinfo.nonce.is_none());
+        assert!(userinfo.at_hash.is_none());
+        assert!(userinfo.acr.is_none());
+        assert!(oidc.amr == userinfo.amr);
+        assert!(oidc.azp == userinfo.azp);
+        assert!(userinfo.jti.is_none());
+        assert!(oidc.s_claims == userinfo.s_claims);
+        assert!(userinfo.claims.is_empty());
+    }
 
-                // does the userinfo endpoint provide the same groups?
-                assert!(
-                    oidc.claims.get(&"groups".to_string())
-                        == userinfo.claims.get(&"groups".to_string())
-                );
-            }
-        )
+    #[idm_test]
+    async fn test_idm_oauth2_openid_short_username(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        // we run the same test as test_idm_oauth2_openid_extensions()
+        // but change the preferred_username setting on the RS
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, true).await;
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+
+        let mut idms_prox_read = idms.proxy_read().await;
+
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
+
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
+
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
+
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
+
+        // == Submit the token exchange code.
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            // From the first step.
+            code_verifier,
+        };
+
+        let token_response = idms_prox_read
+            .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+            .expect("Failed to perform oauth2 token exchange");
+
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(_)) => {}
+            _ => assert!(false),
+        }
+
+        let id_token = token_response.id_token.expect("No id_token in response!");
+        let access_token = token_response.access_token;
+
+        let mut jwkset = idms_prox_read
+            .oauth2_openid_publickey("test_resource_server")
+            .expect("Failed to get public key");
+        let public_jwk = jwkset.keys.pop().expect("no such jwk");
+
+        let jws_validator = JwsValidator::try_from(&public_jwk).expect("failed to build validator");
+
+        let oidc_unverified =
+            OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
+
+        let iat = ct.as_secs() as i64;
+
+        let oidc = oidc_unverified
+            .validate(&jws_validator, iat)
+            .expect("Failed to verify oidc");
+
+        // Do we have the short username in the token claims?
+        assert!(oidc.s_claims.preferred_username == Some("admin".to_string()));
+        // Do the id_token details line up to the userinfo?
+        let userinfo = idms_prox_read
+            .oauth2_openid_userinfo("test_resource_server", &access_token, ct)
+            .expect("failed to get userinfo");
+
+        assert!(oidc.s_claims == userinfo.s_claims);
+    }
+
+    #[idm_test]
+    async fn test_idm_oauth2_openid_group_claims(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        // we run the same test as test_idm_oauth2_openid_extensions()
+        // but change the preferred_username setting on the RS
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, true).await;
+        let client_authz = Some(base64::encode(format!("test_resource_server:{secret}")));
+
+        let mut idms_prox_read = idms.proxy_read().await;
+
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid groups".to_string()
+        );
+
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
+
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
+
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
+
+        // == Submit the token exchange code.
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: None,
+            client_secret: None,
+            // From the first step.
+            code_verifier,
+        };
+
+        let token_response = idms_prox_read
+            .check_oauth2_token_exchange(client_authz.as_deref(), &token_req, ct)
+            .expect("Failed to perform oauth2 token exchange");
+
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(_)) => {}
+            _ => assert!(false),
+        }
+
+        let id_token = token_response.id_token.expect("No id_token in response!");
+        let access_token = token_response.access_token;
+
+        let mut jwkset = idms_prox_read
+            .oauth2_openid_publickey("test_resource_server")
+            .expect("Failed to get public key");
+        let public_jwk = jwkset.keys.pop().expect("no such jwk");
+
+        let jws_validator = JwsValidator::try_from(&public_jwk).expect("failed to build validator");
+
+        let oidc_unverified =
+            OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
+
+        let iat = ct.as_secs() as i64;
+
+        let oidc = oidc_unverified
+            .validate(&jws_validator, iat)
+            .expect("Failed to verify oidc");
+
+        // does our id_token contain the expected groups?
+        assert!(oidc.claims.contains_key(&"groups".to_string()));
+
+        assert!(oidc
+            .claims
+            .get(&"groups".to_string())
+            .expect("unable to find key")
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!(STR_UUID_IDM_ALL_ACCOUNTS)));
+
+        // Do the id_token details line up to the userinfo?
+        let userinfo = idms_prox_read
+            .oauth2_openid_userinfo("test_resource_server", &access_token, ct)
+            .expect("failed to get userinfo");
+
+        // does the userinfo endpoint provide the same groups?
+        assert!(
+            oidc.claims.get(&"groups".to_string()) == userinfo.claims.get(&"groups".to_string())
+        );
     }
 
     //  Check insecure pkce behaviour.
-    #[test]
-    fn test_idm_oauth2_insecure_pkce() {
-        run_idm_test!(|_qs: &QueryServer,
-                       idms: &IdmServer,
-                       _idms_delayed: &mut IdmServerDelayed| {
-            let ct = Duration::from_secs(TEST_CURRENT_TIME);
-            let (_secret, uat, ident, _) =
-                setup_oauth2_resource_server(idms, ct, false, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_insecure_pkce(idms: &IdmServer, _idms_delayed: &mut IdmServerDelayed) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, false, false, false).await;
 
-            let idms_prox_read = task::block_on(idms.proxy_read());
+        let idms_prox_read = idms.proxy_read().await;
 
-            // == Setup the authorisation request
-            let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        // == Setup the authorisation request
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-            // Even in disable pkce mode, we will allow pkce
-            let _consent_request = good_authorisation_request!(
-                idms_prox_read,
-                &ident,
-                &uat,
-                ct,
-                code_challenge,
-                "openid".to_string()
-            );
+        // Even in disable pkce mode, we will allow pkce
+        let _consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-            // Check we allow none.
-            let auth_req = AuthorisationRequest {
-                response_type: "code".to_string(),
-                client_id: "test_resource_server".to_string(),
-                state: "123".to_string(),
-                pkce_request: None,
-                redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                scope: "openid".to_string(),
-                nonce: Some("abcdef".to_string()),
-                oidc_ext: Default::default(),
-                unknown_keys: Default::default(),
-            };
+        // Check we allow none.
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: None,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: Some("abcdef".to_string()),
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-            idms_prox_read
-                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                .expect("Oauth2 authorisation failed");
-        })
+        idms_prox_read
+            .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+            .expect("Oauth2 authorisation failed");
     }
 
-    #[test]
-    fn test_idm_oauth2_openid_legacy_crypto() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, false, true, false);
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
-                // The public key url should offer an rs key
-                // discovery should offer RS256
-                let discovery = idms_prox_read
-                    .oauth2_openid_discovery("test_resource_server")
-                    .expect("Failed to get discovery");
+    #[idm_test]
+    async fn test_idm_oauth2_openid_legacy_crypto(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, false, true, false).await;
+        let mut idms_prox_read = idms.proxy_read().await;
+        // The public key url should offer an rs key
+        // discovery should offer RS256
+        let discovery = idms_prox_read
+            .oauth2_openid_discovery("test_resource_server")
+            .expect("Failed to get discovery");
 
-                let mut jwkset = idms_prox_read
-                    .oauth2_openid_publickey("test_resource_server")
-                    .expect("Failed to get public key");
+        let mut jwkset = idms_prox_read
+            .oauth2_openid_publickey("test_resource_server")
+            .expect("Failed to get public key");
 
-                let jwk = jwkset.keys.pop().expect("no such jwk");
-                let public_jwk = jwk.clone();
+        let jwk = jwkset.keys.pop().expect("no such jwk");
+        let public_jwk = jwk.clone();
 
-                match jwk {
-                    Jwk::RSA { alg, use_, kid, .. } => {
-                        match (
-                            alg.unwrap(),
-                            &discovery.id_token_signing_alg_values_supported[0],
-                        ) {
-                            (JwaAlg::RS256, IdTokenSignAlg::RS256) => {}
-                            _ => panic!(),
-                        };
-                        assert!(use_.unwrap() == JwkUse::Sig);
-                        assert!(kid.is_some());
-                    }
+        match jwk {
+            Jwk::RSA { alg, use_, kid, .. } => {
+                match (
+                    alg.unwrap(),
+                    &discovery.id_token_signing_alg_values_supported[0],
+                ) {
+                    (JwaAlg::RS256, IdTokenSignAlg::RS256) => {}
                     _ => panic!(),
                 };
-
-                // Check that the id_token is signed with the correct key.
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
-
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
-
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
-
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // == Submit the token exchange code.
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: Some("test_resource_server".to_string()),
-                    client_secret: Some(secret),
-                    // From the first step.
-                    code_verifier,
-                };
-
-                let token_response = idms_prox_read
-                    .check_oauth2_token_exchange(None, &token_req, ct)
-                    .expect("Failed to perform oauth2 token exchange");
-
-                // Assert that the session creation was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2SessionRecord(_)) => {}
-                    _ => assert!(false),
-                }
-
-                // 🎉 We got a token!
-                assert!(token_response.token_type == "bearer");
-                let id_token = token_response.id_token.expect("No id_token in response!");
-
-                let jws_validator =
-                    JwsValidator::try_from(&public_jwk).expect("failed to build validator");
-
-                let oidc_unverified =
-                    OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
-
-                let iat = ct.as_secs() as i64;
-
-                let oidc = oidc_unverified
-                    .validate(&jws_validator, iat)
-                    .expect("Failed to verify oidc");
-
-                assert!(oidc.sub == OidcSubject::U(UUID_ADMIN));
+                assert!(use_.unwrap() == JwkUse::Sig);
+                assert!(kid.is_some());
             }
-        )
+            _ => panic!(),
+        };
+
+        // Check that the id_token is signed with the correct key.
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
+
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
+
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
+
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
+
+        // == Submit the token exchange code.
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: Some("test_resource_server".to_string()),
+            client_secret: Some(secret),
+            // From the first step.
+            code_verifier,
+        };
+
+        let token_response = idms_prox_read
+            .check_oauth2_token_exchange(None, &token_req, ct)
+            .expect("Failed to perform oauth2 token exchange");
+
+        // Assert that the session creation was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2SessionRecord(_)) => {}
+            _ => assert!(false),
+        }
+
+        // 🎉 We got a token!
+        assert!(token_response.token_type == "bearer");
+        let id_token = token_response.id_token.expect("No id_token in response!");
+
+        let jws_validator = JwsValidator::try_from(&public_jwk).expect("failed to build validator");
+
+        let oidc_unverified =
+            OidcUnverified::from_str(&id_token).expect("Failed to parse id_token");
+
+        let iat = ct.as_secs() as i64;
+
+        let oidc = oidc_unverified
+            .validate(&jws_validator, iat)
+            .expect("Failed to verify oidc");
+
+        assert!(oidc.sub == OidcSubject::U(UUID_ADMIN));
     }
 
-    #[test]
-    fn test_idm_oauth2_consent_granted_and_changed_workflow() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (_secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_consent_granted_and_changed_workflow(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-                let idms_prox_read = task::block_on(idms.proxy_read());
+        let idms_prox_read = idms.proxy_read().await;
 
-                let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                // Should be in the consent phase;
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        // Should be in the consent phase;
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let _permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        // == Manually submit the consent token to the permit for the permit_success
+        let _permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                drop(idms_prox_read);
+        drop(idms_prox_read);
 
-                // Assert that the consent was submitted
-                let o2cg = match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(o2cg)) => o2cg,
-                    _ => unreachable!(),
-                };
+        // Assert that the consent was submitted
+        let o2cg = match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(o2cg)) => o2cg,
+            _ => unreachable!(),
+        };
 
-                // Manually submit the consent.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                assert!(idms_prox_write.process_oauth2consentgrant(&o2cg).is_ok());
-                assert!(idms_prox_write.commit().is_ok());
+        // Manually submit the consent.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        assert!(idms_prox_write.process_oauth2consentgrant(&o2cg).is_ok());
+        assert!(idms_prox_write.commit().is_ok());
 
-                // == Now try the authorise again, should be in the permitted state.
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        // == Now try the authorise again, should be in the permitted state.
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // We need to reload our identity
-                let ident = idms_prox_read
-                    .process_uat_to_identity(&uat, ct)
-                    .expect("Unable to process uat");
+        // We need to reload our identity
+        let ident = idms_prox_read
+            .process_uat_to_identity(&uat, ct)
+            .expect("Unable to process uat");
 
-                let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                // Should be in the consent phase;
-                let _permit_success =
-                    if let AuthoriseResponse::Permitted(permit_success) = consent_request {
-                        permit_success
-                    } else {
-                        unreachable!();
-                    };
+        // Should be in the consent phase;
+        let _permit_success = if let AuthoriseResponse::Permitted(permit_success) = consent_request
+        {
+            permit_success
+        } else {
+            unreachable!();
+        };
 
-                drop(idms_prox_read);
+        drop(idms_prox_read);
 
-                // Great! Now change the scopes on the oauth2 instance, this revokes the permit.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+        // Great! Now change the scopes on the oauth2 instance, this revokes the permit.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
 
-                let me_extend_scopes = unsafe {
-                    ModifyEvent::new_internal_invalid(
-                        filter!(f_eq(
-                            "oauth2_rs_name",
-                            PartialValue::new_iname("test_resource_server")
-                        )),
-                        ModifyList::new_list(vec![Modify::Present(
-                            AttrString::from("oauth2_rs_scope_map"),
-                            Value::new_oauthscopemap(
-                                UUID_IDM_ALL_ACCOUNTS,
-                                btreeset!["email".to_string(), "openid".to_string()],
-                            )
-                            .expect("invalid oauthscope"),
-                        )]),
+        let me_extend_scopes = unsafe {
+            ModifyEvent::new_internal_invalid(
+                filter!(f_eq(
+                    "oauth2_rs_name",
+                    PartialValue::new_iname("test_resource_server")
+                )),
+                ModifyList::new_list(vec![Modify::Present(
+                    AttrString::from("oauth2_rs_scope_map"),
+                    Value::new_oauthscopemap(
+                        UUID_IDM_ALL_ACCOUNTS,
+                        btreeset!["email".to_string(), "openid".to_string()],
                     )
-                };
+                    .expect("invalid oauthscope"),
+                )]),
+            )
+        };
 
-                assert!(idms_prox_write.qs_write.modify(&me_extend_scopes).is_ok());
-                assert!(idms_prox_write.commit().is_ok());
+        assert!(idms_prox_write.qs_write.modify(&me_extend_scopes).is_ok());
+        assert!(idms_prox_write.commit().is_ok());
 
-                // And do the workflow once more to see if we need to consent again.
+        // And do the workflow once more to see if we need to consent again.
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // We need to reload our identity
-                let ident = idms_prox_read
-                    .process_uat_to_identity(&uat, ct)
-                    .expect("Unable to process uat");
+        // We need to reload our identity
+        let ident = idms_prox_read
+            .process_uat_to_identity(&uat, ct)
+            .expect("Unable to process uat");
 
-                let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-                let auth_req = AuthorisationRequest {
-                    response_type: "code".to_string(),
-                    client_id: "test_resource_server".to_string(),
-                    state: "123".to_string(),
-                    pkce_request: Some(PkceRequest {
-                        code_challenge: Base64UrlSafeData(code_challenge),
-                        code_challenge_method: CodeChallengeMethod::S256,
-                    }),
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    scope: "openid email".to_string(),
-                    nonce: Some("abcdef".to_string()),
-                    oidc_ext: Default::default(),
-                    unknown_keys: Default::default(),
-                };
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: Some(PkceRequest {
+                code_challenge: Base64UrlSafeData(code_challenge),
+                code_challenge_method: CodeChallengeMethod::S256,
+            }),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid email".to_string(),
+            nonce: Some("abcdef".to_string()),
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                let consent_request = idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .expect("Oauth2 authorisation failed");
+        let consent_request = idms_prox_read
+            .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+            .expect("Oauth2 authorisation failed");
 
-                // Should be in the consent phase;
-                let _consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        // Should be in the consent phase;
+        let _consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                drop(idms_prox_read);
+        drop(idms_prox_read);
 
-                // Success! We had to consent again due to the change :)
+        // Success! We had to consent again due to the change :)
 
-                // Now change the supplemental scopes on the oauth2 instance, this revokes the permit.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
+        // Now change the supplemental scopes on the oauth2 instance, this revokes the permit.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
 
-                let me_extend_scopes = unsafe {
-                    ModifyEvent::new_internal_invalid(
-                        filter!(f_eq(
-                            "oauth2_rs_name",
-                            PartialValue::new_iname("test_resource_server")
-                        )),
-                        ModifyList::new_list(vec![Modify::Present(
-                            AttrString::from("oauth2_rs_sup_scope_map"),
-                            Value::new_oauthscopemap(
-                                UUID_IDM_ALL_ACCOUNTS,
-                                btreeset!["newscope".to_string()],
-                            )
-                            .expect("invalid oauthscope"),
-                        )]),
+        let me_extend_scopes = unsafe {
+            ModifyEvent::new_internal_invalid(
+                filter!(f_eq(
+                    "oauth2_rs_name",
+                    PartialValue::new_iname("test_resource_server")
+                )),
+                ModifyList::new_list(vec![Modify::Present(
+                    AttrString::from("oauth2_rs_sup_scope_map"),
+                    Value::new_oauthscopemap(
+                        UUID_IDM_ALL_ACCOUNTS,
+                        btreeset!["newscope".to_string()],
                     )
-                };
+                    .expect("invalid oauthscope"),
+                )]),
+            )
+        };
 
-                assert!(idms_prox_write.qs_write.modify(&me_extend_scopes).is_ok());
-                assert!(idms_prox_write.commit().is_ok());
+        assert!(idms_prox_write.qs_write.modify(&me_extend_scopes).is_ok());
+        assert!(idms_prox_write.commit().is_ok());
 
-                // And do the workflow once more to see if we need to consent again.
+        // And do the workflow once more to see if we need to consent again.
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // We need to reload our identity
-                let ident = idms_prox_read
-                    .process_uat_to_identity(&uat, ct)
-                    .expect("Unable to process uat");
+        // We need to reload our identity
+        let ident = idms_prox_read
+            .process_uat_to_identity(&uat, ct)
+            .expect("Unable to process uat");
 
-                let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-                let auth_req = AuthorisationRequest {
-                    response_type: "code".to_string(),
-                    client_id: "test_resource_server".to_string(),
-                    state: "123".to_string(),
-                    pkce_request: Some(PkceRequest {
-                        code_challenge: Base64UrlSafeData(code_challenge),
-                        code_challenge_method: CodeChallengeMethod::S256,
-                    }),
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    // Note the scope isn't requested here!
-                    scope: "openid email".to_string(),
-                    nonce: Some("abcdef".to_string()),
-                    oidc_ext: Default::default(),
-                    unknown_keys: Default::default(),
-                };
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: Some(PkceRequest {
+                code_challenge: Base64UrlSafeData(code_challenge),
+                code_challenge_method: CodeChallengeMethod::S256,
+            }),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            // Note the scope isn't requested here!
+            scope: "openid email".to_string(),
+            nonce: Some("abcdef".to_string()),
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                let consent_request = idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .expect("Oauth2 authorisation failed");
+        let consent_request = idms_prox_read
+            .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+            .expect("Oauth2 authorisation failed");
 
-                // Should be present in the consent phase however!
-                let _consent_token = if let AuthoriseResponse::ConsentRequested {
-                    consent_token,
-                    scopes,
-                    ..
-                } = consent_request
-                {
-                    assert!(scopes.contains(&"newscope".to_string()));
-                    consent_token
-                } else {
-                    unreachable!();
-                };
-            }
-        )
+        // Should be present in the consent phase however!
+        let _consent_token = if let AuthoriseResponse::ConsentRequested {
+            consent_token,
+            scopes,
+            ..
+        } = consent_request
+        {
+            assert!(scopes.contains(&"newscope".to_string()));
+            consent_token
+        } else {
+            unreachable!();
+        };
     }
 
-    #[test]
-    fn test_idm_oauth2_consent_granted_refint_cleanup_on_delete() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                let (_secret, uat, ident, o2rs_uuid) =
-                    setup_oauth2_resource_server(idms, ct, true, false, false);
+    #[idm_test]
+    async fn test_idm_oauth2_consent_granted_refint_cleanup_on_delete(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        let (_secret, uat, ident, o2rs_uuid) =
+            setup_oauth2_resource_server(idms, ct, true, false, false).await;
 
-                // Assert there are no consent maps yet.
-                assert!(ident.get_oauth2_consent_scopes(o2rs_uuid).is_none());
+        // Assert there are no consent maps yet.
+        assert!(ident.get_oauth2_consent_scopes(o2rs_uuid).is_none());
 
-                let idms_prox_read = task::block_on(idms.proxy_read());
+        let idms_prox_read = idms.proxy_read().await;
 
-                let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        let (_code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                // Should be in the consent phase;
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        // Should be in the consent phase;
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let _permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        // == Manually submit the consent token to the permit for the permit_success
+        let _permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                drop(idms_prox_read);
+        drop(idms_prox_read);
 
-                // Assert that the consent was submitted
-                let o2cg = match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(o2cg)) => o2cg,
-                    _ => unreachable!(),
-                };
+        // Assert that the consent was submitted
+        let o2cg = match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(o2cg)) => o2cg,
+            _ => unreachable!(),
+        };
 
-                // Manually submit the consent.
-                let mut idms_prox_write = task::block_on(idms.proxy_write(ct));
-                assert!(idms_prox_write.process_oauth2consentgrant(&o2cg).is_ok());
+        // Manually submit the consent.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        assert!(idms_prox_write.process_oauth2consentgrant(&o2cg).is_ok());
 
-                let ident = idms_prox_write
-                    .process_uat_to_identity(&uat, ct)
-                    .expect("Unable to process uat");
+        let ident = idms_prox_write
+            .process_uat_to_identity(&uat, ct)
+            .expect("Unable to process uat");
 
-                // Assert that the ident now has the consents.
-                assert!(
-                    ident.get_oauth2_consent_scopes(o2rs_uuid)
-                        == Some(&btreeset!["openid".to_string(), "supplement".to_string()])
-                );
+        // Assert that the ident now has the consents.
+        assert!(
+            ident.get_oauth2_consent_scopes(o2rs_uuid)
+                == Some(&btreeset!["openid".to_string(), "supplement".to_string()])
+        );
 
-                // Now trigger the delete of the RS
-                let de = unsafe {
-                    DeleteEvent::new_internal_invalid(filter!(f_eq(
-                        "oauth2_rs_name",
-                        PartialValue::new_iname("test_resource_server")
-                    )))
-                };
+        // Now trigger the delete of the RS
+        let de = unsafe {
+            DeleteEvent::new_internal_invalid(filter!(f_eq(
+                "oauth2_rs_name",
+                PartialValue::new_iname("test_resource_server")
+            )))
+        };
 
-                assert!(idms_prox_write.qs_write.delete(&de).is_ok());
-                // Assert the consent maps are gone.
-                let ident = idms_prox_write
-                    .process_uat_to_identity(&uat, ct)
-                    .expect("Unable to process uat");
-                assert!(ident.get_oauth2_consent_scopes(o2rs_uuid).is_none());
+        assert!(idms_prox_write.qs_write.delete(&de).is_ok());
+        // Assert the consent maps are gone.
+        let ident = idms_prox_write
+            .process_uat_to_identity(&uat, ct)
+            .expect("Unable to process uat");
+        assert!(ident.get_oauth2_consent_scopes(o2rs_uuid).is_none());
 
-                assert!(idms_prox_write.commit().is_ok());
-            }
-        )
+        assert!(idms_prox_write.commit().is_ok());
     }
 
-    #[test]
+    #[idm_test]
     // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.8
     //
     // It was reported we were vulnerable to this attack, but that isn't the case. First
@@ -3746,174 +3663,168 @@ mod tests {
     // exchange that code exchange with out the verifier, but I'm not sure what damage that would
     // lead to? Regardless, we test for and close off that possible hole in this test.
     //
-    fn test_idm_oauth2_1076_pkce_downgrade() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                // Enable pkce is set to FALSE
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, false, false, false);
+    async fn test_idm_oauth2_1076_pkce_downgrade(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        // Enable pkce is set to FALSE
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, false, false, false).await;
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // Get an ident/uat for now.
+        // Get an ident/uat for now.
 
-                // == Setup the authorisation request
-                // We attempt pkce even though the rs is set to not support pkce.
-                let (code_verifier, _code_challenge) = create_code_verifier!("Whar Garble");
+        // == Setup the authorisation request
+        // We attempt pkce even though the rs is set to not support pkce.
+        let (code_verifier, _code_challenge) = create_code_verifier!("Whar Garble");
 
-                // First, the user does not request pkce in their exchange.
-                let auth_req = AuthorisationRequest {
-                    response_type: "code".to_string(),
-                    client_id: "test_resource_server".to_string(),
-                    state: "123".to_string(),
-                    pkce_request: None,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    scope: "openid".to_string(),
-                    nonce: None,
-                    oidc_ext: Default::default(),
-                    unknown_keys: Default::default(),
-                };
+        // First, the user does not request pkce in their exchange.
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: None,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                let consent_request = idms_prox_read
-                    .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                    .expect("Failed to perform oauth2 authorisation request.");
+        let consent_request = idms_prox_read
+            .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+            .expect("Failed to perform oauth2 authorisation request.");
 
-                // Should be in the consent phase;
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        // Should be in the consent phase;
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-                // == Submit the token exchange code.
-                // This exchange failed because we submitted a verifier when the code exchange
-                // has NO code challenge present.
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
-                    client_id: Some("test_resource_server".to_string()),
-                    client_secret: Some(secret),
-                    // Note the code verifier is set to "something else"
-                    code_verifier,
-                };
+        // == Submit the token exchange code.
+        // This exchange failed because we submitted a verifier when the code exchange
+        // has NO code challenge present.
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            client_id: Some("test_resource_server".to_string()),
+            client_secret: Some(secret),
+            // Note the code verifier is set to "something else"
+            code_verifier,
+        };
 
-                // Assert the exchange fails.
-                assert!(matches!(
-                    idms_prox_read.check_oauth2_token_exchange(None, &token_req, ct),
-                    Err(Oauth2Error::InvalidRequest)
-                ))
-            }
-        )
+        // Assert the exchange fails.
+        assert!(matches!(
+            idms_prox_read.check_oauth2_token_exchange(None, &token_req, ct),
+            Err(Oauth2Error::InvalidRequest)
+        ))
     }
 
-    #[test]
+    #[idm_test]
     // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.1
     //
     // If the origin configured is https, do not allow downgrading to http on redirect
-    fn test_idm_oauth2_redir_http_downgrade() {
-        run_idm_test!(
-            |_qs: &QueryServer, idms: &IdmServer, idms_delayed: &mut IdmServerDelayed| {
-                let ct = Duration::from_secs(TEST_CURRENT_TIME);
-                // Enable pkce is set to FALSE
-                let (secret, uat, ident, _) =
-                    setup_oauth2_resource_server(idms, ct, false, false, false);
+    async fn test_idm_oauth2_redir_http_downgrade(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+    ) {
+        let ct = Duration::from_secs(TEST_CURRENT_TIME);
+        // Enable pkce is set to FALSE
+        let (secret, uat, ident, _) =
+            setup_oauth2_resource_server(idms, ct, false, false, false).await;
 
-                let mut idms_prox_read = task::block_on(idms.proxy_read());
+        let mut idms_prox_read = idms.proxy_read().await;
 
-                // Get an ident/uat for now.
+        // Get an ident/uat for now.
 
-                // == Setup the authorisation request
-                // We attempt pkce even though the rs is set to not support pkce.
-                let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
+        // == Setup the authorisation request
+        // We attempt pkce even though the rs is set to not support pkce.
+        let (code_verifier, code_challenge) = create_code_verifier!("Whar Garble");
 
-                // First, NOTE the lack of https on the redir uri.
-                let auth_req = AuthorisationRequest {
-                    response_type: "code".to_string(),
-                    client_id: "test_resource_server".to_string(),
-                    state: "123".to_string(),
-                    pkce_request: Some(PkceRequest {
-                        code_challenge: Base64UrlSafeData(code_challenge.clone()),
-                        code_challenge_method: CodeChallengeMethod::S256,
-                    }),
-                    redirect_uri: Url::parse("http://demo.example.com/oauth2/result").unwrap(),
-                    scope: "openid".to_string(),
-                    nonce: None,
-                    oidc_ext: Default::default(),
-                    unknown_keys: Default::default(),
-                };
+        // First, NOTE the lack of https on the redir uri.
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: Some(PkceRequest {
+                code_challenge: Base64UrlSafeData(code_challenge.clone()),
+                code_challenge_method: CodeChallengeMethod::S256,
+            }),
+            redirect_uri: Url::parse("http://demo.example.com/oauth2/result").unwrap(),
+            scope: "openid".to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
 
-                assert!(
-                    idms_prox_read
-                        .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
-                        .unwrap_err()
-                        == Oauth2Error::InvalidOrigin
-                );
+        assert!(
+            idms_prox_read
+                .check_oauth2_authorisation(&ident, &uat, &auth_req, ct)
+                .unwrap_err()
+                == Oauth2Error::InvalidOrigin
+        );
 
-                // This does have https
-                let consent_request = good_authorisation_request!(
-                    idms_prox_read,
-                    &ident,
-                    &uat,
-                    ct,
-                    code_challenge,
-                    "openid".to_string()
-                );
+        // This does have https
+        let consent_request = good_authorisation_request!(
+            idms_prox_read,
+            &ident,
+            &uat,
+            ct,
+            code_challenge,
+            "openid".to_string()
+        );
 
-                // Should be in the consent phase;
-                let consent_token =
-                    if let AuthoriseResponse::ConsentRequested { consent_token, .. } =
-                        consent_request
-                    {
-                        consent_token
-                    } else {
-                        unreachable!();
-                    };
+        // Should be in the consent phase;
+        let consent_token =
+            if let AuthoriseResponse::ConsentRequested { consent_token, .. } = consent_request {
+                consent_token
+            } else {
+                unreachable!();
+            };
 
-                // == Manually submit the consent token to the permit for the permit_success
-                let permit_success = idms_prox_read
-                    .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
-                    .expect("Failed to perform oauth2 permit");
+        // == Manually submit the consent token to the permit for the permit_success
+        let permit_success = idms_prox_read
+            .check_oauth2_authorise_permit(&ident, &uat, &consent_token, ct)
+            .expect("Failed to perform oauth2 permit");
 
-                // Assert that the consent was submitted
-                match idms_delayed.async_rx.blocking_recv() {
-                    Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
-                    _ => assert!(false),
-                }
+        // Assert that the consent was submitted
+        match idms_delayed.async_rx.blocking_recv() {
+            Some(DelayedAction::Oauth2ConsentGrant(_)) => {}
+            _ => assert!(false),
+        }
 
-                // == Submit the token exchange code.
-                // NOTE the url is http again
-                let token_req = AccessTokenRequest {
-                    grant_type: "authorization_code".to_string(),
-                    code: permit_success.code,
-                    redirect_uri: Url::parse("http://demo.example.com/oauth2/result").unwrap(),
-                    client_id: Some("test_resource_server".to_string()),
-                    client_secret: Some(secret),
-                    // Note the code verifier is set to "something else"
-                    code_verifier,
-                };
+        // == Submit the token exchange code.
+        // NOTE the url is http again
+        let token_req = AccessTokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: permit_success.code,
+            redirect_uri: Url::parse("http://demo.example.com/oauth2/result").unwrap(),
+            client_id: Some("test_resource_server".to_string()),
+            client_secret: Some(secret),
+            // Note the code verifier is set to "something else"
+            code_verifier,
+        };
 
-                // Assert the exchange fails.
-                assert!(matches!(
-                    idms_prox_read.check_oauth2_token_exchange(None, &token_req, ct),
-                    Err(Oauth2Error::InvalidOrigin)
-                ))
-            }
-        )
+        // Assert the exchange fails.
+        assert!(matches!(
+            idms_prox_read.check_oauth2_token_exchange(None, &token_req, ct),
+            Err(Oauth2Error::InvalidOrigin)
+        ))
     }
 }

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -120,7 +120,7 @@ mod tests {
         wa: &mut WebauthnAuthenticator<SoftPasskey>,
         idms_delayed: &mut IdmServerDelayed,
     ) -> Option<String> {
-        let mut idms_auth = idms.auth();
+        let mut idms_auth = idms.auth().await;
         let origin = idms_auth.get_origin().clone();
 
         let auth_init = AuthEvent::named_init("testperson");

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -75,7 +75,7 @@ mod tests {
 
         // Update session is setup.
 
-        let cutxn = idms.cred_update_transaction();
+        let cutxn = idms.cred_update_transaction().await;
         let origin = cutxn.get_origin().clone();
 
         let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());

--- a/server/lib/src/macros.rs
+++ b/server/lib/src/macros.rs
@@ -13,7 +13,9 @@ macro_rules! setup_test {
             .expect("Failed to init BE");
 
         let qs = QueryServer::new(be, schema_outer, "example.com".to_string());
-        async_std::task::block_on(qs.initialise_helper(duration_from_epoch_now()))
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(qs.initialise_helper(duration_from_epoch_now()))
             .expect("init failed!");
         qs
     }};
@@ -34,11 +36,15 @@ macro_rules! setup_test {
             .expect("Failed to init BE");
 
         let qs = QueryServer::new(be, schema_outer, "example.com".to_string());
-        async_std::task::block_on(qs.initialise_helper(duration_from_epoch_now()))
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(qs.initialise_helper(duration_from_epoch_now()))
             .expect("init failed!");
 
         if !$preload_entries.is_empty() {
-            let mut qs_write = async_std::task::block_on(qs.write(duration_from_epoch_now()));
+            let mut qs_write = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(qs.write(duration_from_epoch_now()));
             qs_write
                 .internal_create($preload_entries)
                 .expect("Failed to preload entries");
@@ -123,7 +129,9 @@ macro_rules! run_create_test {
         };
 
         {
-            let mut qs_write = async_std::task::block_on(qs.write(duration_from_epoch_now()));
+            let mut qs_write = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(qs.write(duration_from_epoch_now()));
             let r = qs_write.create(&ce);
             trace!("test result: {:?}", r);
             assert!(r == $expect);
@@ -139,7 +147,9 @@ macro_rules! run_create_test {
         }
         // Make sure there are no errors.
         trace!("starting verification");
-        let ver = async_std::task::block_on(qs.verify());
+        let ver = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(qs.verify());
         trace!("verification -> {:?}", ver);
         assert!(ver.len() == 0);
     }};
@@ -165,7 +175,9 @@ macro_rules! run_modify_test {
         let qs = setup_test!($preload_entries);
 
         {
-            let mut qs_write = async_std::task::block_on(qs.write(duration_from_epoch_now()));
+            let mut qs_write = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(qs.write(duration_from_epoch_now()));
             $pre_hook(&mut qs_write);
             qs_write.commit().expect("commit failure!");
         }
@@ -178,7 +190,9 @@ macro_rules! run_modify_test {
         };
 
         {
-            let mut qs_write = async_std::task::block_on(qs.write(duration_from_epoch_now()));
+            let mut qs_write = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(qs.write(duration_from_epoch_now()));
             let r = qs_write.modify(&me);
             $check(&mut qs_write);
             trace!("test result: {:?}", r);
@@ -194,7 +208,9 @@ macro_rules! run_modify_test {
         }
         // Make sure there are no errors.
         trace!("starting verification");
-        let ver = async_std::task::block_on(qs.verify());
+        let ver = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(qs.verify());
         trace!("verification -> {:?}", ver);
         assert!(ver.len() == 0);
     }};
@@ -224,7 +240,9 @@ macro_rules! run_delete_test {
         };
 
         {
-            let mut qs_write = async_std::task::block_on(qs.write(duration_from_epoch_now()));
+            let mut qs_write = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(qs.write(duration_from_epoch_now()));
             let r = qs_write.delete(&de);
             trace!("test result: {:?}", r);
             $check(&mut qs_write);
@@ -240,7 +258,9 @@ macro_rules! run_delete_test {
         }
         // Make sure there are no errors.
         trace!("starting verification");
-        let ver = async_std::task::block_on(qs.verify());
+        let ver = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(qs.verify());
         trace!("verification -> {:?}", ver);
         assert!(ver.len() == 0);
     }};

--- a/server/lib/src/macros.rs
+++ b/server/lib/src/macros.rs
@@ -55,30 +55,6 @@ macro_rules! setup_test {
 }
 
 #[cfg(test)]
-macro_rules! entry_str_to_account {
-    ($entry_str:expr) => {{
-        use std::iter::once;
-
-        use crate::entry::{Entry, EntryInvalid, EntryNew};
-        use crate::idm::account::Account;
-        use crate::value::Value;
-
-        let mut e: Entry<EntryInvalid, EntryNew> =
-            unsafe { Entry::unsafe_from_entry_str($entry_str).into_invalid_new() };
-        // Add spn, because normally this is generated but in tests we can't.
-        let spn = e
-            .get_ava_single_iname("name")
-            .map(|s| Value::new_spn_str(s, "example.com"))
-            .expect("Failed to munge spn from name!");
-        e.set_ava("spn", once(spn));
-
-        let e = unsafe { e.into_sealed_committed() };
-
-        Account::try_from_entry_no_groups(&e).expect("Account conversion failure")
-    }};
-}
-
-#[cfg(test)]
 macro_rules! entry_to_account {
     ($entry:expr) => {{
         use std::iter::once;

--- a/server/lib/src/macros.rs
+++ b/server/lib/src/macros.rs
@@ -95,48 +95,6 @@ macro_rules! entry_to_account {
     }};
 }
 
-#[cfg(test)]
-macro_rules! run_idm_test_inner {
-    ($test_fn:expr) => {{
-        #[allow(unused_imports)]
-        use crate::be::{Backend, BackendConfig};
-        #[allow(unused_imports)]
-        use crate::idm::server::{IdmServer, IdmServerDelayed};
-        use crate::prelude::*;
-        #[allow(unused_imports)]
-        use crate::schema::Schema;
-        /*
-        use env_logger;
-        ::std::env::set_var("RUST_LOG", "actix_web=debug,kanidm=debug");
-        let _ = env_logger::builder()
-            .format_timestamp(None)
-            .format_level(false)
-            .is_test(true)
-            .try_init();
-        */
-
-        let test_server = setup_test!();
-
-        let (test_idm_server, mut idms_delayed) =
-            IdmServer::new(test_server.clone(), "https://idm.example.com")
-                .expect("Failed to setup idms");
-
-        $test_fn(&test_server, &test_idm_server, &mut idms_delayed);
-        // Any needed teardown?
-        // Make sure there are no errors.
-        assert!(async_std::task::block_on(test_server.verify()).len() == 0);
-        idms_delayed.check_is_empty_or_panic();
-    }};
-}
-
-#[cfg(test)]
-macro_rules! run_idm_test {
-    ($test_fn:expr) => {{
-        let _ = sketching::test_init();
-        run_idm_test_inner!($test_fn);
-    }};
-}
-
 // Test helpers for all plugins.
 // #[macro_export]
 #[cfg(test)]

--- a/server/lib/src/testkit.rs
+++ b/server/lib/src/testkit.rs
@@ -63,5 +63,7 @@ pub async fn setup_idm_test() -> (IdmServer, IdmServerDelayed) {
     qs.initialise_helper(duration_from_epoch_now())
         .await
         .expect("init failed!");
-    IdmServer::new(qs, "https://idm.example.com").expect("Failed to setup idms")
+    IdmServer::new(qs, "https://idm.example.com")
+        .await
+        .expect("Failed to setup idms")
 }


### PR DESCRIPTION
Fixes #1399 - remove async_std 🎉 also removes legacy test macros, finishes getting to idm_test with the proc macro. Next up I need to do the plugin tests and then done with the legacy test sitch. Another goal is to reduce the amount of "pub" statements because it's currently limiting the complier's ability to detect dead code in the project. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
