### PR TITLE
Fix and isolate GitHub Actions ACLs for Docker build steps

### DIFF
--- a/.github/workflows/docker_build_kanidm.yml
+++ b/.github/workflows/docker_build_kanidm.yml
@@ -1,46 +1,59 @@
 ---
 name: Container - Kanidm
 
-# this will build regardless,
-# but only push to the container registry
-# when you're committing on the master branch.
-
-"on":
+# This is always built and uploads an OCI image as a build artifact, but only
+# pushes to "ghcr.io/kanidm/kanidm:devel" when on "kanidm/kanidm@master". 
+on:
   pull_request:
   push:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   kanidm_build:
+    name: Build kanidm Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -  # https://github.com/docker/login-action/#github-container-registry
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        # don't log in if we're not going to push!
-        if: ${{ github.ref == 'refs/heads/master' }} && ${{ github.repository == 'kanidm/kanidm' }}
-      - name: Build and push kanidmd
-        id: docker_build_kanidm
+      - name: Build kanidm
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}
           platforms: "linux/amd64"
-          # https://github.com/docker/build-push-action/issues/254
-          tags: ghcr.io/kanidm/kanidm:devel
+          tags: ghcr.io/${{ github.repository_owner }}/kanidm:devel
           build-args: |
             "KANIDM_FEATURES="
           #  "KANIDM_BUILD_OPTIONS=-j1"
           file: tools/Dockerfile
+          # Must use OCI exporter for multi-arch: https://github.com/docker/buildx/pull/1813
+          outputs: type=oci,dest=/tmp/kanidm-docker.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kanidm-docker
+          path: /tmp/kanidm-docker.tar
+
+  kanidm_push:
+    name: Push kanidm Docker image
+    # This step is split so that we don't apply "packages: write" permission
+    # except when uploading the final Docker image to GHCR.
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm'
+    needs: kanidm_build
+    permissions:
+      packages: write
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: kanidm-docker
+          path: /tmp
+
+      - name: Push image to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/kanidm-docker.tar:devel" "ghcr.io/${{ github.repository_owner }}/kanidm:devel"

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -1,45 +1,58 @@
 ---
 name: Container - Kanidmd
 
-# this will build regardless,
-# but only push to the container registry
-# when you're committing on the master branch.
-
-"on":
+# This is always built and uploads an OCI image as a build artifact, but only
+# pushes to "ghcr.io/kanidm/kanidmd:devel" when on "kanidm/kanidm@master". 
+on:
   pull_request:
   push:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   kanidmd_build:
+    name: Build kanidmd Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # don't need qemu/buildx if we're not building ARM
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v2
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
-      -  # https://github.com/docker/login-action/#github-container-registry
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        # don't log in if we're not going to push!
-        if: ${{ github.ref == 'refs/heads/master' }} && ${{ github.repository == 'kanidm/kanidm' }}
-      - name: Build and push kanidmd
-        id: docker_build_kanidmd
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build kanidmd
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}
-          platforms: linux/amd64
-          tags: ghcr.io/kanidm/kanidmd:devel
+          platforms: "linux/amd64"
+          tags: ghcr.io/${{ github.repository_owner }}/kanidmd:devel
           # build-args: |
-          #   "KANIDM_BUILD_OPTIONS=-j1"
+          #  "KANIDM_BUILD_OPTIONS=-j1"
           file: server/Dockerfile
+          # Must use OCI exporter for multi-arch: https://github.com/docker/buildx/pull/1813
+          outputs: type=oci,dest=/tmp/kanidmd-docker.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kanidmd-docker
+          path: /tmp/kanidmd-docker.tar
+
+  kanidmd_push:
+    name: Push kanidmd Docker image
+    # This step is split so that we don't apply "packages: write" permission
+    # except when uploading the final Docker image to GHCR.
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm'
+    needs: kanidmd_build
+    permissions:
+      packages: write
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: kanidmd-docker
+          path: /tmp
+
+      - name: Push image to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/kanidmd-docker.tar:devel" "ghcr.io/${{ github.repository_owner }}/kanidmd:devel"

--- a/.github/workflows/docker_build_radiusd.yml
+++ b/.github/workflows/docker_build_radiusd.yml
@@ -1,21 +1,19 @@
 ---
 name: Container - Radiusd
 
-# this will build regardless,
-# but only push to the container registry
-# when you're committing on the master branch.
-
-"on":
+# This is always built and uploads an OCI image as a build artifact, but only
+# pushes to "ghcr.io/kanidm/radius:devel" when on "kanidm/kanidm@master". 
+on:
   pull_request:
   push:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   radius_build:
+    name: Build radius Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,22 +21,40 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -  # https://github.com/docker/login-action/#github-container-registry
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        # don't log in if we're not going to push!
-        if: ${{github.ref == 'refs/heads/master'}} && ${{ github.repository == 'kanidm/kanidm' }}
-      - name: Build and push radius
-        id: docker_build_radius
+      - name: Build radius
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}
           platforms: linux/arm64,linux/amd64
-          # https://github.com/docker/build-push-action/issues/254
-          tags: ghcr.io/kanidm/radius:devel
-          context: .
+          tags: ghcr.io/${{ github.repository_owner }}/radius:devel
           file: rlm_python/Dockerfile
+          # Must use OCI exporter for multi-arch: https://github.com/docker/buildx/pull/1813
+          outputs: type=oci,dest=/tmp/radius-docker.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: radius-docker
+          path: /tmp/radius-docker.tar
+
+  radius_push:
+    name: Push radius Docker image
+    # This step is split so that we don't apply "packages: write" permission
+    # except when uploading the final Docker image to GHCR.
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm'
+    needs: radius_build
+    permissions:
+      packages: write
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: radius-docker
+          path: /tmp
+
+      # Docker won't directly import OCI images and keep their multi-arch
+      # features, but ORAS will: https://oras.land/docs/commands/oras_copy
+      - name: Push image to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/radius-docker.tar:devel" "ghcr.io/${{ github.repository_owner }}/radius:devel"


### PR DESCRIPTION
This fixes up the GitHub Actions for Docker images which broke due to the permission changes I asked for last week:

* Adds an OCI tarball artefact to each Docker "build" step ([example](https://github.com/micolous/kanidm/actions/runs/5572635351) [example](https://github.com/micolous/kanidm/actions/runs/5572635353)).
 
  Previously, this would be discarded entirely.

* Always run the actions on push to any branch, not just pull requests, so it's easier for someone to test their changes before they submit a PR.

  Someone can now also change the `*_push` job's `if` conditions to publish images as themselves on GHCR. [You can see an example of that in action in this run](https://github.com/micolous/kanidm/actions/runs/5572413407/jobs/10178487710), where I uploaded to `ghcr.io/micolous/radius:devel`.

* Upload the OCI tarball as a separate job (using `oras copy`), so that `package: write` permissions aren't applied to the entire build process.

  ORAS will preserve the multi-archness of images (if present); and I was able to pull images into an `amd64` system locally.

I've left the multi-arch hooks as-is to make sure this *can* upload a multi-arch image (even if it's currently invalid, per #1854); though it should at least make that easier to troubleshoot thanks to the artefact uploads.

Checklist

- [x] This pr contains no AI generated code
- [ ] ~~cargo fmt has been run~~
- [ ] ~~cargo clippy has been run~~
- [x] cargo test has been run and passes
- [ ] ~~book chapter included (if relevant)~~
- [ ] ~~design document included (if relevant)~~
