### PR TITLE
during service account recovery, remove invalid credentials

### DIFF
--- a/server/core/src/actors/v1_write.rs
+++ b/server/core/src/actors/v1_write.rs
@@ -420,7 +420,7 @@ impl QueryServerWriteV1 {
             e
         })?;
         idms_prox_write
-            .generate_account_password(&gpe)
+            .generate_service_account_password(&gpe)
             .and_then(|r| idms_prox_write.commit().map(|_| r))
     }
 

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -371,16 +371,6 @@ impl Account {
         self.uuid == UUID_ANONYMOUS
     }
 
-    pub(crate) fn gen_generatedpassword_recover_mod(
-        &self,
-        cleartext: &str,
-        crypto_policy: &CryptoPolicy,
-    ) -> Result<ModifyList<ModifyInvalid>, OperationError> {
-        let ncred = Credential::new_generatedpassword_only(crypto_policy, cleartext)?;
-        let vcred = Value::new_credential("primary", ncred);
-        Ok(ModifyList::new_purge_and_set("primary_credential", vcred))
-    }
-
     pub(crate) fn gen_password_mod(
         &self,
         cleartext: &str,


### PR DESCRIPTION
Fixes #1621 - when resetting a service account credential, this removes other credential types that are not required for those accounts. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
