### PR TITLE
Authsession non empty vec

### DIFF
--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -18,12 +18,12 @@ use kanidm_proto::v1::{
 use tokio::sync::mpsc::UnboundedSender as Sender;
 use uuid::Uuid;
 // use webauthn_rs::prelude::DeviceKey as DeviceKeyV4;
+use nonempty::{nonempty, NonEmpty};
 use webauthn_rs::prelude::Passkey as PasskeyV4;
 use webauthn_rs::prelude::{
     CredentialID, PasskeyAuthentication, RequestChallengeResponse, SecurityKeyAuthentication,
     Webauthn,
 };
-use nonempty::{NonEmpty, nonempty};
 
 use crate::credential::totp::Totp;
 use crate::credential::{BackupCodes, Credential, CredentialType, Password};


### PR DESCRIPTION
References #267 

- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

I tried to update `AuthSessionState::Init` to also use a non empty vec since it looks like there's no path for it to be empty. But that got a few tests to panic so ig it doesn't make sense?