### PR TITLE
Defaulting 'yes' on automatically re-login and re-auth

### DIFF
--- a/tools/cli/src/cli/common.rs
+++ b/tools/cli/src/cli/common.rs
@@ -203,6 +203,7 @@ impl CommonOpt {
                     ToClientError::NeedLogin(username) => {
                         if !Confirm::new()
                             .with_prompt("Would you like to login again?")
+                            .default(true)
                             .interact()
                             .expect("Failed to interact with interactive session")
                         {
@@ -223,6 +224,7 @@ impl CommonOpt {
                     ToClientError::NeedReauth(username) => {
                         if !Confirm::new()
                             .with_prompt("Would you like to re-authenticate?")
+                            .default(true)
                             .interact()
                             .expect("Failed to interact with interactive session")
                         {


### PR DESCRIPTION
- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
