### PR TITLE
Revert to opensuse based radius container.

### DIFF
--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -5,7 +5,7 @@ RUN \
     zypper mr -k repo-oss; \
     zypper mr -k repo-non-oss; \
     zypper mr -k repo-update; \
-    zypper dup -y -v
+    zypper -v dup -y
 
 # ======================
 FROM repos

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -5,6 +5,7 @@ RUN \
     zypper mr -k repo-oss; \
     zypper mr -k repo-non-oss; \
     zypper mr -k repo-update; \
+    zypper ref --force; \
     zypper -v dup -y
 
 # ======================

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -1,22 +1,37 @@
-FROM freeradius/freeradius-server:latest
-EXPOSE 1812 1813
-ARG RADIUS_USER=freerad
-ARG TZ=Etc/UTC
-ENV TZ=$TZ
-# These all need to be on one line else the cache ends up in the layers.
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ARG BASE_IMAGE=opensuse/tumbleweed:latest
+FROM ${BASE_IMAGE} AS repos
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper mr -k repo-oss; \
+    zypper mr -k repo-non-oss; \
+    zypper mr -k repo-update; \
+    zypper dup -y
 
-RUN apt-get update && apt-get install -y \
-    freeradius-utils \
+# ======================
+FROM repos
+EXPOSE 1812 1813
+ARG RADIUS_USER=radiusd
+
+RUN \
+    --mount=type=cache,id=zypp,target=/var/cache/zypp \
+    zypper install -y \
+    freeradius-client \
+    freeradius-server \
+    freeradius-server-python3 \
+    freeradius-server-utils \
     hostname \
     python3 \
+    python3-devel \
     python3-pip \
-    python-is-python3 \
-    tzdata \
+    timezone \
     iproute2 \
-    iputils-ping iputils-tracepath \
+    iputils \
     openssl \
-    curl && apt-get clean
+    curl
+
+# Don't put in the TZ at build time - it needs to be bind mounted at runtime
+# else we are forcing things on people.
+# RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ADD  rlm_python/mods-available/ /etc/raddb/mods-available/
 COPY rlm_python/sites-available/ /etc/raddb/sites-available/
@@ -29,9 +44,8 @@ RUN ln -s /etc/raddb/mods-available/python3 /etc/raddb/mods-enabled/python3 && \
     ln -s /etc/raddb/sites-available/check-eap-tls /etc/raddb/sites-enabled/check-eap-tls
 
 # disable auth via methods we don't support!
-# RUN rm /etc/raddb/mods-available/sql && \
-    # rm /etc/raddb/mods-enabled/{passwd,totp}
-
+RUN rm /etc/raddb/mods-available/sql && \
+    rm /etc/raddb/mods-enabled/{passwd,totp}
 
 # Allows the radiusd user to write to the directory
 RUN chown -R $RADIUS_USER. /etc/raddb/ && \
@@ -42,8 +56,7 @@ RUN mkdir -p /pkg/pykanidm/
 COPY pykanidm/ /pkg/pykanidm/
 
 # install the package and its dependencies
-RUN python3 -m pip install --no-cache-dir --no-warn-script-location /pkg/pykanidm && \
-    rm -rf /pkg/*
+RUN python3 -m pip install --no-cache-dir --no-warn-script-location /pkg/pykanidm
 
 COPY rlm_python/radius_entrypoint.py /radius_entrypoint.py
 

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -5,7 +5,7 @@ RUN \
     zypper mr -k repo-oss; \
     zypper mr -k repo-non-oss; \
     zypper mr -k repo-update; \
-    zypper dup -y
+    zypper dup -y -v
 
 # ======================
 FROM repos

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,8 @@ RUN \
     zypper mr -k repo-oss; \
     zypper mr -k repo-non-oss; \
     zypper mr -k repo-update; \
-    zypper dup -y
+    zypper ref --force ; \
+    zypper -v dup -y
 
 # ======================
 FROM repos AS builder

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,7 +6,8 @@ RUN \
     zypper mr -k repo-oss; \
     zypper mr -k repo-non-oss; \
     zypper mr -k repo-update; \
-    zypper dup -y
+    zypper ref --force; \
+    zypper -v dup -y
 
 FROM repos AS builder
 ARG KANIDM_FEATURES


### PR DESCRIPTION
Fixes #1854 - freeradius docker image doesn't (no longer?) supports aarch64. Revert to the previous suse based container build. There are no other external changes to the way the container works.

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
