### PR TITLE
Absolutely minimal implementation

### DIFF
--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -747,7 +747,16 @@ pub async fn create_server_core(
                     }
                 }
                 audit_event = idms_audit.audit_rx().recv() => {
-                    warn!(?audit_event);
+                    match serde_json::to_string(&audit_event) {
+                        Ok(audit_event) => {
+                            warn!(%audit_event);
+                        }
+                        Err(e) => {
+                            error!(err=?e, "Unable to process audit event to json.");
+                            warn!(?audit_event, json=false);
+                        }
+                    }
+
                 }
             }
         }

--- a/server/lib/src/idm/audit.rs
+++ b/server/lib/src/idm/audit.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum AuditEvent {
+    AuthenticationDenied { spn: String },
+}

--- a/server/lib/src/idm/audit.rs
+++ b/server/lib/src/idm/audit.rs
@@ -1,6 +1,30 @@
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use time::OffsetDateTime;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum AuditSource {
+    Internal,
+    Https(IpAddr),
+}
+
+impl From<Source> for AuditSource {
+    fn from(value: Source) -> Self {
+        match value {
+            Source::Internal => AuditSource::Internal,
+            Source::Https(ip) => AuditSource::Https(ip),
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum AuditEvent {
-    AuthenticationDenied { spn: String },
+    AuthenticationDenied {
+        source: AuditSource,
+        uuid: Uuid,
+        spn: String,
+        #[serde(with = "time::serde::timestamp")]
+        time: OffsetDateTime,
+    },
 }

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -1762,7 +1762,7 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1773,7 +1773,7 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Password);
 
-        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1782,7 +1782,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r2 = idms_auth.auth(&pw_step, ct).await;
+        let r2 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
         debug!("r2 ==> {:?}", r2);
         idms_auth.commit().expect("Must not fail");
 
@@ -1812,7 +1812,7 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1823,7 +1823,7 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::PasswordMfa);
 
-        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1834,7 +1834,7 @@ mod tests {
             .expect("Failed to perform totp step");
 
         let totp_step = AuthEvent::cred_step_totp(sessionid, totp);
-        let r2 = idms_auth.auth(&totp_step, ct).await;
+        let r2 = idms_auth.auth(&totp_step, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1843,7 +1843,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -1872,7 +1872,7 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1883,14 +1883,14 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::PasswordMfa);
 
-        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
         assert!(matches!(state, AuthState::Continue(_)));
 
         let code_step = AuthEvent::cred_step_backup_code(sessionid, code);
-        let r2 = idms_auth.auth(&code_step, ct).await;
+        let r2 = idms_auth.auth(&code_step, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1899,7 +1899,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -1934,7 +1934,7 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1945,7 +1945,7 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Passkey);
 
-        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -1967,7 +1967,7 @@ mod tests {
 
         let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
 
-        let r3 = idms_auth.auth(&passkey_step, ct).await;
+        let r3 = idms_auth.auth(&passkey_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 

--- a/server/lib/src/idm/mod.rs
+++ b/server/lib/src/idm/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod account;
 pub mod applinks;
+pub mod audit;
 pub mod authsession;
 pub mod credupdatesession;
 pub mod delayed;

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -23,6 +23,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
         ident: Identity,
         issue: AuthIssueSession,
         ct: Duration,
+        source: Source,
     ) -> Result<AuthResult, OperationError> {
         // re-auth only works on users, so lets get the user account.
         // hint - it's in the ident!
@@ -138,6 +139,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
             issue,
             self.webauthn,
             ct,
+            source,
         );
 
         // Push the re-auth session to the session maps.
@@ -332,7 +334,7 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -343,7 +345,7 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Passkey);
 
-        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -365,7 +367,7 @@ mod tests {
 
         let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
 
-        let r3 = idms_auth.auth(&passkey_step, ct).await;
+        let r3 = idms_auth.auth(&passkey_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -405,7 +407,7 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct).await;
+        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -416,7 +418,7 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::PasswordMfa);
 
-        let r2 = idms_auth.auth(&auth_begin, ct).await;
+        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -427,7 +429,7 @@ mod tests {
             .expect("Failed to perform totp step");
 
         let totp_step = AuthEvent::cred_step_totp(sessionid, totp);
-        let r2 = idms_auth.auth(&totp_step, ct).await;
+        let r2 = idms_auth.auth(&totp_step, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -436,7 +438,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -478,7 +480,7 @@ mod tests {
         let origin = idms_auth.get_origin().clone();
 
         let auth_allowed = idms_auth
-            .reauth_init(ident.clone(), AuthIssueSession::Token, ct)
+            .reauth_init(ident.clone(), AuthIssueSession::Token, ct, Source::Internal)
             .await
             .expect("Failed to start reauth.");
 
@@ -502,7 +504,7 @@ mod tests {
 
         let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
 
-        let r3 = idms_auth.auth(&passkey_step, ct).await;
+        let r3 = idms_auth.auth(&passkey_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -537,7 +539,7 @@ mod tests {
         let mut idms_auth = idms.auth().await;
 
         let auth_allowed = idms_auth
-            .reauth_init(ident.clone(), AuthIssueSession::Token, ct)
+            .reauth_init(ident.clone(), AuthIssueSession::Token, ct, Source::Internal)
             .await
             .expect("Failed to start reauth.");
 
@@ -562,7 +564,7 @@ mod tests {
             .expect("Failed to perform totp step");
 
         let totp_step = AuthEvent::cred_step_totp(sessionid, totp);
-        let r2 = idms_auth.auth(&totp_step, ct).await;
+        let r2 = idms_auth.auth(&totp_step, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -571,7 +573,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -932,6 +932,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
         &mut self,
         ae: &AuthEvent,
         ct: Duration,
+        source: Source,
     ) -> Result<AuthResult, OperationError> {
         // Match on the auth event, to see what we need to do.
         match &ae.step {
@@ -1006,7 +1007,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
                         });
 
                 let (auth_session, state) =
-                    AuthSession::new(account, init.issue, self.webauthn, ct);
+                    AuthSession::new(account, init.issue, self.webauthn, ct, source);
 
                 match auth_session {
                     Some(auth_session) => {
@@ -2100,7 +2101,11 @@ mod tests {
         let anon_init = AuthEvent::anonymous_init();
         // Expect success
         let r1 = idms_auth
-            .auth(&anon_init, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_init,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         /* Some weird lifetime things happen here ... */
 
@@ -2138,7 +2143,11 @@ mod tests {
         let anon_begin = AuthEvent::begin_mech(sid, AuthMech::Anonymous);
 
         let r2 = idms_auth
-            .auth(&anon_begin, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_begin,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -2176,7 +2185,11 @@ mod tests {
 
         // Expect success
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -2220,7 +2233,11 @@ mod tests {
 
             // Expect failure
             let r2 = idms_auth
-                .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+                .auth(
+                    &anon_step,
+                    Duration::from_secs(TEST_CURRENT_TIME),
+                    Source::Internal,
+                )
                 .await;
             debug!("r2 ==> {:?}", r2);
 
@@ -2264,7 +2281,7 @@ mod tests {
         let mut idms_auth = idms.auth().await;
         let admin_init = AuthEvent::named_init(name);
 
-        let r1 = idms_auth.auth(&admin_init, ct).await;
+        let r1 = idms_auth.auth(&admin_init, ct, Source::Internal).await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2273,7 +2290,7 @@ mod tests {
         // Now push that we want the Password Mech.
         let admin_begin = AuthEvent::begin_mech(sessionid, AuthMech::Password);
 
-        let r2 = idms_auth.auth(&admin_begin, ct).await;
+        let r2 = idms_auth.auth(&admin_begin, ct, Source::Internal).await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2299,7 +2316,11 @@ mod tests {
 
         // Expect success
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -2367,7 +2388,11 @@ mod tests {
 
         // Expect success
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -2418,7 +2443,11 @@ mod tests {
 
         // Expect success
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -2873,7 +2902,9 @@ mod tests {
 
         let mut idms_auth = idms.auth().await;
         let admin_init = AuthEvent::named_init("admin");
-        let r1 = idms_auth.auth(&admin_init, time_low).await;
+        let r1 = idms_auth
+            .auth(&admin_init, time_low, Source::Internal)
+            .await;
 
         let ar = r1.unwrap();
         let AuthResult {
@@ -2893,7 +2924,9 @@ mod tests {
         // And here!
         let mut idms_auth = idms.auth().await;
         let admin_init = AuthEvent::named_init("admin");
-        let r1 = idms_auth.auth(&admin_init, time_high).await;
+        let r1 = idms_auth
+            .auth(&admin_init, time_high, Source::Internal)
+            .await;
 
         let ar = r1.unwrap();
         let AuthResult {
@@ -3039,7 +3072,11 @@ mod tests {
         let anon_step = AuthEvent::cred_step_password(sid, TEST_PASSWORD_INC);
 
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -3080,7 +3117,11 @@ mod tests {
         let admin_init = AuthEvent::named_init("admin");
 
         let r1 = idms_auth
-            .auth(&admin_init, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &admin_init,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
@@ -3090,7 +3131,11 @@ mod tests {
         let admin_begin = AuthEvent::begin_mech(sessionid, AuthMech::Password);
 
         let r2 = idms_auth
-            .auth(&admin_begin, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &admin_begin,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         let ar = r2.unwrap();
         let AuthResult {
@@ -3123,7 +3168,11 @@ mod tests {
 
         // Expect success
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME + 2))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME + 2),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -3187,7 +3236,11 @@ mod tests {
         let anon_step = AuthEvent::cred_step_password(sid_later, TEST_PASSWORD_INC);
 
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
 
@@ -3226,7 +3279,11 @@ mod tests {
 
         // Expect success
         let r2 = idms_auth
-            .auth(&anon_step, Duration::from_secs(TEST_CURRENT_TIME))
+            .auth(
+                &anon_step,
+                Duration::from_secs(TEST_CURRENT_TIME),
+                Source::Internal,
+            )
             .await;
         debug!("r2 ==> {:?}", r2);
         match r2 {

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -29,6 +29,7 @@ use super::event::ReadBackupCodeEvent;
 use super::ldap::{LdapBoundToken, LdapSession};
 use crate::credential::{softlock::CredSoftLock, Credential};
 use crate::idm::account::Account;
+use crate::idm::audit::AuditEvent;
 use crate::idm::authsession::AuthSession;
 use crate::idm::credupdatesession::CredentialUpdateSessionMutex;
 use crate::idm::delayed::{
@@ -82,6 +83,7 @@ pub struct IdmServer {
     /// The configured crypto policy for the IDM server. Later this could be transactional and loaded from the db similar to access. But today it's just to allow dynamic pbkdf2rounds
     crypto_policy: CryptoPolicy,
     async_tx: Sender<DelayedAction>,
+    audit_tx: Sender<AuditEvent>,
     /// [Webauthn] verifier/config
     webauthn: Webauthn,
     pw_badlist_cache: Arc<CowCell<HashSet<String>>>,
@@ -100,6 +102,7 @@ pub struct IdmServerAuthTransaction<'a> {
     pub(crate) sid: Sid,
     // For flagging eventual actions.
     pub(crate) async_tx: Sender<DelayedAction>,
+    pub(crate) audit_tx: Sender<AuditEvent>,
     pub(crate) webauthn: &'a Webauthn,
     pub(crate) pw_badlist_cache: CowCellReadTxn<HashSet<String>>,
     pub(crate) domain_keys: CowCellReadTxn<DomainKeys>,
@@ -120,7 +123,6 @@ pub struct IdmServerProxyReadTransaction<'a> {
     pub qs_read: QueryServerReadTransaction<'a>,
     pub(crate) domain_keys: CowCellReadTxn<DomainKeys>,
     pub(crate) oauth2rs: Oauth2ResourceServersReadTransaction,
-    // pub(crate) async_tx: Sender<DelayedAction>,
 }
 
 pub struct IdmServerProxyWriteTransaction<'a> {
@@ -141,12 +143,15 @@ pub struct IdmServerDelayed {
     pub(crate) async_rx: Receiver<DelayedAction>,
 }
 
+pub struct IdmServerAudit {
+    pub(crate) audit_rx: Receiver<AuditEvent>,
+}
+
 impl IdmServer {
-    // TODO: Make number of authsessions configurable!!!
     pub async fn new(
         qs: QueryServer,
         origin: &str,
-    ) -> Result<(IdmServer, IdmServerDelayed), OperationError> {
+    ) -> Result<(IdmServer, IdmServerDelayed, IdmServerAudit), OperationError> {
         // This is calculated back from:
         //  500 auths / thread -> 0.002 sec per op
         //      we can then spend up to ~0.001s hashing
@@ -156,6 +161,7 @@ impl IdmServer {
         // improves.
         let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(1));
         let (async_tx, async_rx) = unbounded();
+        let (audit_tx, audit_rx) = unbounded();
 
         // Get the domain name, as the relying party id.
         let (
@@ -249,12 +255,14 @@ impl IdmServer {
                 qs,
                 crypto_policy,
                 async_tx,
+                audit_tx,
                 webauthn,
                 pw_badlist_cache: Arc::new(CowCell::new(pw_badlist_set)),
                 domain_keys,
                 oauth2rs: Arc::new(oauth2rs),
             },
             IdmServerDelayed { async_rx },
+            IdmServerAudit { audit_rx },
         ))
     }
 
@@ -277,6 +285,7 @@ impl IdmServer {
             qs_read,
             sid,
             async_tx: self.async_tx.clone(),
+            audit_tx: self.audit_tx.clone(),
             webauthn: &self.webauthn,
             pw_badlist_cache: self.pw_badlist_cache.read(),
             domain_keys: self.domain_keys.read(),
@@ -339,30 +348,44 @@ impl IdmServer {
     }
 }
 
-impl IdmServerDelayed {
-    // I think we can just make this async in the future?
+impl IdmServerAudit {
     #[cfg(test)]
     pub(crate) fn check_is_empty_or_panic(&mut self) {
-        use core::task::{Context, Poll};
-        use futures::task as futures_task;
+        use tokio::sync::mpsc::error::TryRecvError;
 
-        let waker = futures_task::noop_waker();
-        let mut cx = Context::from_waker(&waker);
-        match self.async_rx.poll_recv(&mut cx) {
-            Poll::Pending | Poll::Ready(None) => {}
-            Poll::Ready(Some(m)) => {
+        match self.audit_rx.try_recv() {
+            Err(TryRecvError::Empty) => {}
+            Err(TryRecvError::Disconnected) => {
+                panic!("Task queue disconnected");
+            }
+            Ok(m) => {
                 trace!(?m);
-                panic!("Task queue not empty")
+                panic!("Task queue not empty");
             }
         }
     }
 
-    /*
-    #[cfg(test)]
-    pub(crate) fn blocking_recv(&mut self) -> Option<DelayedAction> {
-        self.async_rx.blocking_recv()
+    pub fn audit_rx(&mut self) -> &mut Receiver<AuditEvent> {
+        &mut self.audit_rx
     }
-    */
+}
+
+impl IdmServerDelayed {
+    #[cfg(test)]
+    pub(crate) fn check_is_empty_or_panic(&mut self) {
+        use tokio::sync::mpsc::error::TryRecvError;
+
+        match self.async_rx.try_recv() {
+            Err(TryRecvError::Empty) => {}
+            Err(TryRecvError::Disconnected) => {
+                panic!("Task queue disconnected");
+            }
+            Ok(m) => {
+                trace!(?m);
+                panic!("Task queue not empty");
+            }
+        }
+    }
 
     #[cfg(test)]
     pub(crate) fn try_recv(&mut self) -> Result<DelayedAction, OperationError> {
@@ -1106,6 +1129,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
                             &creds.cred,
                             ct,
                             &self.async_tx,
+                            &self.audit_tx,
                             self.webauthn,
                             pw_badlist_cache,
                             &self.domain_keys.uat_jwt_signer,
@@ -2050,6 +2074,7 @@ mod tests {
 
     use crate::credential::{Credential, Password};
     use crate::idm::account::DestroySessionTokenEvent;
+    use crate::idm::audit::AuditEvent;
     use crate::idm::delayed::{AuthSessionRecord, DelayedAction};
     use crate::idm::event::{AuthEvent, AuthResult};
     use crate::idm::event::{
@@ -2377,8 +2402,12 @@ mod tests {
         idms_auth.commit().expect("Must not fail");
     }
 
-    #[idm_test]
-    async fn test_idm_simple_password_invalid(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
+    #[idm_test(audit)]
+    async fn test_idm_simple_password_invalid(
+        idms: &IdmServer,
+        _idms_delayed: &IdmServerDelayed,
+        idms_audit: &mut IdmServerAudit,
+    ) {
         init_admin_w_password(idms, TEST_PASSWORD)
             .await
             .expect("Failed to setup admin account");
@@ -2415,6 +2444,12 @@ mod tests {
                 panic!();
             }
         };
+
+        // There should be a queued audit event
+        match idms_audit.audit_rx().try_recv() {
+            Ok(AuditEvent::AuthenticationDenied { .. }) => {}
+            _ => assert!(false),
+        }
 
         idms_auth.commit().expect("Must not fail");
     }
@@ -2987,8 +3022,12 @@ mod tests {
         }
     }
 
-    #[idm_test]
-    async fn test_idm_account_softlocking(idms: &IdmServer, idms_delayed: &mut IdmServerDelayed) {
+    #[idm_test(audit)]
+    async fn test_idm_account_softlocking(
+        idms: &IdmServer,
+        idms_delayed: &mut IdmServerDelayed,
+        idms_audit: &mut IdmServerAudit,
+    ) {
         init_admin_w_password(idms, TEST_PASSWORD)
             .await
             .expect("Failed to setup admin account");
@@ -3025,6 +3064,13 @@ mod tests {
                 panic!();
             }
         };
+
+        // There should be a queued audit event
+        match idms_audit.audit_rx().try_recv() {
+            Ok(AuditEvent::AuthenticationDenied { .. }) => {}
+            _ => assert!(false),
+        }
+
         idms_auth.commit().expect("Must not fail");
 
         // Auth init, softlock present, count == 1, same time (so before unlock_at)
@@ -3119,10 +3165,11 @@ mod tests {
         // Tested in the softlock state machine.
     }
 
-    #[idm_test]
+    #[idm_test(audit)]
     async fn test_idm_account_softlocking_interleaved(
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
+        idms_audit: &mut IdmServerAudit,
     ) {
         init_admin_w_password(idms, TEST_PASSWORD)
             .await
@@ -3165,6 +3212,12 @@ mod tests {
                 panic!();
             }
         };
+
+        match idms_audit.audit_rx().try_recv() {
+            Ok(AuditEvent::AuthenticationDenied { .. }) => {}
+            _ => assert!(false),
+        }
+
         idms_auth.commit().expect("Must not fail");
 
         // Now check that sid_early is denied due to softlock.

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -78,7 +78,7 @@ pub mod prelude {
         f_and, f_andnot, f_eq, f_id, f_inc, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub, Filter,
         FilterInvalid, FilterValid, FC,
     };
-    pub use crate::idm::server::{IdmServer, IdmServerDelayed};
+    pub use crate::idm::server::{IdmServer, IdmServerAudit, IdmServerDelayed};
     pub use crate::modify::{
         m_assert, m_pres, m_purge, m_remove, Modify, ModifyInvalid, ModifyList, ModifyValid,
     };

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -84,7 +84,9 @@ pub mod prelude {
     };
     pub use crate::server::access::AccessControlsTransaction;
     pub use crate::server::batch_modify::BatchModifyEvent;
-    pub use crate::server::identity::{AccessScope, IdentType, IdentUser, Identity, IdentityId};
+    pub use crate::server::identity::{
+        AccessScope, IdentType, IdentUser, Identity, IdentityId, Source,
+    };
     pub use crate::server::{
         QueryServer, QueryServerReadTransaction, QueryServerTransaction,
         QueryServerWriteTransaction,

--- a/server/lib/src/server/identity.rs
+++ b/server/lib/src/server/identity.rs
@@ -6,6 +6,7 @@
 use crate::be::Limits;
 use std::collections::BTreeSet;
 use std::hash::Hash;
+use std::net::IpAddr;
 use std::sync::Arc;
 use uuid::uuid;
 
@@ -15,6 +16,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
 use crate::value::Session;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Source {
+    Internal,
+    Https(IpAddr),
+    // Ldaps,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessScope {

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -1037,8 +1037,6 @@ impl QueryServer {
 
         let phase = Arc::new(CowCell::new(ServerPhase::Bootstrap));
 
-        // log_event!(log, "Starting query worker ...");
-
         #[allow(clippy::expect_used)]
         QueryServer {
             phase,

--- a/server/lib/src/testkit.rs
+++ b/server/lib/src/testkit.rs
@@ -57,7 +57,7 @@ pub async fn setup_pair_test() -> (QueryServer, QueryServer) {
 }
 
 #[allow(clippy::expect_used)]
-pub async fn setup_idm_test() -> (IdmServer, IdmServerDelayed) {
+pub async fn setup_idm_test() -> (IdmServer, IdmServerDelayed, IdmServerAudit) {
     let qs = setup_test().await;
 
     qs.initialise_helper(duration_from_epoch_now())


### PR DESCRIPTION
Fixes #1710 

Refers #22 

This is the absolute minimal impl of event audit for logins. Currently we just report on authentication denied.

I think we need to expand the data we return here, the important one is likely the source ip of the event, but that's going to be a bit more work to wire in - part of me thinks it would be worth just swapping to axum now to save the double handling later .... 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
