### PR TITLE
Improve selinux in tasks daemon

### DIFF
--- a/book/src/DEVELOPER_README.md
+++ b/book/src/DEVELOPER_README.md
@@ -27,10 +27,34 @@ To build the Web UI you'll need [wasm-pack](https://rustwasm.github.io/wasm-pack
 You will need to install rustup and our build dependencies with:
 
 ```bash
-zypper in rustup git libudev-devel sqlite3-devel libopenssl-3-devel
+zypper in rustup git libudev-devel sqlite3-devel libopenssl-3-devel libselinux-devel pam-devel tpm2-0-tss-devel
 ```
 
 You can then use rustup to complete the setup of the toolchain.
+
+In some cases you may need to build other vendored components, or use an alternate linker. In these
+cases we advise you to also install.
+
+```bash
+zypper in clang lld make sccache
+```
+
+You should also adjust your environment with:
+```bash
+export RUSTC_WRAPPER=sccache
+export CC="sccache /usr/bin/clang"
+export CXX="sccache /usr/bin/clang++"
+```
+
+And add the following to a cargo config of your choice (such as ~/.cargo/config), adjusting for cpu arch
+
+```toml
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = [
+    "-C", "link-arg=-fuse-ld=lld",
+]
+```
 
 ### Fedora
 

--- a/server/testkit/tests/integration.rs
+++ b/server/testkit/tests/integration.rs
@@ -28,18 +28,19 @@ async fn get_webdriver_client() -> fantoccini::Client {
     };
     if !in_ci {
         match fantoccini::ClientBuilder::native()
-        .connect("http://localhost:4444")
-        .await
-                {
-                    Ok(val) => val,
-                    Err(_) => {
-                        // trying the default chromedriver port
-                        eprintln!("Couldn't connect on 4444, trying 9515");
-                        fantoccini::ClientBuilder::new(hyper_tls::HttpsConnector::new()).connect("http://localhost:9515")
-                            .await
-                            .unwrap()
-                    }
-                }
+            .connect("http://localhost:4444")
+            .await
+        {
+            Ok(val) => val,
+            Err(_) => {
+                // trying the default chromedriver port
+                eprintln!("Couldn't connect on 4444, trying 9515");
+                fantoccini::ClientBuilder::new(hyper_tls::HttpsConnector::new())
+                    .connect("http://localhost:9515")
+                    .await
+                    .unwrap()
+            }
+        }
     } else {
         println!("In CI setting headless and assuming Chrome");
         let cap = json!({
@@ -48,8 +49,11 @@ async fn get_webdriver_client() -> fantoccini::Client {
             }
         });
         let cap: Capabilities = serde_json::from_value(cap).unwrap();
-        fantoccini::ClientBuilder::new(hyper_tls::HttpsConnector::new()).capabilities(cap).connect("http://localhost:9515").await.unwrap()
-
+        fantoccini::ClientBuilder::new(hyper_tls::HttpsConnector::new())
+            .capabilities(cap)
+            .connect("http://localhost:9515")
+            .await
+            .unwrap()
     }
 }
 

--- a/unix_integration/src/selinux_util.rs
+++ b/unix_integration/src/selinux_util.rs
@@ -1,7 +1,11 @@
 use std::ffi::CString;
+use std::path::Path;
+use std::process::Command;
+use users::get_user_by_uid;
 
 use selinux::{
-    current_mode, kernel_support, label::back_end::File, label::Labeler, KernelSupport, SELinuxMode,
+    current_mode, kernel_support, label::back_end::File, label::Labeler, KernelSupport,
+    SELinuxMode, SecurityContext,
 };
 
 pub fn supported() -> bool {
@@ -16,18 +20,7 @@ pub fn supported() -> bool {
     }
 }
 
-pub fn get_labeler() -> Result<Labeler<File>, String> {
-    if let Ok(v) = Labeler::new(&[], true) {
-        Ok(v)
-    } else {
-        Err("Failed getting handle for SELinux labeling".to_string())
-    }
-}
-
-pub fn do_setfscreatecon_for_path(
-    path_raw: &String,
-    labeler: &Labeler<File>,
-) -> Result<(), String> {
+fn do_setfscreatecon_for_path(path_raw: &String, labeler: &Labeler<File>) -> Result<(), String> {
     match labeler.look_up(&CString::new(path_raw.to_owned()).unwrap(), 0) {
         Ok(context) => {
             if context.set_for_new_file_system_objects(true).is_err() {
@@ -37,6 +30,101 @@ pub fn do_setfscreatecon_for_path(
         }
         Err(_) => {
             return Err("Failed looking up default context for home directory path".to_string());
+        }
+    }
+}
+
+fn get_labeler() -> Result<Labeler<File>, String> {
+    if let Ok(v) = Labeler::new(&[], true) {
+        Ok(v)
+    } else {
+        Err("Failed getting handle for SELinux labeling".to_string())
+    }
+}
+
+pub enum SelinuxLabeler {
+    None,
+    Enabled {
+        labeler: Labeler<File>,
+        sel_lookup_path_raw: String,
+    },
+}
+
+impl SelinuxLabeler {
+    pub fn new(gid: u32, home_prefix: &str) -> Result<Self, String> {
+        let labeler = get_labeler()?;
+
+        // Construct a path for SELinux context lookups.
+        // We do this because the policy only associates a home directory to its owning
+        // user by the name of the directory. Since the real user's home directory is (by
+        // default) their uuid or spn, its context will always be the policy default
+        // (usually user_u or unconfined_u). This lookup path is used to ask the policy
+        // what the context SHOULD be, and we will create policy equivalence rules below
+        // so that relabels in the future do not break it.
+        #[cfg(all(target_family = "unix", feature = "selinux"))]
+        // Yes, gid, because we use the GID number for both the user's UID and primary GID
+        let sel_lookup_path_raw = match get_user_by_uid(gid) {
+            Some(v) => format!("{}{}", home_prefix, v.name().to_str().unwrap()),
+            None => {
+                return Err("Failed looking up username by uid for SELinux relabeling".to_string());
+            }
+        };
+
+        Ok(SelinuxLabeler::Enabled {
+            labeler,
+            sel_lookup_path_raw,
+        })
+    }
+
+    pub fn new_noop() -> Self {
+        SelinuxLabeler::None
+    }
+
+    pub fn do_setfscreatecon_for_path(&self) -> Result<(), String> {
+        match &self {
+            SelinuxLabeler::None => Ok(()),
+            SelinuxLabeler::Enabled {
+                labeler,
+                sel_lookup_path_raw,
+            } => do_setfscreatecon_for_path(sel_lookup_path_raw, labeler),
+        }
+    }
+
+    pub fn label_path<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
+        match &self {
+            SelinuxLabeler::None => Ok(()),
+            SelinuxLabeler::Enabled {
+                labeler,
+                sel_lookup_path_raw,
+            } => {
+                let sel_lookup_path = Path::new(&sel_lookup_path_raw).join(path.as_ref());
+                do_setfscreatecon_for_path(&sel_lookup_path.to_str().unwrap().to_string(), &labeler)
+            }
+        }
+    }
+
+    pub fn setup_equivalence_rule(&self, path: &str) -> Result<(), String> {
+        match &self {
+            SelinuxLabeler::None => Ok(()),
+            SelinuxLabeler::Enabled {
+                labeler: _,
+                sel_lookup_path_raw,
+            } => Command::new("semanage")
+                .args(["fcontext", "-ae", sel_lookup_path_raw, &path])
+                .spawn()
+                .map(|_| ())
+                .map_err(|_| "Failed creating SELinux policy equivalence rule".to_string()),
+        }
+    }
+
+    pub fn set_default_context_for_fs_objects(&self) -> Result<(), String> {
+        match &self {
+            SelinuxLabeler::None => Ok(()),
+            SelinuxLabeler::Enabled { .. } => {
+                SecurityContext::set_default_context_for_new_file_system_objects()
+                    .map(|_| ())
+                    .map_err(|_| "Failed resetting SELinux file creation contexts".to_string())
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1846 - improves selinux to only build a labeler if use selinux is true. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
