### PR TITLE
Fix a typo in the unix daemon debug

### DIFF
--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -692,7 +692,7 @@ async fn main() -> ExitCode {
             let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
                 Ok(l) => l,
                 Err(_e) => {
-                    error!("Failed to bind UNIX socket {}", cfg.sock_path.as_str());
+                    error!("Failed to bind UNIX socket {}", cfg.task_sock_path.as_str());
                     return ExitCode::FAILURE
                 }
             };


### PR DESCRIPTION
Fixes a minor typo I noticed in the error output.

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
