### PR TITLE
Also check running SELinux mode during kanidm_unixd_tasks startup

### DIFF
--- a/unix_integration/src/selinux_util.rs
+++ b/unix_integration/src/selinux_util.rs
@@ -1,9 +1,19 @@
 use std::ffi::CString;
 
-use selinux::{kernel_support, label::back_end::File, label::Labeler, KernelSupport};
+use selinux::{
+    current_mode, kernel_support, label::back_end::File, label::Labeler, KernelSupport, SELinuxMode,
+};
 
 pub fn supported() -> bool {
-    return !matches!(kernel_support(), KernelSupport::Unsupported);
+    // check if the running kernel has SELinux support
+    if matches!(kernel_support(), KernelSupport::Unsupported) {
+        return false;
+    }
+    // check if SELinux is actually running
+    match current_mode() {
+        SELinuxMode::Permissive | SELinuxMode::Enforcing => true,
+        _ => false,
+    }
 }
 
 pub fn get_labeler() -> Result<Labeler<File>, String> {


### PR DESCRIPTION
For `kanidm_unixd_tasks`, check the current SELinux mode in addition to kernel support. If SELinux is disabled at runtime, any attempts to query the policy will fail, so also disable SELinux features if this is the case.

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
