### PR TITLE
Filter rdns and dns for ldap filters

### DIFF
--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -419,14 +419,12 @@ impl LdapServer {
                 });
             };
 
-            let rdn = match self
+            let rdn = self
                 .binddnre
                 .captures(dn)
-                .and_then(|caps| caps.name("val").map(|v| v.as_str().to_string()))
-            {
-                Some(r) => r,
-                None => return Err(OperationError::NoMatchingEntries),
-            };
+                .and_then(|caps| caps.name("val"))
+                .map(|v| v.as_str().to_string())
+                .ok_or(OperationError::NoMatchingEntries)?;
 
             trace!(?rdn, "relative dn");
 

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -40,6 +40,7 @@ lazy_static! {
         #[allow(clippy::expect_used)]
         Regex::new("(?P<name>[^@]+)@(?P<realm>[^@]+)").expect("Invalid SPN regex found")
     };
+
     pub static ref DISALLOWED_NAMES: HashSet<&'static str> = {
         let mut m = HashSet::with_capacity(16);
         m.insert("root");
@@ -61,6 +62,13 @@ lazy_static! {
         #[allow(clippy::expect_used)]
         Regex::new("^[a-z][a-z0-9-_\\.]+$").expect("Invalid Iname regex found")
     };
+
+    pub static ref EXTRACT_VAL_DN: Regex = {
+        #[allow(clippy::expect_used)]
+        Regex::new("^(([^=,]+)=)?(?P<val>[^=,]+)").expect("extract val from dn regex")
+        // Regex::new("^(([^=,]+)=)?(?P<val>[^=,]+)(,.*)?$").expect("Invalid Iname regex found")
+    };
+
     pub static ref NSUNIQUEID_RE: Regex = {
         #[allow(clippy::expect_used)]
         Regex::new("^[0-9a-fA-F]{8}-[0-9a-fA-F]{8}-[0-9a-fA-F]{8}-[0-9a-fA-F]{8}$").expect("Invalid Nsunique regex found")


### PR DESCRIPTION
Fixes #1567 - This improves name2uuid by filtering the inputs to allows rdns/dns to be passed to this function and still correctly matched. 

- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
