### PR TITLE
Add exclusive process lock to Kanidm to prevent accidental duplicate commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ version = "1.1.0-alpha.12-dev"
 dependencies = [
  "clap",
  "clap_complete",
+ "fs2",
  "kanidm_lib_file_permissions",
  "kanidm_proto",
  "kanidmd_core",
@@ -1517,6 +1518,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ dialoguer = "0.10.4"
 dyn-clone = "^1.0.11"
 fernet = "^0.2.1"
 filetime = "^0.2.21"
+fs2 = "^0.4.3"
 futures = "^0.3.28"
 futures-concurrency = "^3.1.0"
 futures-util = { version = "^0.3.21", features = ["sink"] }

--- a/server/daemon/Cargo.toml
+++ b/server/daemon/Cargo.toml
@@ -22,6 +22,7 @@ kanidm_proto.workspace = true
 kanidmd_core.workspace = true
 kanidm_lib_file_permissions.workspace = true
 sketching.workspace = true
+fs2.workspace = true
 
 clap = { workspace = true, features = ["env"] }
 reqwest = { workspace = true }

--- a/server/lib/src/be/idl_sqlite.rs
+++ b/server/lib/src/be/idl_sqlite.rs
@@ -1440,7 +1440,10 @@ impl IdlSqlite {
         // Enable WAL mode, which is just faster and better for our needs.
         let mut flags = OpenFlags::default();
         // Open with multi thread flags and locking options.
-        flags.insert(OpenFlags::SQLITE_OPEN_NO_MUTEX);
+
+        if cfg!(test) {
+            flags.insert(OpenFlags::SQLITE_OPEN_NO_MUTEX);
+        };
 
         // We need to run vacuum in the setup else we hit sqlite lock conditions.
         if vacuum {


### PR DESCRIPTION
Fixes #876 - This adds a file lock to prevent duplicate execution of server commands. I attempted to use sqlite exclusive locks but these don't work with multiple threads, so I have resorted to a simple file lock. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
