### PR TITLE
Add support for argon2id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "argon2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "base64urlsafedata"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +592,15 @@ name = "bitflags"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "blake3"
@@ -1331,6 +1357,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2434,6 +2461,7 @@ dependencies = [
 name = "kanidm_lib_crypto"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "base64 0.21.2",
  "base64urlsafedata",
  "hex",
@@ -3358,6 +3386,17 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ homepage = "https://github.com/kanidm/kanidm/"
 repository = "https://github.com/kanidm/kanidm/"
 
 [workspace.dependencies]
+argon2 = { version = "0.5.0", features = ["alloc"] }
 async-recursion = "1.0.4"
 async-trait = "^0.1.68"
 base32 = "^0.4.0"

--- a/libs/crypto/Cargo.toml
+++ b/libs/crypto/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+argon2.workspace = true
 base64.workspace = true
 base64urlsafedata.workspace = true
 hex.workspace = true

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -153,13 +153,8 @@ impl IdmServer {
         origin: &str,
     ) -> Result<(IdmServer, IdmServerDelayed, IdmServerAudit), OperationError> {
         // This is calculated back from:
-        //  500 auths / thread -> 0.002 sec per op
-        //      we can then spend up to ~0.001s hashing
-        //      that means an attacker could possibly have
-        //      1000 attempts/sec on a compromised pw.
-        // overtime, we could increase this as auth parallelism
-        // improves.
-        let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(1));
+        //  100 password auths / thread -> 0.010 sec per op
+        let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(10));
         let (async_tx, async_rx) = unbounded();
         let (audit_tx, audit_rx) = unbounded();
 

--- a/unix_integration/src/cache.rs
+++ b/unix_integration/src/cache.rs
@@ -105,10 +105,7 @@ impl CacheLayer {
             home_alias,
             uid_attr_map,
             gid_attr_map,
-            allow_id_overrides: allow_id_overrides
-                .into_iter()
-                .map(|name| Id::Name(name))
-                .collect(),
+            allow_id_overrides: allow_id_overrides.into_iter().map(Id::Name).collect(),
             nxset: Mutex::new(HashSet::new()),
             nxcache: Mutex::new(LruCache::new(NXCACHE_SIZE)),
         })


### PR DESCRIPTION
Fixes #1734 - This adds support for argon2id. It also allows auto-tuning it's parameters based on system performance. I am still unsure yet if to change to it by default, as I want to consult some members of the SUSE product security team first. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
