### PR TITLE
Add further incremental replication tests

### DIFF
--- a/server/lib/src/event.rs
+++ b/server/lib/src/event.rs
@@ -818,4 +818,12 @@ impl ReviveRecycledEvent {
             filter: filter.into_valid(),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn new_internal(filter: Filter<FilterValid>) -> Self {
+        ReviveRecycledEvent {
+            ident: Identity::from_internal(),
+            filter,
+        }
+    }
 }

--- a/server/lib/src/repl/consumer.rs
+++ b/server/lib/src/repl/consumer.rs
@@ -51,6 +51,8 @@ impl<'a> QueryServerWriteTransaction<'a> {
             e
         })?;
 
+        trace!(?db_entries);
+
         // Need to probably handle conflicts here in this phase. I think they
         // need to be pushed to a separate list where they are then "created"
         // as a conflict.

--- a/server/lib/src/repl/supplier.rs
+++ b/server/lib/src/repl/supplier.rs
@@ -172,16 +172,20 @@ impl<'a> QueryServerReadTransaction<'a> {
             f_eq("uuid", PVUUID_SYSTEM_CONFIG.clone()),
         ]));
 
-        let entry_filter = filter!(f_and!([
-            f_pres("class"),
-            f_andnot(f_or(vec![
-                // These are from above!
-                f_eq("class", PVCLASS_ATTRIBUTETYPE.clone()),
-                f_eq("class", PVCLASS_CLASSTYPE.clone()),
-                f_eq("uuid", PVUUID_DOMAIN_INFO.clone()),
-                f_eq("uuid", PVUUID_SYSTEM_INFO.clone()),
-                f_eq("uuid", PVUUID_SYSTEM_CONFIG.clone()),
-            ])),
+        let entry_filter = filter_all!(f_or!([
+            f_and!([
+                f_pres("class"),
+                f_andnot(f_or(vec![
+                    // These are from above!
+                    f_eq("class", PVCLASS_ATTRIBUTETYPE.clone()),
+                    f_eq("class", PVCLASS_CLASSTYPE.clone()),
+                    f_eq("uuid", PVUUID_DOMAIN_INFO.clone()),
+                    f_eq("uuid", PVUUID_SYSTEM_INFO.clone()),
+                    f_eq("uuid", PVUUID_SYSTEM_CONFIG.clone()),
+                ])),
+            ]),
+            f_eq("class", PVCLASS_TOMBSTONE.clone()),
+            f_eq("class", PVCLASS_RECYCLED.clone()),
         ]));
 
         let schema_entries = self

--- a/server/lib/src/valueset/cid.rs
+++ b/server/lib/src/valueset/cid.rs
@@ -157,7 +157,6 @@ impl ValueSetT for ValueSetCid {
         }
     }
 
-    /*
     fn to_cid_single(&self) -> Option<Cid> {
         if self.set.len() == 1 {
             self.set.iter().cloned().take(1).next()
@@ -165,7 +164,6 @@ impl ValueSetT for ValueSetCid {
             None
         }
     }
-    */
 
     fn as_cid_set(&self) -> Option<&SmolSet<[Cid; 1]>> {
         Some(&self.set)

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -357,6 +357,11 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
         None
     }
 
+    fn to_cid_single(&self) -> Option<Cid> {
+        error!("to_cid_single should not be called on {:?}", self.syntax());
+        None
+    }
+
     fn to_refer_single(&self) -> Option<Uuid> {
         error!(
             "to_refer_single should not be called on {:?}",


### PR DESCRIPTION
This adds further incremental replication tests - mainly around handling of recycled values and tombstones being correctly ordered. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
