### PR TITLE
Mention client configuration in tool installation guide

### DIFF
--- a/book/src/installing_client_tools.md
+++ b/book/src/installing_client_tools.md
@@ -126,6 +126,19 @@ If you have a ca.pem you may need to bind mount this in as required as well.
 alias kanidm="docker run ..."
 ```
 
+## Initializing the configuration
+
+The client requires a configuration file to connect to the server.
+This should be at `/etc/kanidm/config` or `~/.config/kanidm`, and configures the kanidm command line tool.
+
+Here is a minimal example:
+
+```toml
+uri = "https://idm.example.com"
+verify_ca = true
+verify_hostnames = true
+```
+
 ## Checking that the tools work
 
 Now you can check your instance is working. You may need to provide a CA certificate for


### PR DESCRIPTION
While going through the documentation and testing out the kanidm client, I noticed that the commands to test the client didn't work out of the box. It requires a config to connect to the server, which is thankfully already documented [here](https://github.com/kanidm/kanidm/blob/master/examples/config), but I thought it would still be handy to show a minimal configuration so that users don't have to move away from the documentation during that step.

- [X] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
