### PR TITLE
Improve durability of migrations

### DIFF
--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -1486,8 +1486,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         *self.phase = phase
     }
 
-    #[instrument(level = "info", skip_all)]
-    pub fn commit(mut self) -> Result<(), OperationError> {
+    pub(crate) fn reload(&mut self) -> Result<(), OperationError> {
         // This could be faster if we cache the set of classes changed
         // in an operation so we can check if we need to do the reload or not
         //
@@ -1511,6 +1510,13 @@ impl<'a> QueryServerWriteTransaction<'a> {
         if self.changed_domain {
             self.reload_domain_info()?;
         }
+
+        Ok(())
+    }
+
+    #[instrument(level = "info", skip_all)]
+    pub fn commit(mut self) -> Result<(), OperationError> {
+        self.reload()?;
 
         // Now destructure the transaction ready to reset it.
         let QueryServerWriteTransaction {

--- a/server/lib/src/valueset/jws.rs
+++ b/server/lib/src/valueset/jws.rs
@@ -90,8 +90,11 @@ impl ValueSetT for ValueSetJwsKeyEs256 {
         }
     }
 
-    fn contains(&self, _pv: &PartialValue) -> bool {
-        false
+    fn contains(&self, pv: &PartialValue) -> bool {
+        match pv {
+            PartialValue::Iutf8(kid) => self.set.iter().any(|k| k.get_kid() == kid),
+            _ => false,
+        }
     }
 
     fn substring(&self, _pv: &PartialValue) -> bool {


### PR DESCRIPTION
This improves durability of migrations so that when a version check is not met we abort and roll back all changes to prevent any changes occuring. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
