### PR TITLE
Bring back CpuOptLevel x86_64_v1

### DIFF
--- a/libs/profiles/src/lib.rs
+++ b/libs/profiles/src/lib.rs
@@ -68,7 +68,7 @@ pub fn apply_profile() {
         CpuOptLevel::neon_v8 => {
             println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-features=+neon,+fp-armv8")
         }
-        CpuOptLevel::x86_64_v1 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-feature=+cmov,+cx8,+fxsr,+mmx,+sse,+sse2"),
+        CpuOptLevel::x86_64 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64"),
         CpuOptLevel::x86_64_v2 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64-v2"),
         CpuOptLevel::x86_64_v3 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64-v3"),
     }

--- a/libs/profiles/src/lib.rs
+++ b/libs/profiles/src/lib.rs
@@ -9,6 +9,7 @@ enum CpuOptLevel {
     none,
     native,
     neon_v8,
+    x86_64_v1,
     x86_64_v2,
     x86_64_v3,
 }
@@ -31,6 +32,7 @@ impl std::fmt::Display for CpuOptLevel {
             CpuOptLevel::none => write!(f, "none"),
             CpuOptLevel::native => write!(f, "native"),
             CpuOptLevel::neon_v8 => write!(f, "neon_v8"),
+            CpuOptLevel::x86_64_v1 => write!(f, "x86_64_v1"),
             CpuOptLevel::x86_64_v2 => write!(f, "x86_64_v2"),
             CpuOptLevel::x86_64_v3 => write!(f, "x86_64_v3"),
         }
@@ -66,6 +68,7 @@ pub fn apply_profile() {
         CpuOptLevel::neon_v8 => {
             println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-features=+neon,+fp-armv8")
         }
+        CpuOptLevel::x86_64_v1 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-feature=+cmov,+cx8,+fxsr,+mmx,+sse,+sse2"),
         CpuOptLevel::x86_64_v2 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64-v2"),
         CpuOptLevel::x86_64_v3 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64-v3"),
     }

--- a/libs/profiles/src/lib.rs
+++ b/libs/profiles/src/lib.rs
@@ -9,7 +9,7 @@ enum CpuOptLevel {
     none,
     native,
     neon_v8,
-    x86_64_v1,
+    x86_64_legacy, // don't use this it's the oldest and worst. unless you've got a really old CPU, in which case, sorry?
     x86_64_v2,
     x86_64_v3,
 }
@@ -32,7 +32,7 @@ impl std::fmt::Display for CpuOptLevel {
             CpuOptLevel::none => write!(f, "none"),
             CpuOptLevel::native => write!(f, "native"),
             CpuOptLevel::neon_v8 => write!(f, "neon_v8"),
-            CpuOptLevel::x86_64_v1 => write!(f, "x86_64_v1"),
+            CpuOptLevel::x86_64_legacy => write!(f, "x86_64"),
             CpuOptLevel::x86_64_v2 => write!(f, "x86_64_v2"),
             CpuOptLevel::x86_64_v3 => write!(f, "x86_64_v3"),
         }
@@ -68,7 +68,7 @@ pub fn apply_profile() {
         CpuOptLevel::neon_v8 => {
             println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-features=+neon,+fp-armv8")
         }
-        CpuOptLevel::x86_64 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64"),
+        CpuOptLevel::x86_64_legacy => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64"),
         CpuOptLevel::x86_64_v2 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64-v2"),
         CpuOptLevel::x86_64_v3 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=x86-64-v3"),
     }


### PR DESCRIPTION
Let's not force people to upgrade to x86_64_v2 yet. Default is unchanged
(x86_64_v2).

Fixes: 0d8d9e1a62652b2c ("1355 docker builds (#1384)") (EDIT: fixed reference)

Fixes #

- [x] cargo fmt has been run
- [ ] cargo clippy has been run -- fails, but must be unrelated to this change
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
