### PR TITLE
Openssl build fix

### DIFF
--- a/libs/crypto/build.rs
+++ b/libs/crypto/build.rs
@@ -10,5 +10,4 @@ fn main() {
             println!("cargo:rustc-cfg=openssl3");
         }
     }
-
 }

--- a/libs/crypto/build.rs
+++ b/libs/crypto/build.rs
@@ -1,0 +1,14 @@
+// include!("src/lib/audit_loglevel.rs");
+
+use std::env;
+
+fn main() {
+    if let Ok(v) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&v, 16).unwrap();
+
+        if version >= 0x3000_0000 {
+            println!("cargo:rustc-cfg=openssl3");
+        }
+    }
+
+}

--- a/libs/file_permissions/Cargo.toml
+++ b/libs/file_permissions/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 [target.'cfg(target_family = "windows")'.dependencies]
-whoami.workspace = true
+whoami = {workspace = true}
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
-users.workspace = true
+users = {workspace = true}


### PR DESCRIPTION
Fixes the issue with the MD4 tests because of openssl config

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes