### PR TITLE
Fix block_on in ssh authorised keys

### DIFF
--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -11,7 +11,6 @@ After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
 User=root
 Type=simple
 ExecStart=/usr/sbin/kanidm_unixd_tasks
-KillSignal=SIGINT
 
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -14,7 +14,6 @@ RuntimeDirectory=kanidm-unixd
 
 Type=simple
 ExecStart=/usr/sbin/kanidm_unixd
-KillSignal=SIGINT
 
 # Implied by dynamic user.
 # ProtectHome=

--- a/platform/opensuse/kanidmd.service
+++ b/platform/opensuse/kanidmd.service
@@ -13,7 +13,6 @@ DynamicUser=yes
 UMask=0027
 StateDirectory=kanidm
 ExecStart=/usr/sbin/kanidmd server -c /etc/kanidm/server.toml
-KillSignal=SIGINT
 
 NoNewPrivileges=true
 PrivateTmp=true

--- a/unix_integration/src/client.rs
+++ b/unix_integration/src/client.rs
@@ -50,12 +50,15 @@ impl ClientCodec {
 
 /// Makes a call to kanidm_unixd via a unix socket at `path`
 pub async fn call_daemon(path: &str, req: ClientRequest) -> Result<ClientResponse, Box<dyn Error>> {
+    trace!(?path, ?req);
     let stream = UnixStream::connect(path).await?;
+    trace!("connected");
 
     let mut reqs = Framed::new(stream, ClientCodec::new());
 
     reqs.send(req).await?;
     reqs.flush().await?;
+    trace!("flushed, waiting ...");
 
     match reqs.next().await {
         Some(Ok(res)) => {

--- a/unix_integration/src/ssh_authorizedkeys.rs
+++ b/unix_integration/src/ssh_authorizedkeys.rs
@@ -17,7 +17,6 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
-use futures::executor::block_on;
 use kanidm_unix_common::client::call_daemon;
 use kanidm_unix_common::constants::DEFAULT_CONFIG_PATH;
 use kanidm_unix_common::unix_config::KanidmUnixdConfig;
@@ -66,7 +65,7 @@ async fn main() -> ExitCode {
     }
     let req = ClientRequest::SshKey(opt.account_id);
 
-    match block_on(call_daemon(cfg.sock_path.as_str(), req)) {
+    match call_daemon(cfg.sock_path.as_str(), req).await {
         Ok(r) => match r {
             ClientResponse::SshKeys(sk) => sk.iter().for_each(|k| {
                 println!("{}", k);


### PR DESCRIPTION
We accidentally left a block on in async code that cause ssh authorised keys to fail. This also adds improved debugging and fixes signal handling in the unixd daemons.

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
