### PR TITLE
Allow Authorization header in CORS preflight response

### DIFF
--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -6,7 +6,9 @@ use axum::middleware::from_fn;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Extension, Form, Json, Router};
-use http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, LOCATION};
+use http::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, LOCATION,
+};
 use http::{HeaderMap, HeaderValue, StatusCode};
 use hyper::Body;
 use kanidm_proto::oauth2::AuthorisationResponse;
@@ -862,6 +864,7 @@ pub async fn oauth2_preflight_options() -> impl IntoResponse {
     Response::builder()
         .status(StatusCode::OK)
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(ACCESS_CONTROL_ALLOW_HEADERS, "Authorization")
         .body(Body::empty())
         .unwrap()
 }


### PR DESCRIPTION
This is needed for public clients running as SPAs (like OCIS).

With this commit Owncloud OCIS actually works.

Fixes #1792

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
