### PR TITLE
Upgraded clap, removing atty as a dependency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 Fixes #
 
+Checklist
+
 - [ ] This pr contains no AI generated code
 - [ ] cargo fmt has been run
 - [ ] cargo clippy has been run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +214,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -193,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -219,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
 dependencies = [
  "flate2",
  "futures-core",
@@ -273,7 +322,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "slab",
  "socket2",
  "waker-fn",
@@ -584,7 +633,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "prettyplease 0.2.9",
+ "prettyplease 0.2.10",
  "proc-macro2",
  "quote",
  "regex",
@@ -831,37 +880,54 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
- "once_cell",
- "strsim",
- "termcolor",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_complete"
-version = "3.2.5"
+name = "clap"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
- "clap",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.5.0",
+ "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
+dependencies = [
+ "clap 4.3.11",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -874,10 +940,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compact_jwt"
@@ -975,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.22",
+ "time 0.3.23",
  "version_check",
 ]
 
@@ -992,7 +1070,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "url",
 ]
 
@@ -1014,9 +1092,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -1046,7 +1124,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.25",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -1204,7 +1282,7 @@ dependencies = [
 name = "daemon"
 version = "1.1.0-beta.13-dev"
 dependencies = [
- "clap",
+ "clap 4.3.11",
  "clap_complete",
  "fs2",
  "is-terminal",
@@ -1451,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1526,7 +1604,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "url",
  "webdriver",
@@ -2094,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -2384,7 +2462,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2401,8 +2479,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "rustix 0.38.2",
+ "hermit-abi 0.3.2",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -2445,7 +2523,7 @@ version = "1.1.0-beta.13-dev"
 dependencies = [
  "base64urlsafedata",
  "chrono",
- "clap",
+ "clap 4.3.11",
  "clap_complete",
  "cron",
  "kanidm_client",
@@ -2469,7 +2547,7 @@ version = "1.1.0-beta.13-dev"
 dependencies = [
  "base64urlsafedata",
  "chrono",
- "clap",
+ "clap 4.3.11",
  "clap_complete",
  "cron",
  "kanidm_client",
@@ -2495,7 +2573,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "toml",
  "tracing",
@@ -2541,7 +2619,7 @@ dependencies = [
  "scim_proto",
  "serde",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "tracing",
  "url",
  "urlencoding",
@@ -2554,7 +2632,7 @@ name = "kanidm_tools"
 version = "1.1.0-beta.13-dev"
 dependencies = [
  "async-recursion",
- "clap",
+ "clap 4.3.11",
  "clap_complete",
  "compact_jwt",
  "dialoguer",
@@ -2567,7 +2645,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2583,7 +2661,7 @@ version = "1.1.0-beta.13-dev"
 dependencies = [
  "base64urlsafedata",
  "bytes",
- "clap",
+ "clap 4.3.11",
  "clap_complete",
  "csv",
  "futures",
@@ -2643,7 +2721,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sketching",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "tokio-openssl",
  "tokio-util",
@@ -2695,7 +2773,7 @@ dependencies = [
  "smartstring",
  "smolset",
  "sshkeys",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "tokio-util",
  "toml",
@@ -2739,7 +2817,7 @@ dependencies = [
  "serde_json",
  "sketching",
  "testkit-macros",
- "time 0.3.22",
+ "time 0.3.23",
  "tokio",
  "tracing",
  "url",
@@ -2758,7 +2836,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.5.0",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "url",
  "uuid",
  "wasm-bindgen",
@@ -3278,7 +3356,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -3430,7 +3508,7 @@ dependencies = [
 name = "orca"
 version = "1.1.0-beta.13-dev"
 dependencies = [
- "clap",
+ "clap 4.3.11",
  "crossbeam",
  "csv",
  "dialoguer",
@@ -3746,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
  "syn 2.0.25",
@@ -4007,7 +4085,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -4027,7 +4105,7 @@ checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -4038,9 +4116,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -4048,7 +4126,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "async-compression 0.4.0",
+ "async-compression 0.4.1",
  "base64 0.21.2",
  "bytes",
  "cookie 0.16.2",
@@ -4181,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.22"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -4195,9 +4273,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -4246,7 +4324,7 @@ dependencies = [
  "peg",
  "serde",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4349,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.170"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56657f512baabca8f840542f9ca8152aecf182c473c26e46e58d6aab4f6e439"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -4380,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
+checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
 dependencies = [
  "serde",
 ]
@@ -4409,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.170"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d477848e6b23adba0db397777d5aad864555bc17fd9c89abb3b8009788b7b8"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4420,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",
@@ -4431,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
+checksum = "8acc4422959dd87a76cb117c191dcbffc20467f06c9100b76721dab370f24d3a"
 dependencies = [
  "itoa",
  "serde",
@@ -4585,9 +4663,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 dependencies = [
  "serde",
 ]
@@ -4764,9 +4842,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
+checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
 
 [[package]]
 name = "tempfile"
@@ -4778,17 +4856,8 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -4808,18 +4877,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4884,16 +4953,16 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
  "serde",
  "time-core",
- "time-macros 0.2.9",
+ "time-macros 0.2.10",
 ]
 
 [[package]]
@@ -4914,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -5053,9 +5122,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -5210,7 +5279,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.22",
+ "time 0.3.23",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -5263,9 +5332,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -5352,6 +5421,12 @@ dependencies = [
  "libc",
  "log",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -5621,7 +5696,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.22",
+ "time 0.3.23",
  "unicode-segmentation",
  "url",
 ]
@@ -5878,9 +5953,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]
@@ -5909,7 +5984,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -6044,5 +6119,5 @@ dependencies = [
  "lazy_static",
  "quick-error",
  "regex",
- "time 0.3.22",
+ "time 0.3.23",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ base32 = "^0.4.0"
 base64 = "^0.21.0"
 base64urlsafedata = "0.1.3"
 bytes = "^1.3.0"
-clap = { version = "^3.2", features = ["derive"] }
-clap_complete = "^3.2.5"
+clap = { version = "^4.0", features = ["derive"] }
+clap_complete = "^4.0"
 # Forced by saffron/cron
 chrono = "^0.4.26"
 compact_jwt = { version = "^0.2.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ base32 = "^0.4.0"
 base64 = "^0.21.0"
 base64urlsafedata = "0.1.3"
 bytes = "^1.3.0"
-clap = { version = "^4.0", features = ["derive"] }
-clap_complete = "^4.0"
+clap = { version = "^4.3.11", features = ["derive"] }
+clap_complete = "^4.3.2"
 # Forced by saffron/cron
 chrono = "^0.4.26"
 compact_jwt = { version = "^0.2.3", default-features = false }

--- a/server/daemon/build.rs
+++ b/server/daemon/build.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::path::PathBuf;
 
-use clap::{Args, IntoApp, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::{generate_to, Shell};
 
 include!("src/opt.rs");

--- a/server/daemon/src/opt.rs
+++ b/server/daemon/src/opt.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, Args)]
 struct CommonOpt {
-    #[clap(parse(from_os_str), default_value = "", short, long = "config", env = "KANIDM_CONFIG")]
     /// Path to the server's configuration file. If it does not exist, it will be created.
+    #[clap(short, long = "config", env = "KANIDM_CONFIG")]
     config_path: PathBuf,
     /// Log format (still in very early development)
     #[clap(short, long = "output", env = "KANIDM_OUTPUT", default_value="text")]
@@ -10,7 +10,7 @@ struct CommonOpt {
 
 #[derive(Debug, Args)]
 struct BackupOpt {
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser)]
     /// Output path for the backup content.
     path: PathBuf,
     #[clap(flatten)]
@@ -19,7 +19,7 @@ struct BackupOpt {
 
 #[derive(Debug, Args)]
 struct RestoreOpt {
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser)]
     /// Restore from this path. Should be created with "backup".
     path: PathBuf,
     #[clap(flatten)]
@@ -126,8 +126,9 @@ enum DbScanOpt {
 }
 
 #[derive(Debug, Parser)]
+#[command(name="kanidmd")]
 struct KanidmdParser {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     commands: KanidmdOpt,
 }
 

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -44,7 +44,7 @@ pub struct CommonOpt {
     #[clap(short = 'D', long = "name", env = "KANIDM_NAME")]
     pub username: Option<String>,
     /// Path to a CA certificate file
-    #[clap(parse(from_os_str), short = 'C', long = "ca", env = "KANIDM_CA_PATH")]
+    #[clap(value_parser, short = 'C', long = "ca", env = "KANIDM_CA_PATH")]
     pub ca_path: Option<PathBuf>,
     /// Log format (still in very early development)
     #[clap(short, long = "output", env = "KANIDM_OUTPUT", default_value = "text")]
@@ -54,7 +54,7 @@ pub struct CommonOpt {
 #[derive(Debug, Args)]
 pub struct GroupNamedMembers {
     name: String,
-    #[clap(required = true, min_values = 1)]
+    #[clap(required = true, num_args(1..))]
     members: Vec<String>,
     #[clap(flatten)]
     copt: CommonOpt,
@@ -572,7 +572,7 @@ pub struct FilterOpt {
 
 #[derive(Debug, Args)]
 pub struct CreateOpt {
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser)]
     file: PathBuf,
     #[clap(flatten)]
     commonopts: CommonOpt,
@@ -584,7 +584,7 @@ pub struct ModifyOpt {
     commonopts: CommonOpt,
     #[clap()]
     filter: String,
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser)]
     file: PathBuf,
 }
 
@@ -767,7 +767,7 @@ pub enum PwBadlistOpt {
     Upload {
         #[clap(flatten)]
         copt: CommonOpt,
-        #[clap(parse(from_os_str), required = true, min_values = 1)]
+        #[clap(value_parser, required = true, num_args(1..))]
         paths: Vec<PathBuf>,
         /// Perform a dry run and display the list that would have been uploaded instead.
         #[clap(short = 'n', long)]
@@ -779,7 +779,7 @@ pub enum PwBadlistOpt {
     Remove {
         #[clap(flatten)]
         copt: CommonOpt,
-        #[clap(parse(from_os_str), required = true, min_values = 1)]
+        #[clap(value_parser, required = true, num_args(1..))]
         paths: Vec<PathBuf>,
     },
 }

--- a/tools/cli/src/opt/ssh_authorizedkeys.rs
+++ b/tools/cli/src/opt/ssh_authorizedkeys.rs
@@ -6,7 +6,7 @@ struct SshAuthorizedOpt {
     addr: Option<String>,
     #[clap(short = 'D', long = "name")]
     username: String,
-    #[clap(parse(from_os_str), short = 'C', long = "ca")]
+    #[clap(value_parser, short = 'C', long = "ca")]
     ca_path: Option<PathBuf>,
     account_id: String,
 }

--- a/tools/iam_migrations/freeipa/src/opt.rs
+++ b/tools/iam_migrations/freeipa/src/opt.rs
@@ -11,11 +11,11 @@ pub struct Opt {
     #[clap(short, long, env = "KANIDM_DEBUG")]
     pub debug: bool,
     /// Path to the client config file.
-    #[clap(parse(from_os_str), short, long, default_value_os_t = DEFAULT_CLIENT_CONFIG_PATH.into())]
+    #[clap(value_parser, short, long, default_value_os_t = DEFAULT_CLIENT_CONFIG_PATH.into())]
     pub client_config: PathBuf,
 
     /// Path to the ipa-sync config file.
-    #[clap(parse(from_os_str), short, long, default_value_os_t = DEFAULT_IPA_CONFIG_PATH.into())]
+    #[clap(value_parser, short, long, default_value_os_t = DEFAULT_IPA_CONFIG_PATH.into())]
     pub ipa_sync_config: PathBuf,
 
     /// Dump the ldap protocol inputs, as well as the scim outputs. This can be used

--- a/tools/iam_migrations/ldap/src/opt.rs
+++ b/tools/iam_migrations/ldap/src/opt.rs
@@ -10,11 +10,11 @@ pub struct Opt {
     #[clap(short, long, env = "KANIDM_DEBUG")]
     pub debug: bool,
     /// Path to the client config file.
-    #[clap(parse(from_os_str), short, long, default_value_os_t = DEFAULT_CLIENT_CONFIG_PATH.into())]
+    #[clap(short, long, value_parser, default_value_os_t = DEFAULT_CLIENT_CONFIG_PATH.into())]
     pub client_config: PathBuf,
 
     /// Path to the ldap-sync config file.
-    #[clap(parse(from_os_str), short, long, default_value_os_t = DEFAULT_LDAP_CONFIG_PATH.into())]
+    #[clap(short, long, value_parser, default_value_os_t = DEFAULT_LDAP_CONFIG_PATH.into())]
     pub ldap_sync_config: PathBuf,
 
     /// Dump the ldap protocol inputs, as well as the scim outputs. This can be used

--- a/tools/orca/src/opt.rs
+++ b/tools/orca/src/opt.rs
@@ -11,10 +11,10 @@ struct CommonOpt {
 struct PreProcOpt {
     #[clap(flatten)]
     pub copt: CommonOpt,
-    #[clap(parse(from_os_str), short, long = "input")]
+    #[clap(value_parser, short, long = "input")]
     /// Path to unprocessed data in json format.
     pub input_path: PathBuf,
-    #[clap(parse(from_os_str), short, long = "output")]
+    #[clap(value_parser, short, long = "output")]
     /// Path to write the processed output.
     pub output_path: PathBuf,
 }
@@ -23,7 +23,7 @@ struct PreProcOpt {
 struct GenerateOpt {
     #[clap(flatten)]
     pub copt: CommonOpt,
-    #[clap(parse(from_os_str), short, long = "output")]
+    #[clap(value_parser, short, long = "output")]
     /// Path to write the generated output.
     pub output_path: PathBuf,
 }
@@ -34,7 +34,7 @@ struct SetupOpt {
     pub copt: CommonOpt,
     #[clap(name = "target")]
     pub target: TargetOpt,
-    #[clap(parse(from_os_str), short, long = "profile")]
+    #[clap(value_parser, short, long = "profile")]
     /// Path to the test profile.
     pub profile_path: PathBuf,
 }
@@ -48,12 +48,12 @@ struct RunOpt {
     #[clap(name = "test-type")]
     /// Which type of test to run against this system
     pub test_type: TestTypeOpt,
-    #[clap(parse(from_os_str), short, long = "profile")]
+    #[clap(value_parser, short, long = "profile")]
     /// Path to the test profile.
     pub profile_path: PathBuf,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Subcommand, Clone)]
 /// The target to run against
 pub(crate) enum TargetOpt {
     #[clap(name = "ds")]
@@ -84,7 +84,7 @@ impl FromStr for TargetOpt {
     }
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Subcommand, Clone)]
 pub(crate) enum TestTypeOpt {
     #[clap(name = "search-basic")]
     /// Perform a basic search-only test

--- a/unix_integration/build.rs
+++ b/unix_integration/build.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::path::PathBuf;
 
-use clap::{IntoApp, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::{generate_to, Shell};
 
 include!("src/opt/ssh_authorizedkeys.rs");

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -427,23 +427,21 @@ async fn main() -> ExitCode {
         )
         .arg(
             Arg::new("unixd-config")
-                .takes_value(true)
                 .help("Set the unixd config file path")
                 .short('u')
                 .long("unixd-config")
                 .default_value(DEFAULT_CONFIG_PATH)
                 .env("KANIDM_UNIX_CONFIG")
-                .action(ArgAction::StoreValue),
+                .action(ArgAction::Set),
         )
         .arg(
             Arg::new("client-config")
-                .takes_value(true)
                 .help("Set the client config file path")
                 .short('c')
                 .long("client-config")
                 .default_value(DEFAULT_CLIENT_CONFIG_PATH)
                 .env("KANIDM_CLIENT_CONFIG")
-                .action(ArgAction::StoreValue),
+                .action(ArgAction::Set),
         )
         .get_matches();
 

--- a/unix_integration/src/opt/ssh_authorizedkeys.rs
+++ b/unix_integration/src/opt/ssh_authorizedkeys.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Parser)]
+#[command(name="kanidm_ssh_authorizedkeys")]
 struct SshAuthorizedOpt {
     #[clap(short, long)]
     debug: bool,

--- a/unix_integration/src/opt/tool.rs
+++ b/unix_integration/src/opt/tool.rs
@@ -42,6 +42,7 @@ pub enum KanidmUnixOpt {
 
 #[derive(Debug, clap::Parser)]
 #[clap(about = "Kanidm Unixd Management Utility")]
+#[command(name = "kanidm_unixd")]
 pub struct KanidmUnixParser {
     #[clap(subcommand)]
     pub commands: KanidmUnixOpt,


### PR DESCRIPTION
Fixes the security alert

- Removes atty as a downstream dependency of clap
- upgrades clap

Checklist:

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
