### PR TITLE
Document OpenID connect setup for Miniflux

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@
 - Sebastiano Tocci(Seba-T)
 - Minh Phan (MinhPhan8803)
 - Kenton Groombridge (0xC0ncord)
+- Martin Weinelt (hexa)
 
 ## Acknowledgements
 

--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -262,6 +262,23 @@ In the virtual host, to protect a location:
 </Location>
 ```
 
+### Miniflux
+
+Miniflux is a feedreader that supports OAuth 2.0 and OpenID connect. It automatically appends
+the `.well-known` parts to the discovery endpoint. The application name in the redirect URL
+needs to match the `OAUTH2_PROVIDER` name.
+
+```
+OAUTH2_PROVIDER = "kanidm";
+OAUTH2_CLIENT_ID = "miniflux";
+OAUTH2_CLIENT_SECRET = "<oauth2_rs_basic_secret>";
+OAUTH2_REDIRECT_URL = "https://feeds.example.com/oauth2/kanidm/callback";
+OAUTH2_OIDC_DISCOVERY_ENDPOINT = "https://idm.example.com/oauth2/openid/<oauth2_rs_name>";
+````
+
+Currently Miniflux [does not support PKCE](https://github.com/miniflux/v2/issues/1910) and Kanidm will
+prevent logins until you [disable PKCE](#extended-options-for-legacy-clients) for the resource server.
+
 ### Nextcloud
 
 Install the module [from the nextcloud market place](https://apps.nextcloud.com/apps/user_oidc) - it


### PR DESCRIPTION
This change adds documentation on how to set up OpenID connect with Miniflux, a feedreader application.

Miniflux currently does not support PKCE, and I've therefore raised and upstream issue, that I reference in the book section.

Fixes #

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
