### PR TITLE
Correcting command typo, works with kanidm/server img ac1fddd16083

### DIFF
--- a/book/src/server_configuration.md
+++ b/book/src/server_configuration.md
@@ -48,7 +48,7 @@ text=The server must not be running at this point, as it requires exclusive acce
 
 ```bash
 docker run --rm -i -t -v kanidmd:/data \
-    kanidm/server:latest /sbin/kanidmd recover-account -c /data/server.toml admin
+    kanidm/server:latest /sbin/kanidmd recover_account -c /data/server.toml admin
 # success - recovery of account password for admin: vv...
 ```
 


### PR DESCRIPTION
Fixes # - NA, I am lazy and this is just a doc change.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
