### PR TITLE
Fix path-relative links in documentation

### DIFF
--- a/book/src/integrations/pam_and_nsswitch.md
+++ b/book/src/integrations/pam_and_nsswitch.md
@@ -42,7 +42,7 @@ systemctl status kanidm-unixd-tasks
 > provides supporting Kanidm's capabilities.
 
 Both unixd daemons use the connection configuration from /etc/kanidm/config. This is the covered in
-[client_tools](./client_tools.md#kanidm-configuration).
+[client_tools](../client_tools.md#kanidm-configuration).
 
 You can also configure some unixd-specific options with the file /etc/kanidm/unixd:
 
@@ -119,8 +119,8 @@ passwd: compat kanidm
 group: compat kanidm
 ```
 
-You can [create a user](./accounts_and_groups.md#creating-accounts) then
-[enable POSIX feature on the user](./posix_accounts.md#enabling-posix-attributes-on-accounts).
+You can [create a user](../accounts_and_groups.md#creating-accounts) then
+[enable POSIX feature on the user](../posix_accounts.md#enabling-posix-attributes-on-accounts).
 
 You can then test that the POSIX extended user is able to be resolved with:
 


### PR DESCRIPTION
The documentation for [pam and nsswitch integrations was not path relative](https://kanidm.github.io/kanidm/stable/integrations/pam_and_nsswitch.html) and would 404 in all links to documentation. This fixes them by pointing to the parent directory. I also ran [muffet](https://github.com/raviqqe/muffet) to triple check there were no other locations where this was occurring and did not identify any.

Fixes #

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
