### PR TITLE
Harden migrate session to prevent duplicate migration errors

### DIFF
--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -1195,4 +1195,9 @@ impl ValueSetT for ValueSetApiToken {
         // This is what ties us as a type that can be refint checked.
         Some(Box::new(self.map.keys().copied()))
     }
+
+    fn migrate_session_to_apitoken(&self) -> Result<ValueSet, OperationError> {
+        // We are already in the api token format, don't do anything.
+        Ok(Box::new(self.clone()))
+    }
 }


### PR DESCRIPTION
Relates #1594 - this hardens the valueset migrate code to allow duplicate session migrations to no-op without error. 

This will be backported to .11 and .12. 

- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
