### PR TITLE
Add unixd exit code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4709,8 +4709,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-forest"
-version = "0.1.4"
-source = "git+https://github.com/QnnOkabayashi/tracing-forest.git?rev=48d78f7294ceee47a22eee5c80964143c4fb3fe1#48d78f7294ceee47a22eee5c80964143c4fb3fe1"
+version = "0.1.5"
+source = "git+https://github.com/QnnOkabayashi/tracing-forest.git?rev=77daf8c8abf010b87d45ece2bf656983c6f8cecb#77daf8c8abf010b87d45ece2bf656983c6f8cecb"
 dependencies = [
  "smallvec",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,6 +2343,7 @@ dependencies = [
 name = "kanidm_unix_int"
 version = "1.1.0-alpha.12-dev"
 dependencies = [
+ "anyhow",
  "bytes",
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "anymap2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,7 +2343,6 @@ dependencies = [
 name = "kanidm_unix_int"
 version = "1.1.0-alpha.12-dev"
 dependencies = [
- "anyhow",
  "bytes",
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "anymap2"
@@ -2343,6 +2343,7 @@ dependencies = [
 name = "kanidm_unix_int"
 version = "1.1.0-alpha.12-dev"
 dependencies = [
+ "anyhow",
  "bytes",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ walkdir = "2"
 yew = "^0.20.0"
 yew-router = "^0.17.0"
 zxcvbn = "^2.2.1"
+anyhow = "^1.0.69"
 
 # enshrinken the WASMs
 [profile.release.package.kanidmd_web_ui]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ tracing = { version = "^0.1.37" }
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter"] }
 
 # tracing-forest = { path = "/Users/william/development/tracing-forest/tracing-forest" }
-tracing-forest = { git = "https://github.com/QnnOkabayashi/tracing-forest.git", rev = "48d78f7294ceee47a22eee5c80964143c4fb3fe1" }
+tracing-forest = { git = "https://github.com/QnnOkabayashi/tracing-forest.git", rev = "77daf8c8abf010b87d45ece2bf656983c6f8cecb" }
 
 url = "^2.3.1"
 urlencoding = "2.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,6 @@ walkdir = "2"
 yew = "^0.20.0"
 yew-router = "^0.17.0"
 zxcvbn = "^2.2.1"
-anyhow = "^1.0.69"
 
 # enshrinken the WASMs
 [profile.release.package.kanidmd_web_ui]

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -81,8 +81,6 @@ tracing.workspace = true
 reqwest = { workspace = true, default-features = false }
 walkdir.workspace = true
 
-anyhow = { workspace = true }
-
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 users.workspace = true
 

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -75,7 +75,7 @@ serde_json.workspace = true
 sketching.workspace = true
 
 toml.workspace = true
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net", "io-util"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 reqwest = { workspace = true, default-features = false }

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -81,6 +81,8 @@ tracing.workspace = true
 reqwest = { workspace = true, default-features = false }
 walkdir.workspace = true
 
+anyhow = { workspace = true }
+
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 users.workspace = true
 

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -75,7 +75,7 @@ serde_json.workspace = true
 sketching.workspace = true
 
 toml.workspace = true
-tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 reqwest = { workspace = true, default-features = false }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -425,7 +425,6 @@ async fn main() {
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-    #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         error!("Failed to pull the client config path");
         return ExitCode::FAILURE;
@@ -461,7 +460,6 @@ async fn main() {
         }
     }
 
-    #[allow(clippy::expect_used)]
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
         error!("Failed to pull the unixd config path");
         return ExitCode::FAILURE;

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -433,7 +433,7 @@ async fn main() -> ExitCode {
                 // TODO: this wording is not great m'kay.
             } else if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
                 error!("Refusing to run - this process must not operate as root.");
-                return;
+                return
             };
             if clap_args.get_flag("debug") {
                 std::env::set_var("RUST_LOG", "debug");
@@ -444,7 +444,7 @@ async fn main() -> ExitCode {
 
             let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
                 error!("Failed to pull the client config path");
-                return ExitCode::FAILURE
+                return
             };
             let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
@@ -478,7 +478,7 @@ async fn main() -> ExitCode {
 
             let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
                 error!("Failed to pull the unixd config path");
-                return ExitCode::FAILURE
+                return
             };
             let unixd_path = PathBuf::from(unixd_path_str);
 

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -426,7 +426,7 @@ async fn main() {
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("debug"))
+                .or_else(|_| EnvFilter::try_new("info"))
                 .expect("Failed to init envfilter")
             )
         )

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -41,9 +41,9 @@ use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
 
-//=== the codec
+use anyhow::{Result, self};
 
-use std::process::ExitCode;
+//=== the codec
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;
@@ -422,73 +422,69 @@ async fn main() {
         std::env::set_var("RUST_LOG", "debug");
     }
 
-    debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
-    debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+    println!("DEBUG: Profile -> {}", env!("KANIDM_PROFILE_NAME"));
+    println!("DEBUG: CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+    println!("###################################");
+    println!("Starting up:\n###################################");
 
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
-        error!("Failed to pull the client config path");
-        return ExitCode::FAILURE;
+        anyhow::bail!("Failed to pull the client config path");
     };
     //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
     let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
-        error!(
+        anyhow::bail!(
             "Client config missing from {} - cannot start up. Quitting.",
             cfg_path_str
         );
-        return ExitCode::FAILURE;
     } else {
         let cfg_meta = match metadata(&cfg_path) {
             Ok(v) => v,
             Err(e) => {
-                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                return ExitCode::FAILURE;
+                anyhow::bail!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
             }
         };
         if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
                 cfg_path_str
                 );
         }
 
         if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
-            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
                 cfg_path_str
             );
         }
     }
 
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
-        error!("Failed to pull the unixd config path");
-        return ExitCode::FAILURE;
+        anyhow::bail!("Failed to pull the unixd config path");
     };
     //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
     let unixd_path = PathBuf::from(unixd_path_str);
 
     if !unixd_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
-        error!(
+        anyhow::bail!(
             "unixd config missing from {} - cannot start up. Quitting.",
             unixd_path_str
         );
-        return ExitCode::FAILURE;
     } else {
         let unixd_meta = match metadata(&unixd_path) {
             Ok(v) => v,
             Err(e) => {
-                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                return ExitCode::FAILURE;
+                anyhow::bail!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
             }
         };
         if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
                 unixd_path_str);
         }
 
         if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
-            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
                 unixd_path_str
             );
         }
@@ -498,16 +494,14 @@ async fn main() {
     let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&cfg_path) {
         Ok(v) => v,
         Err(_) => {
-            error!("Failed to parse {}", cfg_path_str);
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to parse {}", cfg_path_str);
         }
     };
 
     let cfg = match KanidmUnixdConfig::new().read_options_from_optional_config(&unixd_path) {
         Ok(v) => v,
         Err(_) => {
-            error!("Failed to parse {}", unixd_path_str);
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to parse {}", unixd_path_str);
         }
     };
 
@@ -519,10 +513,9 @@ async fn main() {
         eprintln!("###################################");
         eprintln!("Client config (from {:#?})", &cfg_path);
         eprintln!("{}", cb);
-        return ExitCode::SUCCESS;
+        return Ok(());
     }
-
-    debug!("🧹 Cleaning up sockets from previous invocations");
+    println!("DEBUG: 🧹 Cleaning up sockets from previous invocations");
     rm_if_exist(cfg.sock_path.as_str());
     rm_if_exist(cfg.task_sock_path.as_str());
 
@@ -532,13 +525,12 @@ async fn main() {
         // We only need to check the parent folder path permissions as the db itself may not exist yet.
         if let Some(db_parent_path) = db_path.parent() {
             if !db_parent_path.exists() {
-                error!(
+                anyhow::bail!(
                     "Refusing to run, DB folder {} does not exist",
                     db_parent_path
                         .to_str()
                         .unwrap_or("<db_parent_path invalid>")
                 );
-                return ExitCode::FAILURE;
             }
 
             let db_par_path_buf = db_parent_path.to_path_buf();
@@ -546,34 +538,32 @@ async fn main() {
             let i_meta = match metadata(&db_par_path_buf) {
                 Ok(v) => v,
                 Err(e) => {
-                    error!(
+                    anyhow::bail!(
                         "Unable to read metadata for {} - {:?}",
                         db_par_path_buf
                             .to_str()
                             .unwrap_or("<db_par_path_buf invalid>"),
                         e
                     );
-                    return ExitCode::FAILURE;
                 }
             };
 
             if !i_meta.is_dir() {
-                error!(
+                anyhow::bail!(
                     "Refusing to run - DB folder {} may not be a directory",
                     db_par_path_buf
                         .to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
                 );
-                return ExitCode::FAILURE;
             }
             if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+                println!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
                 .unwrap_or("<db_par_path_buf invalid>")
                 );
             }
 
             if i_meta.mode() & 0o007 != 0 {
-                warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
+                println!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
                 .unwrap_or("<db_par_path_buf invalid>")
                 );
             }
@@ -582,22 +572,20 @@ async fn main() {
         // check to see if the db's already there
         if db_path.exists() {
             if !db_path.is_file() {
-                error!(
+                anyhow::bail!(
                     "Refusing to run - DB path {} already exists and is not a file.",
                     db_path.to_str().unwrap_or("<db_path invalid>")
                 );
-                return ExitCode::FAILURE;
             };
 
             match metadata(&db_path) {
                 Ok(v) => v,
                 Err(e) => {
-                    error!(
+                    anyhow::bail!(
                         "Unable to read metadata for {} - {:?}",
                         db_path.to_str().unwrap_or("<db_path invalid>"),
                         e
                     );
-                    return ExitCode::FAILURE;
                 }
             };
             // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
@@ -609,8 +597,7 @@ async fn main() {
     let rsclient = match cb.build() {
         Ok(rsc) => rsc,
         Err(_e) => {
-            error!("Failed to build async client");
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to build async client");
         }
     };
 
@@ -630,8 +617,7 @@ async fn main() {
     {
         Ok(c) => c,
         Err(_e) => {
-            error!("Failed to build cache layer.");
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to build cache layer.");
         }
     };
 
@@ -642,8 +628,7 @@ async fn main() {
     let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
         Ok(l) => l,
         Err(_e) => {
-            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
         }
     };
     // Setup the root-only socket. Take away all others.
@@ -651,12 +636,13 @@ async fn main() {
     let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
         Ok(l) => l,
         Err(_e) => {
-            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
         }
     };
     // Undo it.
     let _ = unsafe { umask(before) };
+
+    println!("Start up complete.\n###################################");
 
     tracing_forest::worker_task()
         .set_global(true)
@@ -687,26 +673,26 @@ async fn main() {
             };
             let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
-            if !cfg_path.exists() {
-                // there's no point trying to start up if we can't read a usable config!
-                error!(
-                    "Client config missing from {} - cannot start up. Quitting.",
-                    cfg_path_str
+    if !cfg_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "Client config missing from {} - cannot start up. Quitting.",
+            cfg_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let cfg_meta = match metadata(&cfg_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                cfg_path_str
                 );
-                return ExitCode::FAILURE
-            } else {
-                let cfg_meta = match metadata(&cfg_path) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                        return ExitCode::FAILURE
-                    }
-                };
-                if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-                    warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                        cfg_path_str
-                        );
-                }
+        }
 
                 if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
                     warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
@@ -721,25 +707,25 @@ async fn main() {
             };
             let unixd_path = PathBuf::from(unixd_path_str);
 
-            if !unixd_path.exists() {
-                // there's no point trying to start up if we can't read a usable config!
-                error!(
-                    "unixd config missing from {} - cannot start up. Quitting.",
-                    unixd_path_str
-                );
-                return ExitCode::FAILURE
-            } else {
-                let unixd_meta = match metadata(&unixd_path) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                        return ExitCode::FAILURE
-                    }
-                };
-                if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-                    warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                        unixd_path_str);
-                }
+    if !unixd_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "unixd config missing from {} - cannot start up. Quitting.",
+            unixd_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let unixd_meta = match metadata(&unixd_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                unixd_path_str);
+        }
 
                 if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
                     warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
@@ -782,51 +768,51 @@ async fn main() {
 
 
 
-            // Check the db path will be okay.
-            if !cfg.db_path.is_empty() {
-                let db_path = PathBuf::from(cfg.db_path.as_str());
-                // We only need to check the parent folder path permissions as the db itself may not exist yet.
-                if let Some(db_parent_path) = db_path.parent() {
-                    if !db_parent_path.exists() {
-                        error!(
-                            "Refusing to run, DB folder {} does not exist",
-                            db_parent_path
-                                .to_str()
-                                .unwrap_or("<db_parent_path invalid>")
-                        );
-                        return ExitCode::FAILURE
-                    }
+    // Check the db path will be okay.
+    if !cfg.db_path.is_empty() {
+        let db_path = PathBuf::from(cfg.db_path.as_str());
+        // We only need to check the parent folder path permissions as the db itself may not exist yet.
+        if let Some(db_parent_path) = db_path.parent() {
+            if !db_parent_path.exists() {
+                error!(
+                    "Refusing to run, DB folder {} does not exist",
+                    db_parent_path
+                        .to_str()
+                        .unwrap_or("<db_parent_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            }
 
                     let db_par_path_buf = db_parent_path.to_path_buf();
 
-                    let i_meta = match metadata(&db_par_path_buf) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            error!(
-                                "Unable to read metadata for {} - {:?}",
-                                db_par_path_buf
-                                    .to_str()
-                                    .unwrap_or("<db_par_path_buf invalid>"),
-                                e
-                            );
-                            return ExitCode::FAILURE
-                        }
-                    };
+            let i_meta = match metadata(&db_par_path_buf) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_par_path_buf
+                            .to_str()
+                            .unwrap_or("<db_par_path_buf invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
 
-                    if !i_meta.is_dir() {
-                        error!(
-                            "Refusing to run - DB folder {} may not be a directory",
-                            db_par_path_buf
-                                .to_str()
-                                .unwrap_or("<db_par_path_buf invalid>")
-                        );
-                        return ExitCode::FAILURE
-                    }
-                    if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                        warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+            if !i_meta.is_dir() {
+                error!(
+                    "Refusing to run - DB folder {} may not be a directory",
+                    db_par_path_buf
+                        .to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
-                        );
-                    }
+                );
+                return ExitCode::FAILURE;
+            }
+            if !kanidm_lib_file_permissions::readonly(&i_meta) {
+                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+                .unwrap_or("<db_par_path_buf invalid>")
+                );
+            }
 
                     if i_meta.mode() & 0o007 != 0 {
                         warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
@@ -835,30 +821,30 @@ async fn main() {
                     }
                 }
 
-                // check to see if the db's already there
-                if db_path.exists() {
-                    if !db_path.is_file() {
-                        error!(
-                            "Refusing to run - DB path {} already exists and is not a file.",
-                            db_path.to_str().unwrap_or("<db_path invalid>")
-                        );
-                        return ExitCode::FAILURE
-                    };
+        // check to see if the db's already there
+        if db_path.exists() {
+            if !db_path.is_file() {
+                error!(
+                    "Refusing to run - DB path {} already exists and is not a file.",
+                    db_path.to_str().unwrap_or("<db_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            };
 
-                    match metadata(&db_path) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            error!(
-                                "Unable to read metadata for {} - {:?}",
-                                db_path.to_str().unwrap_or("<db_path invalid>"),
-                                e
-                            );
-                            return ExitCode::FAILURE
-                        }
-                    };
-                    // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
-                };
-            }
+            match metadata(&db_path) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_path.to_str().unwrap_or("<db_path invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
+        };
+    }
 
             let cb = cb.connect_timeout(cfg.conn_timeout);
 
@@ -894,27 +880,26 @@ async fn main() {
 
             let cachelayer = Arc::new(cl_inner);
 
-            // Set the umask while we open the path for most clients.
-            let before = unsafe { umask(0) };
-            let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
-                Ok(l) => l,
-                Err(_e) => {
-                    error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-                    return ExitCode::FAILURE
-                }
-            };
-            // Setup the root-only socket. Take away all others.
-            let _ = unsafe { umask(0o0077) };
-            let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
-                Ok(l) => l,
-                Err(_e) => {
-                    error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-                    return ExitCode::FAILURE
-                }
-            };
-
-            // Undo it.
-            let _ = unsafe { umask(before) };
+    // Set the umask while we open the path for most clients.
+    let before = unsafe { umask(0) };
+    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Setup the root-only socket. Take away all others.
+    let _ = unsafe { umask(0o0077) };
+    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Undo it.
+    let _ = unsafe { umask(before) };
 
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
@@ -986,6 +971,6 @@ async fn main() {
             server.await;
         })
         .await;
-    ExitCode::SUCCESS
+    Ok(())
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -425,14 +425,13 @@ async fn main() -> ExitCode {
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-
     #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         error!("Failed to pull the client config path");
         return ExitCode::FAILURE;
     };
     //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
-    let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
+    let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
@@ -665,12 +664,13 @@ async fn main() -> ExitCode {
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| subscriber
-            .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
-                .expect("Failed to init envfilter")
+        .build_on(|subscriber| {
+            subscriber.with(
+                EnvFilter::try_from_default_env()
+                    .or_else(|_| EnvFilter::try_new("info"))
+                    .expect("Failed to init envfilter"),
             )
-        )
+        })
         .on(async {
             if clap_args.get_flag("skip-root-check") {
                 warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
@@ -945,7 +945,8 @@ async fn main() -> ExitCode {
                             // It did? Great, now we can wait and spin on that one
                             // client.
                             if let Err(e) =
-                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx).await
+                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx)
+                                    .await
                             {
                                 error!("Task client error occurred; error = {:?}", e);
                             }
@@ -968,7 +969,8 @@ async fn main() -> ExitCode {
                         Ok((socket, _addr)) => {
                             let cachelayer_ref = cachelayer.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
+                                if let Err(e) =
+                                    handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
                                 {
                                     error!("handle_client error occurred; error = {:?}", e);
                                 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -43,6 +43,7 @@ use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_u
 
 //=== the codec
 
+use std::process::ExitCode;
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,7 +427,7 @@ async fn main() -> ExitCode {
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("debug"))
+                .or_else(|_| EnvFilter::try_new("info"))
                 .expect("Failed to init envfilter")
             )
         )

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -678,20 +678,6 @@ async fn main() -> ExitCode {
             // Undo it.
             let _ = unsafe { umask(before) };
 
-    println!("Start up complete.\n###################################");
-
-    tracing_forest::worker_task()
-        .set_global(true)
-        // Fall back to stderr
-        .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| {
-            subscriber.with(
-                EnvFilter::try_from_default_env()
-                    .or_else(|_| EnvFilter::try_new("info"))
-                    .expect("Failed to init envfilter"),
-            )
-        })
-        .on(async {
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
 

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
+use std::process::ExitCode;
 
 use bytes::{BufMut, BytesMut};
 use clap::{Arg, ArgAction, Command};

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -422,6 +422,237 @@ async fn main() -> ExitCode {
         std::env::set_var("RUST_LOG", "debug");
     }
 
+    debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
+    debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+
+
+    #[allow(clippy::expect_used)]
+    let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
+    let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
+
+    if !cfg_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "Client config missing from {} - cannot start up. Quitting.",
+            cfg_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let cfg_meta = match metadata(&cfg_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                cfg_path_str
+                );
+        }
+
+        if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
+            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+                cfg_path_str
+            );
+        }
+    }
+
+    #[allow(clippy::expect_used)]
+    let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
+    let unixd_path = PathBuf::from(unixd_path_str);
+
+    if !unixd_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "unixd config missing from {} - cannot start up. Quitting.",
+            unixd_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let unixd_meta = match metadata(&unixd_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                unixd_path_str);
+        }
+
+        if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
+            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+                unixd_path_str
+            );
+        }
+    }
+
+    // setup
+    let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&cfg_path) {
+        Ok(v) => v,
+        Err(_) => {
+            error!("Failed to parse {}", cfg_path_str);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cfg = match KanidmUnixdConfig::new().read_options_from_optional_config(&unixd_path) {
+        Ok(v) => v,
+        Err(_) => {
+            error!("Failed to parse {}", unixd_path_str);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if clap_args.get_flag("configtest") {
+        eprintln!("###################################");
+        eprintln!("Dumping configs:\n###################################");
+        eprintln!("kanidm_unixd config (from {:#?})", &unixd_path);
+        eprintln!("{}", cfg);
+        eprintln!("###################################");
+        eprintln!("Client config (from {:#?})", &cfg_path);
+        eprintln!("{}", cb);
+        return ExitCode::SUCCESS;
+    }
+
+    debug!("🧹 Cleaning up sockets from previous invocations");
+    rm_if_exist(cfg.sock_path.as_str());
+    rm_if_exist(cfg.task_sock_path.as_str());
+
+    // Check the db path will be okay.
+    if !cfg.db_path.is_empty() {
+        let db_path = PathBuf::from(cfg.db_path.as_str());
+        // We only need to check the parent folder path permissions as the db itself may not exist yet.
+        if let Some(db_parent_path) = db_path.parent() {
+            if !db_parent_path.exists() {
+                error!(
+                    "Refusing to run, DB folder {} does not exist",
+                    db_parent_path
+                        .to_str()
+                        .unwrap_or("<db_parent_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            }
+
+            let db_par_path_buf = db_parent_path.to_path_buf();
+
+            let i_meta = match metadata(&db_par_path_buf) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_par_path_buf
+                            .to_str()
+                            .unwrap_or("<db_par_path_buf invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+
+            if !i_meta.is_dir() {
+                error!(
+                    "Refusing to run - DB folder {} may not be a directory",
+                    db_par_path_buf
+                        .to_str()
+                        .unwrap_or("<db_par_path_buf invalid>")
+                );
+                return ExitCode::FAILURE;
+            }
+            if !kanidm_lib_file_permissions::readonly(&i_meta) {
+                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+                .unwrap_or("<db_par_path_buf invalid>")
+                );
+            }
+
+            if i_meta.mode() & 0o007 != 0 {
+                warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
+                .unwrap_or("<db_par_path_buf invalid>")
+                );
+            }
+        }
+
+        // check to see if the db's already there
+        if db_path.exists() {
+            if !db_path.is_file() {
+                error!(
+                    "Refusing to run - DB path {} already exists and is not a file.",
+                    db_path.to_str().unwrap_or("<db_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            };
+
+            match metadata(&db_path) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_path.to_str().unwrap_or("<db_path invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
+        };
+    }
+
+    let cb = cb.connect_timeout(cfg.conn_timeout);
+
+    let rsclient = match cb.build() {
+        Ok(rsc) => rsc,
+        Err(_e) => {
+            error!("Failed to build async client");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cl_inner = match CacheLayer::new(
+        cfg.db_path.as_str(), // The sqlite db path
+        cfg.cache_timeout,
+        rsclient,
+        cfg.pam_allowed_login_groups.clone(),
+        cfg.default_shell.clone(),
+        cfg.home_prefix.clone(),
+        cfg.home_attr,
+        cfg.home_alias,
+        cfg.uid_attr_map,
+        cfg.gid_attr_map,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(_e) => {
+            error!("Failed to build cache layer.");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cachelayer = Arc::new(cl_inner);
+
+    // Set the umask while we open the path for most clients.
+    let before = unsafe { umask(0) };
+    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Setup the root-only socket. Take away all others.
+    let _ = unsafe { umask(0o0077) };
+    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Undo it.
+    let _ = unsafe { umask(before) };
+
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,6 +427,7 @@ async fn main() {
     println!("###################################");
     println!("Starting up:\n###################################");
 
+    #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         anyhow::bail!("Failed to pull the client config path");
     };
@@ -459,6 +460,7 @@ async fn main() {
         }
     }
 
+    #[allow(clippy::expect_used)]
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
         anyhow::bail!("Failed to pull the unixd config path");
     };

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -41,9 +41,8 @@ use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
 
-use anyhow::{Result, self};
-
 //=== the codec
+
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;
@@ -422,241 +421,16 @@ async fn main() -> ExitCode {
         std::env::set_var("RUST_LOG", "debug");
     }
 
-    println!("DEBUG: Profile -> {}", env!("KANIDM_PROFILE_NAME"));
-    println!("DEBUG: CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
-    println!("###################################");
-    println!("Starting up:\n###################################");
-
-    #[allow(clippy::expect_used)]
-    let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
-        anyhow::bail!("Failed to pull the client config path");
-    };
-    //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
-    let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
-
-    if !cfg_path.exists() {
-        // there's no point trying to start up if we can't read a usable config!
-        anyhow::bail!(
-            "Client config missing from {} - cannot start up. Quitting.",
-            cfg_path_str
-        );
-    } else {
-        let cfg_meta = match metadata(&cfg_path) {
-            Ok(v) => v,
-            Err(e) => {
-                anyhow::bail!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-            }
-        };
-        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                cfg_path_str
-                );
-        }
-
-        if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
-            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
-                cfg_path_str
-            );
-        }
-    }
-
-    #[allow(clippy::expect_used)]
-    let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
-        anyhow::bail!("Failed to pull the unixd config path");
-    };
-    //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
-    let unixd_path = PathBuf::from(unixd_path_str);
-
-    if !unixd_path.exists() {
-        // there's no point trying to start up if we can't read a usable config!
-        anyhow::bail!(
-            "unixd config missing from {} - cannot start up. Quitting.",
-            unixd_path_str
-        );
-    } else {
-        let unixd_meta = match metadata(&unixd_path) {
-            Ok(v) => v,
-            Err(e) => {
-                anyhow::bail!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-            }
-        };
-        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                unixd_path_str);
-        }
-
-        if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
-            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
-                unixd_path_str
-            );
-        }
-    }
-
-    // setup
-    let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&cfg_path) {
-        Ok(v) => v,
-        Err(_) => {
-            anyhow::bail!("Failed to parse {}", cfg_path_str);
-        }
-    };
-
-    let cfg = match KanidmUnixdConfig::new().read_options_from_optional_config(&unixd_path) {
-        Ok(v) => v,
-        Err(_) => {
-            anyhow::bail!("Failed to parse {}", unixd_path_str);
-        }
-    };
-
-    if clap_args.get_flag("configtest") {
-        eprintln!("###################################");
-        eprintln!("Dumping configs:\n###################################");
-        eprintln!("kanidm_unixd config (from {:#?})", &unixd_path);
-        eprintln!("{}", cfg);
-        eprintln!("###################################");
-        eprintln!("Client config (from {:#?})", &cfg_path);
-        eprintln!("{}", cb);
-        return Ok(());
-    }
-    println!("DEBUG: 🧹 Cleaning up sockets from previous invocations");
-    rm_if_exist(cfg.sock_path.as_str());
-    rm_if_exist(cfg.task_sock_path.as_str());
-
-    // Check the db path will be okay.
-    if !cfg.db_path.is_empty() {
-        let db_path = PathBuf::from(cfg.db_path.as_str());
-        // We only need to check the parent folder path permissions as the db itself may not exist yet.
-        if let Some(db_parent_path) = db_path.parent() {
-            if !db_parent_path.exists() {
-                anyhow::bail!(
-                    "Refusing to run, DB folder {} does not exist",
-                    db_parent_path
-                        .to_str()
-                        .unwrap_or("<db_parent_path invalid>")
-                );
-            }
-
-            let db_par_path_buf = db_parent_path.to_path_buf();
-
-            let i_meta = match metadata(&db_par_path_buf) {
-                Ok(v) => v,
-                Err(e) => {
-                    anyhow::bail!(
-                        "Unable to read metadata for {} - {:?}",
-                        db_par_path_buf
-                            .to_str()
-                            .unwrap_or("<db_par_path_buf invalid>"),
-                        e
-                    );
-                }
-            };
-
-            if !i_meta.is_dir() {
-                anyhow::bail!(
-                    "Refusing to run - DB folder {} may not be a directory",
-                    db_par_path_buf
-                        .to_str()
-                        .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
-            if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                println!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
-                .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
-
-            if i_meta.mode() & 0o007 != 0 {
-                println!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
-                .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
-        }
-
-        // check to see if the db's already there
-        if db_path.exists() {
-            if !db_path.is_file() {
-                anyhow::bail!(
-                    "Refusing to run - DB path {} already exists and is not a file.",
-                    db_path.to_str().unwrap_or("<db_path invalid>")
-                );
-            };
-
-            match metadata(&db_path) {
-                Ok(v) => v,
-                Err(e) => {
-                    anyhow::bail!(
-                        "Unable to read metadata for {} - {:?}",
-                        db_path.to_str().unwrap_or("<db_path invalid>"),
-                        e
-                    );
-                }
-            };
-            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
-        };
-    }
-
-    let cb = cb.connect_timeout(cfg.conn_timeout);
-
-    let rsclient = match cb.build() {
-        Ok(rsc) => rsc,
-        Err(_e) => {
-            anyhow::bail!("Failed to build async client");
-        }
-    };
-
-    let cl_inner = match CacheLayer::new(
-        cfg.db_path.as_str(), // The sqlite db path
-        cfg.cache_timeout,
-        rsclient,
-        cfg.pam_allowed_login_groups.clone(),
-        cfg.default_shell.clone(),
-        cfg.home_prefix.clone(),
-        cfg.home_attr,
-        cfg.home_alias,
-        cfg.uid_attr_map,
-        cfg.gid_attr_map,
-    )
-    .await
-    {
-        Ok(c) => c,
-        Err(_e) => {
-            anyhow::bail!("Failed to build cache layer.");
-        }
-    };
-
-    let cachelayer = Arc::new(cl_inner);
-
-    // Set the umask while we open the path for most clients.
-    let before = unsafe { umask(0) };
-    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
-        Ok(l) => l,
-        Err(_e) => {
-            anyhow::bail!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-        }
-    };
-    // Setup the root-only socket. Take away all others.
-    let _ = unsafe { umask(0o0077) };
-    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
-        Ok(l) => l,
-        Err(_e) => {
-            anyhow::bail!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-        }
-    };
-    // Undo it.
-    let _ = unsafe { umask(before) };
-
-    println!("Start up complete.\n###################################");
-
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| {
-            subscriber.with(
-                EnvFilter::try_from_default_env()
-                    .or_else(|_| EnvFilter::try_new("info"))
-                    .expect("Failed to init envfilter"),
+        .build_on(|subscriber| subscriber
+            .with(EnvFilter::try_from_default_env()
+                .or_else(|_| EnvFilter::try_new("info"))
+                .expect("Failed to init envfilter")
             )
-        })
+        )
         .on(async {
             if clap_args.get_flag("skip-root-check") {
                 warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
@@ -904,6 +678,20 @@ async fn main() -> ExitCode {
             // Undo it.
             let _ = unsafe { umask(before) };
 
+    println!("Start up complete.\n###################################");
+
+    tracing_forest::worker_task()
+        .set_global(true)
+        // Fall back to stderr
+        .map_sender(|sender| sender.or_stderr())
+        .build_on(|subscriber| {
+            subscriber.with(
+                EnvFilter::try_from_default_env()
+                    .or_else(|_| EnvFilter::try_new("info"))
+                    .expect("Failed to init envfilter"),
+            )
+        })
+        .on(async {
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
 
@@ -931,8 +719,7 @@ async fn main() -> ExitCode {
                             // It did? Great, now we can wait and spin on that one
                             // client.
                             if let Err(e) =
-                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx)
-                                    .await
+                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx).await
                             {
                                 error!("Task client error occurred; error = {:?}", e);
                             }
@@ -955,8 +742,7 @@ async fn main() -> ExitCode {
                         Ok((socket, _addr)) => {
                             let cachelayer_ref = cachelayer.clone();
                             tokio::spawn(async move {
-                                if let Err(e) =
-                                    handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
+                                if let Err(e) = handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
                                 {
                                     error!("handle_client error occurred; error = {:?}", e);
                                 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -424,14 +424,13 @@ async fn main() {
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-
     #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         error!("Failed to pull the client config path");
         return ExitCode::FAILURE;
     };
     //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
-    let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
+    let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
@@ -664,12 +663,13 @@ async fn main() {
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| subscriber
-            .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
-                .expect("Failed to init envfilter")
+        .build_on(|subscriber| {
+            subscriber.with(
+                EnvFilter::try_from_default_env()
+                    .or_else(|_| EnvFilter::try_new("info"))
+                    .expect("Failed to init envfilter"),
             )
-        )
+        })
         .on(async {
             if clap_args.get_flag("skip-root-check") {
                 warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
@@ -944,7 +944,8 @@ async fn main() {
                             // It did? Great, now we can wait and spin on that one
                             // client.
                             if let Err(e) =
-                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx).await
+                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx)
+                                    .await
                             {
                                 error!("Task client error occurred; error = {:?}", e);
                             }
@@ -967,7 +968,8 @@ async fn main() {
                         Ok((socket, _addr)) => {
                             let cachelayer_ref = cachelayer.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
+                                if let Err(e) =
+                                    handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
                                 {
                                     error!("handle_client error occurred; error = {:?}", e);
                                 }
@@ -983,8 +985,8 @@ async fn main() {
             info!("Server started ...");
 
             server.await;
-    })
-    .await;
+        })
+        .await;
     ExitCode::SUCCESS
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -16,9 +16,9 @@ use std::io;
 use std::io::{Error as IoError, ErrorKind};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
-use std::process::ExitCode;
 
 use bytes::{BufMut, BytesMut};
 use clap::{Arg, ArgAction, Command};

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -426,7 +426,11 @@ async fn main() {
 
 
     #[allow(clippy::expect_used)]
-    let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
+    let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
+        error!("Failed to pull the client config path");
+        return ExitCode::FAILURE;
+    };
+    //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
     let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
@@ -458,7 +462,11 @@ async fn main() {
     }
 
     #[allow(clippy::expect_used)]
-    let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
+    let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
+        error!("Failed to pull the unixd config path");
+        return ExitCode::FAILURE;
+    };
+    //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
     let unixd_path = PathBuf::from(unixd_path_str);
 
     if !unixd_path.exists() {

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -43,6 +43,7 @@ use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_u
 
 //=== the codec
 
+use std::process::ExitCode;
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;
@@ -746,6 +747,7 @@ async fn main() {
             server.await;
             ExitCode::SUCCESS
     })
-    .await
+    .await;
+    ExitCode::SUCCESS
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,7 +427,11 @@ async fn main() -> ExitCode {
 
 
     #[allow(clippy::expect_used)]
-    let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
+    let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
+        error!("Failed to pull the client config path");
+        return ExitCode::FAILURE;
+    };
+    //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
     let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
@@ -459,7 +463,11 @@ async fn main() -> ExitCode {
     }
 
     #[allow(clippy::expect_used)]
-    let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
+    let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
+        error!("Failed to pull the unixd config path");
+        return ExitCode::FAILURE;
+    };
+    //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
     let unixd_path = PathBuf::from(unixd_path_str);
 
     if !unixd_path.exists() {

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -425,7 +425,6 @@ async fn main() -> ExitCode {
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-    #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         error!("Failed to pull the client config path");
         return ExitCode::FAILURE;
@@ -461,7 +460,6 @@ async fn main() -> ExitCode {
         }
     }
 
-    #[allow(clippy::expect_used)]
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
         error!("Failed to pull the unixd config path");
         return ExitCode::FAILURE;

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -19,7 +19,6 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
-use std::process::ExitCode;
 
 use bytes::{BufMut, BytesMut};
 use clap::{Arg, ArgAction, Command};

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,7 +427,7 @@ async fn main() -> ExitCode {
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
+                .or_else(|_| EnvFilter::try_new("debug"))
                 .expect("Failed to init envfilter")
             )
         )

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -417,10 +417,6 @@ async fn main() -> ExitCode {
         )
         .get_matches();
 
-    if clap_args.get_flag("debug") {
-        std::env::set_var("RUST_LOG", "debug");
-    }
-
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr
@@ -437,8 +433,11 @@ async fn main() -> ExitCode {
                 // TODO: this wording is not great m'kay.
             } else if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
                 error!("Refusing to run - this process must not operate as root.");
-                return ExitCode::FAILURE
+                return;
             };
+            if clap_args.get_flag("debug") {
+                std::env::set_var("RUST_LOG", "debug");
+            }
 
             debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
             debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -41,9 +41,8 @@ use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
 
-use anyhow::{Result, self};
-
 //=== the codec
+
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;
@@ -422,241 +421,16 @@ async fn main() {
         std::env::set_var("RUST_LOG", "debug");
     }
 
-    println!("DEBUG: Profile -> {}", env!("KANIDM_PROFILE_NAME"));
-    println!("DEBUG: CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
-    println!("###################################");
-    println!("Starting up:\n###################################");
-
-    #[allow(clippy::expect_used)]
-    let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
-        anyhow::bail!("Failed to pull the client config path");
-    };
-    //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
-    let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
-
-    if !cfg_path.exists() {
-        // there's no point trying to start up if we can't read a usable config!
-        anyhow::bail!(
-            "Client config missing from {} - cannot start up. Quitting.",
-            cfg_path_str
-        );
-    } else {
-        let cfg_meta = match metadata(&cfg_path) {
-            Ok(v) => v,
-            Err(e) => {
-                anyhow::bail!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-            }
-        };
-        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                cfg_path_str
-                );
-        }
-
-        if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
-            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
-                cfg_path_str
-            );
-        }
-    }
-
-    #[allow(clippy::expect_used)]
-    let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
-        anyhow::bail!("Failed to pull the unixd config path");
-    };
-    //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
-    let unixd_path = PathBuf::from(unixd_path_str);
-
-    if !unixd_path.exists() {
-        // there's no point trying to start up if we can't read a usable config!
-        anyhow::bail!(
-            "unixd config missing from {} - cannot start up. Quitting.",
-            unixd_path_str
-        );
-    } else {
-        let unixd_meta = match metadata(&unixd_path) {
-            Ok(v) => v,
-            Err(e) => {
-                anyhow::bail!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-            }
-        };
-        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                unixd_path_str);
-        }
-
-        if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
-            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
-                unixd_path_str
-            );
-        }
-    }
-
-    // setup
-    let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&cfg_path) {
-        Ok(v) => v,
-        Err(_) => {
-            anyhow::bail!("Failed to parse {}", cfg_path_str);
-        }
-    };
-
-    let cfg = match KanidmUnixdConfig::new().read_options_from_optional_config(&unixd_path) {
-        Ok(v) => v,
-        Err(_) => {
-            anyhow::bail!("Failed to parse {}", unixd_path_str);
-        }
-    };
-
-    if clap_args.get_flag("configtest") {
-        eprintln!("###################################");
-        eprintln!("Dumping configs:\n###################################");
-        eprintln!("kanidm_unixd config (from {:#?})", &unixd_path);
-        eprintln!("{}", cfg);
-        eprintln!("###################################");
-        eprintln!("Client config (from {:#?})", &cfg_path);
-        eprintln!("{}", cb);
-        return Ok(());
-    }
-    println!("DEBUG: 🧹 Cleaning up sockets from previous invocations");
-    rm_if_exist(cfg.sock_path.as_str());
-    rm_if_exist(cfg.task_sock_path.as_str());
-
-    // Check the db path will be okay.
-    if !cfg.db_path.is_empty() {
-        let db_path = PathBuf::from(cfg.db_path.as_str());
-        // We only need to check the parent folder path permissions as the db itself may not exist yet.
-        if let Some(db_parent_path) = db_path.parent() {
-            if !db_parent_path.exists() {
-                anyhow::bail!(
-                    "Refusing to run, DB folder {} does not exist",
-                    db_parent_path
-                        .to_str()
-                        .unwrap_or("<db_parent_path invalid>")
-                );
-            }
-
-            let db_par_path_buf = db_parent_path.to_path_buf();
-
-            let i_meta = match metadata(&db_par_path_buf) {
-                Ok(v) => v,
-                Err(e) => {
-                    anyhow::bail!(
-                        "Unable to read metadata for {} - {:?}",
-                        db_par_path_buf
-                            .to_str()
-                            .unwrap_or("<db_par_path_buf invalid>"),
-                        e
-                    );
-                }
-            };
-
-            if !i_meta.is_dir() {
-                anyhow::bail!(
-                    "Refusing to run - DB folder {} may not be a directory",
-                    db_par_path_buf
-                        .to_str()
-                        .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
-            if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                println!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
-                .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
-
-            if i_meta.mode() & 0o007 != 0 {
-                println!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
-                .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
-        }
-
-        // check to see if the db's already there
-        if db_path.exists() {
-            if !db_path.is_file() {
-                anyhow::bail!(
-                    "Refusing to run - DB path {} already exists and is not a file.",
-                    db_path.to_str().unwrap_or("<db_path invalid>")
-                );
-            };
-
-            match metadata(&db_path) {
-                Ok(v) => v,
-                Err(e) => {
-                    anyhow::bail!(
-                        "Unable to read metadata for {} - {:?}",
-                        db_path.to_str().unwrap_or("<db_path invalid>"),
-                        e
-                    );
-                }
-            };
-            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
-        };
-    }
-
-    let cb = cb.connect_timeout(cfg.conn_timeout);
-
-    let rsclient = match cb.build() {
-        Ok(rsc) => rsc,
-        Err(_e) => {
-            anyhow::bail!("Failed to build async client");
-        }
-    };
-
-    let cl_inner = match CacheLayer::new(
-        cfg.db_path.as_str(), // The sqlite db path
-        cfg.cache_timeout,
-        rsclient,
-        cfg.pam_allowed_login_groups.clone(),
-        cfg.default_shell.clone(),
-        cfg.home_prefix.clone(),
-        cfg.home_attr,
-        cfg.home_alias,
-        cfg.uid_attr_map,
-        cfg.gid_attr_map,
-    )
-    .await
-    {
-        Ok(c) => c,
-        Err(_e) => {
-            anyhow::bail!("Failed to build cache layer.");
-        }
-    };
-
-    let cachelayer = Arc::new(cl_inner);
-
-    // Set the umask while we open the path for most clients.
-    let before = unsafe { umask(0) };
-    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
-        Ok(l) => l,
-        Err(_e) => {
-            anyhow::bail!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-        }
-    };
-    // Setup the root-only socket. Take away all others.
-    let _ = unsafe { umask(0o0077) };
-    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
-        Ok(l) => l,
-        Err(_e) => {
-            anyhow::bail!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-        }
-    };
-    // Undo it.
-    let _ = unsafe { umask(before) };
-
-    println!("Start up complete.\n###################################");
-
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| {
-            subscriber.with(
-                EnvFilter::try_from_default_env()
-                    .or_else(|_| EnvFilter::try_new("info"))
-                    .expect("Failed to init envfilter"),
+        .build_on(|subscriber| subscriber
+            .with(EnvFilter::try_from_default_env()
+                .or_else(|_| EnvFilter::try_new("info"))
+                .expect("Failed to init envfilter")
             )
-        })
+        )
         .on(async {
             if clap_args.get_flag("skip-root-check") {
                 warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
@@ -675,26 +449,26 @@ async fn main() {
             };
             let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
-    if !cfg_path.exists() {
-        // there's no point trying to start up if we can't read a usable config!
-        error!(
-            "Client config missing from {} - cannot start up. Quitting.",
-            cfg_path_str
-        );
-        return ExitCode::FAILURE;
-    } else {
-        let cfg_meta = match metadata(&cfg_path) {
-            Ok(v) => v,
-            Err(e) => {
-                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                return ExitCode::FAILURE;
-            }
-        };
-        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                cfg_path_str
+            if !cfg_path.exists() {
+                // there's no point trying to start up if we can't read a usable config!
+                error!(
+                    "Client config missing from {} - cannot start up. Quitting.",
+                    cfg_path_str
                 );
-        }
+                return
+            } else {
+                let cfg_meta = match metadata(&cfg_path) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
+                        return
+                    }
+                };
+                if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
+                    warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                        cfg_path_str
+                        );
+                }
 
                 if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
                     warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
@@ -709,25 +483,25 @@ async fn main() {
             };
             let unixd_path = PathBuf::from(unixd_path_str);
 
-    if !unixd_path.exists() {
-        // there's no point trying to start up if we can't read a usable config!
-        error!(
-            "unixd config missing from {} - cannot start up. Quitting.",
-            unixd_path_str
-        );
-        return ExitCode::FAILURE;
-    } else {
-        let unixd_meta = match metadata(&unixd_path) {
-            Ok(v) => v,
-            Err(e) => {
-                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                return ExitCode::FAILURE;
-            }
-        };
-        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                unixd_path_str);
-        }
+            if !unixd_path.exists() {
+                // there's no point trying to start up if we can't read a usable config!
+                error!(
+                    "unixd config missing from {} - cannot start up. Quitting.",
+                    unixd_path_str
+                );
+                return
+            } else {
+                let unixd_meta = match metadata(&unixd_path) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
+                        return
+                    }
+                };
+                if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
+                    warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                        unixd_path_str);
+                }
 
                 if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
                     warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
@@ -770,51 +544,51 @@ async fn main() {
 
 
 
-    // Check the db path will be okay.
-    if !cfg.db_path.is_empty() {
-        let db_path = PathBuf::from(cfg.db_path.as_str());
-        // We only need to check the parent folder path permissions as the db itself may not exist yet.
-        if let Some(db_parent_path) = db_path.parent() {
-            if !db_parent_path.exists() {
-                error!(
-                    "Refusing to run, DB folder {} does not exist",
-                    db_parent_path
-                        .to_str()
-                        .unwrap_or("<db_parent_path invalid>")
-                );
-                return ExitCode::FAILURE;
-            }
+            // Check the db path will be okay.
+            if !cfg.db_path.is_empty() {
+                let db_path = PathBuf::from(cfg.db_path.as_str());
+                // We only need to check the parent folder path permissions as the db itself may not exist yet.
+                if let Some(db_parent_path) = db_path.parent() {
+                    if !db_parent_path.exists() {
+                        error!(
+                            "Refusing to run, DB folder {} does not exist",
+                            db_parent_path
+                                .to_str()
+                                .unwrap_or("<db_parent_path invalid>")
+                        );
+                        return
+                    }
 
                     let db_par_path_buf = db_parent_path.to_path_buf();
 
-            let i_meta = match metadata(&db_par_path_buf) {
-                Ok(v) => v,
-                Err(e) => {
-                    error!(
-                        "Unable to read metadata for {} - {:?}",
-                        db_par_path_buf
-                            .to_str()
-                            .unwrap_or("<db_par_path_buf invalid>"),
-                        e
-                    );
-                    return ExitCode::FAILURE;
-                }
-            };
+                    let i_meta = match metadata(&db_par_path_buf) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!(
+                                "Unable to read metadata for {} - {:?}",
+                                db_par_path_buf
+                                    .to_str()
+                                    .unwrap_or("<db_par_path_buf invalid>"),
+                                e
+                            );
+                            return
+                        }
+                    };
 
-            if !i_meta.is_dir() {
-                error!(
-                    "Refusing to run - DB folder {} may not be a directory",
-                    db_par_path_buf
-                        .to_str()
+                    if !i_meta.is_dir() {
+                        error!(
+                            "Refusing to run - DB folder {} may not be a directory",
+                            db_par_path_buf
+                                .to_str()
+                                .unwrap_or("<db_par_path_buf invalid>")
+                        );
+                        return
+                    }
+                    if !kanidm_lib_file_permissions::readonly(&i_meta) {
+                        warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
-                );
-                return ExitCode::FAILURE;
-            }
-            if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
-                .unwrap_or("<db_par_path_buf invalid>")
-                );
-            }
+                        );
+                    }
 
                     if i_meta.mode() & 0o007 != 0 {
                         warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
@@ -823,30 +597,30 @@ async fn main() {
                     }
                 }
 
-        // check to see if the db's already there
-        if db_path.exists() {
-            if !db_path.is_file() {
-                error!(
-                    "Refusing to run - DB path {} already exists and is not a file.",
-                    db_path.to_str().unwrap_or("<db_path invalid>")
-                );
-                return ExitCode::FAILURE;
-            };
+                // check to see if the db's already there
+                if db_path.exists() {
+                    if !db_path.is_file() {
+                        error!(
+                            "Refusing to run - DB path {} already exists and is not a file.",
+                            db_path.to_str().unwrap_or("<db_path invalid>")
+                        );
+                        return
+                    };
 
-            match metadata(&db_path) {
-                Ok(v) => v,
-                Err(e) => {
-                    error!(
-                        "Unable to read metadata for {} - {:?}",
-                        db_path.to_str().unwrap_or("<db_path invalid>"),
-                        e
-                    );
-                    return ExitCode::FAILURE;
-                }
-            };
-            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
-        };
-    }
+                    match metadata(&db_path) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!(
+                                "Unable to read metadata for {} - {:?}",
+                                db_path.to_str().unwrap_or("<db_path invalid>"),
+                                e
+                            );
+                            return
+                        }
+                    };
+                    // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
+                };
+            }
 
             let cb = cb.connect_timeout(cfg.conn_timeout);
 
@@ -882,27 +656,42 @@ async fn main() {
 
             let cachelayer = Arc::new(cl_inner);
 
-    // Set the umask while we open the path for most clients.
-    let before = unsafe { umask(0) };
-    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
-        Ok(l) => l,
-        Err(_e) => {
-            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-            return ExitCode::FAILURE;
-        }
-    };
-    // Setup the root-only socket. Take away all others.
-    let _ = unsafe { umask(0o0077) };
-    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
-        Ok(l) => l,
-        Err(_e) => {
-            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-            return ExitCode::FAILURE;
-        }
-    };
-    // Undo it.
-    let _ = unsafe { umask(before) };
+            // Set the umask while we open the path for most clients.
+            let before = unsafe { umask(0) };
+            let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
+                Ok(l) => l,
+                Err(_e) => {
+                    error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
+                    return
+                }
+            };
+            // Setup the root-only socket. Take away all others.
+            let _ = unsafe { umask(0o0077) };
+            let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
+                Ok(l) => l,
+                Err(_e) => {
+                    error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
+                    return
+                }
+            };
 
+            // Undo it.
+            let _ = unsafe { umask(before) };
+
+    println!("Start up complete.\n###################################");
+
+    tracing_forest::worker_task()
+        .set_global(true)
+        // Fall back to stderr
+        .map_sender(|sender| sender.or_stderr())
+        .build_on(|subscriber| {
+            subscriber.with(
+                EnvFilter::try_from_default_env()
+                    .or_else(|_| EnvFilter::try_new("info"))
+                    .expect("Failed to init envfilter"),
+            )
+        })
+        .on(async {
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
 
@@ -930,8 +719,7 @@ async fn main() {
                             // It did? Great, now we can wait and spin on that one
                             // client.
                             if let Err(e) =
-                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx)
-                                    .await
+                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx).await
                             {
                                 error!("Task client error occurred; error = {:?}", e);
                             }
@@ -954,8 +742,7 @@ async fn main() {
                         Ok((socket, _addr)) => {
                             let cachelayer_ref = cachelayer.clone();
                             tokio::spawn(async move {
-                                if let Err(e) =
-                                    handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
+                                if let Err(e) = handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
                                 {
                                     error!("handle_client error occurred; error = {:?}", e);
                                 }
@@ -971,8 +758,7 @@ async fn main() {
             info!("Server started ...");
 
             server.await;
-        })
-        .await;
-    Ok(())
+    })
+    .await;
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -417,13 +417,17 @@ async fn main() -> ExitCode {
         )
         .get_matches();
 
+    if clap_args.get_flag("debug") {
+        std::env::set_var("RUST_LOG", "debug");
+    }
+
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("debug"))
+                .or_else(|_| EnvFilter::try_new("info"))
                 .expect("Failed to init envfilter")
             )
         )
@@ -435,9 +439,6 @@ async fn main() -> ExitCode {
                 error!("Refusing to run - this process must not operate as root.");
                 return
             };
-            if clap_args.get_flag("debug") {
-                std::env::set_var("RUST_LOG", "debug");
-            }
 
             debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
             debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -42,6 +42,7 @@ use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_u
 
 //=== the codec
 
+use std::process::ExitCode;
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;
@@ -745,5 +746,6 @@ async fn main() {
             server.await;
     })
     .await;
+    ExitCode::SUCCESS
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -365,7 +365,7 @@ async fn handle_client(
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> ExitCode {
+async fn main() {
     let cuid = get_current_uid();
     let ceuid = get_effective_uid();
     let cgid = get_current_gid();

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -18,6 +18,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use std::process::ExitCode;
 
 use bytes::{BufMut, BytesMut};
 use clap::{Arg, ArgAction, Command};
@@ -364,7 +365,7 @@ async fn handle_client(
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() {
+async fn main() -> ExitCode {
     let cuid = get_current_uid();
     let ceuid = get_effective_uid();
     let cgid = get_current_gid();
@@ -436,7 +437,7 @@ async fn main() {
                 // TODO: this wording is not great m'kay.
             } else if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
                 error!("Refusing to run - this process must not operate as root.");
-                return
+                return ExitCode::FAILURE
             };
 
             debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
@@ -444,7 +445,7 @@ async fn main() {
 
             let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
                 error!("Failed to pull the client config path");
-                return
+                return ExitCode::FAILURE
             };
             let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
@@ -454,13 +455,13 @@ async fn main() {
                     "Client config missing from {} - cannot start up. Quitting.",
                     cfg_path_str
                 );
-                return
+                return ExitCode::FAILURE
             } else {
                 let cfg_meta = match metadata(&cfg_path) {
                     Ok(v) => v,
                     Err(e) => {
                         error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                        return
+                        return ExitCode::FAILURE
                     }
                 };
                 if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
@@ -478,7 +479,7 @@ async fn main() {
 
             let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
                 error!("Failed to pull the unixd config path");
-                return
+                return ExitCode::FAILURE
             };
             let unixd_path = PathBuf::from(unixd_path_str);
 
@@ -488,13 +489,13 @@ async fn main() {
                     "unixd config missing from {} - cannot start up. Quitting.",
                     unixd_path_str
                 );
-                return
+                return ExitCode::FAILURE
             } else {
                 let unixd_meta = match metadata(&unixd_path) {
                     Ok(v) => v,
                     Err(e) => {
                         error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                        return
+                        return ExitCode::FAILURE
                     }
                 };
                 if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
@@ -514,7 +515,7 @@ async fn main() {
                 Ok(v) => v,
                 Err(_) => {
                     error!("Failed to parse {}", cfg_path_str);
-                    return
+                    return ExitCode::FAILURE
                 }
             };
 
@@ -522,7 +523,7 @@ async fn main() {
                 Ok(v) => v,
                 Err(_) => {
                     error!("Failed to parse {}", unixd_path_str);
-                    return
+                    return ExitCode::FAILURE
                 }
             };
 
@@ -534,7 +535,7 @@ async fn main() {
                 eprintln!("###################################");
                 eprintln!("Client config (from {:#?})", &cfg_path);
                 eprintln!("{}", cb);
-                return;
+                return ExitCode::SUCCESS;
             }
 
             debug!("🧹 Cleaning up sockets from previous invocations");
@@ -555,7 +556,7 @@ async fn main() {
                                 .to_str()
                                 .unwrap_or("<db_parent_path invalid>")
                         );
-                        return
+                        return ExitCode::FAILURE
                     }
 
                     let db_par_path_buf = db_parent_path.to_path_buf();
@@ -570,7 +571,7 @@ async fn main() {
                                     .unwrap_or("<db_par_path_buf invalid>"),
                                 e
                             );
-                            return
+                            return ExitCode::FAILURE
                         }
                     };
 
@@ -581,7 +582,7 @@ async fn main() {
                                 .to_str()
                                 .unwrap_or("<db_par_path_buf invalid>")
                         );
-                        return
+                        return ExitCode::FAILURE
                     }
                     if !kanidm_lib_file_permissions::readonly(&i_meta) {
                         warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
@@ -603,7 +604,7 @@ async fn main() {
                             "Refusing to run - DB path {} already exists and is not a file.",
                             db_path.to_str().unwrap_or("<db_path invalid>")
                         );
-                        return
+                        return ExitCode::FAILURE
                     };
 
                     match metadata(&db_path) {
@@ -614,7 +615,7 @@ async fn main() {
                                 db_path.to_str().unwrap_or("<db_path invalid>"),
                                 e
                             );
-                            return
+                            return ExitCode::FAILURE
                         }
                     };
                     // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
@@ -627,7 +628,7 @@ async fn main() {
                 Ok(rsc) => rsc,
                 Err(_e) => {
                     error!("Failed to build async client");
-                    return
+                    return ExitCode::FAILURE
                 }
             };
 
@@ -649,7 +650,7 @@ async fn main() {
                 Ok(c) => c,
                 Err(_e) => {
                     error!("Failed to build cache layer.");
-                    return
+                    return ExitCode::FAILURE
                 }
             };
 
@@ -661,7 +662,7 @@ async fn main() {
                 Ok(l) => l,
                 Err(_e) => {
                     error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-                    return
+                    return ExitCode::FAILURE
                 }
             };
             // Setup the root-only socket. Take away all others.
@@ -670,7 +671,7 @@ async fn main() {
                 Ok(l) => l,
                 Err(_e) => {
                     error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-                    return
+                    return ExitCode::FAILURE
                 }
             };
 
@@ -743,7 +744,8 @@ async fn main() {
             info!("Server started ...");
 
             server.await;
+            ExitCode::SUCCESS
     })
-    .await;
+    .await
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -424,7 +424,6 @@ async fn main() {
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-    #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         error!("Failed to pull the client config path");
         return ExitCode::FAILURE;
@@ -460,7 +459,6 @@ async fn main() {
         }
     }
 
-    #[allow(clippy::expect_used)]
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
         error!("Failed to pull the unixd config path");
         return ExitCode::FAILURE;

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -426,7 +426,7 @@ async fn main() {
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
+                .or_else(|_| EnvFilter::try_new("debug"))
                 .expect("Failed to init envfilter")
             )
         )

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,7 +427,11 @@ async fn main() {
 
 
     #[allow(clippy::expect_used)]
-    let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
+    let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
+        error!("Failed to pull the client config path");
+        return ExitCode::FAILURE;
+    };
+    //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
     let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
@@ -459,7 +463,11 @@ async fn main() {
     }
 
     #[allow(clippy::expect_used)]
-    let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
+    let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
+        error!("Failed to pull the unixd config path");
+        return ExitCode::FAILURE;
+    };
+    //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
     let unixd_path = PathBuf::from(unixd_path_str);
 
     if !unixd_path.exists() {

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -423,7 +423,7 @@ async fn main() -> ExitCode {
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
+                .or_else(|_| EnvFilter::try_new("debug"))
                 .expect("Failed to init envfilter")
             )
         )

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -422,6 +422,237 @@ async fn main() {
         std::env::set_var("RUST_LOG", "debug");
     }
 
+    debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
+    debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+
+
+    #[allow(clippy::expect_used)]
+    let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
+    let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
+
+    if !cfg_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "Client config missing from {} - cannot start up. Quitting.",
+            cfg_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let cfg_meta = match metadata(&cfg_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                cfg_path_str
+                );
+        }
+
+        if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
+            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+                cfg_path_str
+            );
+        }
+    }
+
+    #[allow(clippy::expect_used)]
+    let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
+    let unixd_path = PathBuf::from(unixd_path_str);
+
+    if !unixd_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "unixd config missing from {} - cannot start up. Quitting.",
+            unixd_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let unixd_meta = match metadata(&unixd_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                unixd_path_str);
+        }
+
+        if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
+            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+                unixd_path_str
+            );
+        }
+    }
+
+    // setup
+    let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&cfg_path) {
+        Ok(v) => v,
+        Err(_) => {
+            error!("Failed to parse {}", cfg_path_str);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cfg = match KanidmUnixdConfig::new().read_options_from_optional_config(&unixd_path) {
+        Ok(v) => v,
+        Err(_) => {
+            error!("Failed to parse {}", unixd_path_str);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if clap_args.get_flag("configtest") {
+        eprintln!("###################################");
+        eprintln!("Dumping configs:\n###################################");
+        eprintln!("kanidm_unixd config (from {:#?})", &unixd_path);
+        eprintln!("{}", cfg);
+        eprintln!("###################################");
+        eprintln!("Client config (from {:#?})", &cfg_path);
+        eprintln!("{}", cb);
+        return ExitCode::SUCCESS;
+    }
+
+    debug!("🧹 Cleaning up sockets from previous invocations");
+    rm_if_exist(cfg.sock_path.as_str());
+    rm_if_exist(cfg.task_sock_path.as_str());
+
+    // Check the db path will be okay.
+    if !cfg.db_path.is_empty() {
+        let db_path = PathBuf::from(cfg.db_path.as_str());
+        // We only need to check the parent folder path permissions as the db itself may not exist yet.
+        if let Some(db_parent_path) = db_path.parent() {
+            if !db_parent_path.exists() {
+                error!(
+                    "Refusing to run, DB folder {} does not exist",
+                    db_parent_path
+                        .to_str()
+                        .unwrap_or("<db_parent_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            }
+
+            let db_par_path_buf = db_parent_path.to_path_buf();
+
+            let i_meta = match metadata(&db_par_path_buf) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_par_path_buf
+                            .to_str()
+                            .unwrap_or("<db_par_path_buf invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+
+            if !i_meta.is_dir() {
+                error!(
+                    "Refusing to run - DB folder {} may not be a directory",
+                    db_par_path_buf
+                        .to_str()
+                        .unwrap_or("<db_par_path_buf invalid>")
+                );
+                return ExitCode::FAILURE;
+            }
+            if !kanidm_lib_file_permissions::readonly(&i_meta) {
+                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+                .unwrap_or("<db_par_path_buf invalid>")
+                );
+            }
+
+            if i_meta.mode() & 0o007 != 0 {
+                warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
+                .unwrap_or("<db_par_path_buf invalid>")
+                );
+            }
+        }
+
+        // check to see if the db's already there
+        if db_path.exists() {
+            if !db_path.is_file() {
+                error!(
+                    "Refusing to run - DB path {} already exists and is not a file.",
+                    db_path.to_str().unwrap_or("<db_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            };
+
+            match metadata(&db_path) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_path.to_str().unwrap_or("<db_path invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
+        };
+    }
+
+    let cb = cb.connect_timeout(cfg.conn_timeout);
+
+    let rsclient = match cb.build() {
+        Ok(rsc) => rsc,
+        Err(_e) => {
+            error!("Failed to build async client");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cl_inner = match CacheLayer::new(
+        cfg.db_path.as_str(), // The sqlite db path
+        cfg.cache_timeout,
+        rsclient,
+        cfg.pam_allowed_login_groups.clone(),
+        cfg.default_shell.clone(),
+        cfg.home_prefix.clone(),
+        cfg.home_attr,
+        cfg.home_alias,
+        cfg.uid_attr_map,
+        cfg.gid_attr_map,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(_e) => {
+            error!("Failed to build cache layer.");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cachelayer = Arc::new(cl_inner);
+
+    // Set the umask while we open the path for most clients.
+    let before = unsafe { umask(0) };
+    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Setup the root-only socket. Take away all others.
+    let _ = unsafe { umask(0o0077) };
+    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Undo it.
+    let _ = unsafe { umask(before) };
+
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -678,20 +678,6 @@ async fn main() {
             // Undo it.
             let _ = unsafe { umask(before) };
 
-    println!("Start up complete.\n###################################");
-
-    tracing_forest::worker_task()
-        .set_global(true)
-        // Fall back to stderr
-        .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| {
-            subscriber.with(
-                EnvFilter::try_from_default_env()
-                    .or_else(|_| EnvFilter::try_new("info"))
-                    .expect("Failed to init envfilter"),
-            )
-        })
-        .on(async {
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
 

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -425,14 +425,13 @@ async fn main() {
     debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
     debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-
     #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         error!("Failed to pull the client config path");
         return ExitCode::FAILURE;
     };
     //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
-    let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
+    let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
@@ -665,12 +664,13 @@ async fn main() {
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| subscriber
-            .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
-                .expect("Failed to init envfilter")
+        .build_on(|subscriber| {
+            subscriber.with(
+                EnvFilter::try_from_default_env()
+                    .or_else(|_| EnvFilter::try_new("info"))
+                    .expect("Failed to init envfilter"),
             )
-        )
+        })
         .on(async {
             if clap_args.get_flag("skip-root-check") {
                 warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
@@ -945,7 +945,8 @@ async fn main() {
                             // It did? Great, now we can wait and spin on that one
                             // client.
                             if let Err(e) =
-                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx).await
+                                handle_task_client(socket, &task_channel_tx, &mut task_channel_rx)
+                                    .await
                             {
                                 error!("Task client error occurred; error = {:?}", e);
                             }
@@ -968,7 +969,8 @@ async fn main() {
                         Ok((socket, _addr)) => {
                             let cachelayer_ref = cachelayer.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
+                                if let Err(e) =
+                                    handle_client(socket, cachelayer_ref.clone(), &tc_tx).await
                                 {
                                     error!("handle_client error occurred; error = {:?}", e);
                                 }
@@ -984,9 +986,8 @@ async fn main() {
             info!("Server started ...");
 
             server.await;
-            ExitCode::SUCCESS
-    })
-    .await;
+        })
+        .await;
     ExitCode::SUCCESS
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -426,6 +426,7 @@ async fn main() {
     println!("###################################");
     println!("Starting up:\n###################################");
 
+    #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         anyhow::bail!("Failed to pull the client config path");
     };
@@ -458,6 +459,7 @@ async fn main() {
         }
     }
 
+    #[allow(clippy::expect_used)]
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
         anyhow::bail!("Failed to pull the unixd config path");
     };

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -40,9 +40,9 @@ use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 use users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
 
-//=== the codec
+use anyhow::{Result, self};
 
-use std::process::ExitCode;
+//=== the codec
 type AsyncTaskRequest = (TaskRequest, oneshot::Sender<()>);
 
 struct ClientCodec;
@@ -421,73 +421,69 @@ async fn main() {
         std::env::set_var("RUST_LOG", "debug");
     }
 
-    debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
-    debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+    println!("DEBUG: Profile -> {}", env!("KANIDM_PROFILE_NAME"));
+    println!("DEBUG: CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
+    println!("###################################");
+    println!("Starting up:\n###################################");
 
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
-        error!("Failed to pull the client config path");
-        return ExitCode::FAILURE;
+        anyhow::bail!("Failed to pull the client config path");
     };
     //let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
     let cfg_path: PathBuf = PathBuf::from(cfg_path_str);
 
     if !cfg_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
-        error!(
+        anyhow::bail!(
             "Client config missing from {} - cannot start up. Quitting.",
             cfg_path_str
         );
-        return ExitCode::FAILURE;
     } else {
         let cfg_meta = match metadata(&cfg_path) {
             Ok(v) => v,
             Err(e) => {
-                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                return ExitCode::FAILURE;
+                anyhow::bail!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
             }
         };
         if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
                 cfg_path_str
                 );
         }
 
         if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
-            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
                 cfg_path_str
             );
         }
     }
 
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
-        error!("Failed to pull the unixd config path");
-        return ExitCode::FAILURE;
+        anyhow::bail!("Failed to pull the unixd config path");
     };
     //let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
     let unixd_path = PathBuf::from(unixd_path_str);
 
     if !unixd_path.exists() {
         // there's no point trying to start up if we can't read a usable config!
-        error!(
+        anyhow::bail!(
             "unixd config missing from {} - cannot start up. Quitting.",
             unixd_path_str
         );
-        return ExitCode::FAILURE;
     } else {
         let unixd_meta = match metadata(&unixd_path) {
             Ok(v) => v,
             Err(e) => {
-                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                return ExitCode::FAILURE;
+                anyhow::bail!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
             }
         };
         if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+            println!("WARNING: permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
                 unixd_path_str);
         }
 
         if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
-            warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
+            println!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
                 unixd_path_str
             );
         }
@@ -497,16 +493,14 @@ async fn main() {
     let cb = match KanidmClientBuilder::new().read_options_from_optional_config(&cfg_path) {
         Ok(v) => v,
         Err(_) => {
-            error!("Failed to parse {}", cfg_path_str);
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to parse {}", cfg_path_str);
         }
     };
 
     let cfg = match KanidmUnixdConfig::new().read_options_from_optional_config(&unixd_path) {
         Ok(v) => v,
         Err(_) => {
-            error!("Failed to parse {}", unixd_path_str);
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to parse {}", unixd_path_str);
         }
     };
 
@@ -518,10 +512,9 @@ async fn main() {
         eprintln!("###################################");
         eprintln!("Client config (from {:#?})", &cfg_path);
         eprintln!("{}", cb);
-        return ExitCode::SUCCESS;
+        return Ok(());
     }
-
-    debug!("🧹 Cleaning up sockets from previous invocations");
+    println!("DEBUG: 🧹 Cleaning up sockets from previous invocations");
     rm_if_exist(cfg.sock_path.as_str());
     rm_if_exist(cfg.task_sock_path.as_str());
 
@@ -531,13 +524,12 @@ async fn main() {
         // We only need to check the parent folder path permissions as the db itself may not exist yet.
         if let Some(db_parent_path) = db_path.parent() {
             if !db_parent_path.exists() {
-                error!(
+                anyhow::bail!(
                     "Refusing to run, DB folder {} does not exist",
                     db_parent_path
                         .to_str()
                         .unwrap_or("<db_parent_path invalid>")
                 );
-                return ExitCode::FAILURE;
             }
 
             let db_par_path_buf = db_parent_path.to_path_buf();
@@ -545,34 +537,32 @@ async fn main() {
             let i_meta = match metadata(&db_par_path_buf) {
                 Ok(v) => v,
                 Err(e) => {
-                    error!(
+                    anyhow::bail!(
                         "Unable to read metadata for {} - {:?}",
                         db_par_path_buf
                             .to_str()
                             .unwrap_or("<db_par_path_buf invalid>"),
                         e
                     );
-                    return ExitCode::FAILURE;
                 }
             };
 
             if !i_meta.is_dir() {
-                error!(
+                anyhow::bail!(
                     "Refusing to run - DB folder {} may not be a directory",
                     db_par_path_buf
                         .to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
                 );
-                return ExitCode::FAILURE;
             }
             if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+                println!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
                 .unwrap_or("<db_par_path_buf invalid>")
                 );
             }
 
             if i_meta.mode() & 0o007 != 0 {
-                warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
+                println!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
                 .unwrap_or("<db_par_path_buf invalid>")
                 );
             }
@@ -581,22 +571,20 @@ async fn main() {
         // check to see if the db's already there
         if db_path.exists() {
             if !db_path.is_file() {
-                error!(
+                anyhow::bail!(
                     "Refusing to run - DB path {} already exists and is not a file.",
                     db_path.to_str().unwrap_or("<db_path invalid>")
                 );
-                return ExitCode::FAILURE;
             };
 
             match metadata(&db_path) {
                 Ok(v) => v,
                 Err(e) => {
-                    error!(
+                    anyhow::bail!(
                         "Unable to read metadata for {} - {:?}",
                         db_path.to_str().unwrap_or("<db_path invalid>"),
                         e
                     );
-                    return ExitCode::FAILURE;
                 }
             };
             // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
@@ -608,8 +596,7 @@ async fn main() {
     let rsclient = match cb.build() {
         Ok(rsc) => rsc,
         Err(_e) => {
-            error!("Failed to build async client");
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to build async client");
         }
     };
 
@@ -629,8 +616,7 @@ async fn main() {
     {
         Ok(c) => c,
         Err(_e) => {
-            error!("Failed to build cache layer.");
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to build cache layer.");
         }
     };
 
@@ -641,8 +627,7 @@ async fn main() {
     let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
         Ok(l) => l,
         Err(_e) => {
-            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
         }
     };
     // Setup the root-only socket. Take away all others.
@@ -650,12 +635,13 @@ async fn main() {
     let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
         Ok(l) => l,
         Err(_e) => {
-            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-            return ExitCode::FAILURE;
+            anyhow::bail!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
         }
     };
     // Undo it.
     let _ = unsafe { umask(before) };
+
+    println!("Start up complete.\n###################################");
 
     tracing_forest::worker_task()
         .set_global(true)
@@ -686,26 +672,26 @@ async fn main() {
             };
             let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
-            if !cfg_path.exists() {
-                // there's no point trying to start up if we can't read a usable config!
-                error!(
-                    "Client config missing from {} - cannot start up. Quitting.",
-                    cfg_path_str
+    if !cfg_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "Client config missing from {} - cannot start up. Quitting.",
+            cfg_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let cfg_meta = match metadata(&cfg_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                cfg_path_str
                 );
-                return
-            } else {
-                let cfg_meta = match metadata(&cfg_path) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                        return
-                    }
-                };
-                if !kanidm_lib_file_permissions::readonly(&cfg_meta) {
-                    warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                        cfg_path_str
-                        );
-                }
+        }
 
                 if cfg_meta.uid() == cuid || cfg_meta.uid() == ceuid {
                     warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
@@ -720,25 +706,25 @@ async fn main() {
             };
             let unixd_path = PathBuf::from(unixd_path_str);
 
-            if !unixd_path.exists() {
-                // there's no point trying to start up if we can't read a usable config!
-                error!(
-                    "unixd config missing from {} - cannot start up. Quitting.",
-                    unixd_path_str
-                );
-                return
-            } else {
-                let unixd_meta = match metadata(&unixd_path) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                        return
-                    }
-                };
-                if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
-                    warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
-                        unixd_path_str);
-                }
+    if !unixd_path.exists() {
+        // there's no point trying to start up if we can't read a usable config!
+        error!(
+            "unixd config missing from {} - cannot start up. Quitting.",
+            unixd_path_str
+        );
+        return ExitCode::FAILURE;
+    } else {
+        let unixd_meta = match metadata(&unixd_path) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
+                return ExitCode::FAILURE;
+            }
+        };
+        if !kanidm_lib_file_permissions::readonly(&unixd_meta) {
+            warn!("permissions on {} may not be secure. Should be readonly to running uid. This could be a security risk ...",
+                unixd_path_str);
+        }
 
                 if unixd_meta.uid() == cuid || unixd_meta.uid() == ceuid {
                     warn!("WARNING: {} owned by the current uid, which may allow file permission changes. This could be a security risk ...",
@@ -781,51 +767,51 @@ async fn main() {
 
 
 
-            // Check the db path will be okay.
-            if !cfg.db_path.is_empty() {
-                let db_path = PathBuf::from(cfg.db_path.as_str());
-                // We only need to check the parent folder path permissions as the db itself may not exist yet.
-                if let Some(db_parent_path) = db_path.parent() {
-                    if !db_parent_path.exists() {
-                        error!(
-                            "Refusing to run, DB folder {} does not exist",
-                            db_parent_path
-                                .to_str()
-                                .unwrap_or("<db_parent_path invalid>")
-                        );
-                        return
-                    }
+    // Check the db path will be okay.
+    if !cfg.db_path.is_empty() {
+        let db_path = PathBuf::from(cfg.db_path.as_str());
+        // We only need to check the parent folder path permissions as the db itself may not exist yet.
+        if let Some(db_parent_path) = db_path.parent() {
+            if !db_parent_path.exists() {
+                error!(
+                    "Refusing to run, DB folder {} does not exist",
+                    db_parent_path
+                        .to_str()
+                        .unwrap_or("<db_parent_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            }
 
                     let db_par_path_buf = db_parent_path.to_path_buf();
 
-                    let i_meta = match metadata(&db_par_path_buf) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            error!(
-                                "Unable to read metadata for {} - {:?}",
-                                db_par_path_buf
-                                    .to_str()
-                                    .unwrap_or("<db_par_path_buf invalid>"),
-                                e
-                            );
-                            return
-                        }
-                    };
+            let i_meta = match metadata(&db_par_path_buf) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_par_path_buf
+                            .to_str()
+                            .unwrap_or("<db_par_path_buf invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
 
-                    if !i_meta.is_dir() {
-                        error!(
-                            "Refusing to run - DB folder {} may not be a directory",
-                            db_par_path_buf
-                                .to_str()
-                                .unwrap_or("<db_par_path_buf invalid>")
-                        );
-                        return
-                    }
-                    if !kanidm_lib_file_permissions::readonly(&i_meta) {
-                        warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+            if !i_meta.is_dir() {
+                error!(
+                    "Refusing to run - DB folder {} may not be a directory",
+                    db_par_path_buf
+                        .to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
-                        );
-                    }
+                );
+                return ExitCode::FAILURE;
+            }
+            if !kanidm_lib_file_permissions::readonly(&i_meta) {
+                warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
+                .unwrap_or("<db_par_path_buf invalid>")
+                );
+            }
 
                     if i_meta.mode() & 0o007 != 0 {
                         warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
@@ -834,30 +820,30 @@ async fn main() {
                     }
                 }
 
-                // check to see if the db's already there
-                if db_path.exists() {
-                    if !db_path.is_file() {
-                        error!(
-                            "Refusing to run - DB path {} already exists and is not a file.",
-                            db_path.to_str().unwrap_or("<db_path invalid>")
-                        );
-                        return
-                    };
+        // check to see if the db's already there
+        if db_path.exists() {
+            if !db_path.is_file() {
+                error!(
+                    "Refusing to run - DB path {} already exists and is not a file.",
+                    db_path.to_str().unwrap_or("<db_path invalid>")
+                );
+                return ExitCode::FAILURE;
+            };
 
-                    match metadata(&db_path) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            error!(
-                                "Unable to read metadata for {} - {:?}",
-                                db_path.to_str().unwrap_or("<db_path invalid>"),
-                                e
-                            );
-                            return
-                        }
-                    };
-                    // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
-                };
-            }
+            match metadata(&db_path) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "Unable to read metadata for {} - {:?}",
+                        db_path.to_str().unwrap_or("<db_path invalid>"),
+                        e
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+            // TODO: permissions dance to enumerate the user's ability to write to the file? ref #456 - r2d2 will happily keep trying to do things without bailing.
+        };
+    }
 
             let cb = cb.connect_timeout(cfg.conn_timeout);
 
@@ -893,27 +879,26 @@ async fn main() {
 
             let cachelayer = Arc::new(cl_inner);
 
-            // Set the umask while we open the path for most clients.
-            let before = unsafe { umask(0) };
-            let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
-                Ok(l) => l,
-                Err(_e) => {
-                    error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
-                    return
-                }
-            };
-            // Setup the root-only socket. Take away all others.
-            let _ = unsafe { umask(0o0077) };
-            let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
-                Ok(l) => l,
-                Err(_e) => {
-                    error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
-                    return
-                }
-            };
-
-            // Undo it.
-            let _ = unsafe { umask(before) };
+    // Set the umask while we open the path for most clients.
+    let before = unsafe { umask(0) };
+    let listener = match UnixListener::bind(cfg.sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket at {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Setup the root-only socket. Take away all others.
+    let _ = unsafe { umask(0o0077) };
+    let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
+        Ok(l) => l,
+        Err(_e) => {
+            error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
+            return ExitCode::FAILURE;
+        }
+    };
+    // Undo it.
+    let _ = unsafe { umask(before) };
 
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
@@ -985,6 +970,6 @@ async fn main() {
             server.await;
         })
         .await;
-    ExitCode::SUCCESS
+    Ok(())
     // TODO: can we catch signals to clean up sockets etc, especially handy when running as root
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,6 +427,7 @@ async fn main() -> ExitCode {
     println!("###################################");
     println!("Starting up:\n###################################");
 
+    #[allow(clippy::expect_used)]
     let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
         anyhow::bail!("Failed to pull the client config path");
     };
@@ -459,6 +460,7 @@ async fn main() -> ExitCode {
         }
     }
 
+    #[allow(clippy::expect_used)]
     let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
         anyhow::bail!("Failed to pull the unixd config path");
     };

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -677,20 +677,6 @@ async fn main() {
             // Undo it.
             let _ = unsafe { umask(before) };
 
-    println!("Start up complete.\n###################################");
-
-    tracing_forest::worker_task()
-        .set_global(true)
-        // Fall back to stderr
-        .map_sender(|sender| sender.or_stderr())
-        .build_on(|subscriber| {
-            subscriber.with(
-                EnvFilter::try_from_default_env()
-                    .or_else(|_| EnvFilter::try_new("info"))
-                    .expect("Failed to init envfilter"),
-            )
-        })
-        .on(async {
             let (task_channel_tx, mut task_channel_rx) = channel(16);
             let task_channel_tx = Arc::new(task_channel_tx);
 


### PR DESCRIPTION
Fixes #1025 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

Solution: Move all initialization code out of tracing forest, allowing return an exit code in daemon main. Tracing forest now limited to handling the task loop.
Also changed a few `.expect()` to log messages.