### PR TITLE
fixing get-tags-action in book build

### DIFF
--- a/.github/workflows/kanidm_book.yml
+++ b/.github/workflows/kanidm_book.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           repo: ${{ github.repository }}
           limit: 100
+          github-token: ${{ github.token }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm-ipa-sync"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "base64urlsafedata",
  "chrono",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_client"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "kanidm_proto",
  "reqwest",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_proto"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "base32",
  "base64urlsafedata",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_tools"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_unix_int"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "bytes",
  "clap",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "kanidmd_core"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "kanidmd_lib"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "kanidmd_testkit"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "compact_jwt",
  "futures",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "nss_kanidm"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "kanidm_unix_int",
  "lazy_static",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "orca"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "clap",
  "crossbeam",
@@ -3096,7 +3096,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pam_kanidm"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "kanidm_unix_int",
  "libc",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "profiles"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "base64 0.21.0",
  "serde",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "sketching"
-version = "1.1.0-beta.13"
+version = "1.1.0-beta.13-dev"
 dependencies = [
  "async-trait",
  "num_enum",


### PR DESCRIPTION
Fixes the failure that popped here https://github.com/yaleman/kanidm/actions/runs/5084942938/jobs/9137868640

```
Run oraad/get-tags-action@v1.0.0
Error: API rate limit exceeded for installation ID 16164673.
```

- [x] This pr contains no AI generated code
