### PR TITLE
1755 - Expire-At epoch/now

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -475,7 +475,11 @@ impl KanidmClient {
             warn!(server_version = ?ver, client_version = ?EXPECT_VERSION, "Mismatched client and server version - features may not work, or other unforeseen errors may occur.")
         }
 
-        debug_assert!(matching);
+        #[cfg(debug_assertions)]
+        if !matching {
+            error!("You're in debug/dev mode, so we're going to quit here.");
+            std::process::exit(1);
+        }
 
         // Check is done once, mark as no longer needing to occur
         *guard = false;

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -417,6 +417,36 @@ impl PersonOpt {
                             Err(e) => error!("Error -> {:?}", e),
                             _ => println!("Success"),
                         }
+                    } else if matches!(ano.datetime.as_str(), "now") {
+                        // set the expiry to *now*
+                        let now = OffsetDateTime::now_utc().format(&Rfc3339).unwrap();
+                        debug!("Setting expiry to {}", now);
+                        match client
+                            .idm_person_account_set_attr(
+                                ano.aopts.account_id.as_str(),
+                                "account_expire",
+                                &[&now],
+                            )
+                            .await
+                        {
+                            Err(e) => error!("Error setting expiry to 'now' -> {:?}", e),
+                            _ => println!("Success"),
+                        }
+                    } else if matches!(ano.datetime.as_str(), "epoch") {
+                        // set the expiry to the epoch
+                        let epoch_str = OffsetDateTime::UNIX_EPOCH.format(&Rfc3339).unwrap();
+                        debug!("Setting expiry to {}", epoch_str);
+                        match client
+                            .idm_person_account_set_attr(
+                                ano.aopts.account_id.as_str(),
+                                "account_expire",
+                                &[&epoch_str],
+                            )
+                            .await
+                        {
+                            Err(e) => error!("Error setting expiry to 'epoch' -> {:?}", e),
+                            _ => println!("Success"),
+                        }
                     } else {
                         if let Err(e) = OffsetDateTime::parse(ano.datetime.as_str(), &Rfc3339) {
                             error!("Error -> {:?}", e);
@@ -447,7 +477,11 @@ impl PersonOpt {
                             )
                             .await
                         {
-                            Err(e) => error!("Error -> {:?}", e),
+                            Err(e) => error!(
+                                "Error setting begin-from to '{}' -> {:?}",
+                                ano.datetime.as_str(),
+                                e
+                            ),
                             _ => println!("Success"),
                         }
                     } else {
@@ -465,7 +499,11 @@ impl PersonOpt {
                             )
                             .await
                         {
-                            Err(e) => error!("Error -> {:?}", e),
+                            Err(e) => error!(
+                                "Error setting begin-from to '{}' -> {:?}",
+                                ano.datetime.as_str(),
+                                e
+                            ),
                             _ => println!("Success"),
                         }
                     }

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -119,9 +119,12 @@ pub struct AccountNamedExpireDateTimeOpt {
     aopts: AccountCommonOpt,
     #[clap(flatten)]
     copt: CommonOpt,
-    #[clap(name = "datetime")]
-    /// An rfc3339 time of the format "YYYY-MM-DDTHH:MM:SS+TZ", "2020-09-25T11:22:02+10:00"
-    /// or the word "never", "clear" to remove account expiry.
+    #[clap(name = "datetime", verbatim_doc_comment)]
+    /// This accepts mulitple options:
+    /// - An RFC3339 time of the format "YYYY-MM-DDTHH:MM:SS+TZ", "2020-09-25T11:22:02+10:00"
+    /// - One of "any", "clear" or "never" to remove account expiry.
+    /// - "epoch" to set the expiry to the UNIX epoch
+    /// - "now" to expire immediately (this will affect authentication with Kanidm, but external systems may not be aware of the change until next time it's validated, typically ~15 minutes)
     datetime: String,
 }
 


### PR DESCRIPTION
Fixes #1755

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
