### PR TITLE
Unixd daemon improvement

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@
 - h7x4
 - Pi-Cla
 - Sebastiano Tocci(Seba-T)
+- Minh Phan (MinhPhan8803)
 
 ## Acknowledgements
 

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -75,7 +75,7 @@ serde_json.workspace = true
 sketching.workspace = true
 
 toml.workspace = true
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net", "io-util"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 reqwest = { workspace = true, default-features = false }

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -75,7 +75,7 @@ serde_json.workspace = true
 sketching.workspace = true
 
 toml.workspace = true
-tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 reqwest = { workspace = true, default-features = false }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -432,7 +432,7 @@ async fn main() {
                 // TODO: this wording is not great m'kay.
             } else if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
                 error!("Refusing to run - this process must not operate as root.");
-                return;
+                return
             };
             if clap_args.get_flag("debug") {
                 std::env::set_var("RUST_LOG", "debug");
@@ -441,9 +441,10 @@ async fn main() {
             debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
             debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 
-
-            #[allow(clippy::expect_used)]
-            let cfg_path_str = clap_args.get_one::<String>("client-config").expect("Failed to pull the client config path");
+            let Some(cfg_path_str) = clap_args.get_one::<String>("client-config") else {
+                error!("Failed to pull the client config path");
+                return
+            };
             let cfg_path: PathBuf =  PathBuf::from(cfg_path_str);
 
             if !cfg_path.exists() {
@@ -474,8 +475,10 @@ async fn main() {
                 }
             }
 
-            #[allow(clippy::expect_used)]
-            let unixd_path_str = clap_args.get_one::<String>("unixd-config").expect("Failed to pull the unixd config path");
+            let Some(unixd_path_str) = clap_args.get_one::<String>("unixd-config") else {
+                error!("Failed to pull the unixd config path");
+                return
+            };
             let unixd_path = PathBuf::from(unixd_path_str);
 
             if !unixd_path.exists() {

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -422,7 +422,7 @@ async fn main() {
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("info"))
+                .or_else(|_| EnvFilter::try_new("debug"))
                 .expect("Failed to init envfilter")
             )
         )

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -363,7 +363,7 @@ async fn handle_client(
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let cuid = get_current_uid();
     let ceuid = get_effective_uid();

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -416,13 +416,17 @@ async fn main() {
         )
         .get_matches();
 
+    if clap_args.get_flag("debug") {
+        std::env::set_var("RUST_LOG", "debug");
+    }
+
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr
         .map_sender(|sender| sender.or_stderr())
         .build_on(|subscriber| subscriber
             .with(EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("debug"))
+                .or_else(|_| EnvFilter::try_new("info"))
                 .expect("Failed to init envfilter")
             )
         )
@@ -434,9 +438,6 @@ async fn main() {
                 error!("Refusing to run - this process must not operate as root.");
                 return
             };
-            if clap_args.get_flag("debug") {
-                std::env::set_var("RUST_LOG", "debug");
-            }
 
             debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
             debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -416,17 +416,6 @@ async fn main() {
         )
         .get_matches();
 
-    if clap_args.get_flag("skip-root-check") {
-        warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
-        // TODO: this wording is not great m'kay.
-    } else if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
-        error!("Refusing to run - this process must not operate as root.");
-        return;
-    };
-    if clap_args.get_flag("debug") {
-        std::env::set_var("RUST_LOG", "debug");
-    }
-
     tracing_forest::worker_task()
         .set_global(true)
         // Fall back to stderr
@@ -438,6 +427,17 @@ async fn main() {
             )
         )
         .on(async {
+            if clap_args.get_flag("skip-root-check") {
+                warn!("Skipping root user check, if you're running this for testing, ensure you clean up temporary files.")
+                // TODO: this wording is not great m'kay.
+            } else if cuid == 0 || ceuid == 0 || cgid == 0 || cegid == 0 {
+                error!("Refusing to run - this process must not operate as root.");
+                return;
+            };
+            if clap_args.get_flag("debug") {
+                std::env::set_var("RUST_LOG", "debug");
+            }
+
             debug!("Profile -> {}", env!("KANIDM_PROFILE_NAME"));
             debug!("CPU Flags -> {}", env!("KANIDM_CPU_FLAGS"));
 


### PR DESCRIPTION
Couple misc fixes for unixd daemon.

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

- Removed some `.expects()`
- Move all logs into tracing forest (use the global subscriber).
- Fix cargo.toml (previously couldnt compile in debug build).
- Still no exit code sadly.