### PR TITLE
RPM packaging for EL8 and EL9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ kanidm-client-tools.tar.gz
 .coverage
 pykanidm/dist/
 pykanidm/site/
+
+# packaging
+cache/

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,10 @@ release/kanidm-unixd:
 		--bin kanidm_unixd_tasks \
 		--bin kanidm-unix
 
+.PHONY: release
+release: ## Build all release targets
+release: release/kanidm release/kanidm-ssh release/kanidm-unixd release/kanidmd webui
+
 # cert things
 
 .PHONY: cert/clean

--- a/book/src/server_configuration.md
+++ b/book/src/server_configuration.md
@@ -27,8 +27,12 @@ text=You MUST set the `domain` name correctly, aligned with your `origin`, else 
 You should test your configuration is valid before you proceed.
 
 ```bash
+# Docker:
 docker run --rm -i -t -v kanidmd:/data \
     kanidm/server:latest /sbin/kanidmd configtest -c /data/server.toml
+
+# OS package:
+sudo -u kanidm -- kanidmd configtest -c /etc/kanidm/server.toml
 ```
 
 ## Default Admin Account
@@ -47,9 +51,12 @@ text=The server must not be running at this point, as it requires exclusive acce
 <!-- deno-fmt-ignore-end -->
 
 ```bash
+# Docker:
 docker run --rm -i -t -v kanidmd:/data \
     kanidm/server:latest /sbin/kanidmd recover-account -c /data/server.toml admin
-# success - recovery of account password for admin: vv...
+
+# OS Package:
+sudo -u kanidm -- kanidmd recover-account -c /etc/kanidm/server.toml admin
 ```
 
 After the recovery is complete the server can be started again.
@@ -57,16 +64,20 @@ After the recovery is complete the server can be started again.
 ## Run the Server
 
 Now we can run the server so that it can accept connections. This defaults to using
-`-c /data/server.toml`
+`/sbin/kanidm -c /data/server.toml`
 
 ```bash
+# Docker:
 docker run -p 443:8443 -v kanidmd:/data kanidm/server:latest
+
+# OS Package:
+sudo systemctl enable --now kanidm-server
 ```
 
 ## Using the NET\_BIND\_SERVICE capability
 
 If you plan to run without using docker port mapping or some other reverse proxy, and your
-bindaddress or ldapbindaddress port is less than `1024` you will need the `NET_BIND_SERVICE` in
+`bindaddress` or `ldapbindaddress` port is less than `1024` you will need the `NET_BIND_SERVICE` in
 docker to allow these port binds. You can add this with `--cap-add` in your docker run command.
 
 ```bash

--- a/platform/el/Makefile
+++ b/platform/el/Makefile
@@ -1,0 +1,52 @@
+CURDIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
+export KANIDM_BUILD_PROFILE ?= release_suse_generic
+export RUST_TOOLCHAIN ?= stable
+export CACHE_DIR ?= $(CURDIR)/cache
+
+
+kanidm-builder-el9:
+	BASE_IMAGE=almalinux:9 IMAGE_NAME=$@ ./build-image.sh
+
+kanidm-builder-el8:
+	BASE_IMAGE=almalinux:8 IMAGE_NAME=$@ ./build-image.sh
+
+build-images: kanidm-builder-el9 kanidm-builder-el8
+
+
+el9: export IMAGE_NAME=kanidm-builder-el9:latest
+el9: export TARGET_DIR=$(CURDIR)/cache/target-el9
+el9:
+	./run-image.sh $(CMD)
+
+prep-el9:
+	$(MAKE) el9 CMD="bash -lc 'cargo install wasm-pack mdbook'"
+
+run-el9:
+	$(MAKE) el9 CMD="bash -l"
+
+build-el9:
+	$(MAKE) el9 CMD='bash -lc "make release"'
+
+rpms-el9:
+	$(MAKE) el9 CMD='bash -lc "platform/el/build-rpms.sh"'
+
+
+el8: export IMAGE_NAME=kanidm-builder-el8:latest
+el8: export TARGET_DIR=$(CURDIR)/cache/target-el8
+el8:
+	./run-image.sh $(CMD)
+
+prep-el8:
+	$(MAKE) el8 CMD="bash -lc 'cargo install wasm-pack mdbook'"
+
+run-el8:
+	$(MAKE) el8 CMD="bash -l"
+
+build-el8:
+	$(MAKE) el8 CMD='bash -lc "make release"'
+
+rpms-el8:
+	$(MAKE) el8 CMD='bash -lc "platform/el/build-rpms.sh"'
+
+build-rpms: rpms-el9 rpms-el8

--- a/platform/el/build-image.sh
+++ b/platform/el/build-image.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Should have probably been just a Dockerfile ...
+
+set -uex
+
+CURDIR=$(readlink -f $(dirname -- "$0"))
+CACHE_DIR=${CACHE_DIR:-$(readlink -f $CURDIR/cache)}
+
+BASE_IMAGE=${BASE_IMAGE:-almalinux:9}
+IMAGE_NAME=${IMAGE_NAME:-kanidm-builder-el9}
+RUST_TOOLCHAIN=${RUST_TOOLCHAIN:-stable}
+
+OS_PACKAGES=(
+    openssl-devel
+    systemd-devel
+    sqlite-devel
+    openssl-devel
+    pam-devel
+    clang
+    which
+    git
+    rpm-build
+    systemd-rpm-macros
+    rsync
+    perl-core
+)
+
+c=$(buildah from $BASE_IMAGE)
+
+# Install a rust toolchain
+export CARGO_HOME=$CACHE_DIR/cargo
+export RUSTUP_HOME=$CACHE_DIR/rustup
+export RUSTUP_INIT_SKIP_PATH_CHECK=yes
+
+mkdir -p $CARGO_HOME $RUSTUP_HOME
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o $CACHE_DIR/rustup-init.sh
+sh $CACHE_DIR/rustup-init.sh -y --no-modify-path --default-toolchain=$RUST_TOOLCHAIN
+
+# Install system dependencies
+mkdir -p $CACHE_DIR/dnf
+buildah run -v $CACHE_DIR/dnf:/var/cache/dnf "$c" -- dnf --setopt=keepcache=True install -y "${OS_PACKAGES[@]}"
+
+cat > $CACHE_DIR/rustenv.sh <<'EOF'
+export CARGO_HOME=/cargo
+export RUSTUP_HOME=/rustup
+export CC=/usr/bin/clang
+export PATH="/cargo/bin:$PATH"
+EOF
+buildah copy --chmod 0755 $c $CACHE_DIR/rustenv.sh /etc/profile.d/rustenv.sh
+
+buildah config \
+    --workingdir=/src \
+    --volume=/src \
+    --volume=/cargo \
+    --volume=/rustup \
+    $c
+
+buildah commit --rm $c $IMAGE_NAME

--- a/platform/el/build-rpms.sh
+++ b/platform/el/build-rpms.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -uex
+
+CURDIR="$(readlink -f $(dirname -- "$0"))"
+TOPDIR="$(git rev-parse --show-toplevel)"
+
+VERSION=$(grep -m1 -F 'version = ' $TOPDIR/Cargo.toml | cut -d'"' -f2)
+VERSION=$(echo $VERSION | sed 's/-/~/g')
+COMMIT=$(git rev-parse --short HEAD)
+
+rm -rf /src/target/.rpmbuild/
+mkdir -p /src/target/.rpmbuild/{RPMS,BUILDROOT,BUILD,SOURCES}
+
+(
+    cd $TOPDIR
+    rpmbuild --build-in-place -bb "$CURDIR/kanidm.spec" \
+        -D "_version ${VERSION}.${COMMIT}" \
+        -D "_release ${RELEASE:-0}" \
+        -D "_topdir /src/target/.rpmbuild" \
+        -D "_sourcedir /src/platform/el"
+)
+
+mkdir -p /src/target/release/rpms
+find /src/target/.rpmbuild/RPMS/ -iname '*.rpm' -exec cp -v '{}' /src/target/release/rpms \;

--- a/platform/el/kanidm.spec
+++ b/platform/el/kanidm.spec
@@ -1,0 +1,186 @@
+Name:           kanidm
+Version:        %{_version}
+Release:        %{_release}
+Summary:        A simple, secure and fast identity management platform
+License:        MPL-2.0
+URL:            https://github.com/Firstyear/kanidm
+
+Requires:       %{name}-client
+Requires:       %{name}-unixd
+SOURCE1:        kanidm.sysusers
+%{?systemd_requires}
+
+%description
+Kanidm is a simple and secure identity management platform, which provides
+services to allow other systems and application to authenticate against. The
+project aims for the highest levels of reliability, security and ease of use.
+
+
+%package client
+Summary:        Client tools for interacting with Kanidm
+License:        MPL-2.0
+
+%description client
+Client utilities for interactive with kanidm servers
+
+
+%package server
+Summary:        Kanidm server
+License:        MPL-2.0
+Requires:       %{name}-client
+
+%description server
+Kanidm server
+
+
+%package unixd
+Summary:        Kanidm authentication for use on clients
+License:        MPL-2.0
+Requires:       %{name}-client
+
+
+%description unixd
+This package provides PAM and NSS modules for resolving POSIX entries from Kanidm.
+
+
+%package docs
+Summary:        Kanidm book and rustdoc
+License:        MPL-2.0
+
+%description docs
+Documentation for using and configuring Kanidm.
+
+
+#----------------------------------------------------------------------------
+
+%prep
+
+%build
+
+%install
+# Completions
+install -D -d -m 0755 %{buildroot}%{_datadir}/zsh/site-functions/
+install -D -d -m 0755 %{buildroot}%{_datadir}/bash-completion/completions/
+cp %{_builddir}/target/release/build/completions/_kan*                          %{buildroot}%{_datadir}/zsh/site-functions/
+cp %{_builddir}/target/release/build/completions/kan*.bash                      %{buildroot}%{_datadir}/bash-completion/completions
+
+# Binaries
+install -D -d -m 0755 %{buildroot}%{_bindir}
+install -m 0755 %{_builddir}/target/release/kanidm                              -t %{buildroot}/%{_bindir}/
+
+install -D -d -m 0755 %{buildroot}%{_sbindir}
+install -m 0755 %{_builddir}/target/release/kanidmd                             -t %{buildroot}/%{_sbindir}
+install -m 0755 %{_builddir}/target/release/kanidm-unix                         -t %{buildroot}/%{_sbindir}
+install -m 0755 %{_builddir}/target/release/kanidm_ssh_authorizedkeys           -t %{buildroot}/%{_sbindir}
+install -m 0755 %{_builddir}/target/release/kanidm_ssh_authorizedkeys_direct    -t %{buildroot}/%{_sbindir}
+install -m 0755 %{_builddir}/target/release/kanidm_unixd                        -t %{buildroot}/%{_sbindir}
+install -m 0755 %{_builddir}/target/release/kanidm_unixd_tasks                  -t %{buildroot}/%{_sbindir}
+
+install -D -d -m 0755 %{buildroot}%{_libdir} %{buildroot}/%{_lib}/security
+install -m 0644 %{_builddir}/target/release/libnss_kanidm.so                    %{buildroot}/%{_libdir}/libnss_kanidm.so.2
+install -m 0644 %{_builddir}/target/release/libpam_kanidm.so                    %{buildroot}/%_lib/security/pam_kanidm.so
+
+# Services
+install -D -d -m 0755 %{buildroot}%{_unitdir}
+install -m 0644 %{_builddir}/platform/systemd/kanidmd.service                   -t %{buildroot}%{_unitdir}
+install -m 0644 %{_builddir}/platform/systemd/kanidm-unixd.service              -t %{buildroot}%{_unitdir}
+install -m 0644 %{_builddir}/platform/systemd/kanidm-unixd-tasks.service        -t %{buildroot}%{_unitdir}
+install -pDm 0644 %{SOURCE1}                                                     %{buildroot}%{_sysusersdir}/kanidm-server.conf
+
+# Configuration
+install -D -d -m 0755 %{buildroot}%{_sysconfdir}/kanidm/
+install -m 0640 %{_builddir}/examples/server.toml                               -t %{buildroot}%{_sysconfdir}/kanidm
+install -m 0644 %{_builddir}/examples/config                                    -t %{buildroot}%{_sysconfdir}/kanidm
+install -m 0644 %{_builddir}/examples/unixd                                     -t %{buildroot}%{_sysconfdir}/kanidm
+
+# Data & state
+install -D -d -m 0755 %{buildroot}%{_datadir}/kanidm/docs/
+install -D -d -m 0755 %{buildroot}%{_datadir}/kanidm/ui/pkg
+install -D -d -m 0750 %{buildroot}%{_sharedstatedir}/kanidm
+cp -r %{_builddir}/docs                                                          %{buildroot}%{_datadir}/kanidm/docs/
+cp -r %{_builddir}/server/web_ui/pkg/                                            %{buildroot}%{_datadir}/kanidm/ui/
+find %{buildroot}%{_datadir}/kanidm/ -type d -exec chmod 0755 {} +
+find %{buildroot}%{_datadir}/kanidm/ -type f -exec chmod 0644 {} +
+
+
+
+#----------------------------------------------------------------------------
+
+%pre server
+%sysusers_create_compat %{SOURCE1}
+
+%post server
+%systemd_post kanidmd.service
+
+%preun server
+%systemd_preun kanidmd.service
+
+%postun server
+%systemd_postun kanidmd.service
+
+#----------------------------------------------------------------------------
+
+%post unixd
+%systemd_post kanidm-unixd.service
+%systemd_post kanidm-unixd-tasks.service
+
+%preun unixd
+%systemd_preun kanidm-unixd.service
+%systemd_preun kanidm-unixd-tasks.service
+
+%postun unixd
+%systemd_postun kanidm-unixd.service
+%systemd_postun kanidm-unixd-tasks.service
+
+#----------------------------------------------------------------------------
+
+%files
+%defattr(-,root,root)
+
+
+%files server
+%{_sbindir}/kanidmd
+%{_unitdir}/kanidmd.service
+%{_sysusersdir}/kanidm-server.conf
+
+%dir %{_datadir}/kanidm
+%{_datadir}/kanidm/**/*
+%{_datadir}/zsh/site-functions/_kanidmd
+%{_datadir}/bash-completion/completions/kanidmd.bash
+
+%attr(0750, kanidm, kanidm) %dir %{_sharedstatedir}/kanidm
+%attr(0755, root, kanidm) %dir %{_sysconfdir}/kanidm
+%attr(0640, root, kanidm) %config(noreplace) %{_sysconfdir}/kanidm/server.toml
+
+
+%files client
+%defattr(-,root,root)
+%{_bindir}/kanidm
+%attr(0644, root, root) %config(noreplace) %{_sysconfdir}/kanidm/config
+%{_datadir}/zsh/site-functions/_kanidm
+%{_datadir}/bash-completion/completions/kanidm.bash
+
+
+%files unixd
+%{_libdir}/libnss_kanidm.so.2
+%attr(0644, root, root) %config(noreplace) %{_sysconfdir}/kanidm/unixd
+/%_lib/security/pam_kanidm.so
+%{_sbindir}/kanidm-unix
+%{_sbindir}/kanidm_ssh_authorizedkeys
+%{_sbindir}/kanidm_ssh_authorizedkeys_direct
+%{_sbindir}/kanidm_unixd
+%{_sbindir}/kanidm_unixd_tasks
+%{_unitdir}/kanidm-unixd.service
+%{_unitdir}/kanidm-unixd-tasks.service
+%{_datadir}/zsh/site-functions/_kanidm_*
+%{_datadir}/bash-completion/completions/kanidm_*.bash
+
+
+%files docs
+%dir %{_datadir}/kanidm
+%dir %{_datadir}/kanidm/docs
+%doc %{_datadir}/kanidm/docs/*
+
+%changelog
+* Fri Apr 28 2023 Georgi Valkov <georgi.t.valkov@gmail.com>
+- Initial package

--- a/platform/el/kanidm.sysusers
+++ b/platform/el/kanidm.sysusers
@@ -1,0 +1,1 @@
+u kanidm - "Kanidm runtime user" /var/lib/kanidm /sbin/nologin

--- a/platform/el/run-image.sh
+++ b/platform/el/run-image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eux
+
+TOPDIR=$(git rev-parse --show-toplevel)
+CURDIR=$(readlink -f $(dirname -- "$0"))
+
+CACHE_DIR=${CACHE_DIR:-$(readlink -f $CURDIR/cache)}
+
+if [[ -e ~/.cargo/registry && ! -e $CACHE_DIR/cargo/registry ]]; then
+    rsync -a ~/.cargo/registry $CACHE_DIR/cargo/
+    rsync -a ~/.cargo/git $CACHE_DIR/cargo/
+fi
+
+mkdir -p $TARGET_DIR
+
+podman run --rm -it \
+    -v $CACHE_DIR/cargo/:/cargo  \
+    -v $CACHE_DIR/rustup/:/rustup  \
+    -v $CACHE_DIR/dnf:/var/cache/dnf \
+    -v $TOPDIR:/src \
+    -v $TARGET_DIR:/src/target \
+    -e KANIDM_BUILD_PROFILE=${KANIDM_BUILD_PROFILE} \
+    $IMAGE_NAME "$@"

--- a/platform/systemd/kanidm-unixd-tasks.service
+++ b/platform/systemd/kanidm-unixd-tasks.service
@@ -1,15 +1,9 @@
-# Source: https://build.opensuse.org/package/view_file/home:firstyear:kanidm/kanidm/kanidm-unixd-tasks.service
-# You should not need to edit this file. Instead, use a drop-in file:
-#   systemctl edit kanidm-unixd-tasks.service
-
-
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
 
 [Service]
 User=root
-Type=simple
 ExecStart=/usr/sbin/kanidm_unixd_tasks
 KillSignal=SIGINT
 

--- a/platform/systemd/kanidm-unixd.service
+++ b/platform/systemd/kanidm-unixd.service
@@ -1,7 +1,3 @@
-# Source: https://build.opensuse.org/package/view_file/home:firstyear:kanidm/kanidm/kanidm-unixd.service
-# You should not need to edit this file. Instead, use a drop-in file:
-#   systemctl edit kanidm-unixd.service
-
 [Unit]
 Description=Kanidm Local Client Resolver
 After=chronyd.service ntpd.service network-online.target

--- a/platform/systemd/kanidmd.service
+++ b/platform/systemd/kanidmd.service
@@ -1,20 +1,15 @@
-# Source: https://build.opensuse.org/package/view_file/home:firstyear:kanidm/kanidm/kanidmd.service
-# You should not need to edit this file. Instead, use a drop-in file as described in:
-#   /usr/lib/systemd/system/kanidmd.service.d/custom.conf
-
 [Unit]
 Description=Kanidm Identity Server
 After=chronyd.service ntpd.service network-online.target
 Before=radiusd.service
 
 [Service]
-Type=simple
-DynamicUser=yes
+User=kanidm
+Group=kanidm
 UMask=0027
-StateDirectory=kanidm
 ExecStart=/usr/sbin/kanidmd server -c /etc/kanidm/server.toml
 KillSignal=SIGINT
-
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
 PrivateTmp=true
 PrivateDevices=true
@@ -25,6 +20,7 @@ ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
 MemoryDenyWriteExecute=true
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hello,

This PR brings fairly complete EL8 and EL9 (i.e. CentOS, Alma, Rocky) RPM packaging to Kanidm. Since those distributions don't package sufficiently recent Rust toolchains, the approach taken here is to first build the project inside a container and then use rpmbuild to package the results from the working tree (sort of like how it would be done if [FPM](https://github.com/jordansissel/fpm) was used). 

Key points:
- kanidm-server, kanidm-client and kanidm-unixd all include example configuration files.
- Switched to an install-time created user (i.e. `systemd-sysusers) instead of using `DynamicUsers` and `StateDirectory`. 
- Somewhat simpler spec file compared to the OpenSuse one. 

Things that can be improved:
- The dependency to podman/buildah can be dropped - `build-image.sh` can be just a Dockerfile.
- I haven't done much testing on the kanidm-unixd package. 
- Integrate package generation with CI.
- Write a `book/src/packaging_rpms.md`