### PR TITLE
fixed return value of add_ava_int

### DIFF
--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2138,7 +2138,7 @@ impl Entry<EntryReduced, EntryCommitted> {
 
 // impl<STATE> Entry<EntryValid, STATE> {
 impl<VALID, STATE> Entry<VALID, STATE> {
-    /// This internally adds an AVA to the entry. If the entry was newely added, then true is returned.
+    /// This internally adds an AVA to the entry. If the entry was newly added, then true is returned.
     /// If the value already existed, or was unable to be added, false is returned. Alternately,
     /// you can think of this boolean as "if a write occurred to the structure", true indicating that
     /// a change occurred.
@@ -2154,7 +2154,7 @@ impl<VALID, STATE> Entry<VALID, STATE> {
                 .expect("Unable to fail - non-zero iter, and single value type!");
             self.attrs.insert(AttrString::from(attr), vs);
             // The attribute did not exist before.
-            false
+            true
         }
         // Doesn't matter if it already exists, equality will replace.
     }


### PR DESCRIPTION
add_ava_int was returning the wrong value when the entry didn't exist and was added from scratch
- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
