### PR TITLE
Fix use-reset-token command hint

### DIFF
--- a/book/src/authentication.md
+++ b/book/src/authentication.md
@@ -74,7 +74,7 @@ kanidm person credential create-reset-token demo_user --name idm_admin
 # ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 # 
 # This link: https://localhost:8443/ui/reset?token=8qDRG-AE1qC-zjjAT-0Fkd6
-# Or run this command: kanidm person credential use_reset_token 8qDRG-AE1qC-zjjAT-0Fkd6
+# Or run this command: kanidm person credential use-reset-token 8qDRG-AE1qC-zjjAT-0Fkd6
 ```
 
 If the user wishes you can direct them to `https://idm.mydomain.name/ui/reset` where they can

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -588,7 +588,7 @@ impl AccountCredential {
                         println!();
                         println!("This link: {}", url.as_str());
                         println!(
-                            "Or run this command: kanidm person credential use_reset_token {}",
+                            "Or run this command: kanidm person credential use-reset-token {}",
                             cuintent_token.token
                         );
                         println!();

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -160,7 +160,7 @@ pub struct AccountNamedTagPkOpt {
 }
 
 #[derive(Debug, Args)]
-/// Command-line options for account credental use_reset_token
+/// Command-line options for account credental use-reset-token
 pub struct UseResetTokenOpt {
     #[clap(flatten)]
     copt: CommonOpt,


### PR DESCRIPTION
Running `kanidm person credential create-reset-token` prints out information on how to do the credential reset.

This fixes the provided cli command, the book, and struct comment .
