### PR TITLE
Fix RADIUS docker image file permissions

### DIFF
--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -34,7 +34,7 @@ RUN ln -s /etc/raddb/mods-available/python3 /etc/raddb/mods-enabled/python3 && \
 
 
 # Allows the radiusd user to write to the directory
-RUN chown -R $RADIUS_USER. /etc/raddb && \
+RUN chown -R $RADIUS_USER. /etc/raddb/ && \
     chmod 775 /etc/raddb/certs && \
     chmod 640 /etc/raddb/clients.conf
 


### PR DESCRIPTION
Fixes #1438 

Apparently `/etc/raddb` is a symlink now.
This `chown`s the directory linked to, and not the symlink itself.
