### PR TITLE
Resolve ability to delete ssh keys with spaces in tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "urlencoding",
  "uuid",
 ]
 

--- a/server/core/Cargo.toml
+++ b/server/core/Cargo.toml
@@ -38,6 +38,7 @@ tokio-openssl = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 toml = {workspace = true}
 tracing = { workspace = true, features = ["attributes"] }
+urlencoding.workspace = true
 uuid = { workspace = true, features = ["serde", "v4" ] }
 
 [build-dependencies]

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -144,10 +144,19 @@ impl RequestExtensions for tide::Request<AppState> {
     }
 
     fn get_url_param(&self, param: &str) -> Result<String, tide::Error> {
-        self.param(param).map(str::to_string).map_err(|e| {
-            error!(?e);
-            tide::Error::from_str(tide::StatusCode::ImATeapot, "teapot")
-        })
+        self.param(param)
+            .map_err(|e| {
+                error!(?e);
+                tide::Error::from_str(tide::StatusCode::ImATeapot, "teapot")
+            })
+            .and_then(|data| {
+                urlencoding::decode(data)
+                    .map(|s| s.into_owned())
+                    .map_err(|e| {
+                        error!(?e);
+                        tide::Error::from_str(tide::StatusCode::ImATeapot, "teapot")
+                    })
+            })
     }
 
     fn get_url_param_uuid(&self, param: &str) -> Result<Uuid, tide::Error> {

--- a/server/lib/src/be/dbentry.rs
+++ b/server/lib/src/be/dbentry.rs
@@ -424,11 +424,10 @@ impl std::fmt::Debug for DbEntry {
             DbEntryVers::V2(dbe_v2) => {
                 write!(f, "v2 - {{ ")?;
                 for (k, vs) in dbe_v2.attrs.iter() {
-                    write!(f, "{k} - [")?;
-                    write!(f, "{vs:?}, ")?;
-                    write!(f, "], ")?;
+                    write!(f, "\n{k:>16} - ")?;
+                    write!(f, "{vs:?}")?;
                 }
-                write!(f, "}}")
+                write!(f, "\n        }}")
             }
         }
     }

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -451,6 +451,19 @@ async fn test_server_rest_sshkey_lifecycle(rsclient: KanidmClient) {
     let skn = rsclient.idm_account_get_ssh_pubkey("admin", "k2").await;
     assert!(skn.is_ok());
     assert!(skn.unwrap() == Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBx4TpJYQjd0YI5lQIHqblIsCIK5NKVFURYS/eM3o6/Z william@amethyst".to_string()));
+
+    // Add a key and delete with a space in the name.
+    let r5 = rsclient
+            .idm_service_account_post_ssh_pubkey("admin", "Yk 5 Nfc", "sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBENubZikrb8hu+HeVRdZ0pp/VAk2qv4JDbuJhvD0yNdWDL2e3cBbERiDeNPkWx58Q4rVnxkbV1fa8E2waRtT91wAAAAEc3NoOg== william@maxixe").await;
+    assert!(r5.is_ok());
+
+    let r6 = rsclient
+        .idm_service_account_delete_ssh_pubkey("admin", "Yk 5 Nfc")
+        .await;
+    assert!(r6.is_ok());
+
+    let sk5 = rsclient.idm_account_get_ssh_pubkeys("admin").await.unwrap();
+    assert!(sk5.len() == 1);
 }
 
 #[kanidmd_testkit::test]


### PR DESCRIPTION
Fixes #1662 - when we deleted an ssh key by tag, we were getting the tag name from a url parameter. Tide does NOT url decode these for us! As a result when a space was present in the tag name we would attempt to delete `yk%20nfc` instead of `yk nfc`. 

This fixes the url parameter function to always url decode inputs to ensure they work even if they have spaces. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
