### PR TITLE
Update book: fix use of dashes to reflect last binaries

### DIFF
--- a/book/src/accounts_and_groups.md
+++ b/book/src/accounts_and_groups.md
@@ -86,8 +86,8 @@ kanidm person create demo_user "Demonstration User" --name idm_admin
 kanidm person get demo_user --name idm_admin
 
 kanidm group create demo_group --name idm_admin
-kanidm group add-members demo_group demo_user --name idm_admin
-kanidm group list-members demo_group --name idm_admin
+kanidm group add_members demo_group demo_user --name idm_admin
+kanidm group list_members demo_group --name idm_admin
 ```
 
 You can also use anonymous to view accounts and groups - note that you won't see certain fields due
@@ -156,17 +156,18 @@ add the "--rw" flag during the generate command. It is recommended you only add 
 api-token is performing writes to Kanidm.
 
 ```bash
-kanidm service-account api-token generate --name admin ACCOUNT_ID LABEL [EXPIRY] --rw
-kanidm service-account api-token generate --name admin demo_service "Test Token" --rw
-kanidm service-account api-token generate --name admin demo_service "Test Token" 2020-09-25T11:22:02+10:00 --rw
+kanidm service-account api-token generate --name idm_admin ACCOUNT_ID LABEL [EXPIRY] --rw
+kanidm service-account api-token generate --name idm_admin demo_service "Test Token" --rw
+kanidm service-account api-token generate --name idm_admin demo_service "Test Token" 2020-09-25T11:22:02+10:00 --rw
 ```
 
 To destroy (revoke) an api token you will need it's token id. This can be shown with the "status"
 command.
 
 ```bash
-kanidm service-account api-token destroy --name admin ACCOUNT_ID TOKEN_ID
-kanidm service-account api-token destroy --name admin demo_service 4de2a4e9-e06a-4c5e-8a1b-33f4e7dd5dc7
+kanidm service-account api-token status demo_service --name idm_admin
+kanidm service-account api-token destroy --name idm_admin ACCOUNT_ID TOKEN_ID
+kanidm service-account api-token destroy --name idm_admin demo_service 4de2a4e9-e06a-4c5e-8a1b-33f4e7dd5dc7
 ```
 
 Api tokens can also be used to gain extended search permissions with LDAP. To do this you can bind
@@ -211,8 +212,8 @@ An example can be easily shown with:
 kanidm group create group_1 --name idm_admin
 kanidm group create group_2 --name idm_admin
 kanidm person create nest_example "Nesting Account Example" --name idm_admin
-kanidm group add-members group_1 group_2 --name idm_admin
-kanidm group add-members group_2 nest_example --name idm_admin
+kanidm group add_members group_1 group_2 --name idm_admin
+kanidm group add_members group_2 nest_example --name idm_admin
 kanidm person get nest_example --name anonymous
 ```
 
@@ -281,7 +282,7 @@ Adding the user to the `idm_people_self_write_mail` group, as shown below, allow
 their own mail.
 
 ```bash
-kanidm group add-members idm_people_self_write_mail_priv demo_user --name idm_admin
+kanidm group add_members idm_people_self_write_mail_priv demo_user --name idm_admin
 ```
 
 ## Why Can't I Change admin With idm\_admin?

--- a/book/src/authentication.md
+++ b/book/src/authentication.md
@@ -44,7 +44,7 @@ These processes are very similar. You can send a credential reset link to a user
 directly enroll their own credentials. To generate this link or qrcode:
 
 ```bash
-kanidm person credential create-reset-token demo_user --name idm_admin
+kanidm person credential create_reset_token demo_user --name idm_admin
 # The person can use one of the following to allow the credential reset
 # 
 # Scan this QR Code:

--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -125,8 +125,8 @@ kanidm system oauth2 create nextcloud "Nextcloud Production" https://nextcloud.e
 You can create a scope map with:
 
 ```bash
-kanidm system oauth2 update-scope-map <name> <kanidm_group_name> [scopes]...
-kanidm system oauth2 update-scope-map nextcloud nextcloud_admins admin
+kanidm system oauth2 update_scope_map <name> <kanidm_group_name> [scopes]...
+kanidm system oauth2 update_scope_map nextcloud nextcloud_admins admin
 ```
 
 <!-- deno-fmt-ignore-start -->
@@ -153,8 +153,8 @@ text=If you are creating an OpenID Connect (OIDC) resource server you <b>MUST</b
 You can create a supplemental scope map with:
 
 ```bash
-kanidm system oauth2 update-sup-scope-map <name> <kanidm_group_name> [scopes]...
-kanidm system oauth2 update-sup-scope-map nextcloud nextcloud_admins admin
+kanidm system oauth2 update_sup_scope_map <name> <kanidm_group_name> [scopes]...
+kanidm system oauth2 update_sup_scope_map nextcloud nextcloud_admins admin
 ```
 
 Once created you can view the details of the resource server.
@@ -175,7 +175,7 @@ oauth2_rs_token_key: hidden
 You can see "oauth2\_rs\_basic\_secret" with:
 
 ```bash
-kanidm system oauth2 show-basic-secret nextcloud
+kanidm system oauth2 show_basic_secret nextcloud
 ---
 <secret>
 ```
@@ -195,7 +195,7 @@ invalidate a resource servers active sessions/tokens, you can reset the secret m
 server with:
 
 ```bash
-kanidm system oauth2 reset-secrets
+kanidm system oauth2 reset_secrets
 ```
 
 Each resource server has unique signing keys and access secrets, so this is limited to each resource
@@ -219,13 +219,13 @@ title=WARNING text=Changing these settings MAY have serious consequences on the 
 To disable PKCE for a resource server:
 
 ```bash
-kanidm system oauth2 warning-insecure-client-disable-pkce <resource server name>
+kanidm system oauth2 warning_insecure_client_disable_pkce <resource server name>
 ```
 
 To enable legacy cryptograhy (RSA PKCS1-5 SHA256):
 
 ```bash
-kanidm system oauth2 warning-enable-legacy-crypto <resource server name>
+kanidm system oauth2 warning_enable_legacy_crypto <resource server name>
 ```
 
 ## Example Integrations

--- a/book/src/integrations/radius.md
+++ b/book/src/integrations/radius.md
@@ -66,8 +66,8 @@ For an account to use RADIUS they must first generate a RADIUS secret unique to 
 default, all accounts can self-create this secret.
 
 ```bash
-kanidm person radius generate-secret --name william william
-kanidm person radius show-secret --name william william
+kanidm person radius generate_secret --name william william
+kanidm person radius show_secret --name william william
 ```
 
 ## Account Group Configuration

--- a/book/src/ssh_key_dist.md
+++ b/book/src/ssh_key_dist.md
@@ -10,9 +10,9 @@ To view the current SSH public keys on accounts, you can use:
 
 ```bash
 kanidm person|service-account \
-    ssh list-publickeys --name <login user> <account to view>
+    ssh list_publickeys --name <login user> <account to view>
 kanidm person|service-account \
-    ssh list-publickeys --name idm_admin william
+    ssh list_publickeys --name idm_admin william
 ```
 
 All users by default can self-manage their SSH public keys. To upload a key, a command like this is
@@ -20,13 +20,13 @@ the best way to do so:
 
 ```bash
 kanidm person|service-account \
-    ssh add-publickey --name william william 'test-key' "`cat ~/.ssh/id_ecdsa.pub`"
+    ssh add_publickey --name william william 'test-key' "`cat ~/.ssh/id_ecdsa.pub`"
 ```
 
 To remove (revoke) an SSH public key, delete them by the tag name:
 
 ```bash
-kanidm person|service-account ssh delete-publickey --name william william 'test-key'
+kanidm person|service-account ssh delete_publickey --name william william 'test-key'
 ```
 
 ## Security Notes
@@ -35,7 +35,7 @@ As a security feature, Kanidm validates _all_ public keys to ensure they are val
 Uploading a private key or other data will be rejected. For example:
 
 ```bash
-kanidm person|service-account ssh add-publickey --name william william 'test-key' "invalid"
+kanidm person|service-account ssh add_publickey --name william william 'test-key' "invalid"
 Enter password:
   ... Some(SchemaViolation(InvalidAttributeSyntax)))' ...
 ```


### PR DESCRIPTION
Also fixed the use of `idm_admin` instead of `admin` in a couple of commands and added a missing `status` command mentioned in the docs.

- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
