### PR TITLE
20230727 unix int modularity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,7 +4219,6 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,7 +2674,6 @@ dependencies = [
  "lru 0.8.1",
  "notify-debouncer-full",
  "profiles",
- "reqwest",
  "rpassword 7.2.0",
  "rusqlite",
  "selinux",
@@ -2687,6 +2686,7 @@ dependencies = [
  "tracing",
  "tss-esapi",
  "users",
+ "uuid",
  "walkdir",
 ]
 
@@ -4219,6 +4219,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "uuid",
 ]
 
 [[package]]

--- a/proto/src/v1.rs
+++ b/proto/src/v1.rs
@@ -556,7 +556,7 @@ impl fmt::Display for RadiusAuthToken {
 pub struct UnixGroupToken {
     pub name: String,
     pub spn: String,
-    pub uuid: String,
+    pub uuid: Uuid,
     pub gidnumber: u32,
 }
 
@@ -580,7 +580,7 @@ pub struct UnixUserToken {
     pub spn: String,
     pub displayname: String,
     pub gidnumber: u32,
-    pub uuid: String,
+    pub uuid: Uuid,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell: Option<String>,
     pub groups: Vec<UnixGroupToken>,

--- a/server/lib/src/idm/unix.rs
+++ b/server/lib/src/idm/unix.rs
@@ -150,7 +150,7 @@ impl UnixUserAccount {
             spn: self.spn.clone(),
             displayname: self.displayname.clone(),
             gidnumber: self.gidnumber,
-            uuid: self.uuid.as_hyphenated().to_string(),
+            uuid: self.uuid,
             shell: self.shell.clone(),
             groups,
             sshkeys: self.sshkeys.clone(),
@@ -449,7 +449,7 @@ impl UnixGroup {
         Ok(UnixGroupToken {
             name: self.name.clone(),
             spn: self.spn.clone(),
-            uuid: self.uuid.as_hyphenated().to_string(),
+            uuid: self.uuid,
             gidnumber: self.gidnumber,
         })
     }

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -563,7 +563,7 @@ async fn test_server_rest_posix_lifecycle(rsclient: KanidmClient) {
         .unwrap();
     // get the account by uuid
     let r3 = rsclient
-        .idm_account_unix_token_get(r.uuid.as_str())
+        .idm_account_unix_token_get(&r.uuid.hyphenated().to_string())
         .await
         .unwrap();
 
@@ -590,7 +590,7 @@ async fn test_server_rest_posix_lifecycle(rsclient: KanidmClient) {
         .unwrap();
     // get the group by uuid
     let r3 = rsclient
-        .idm_group_unix_token_get(r.uuid.as_str())
+        .idm_group_unix_token_get(&r.uuid.hyphenated().to_string())
         .await
         .unwrap();
 

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -58,7 +58,7 @@ kanidm_lib_crypto = { workspace = true }
 kanidm_lib_file_permissions = { workspace = true }
 notify-debouncer-full = { workspace = true }
 rpassword = { workspace = true }
-rusqlite = { workspace = true }
+rusqlite = { workspace = true, features = ["uuid"] }
 selinux = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -69,7 +69,7 @@ tokio = { workspace = true, features = ["rt", "fs", "macros", "sync", "time", "n
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tss-esapi = { workspace = true, optional = true }
-reqwest = { workspace = true, default-features = false }
+uuid = { workspace = true }
 walkdir = { workspace = true }
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -58,7 +58,7 @@ kanidm_lib_crypto = { workspace = true }
 kanidm_lib_file_permissions = { workspace = true }
 notify-debouncer-full = { workspace = true }
 rpassword = { workspace = true }
-rusqlite = { workspace = true, features = ["uuid"] }
+rusqlite = { workspace = true }
 selinux = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -28,6 +28,7 @@ use kanidm_proto::constants::DEFAULT_CLIENT_CONFIG_PATH;
 use kanidm_unix_common::constants::DEFAULT_CONFIG_PATH;
 use kanidm_unix_common::db::Db;
 use kanidm_unix_common::resolver::Resolver;
+use kanidm_unix_common::idprovider::kanidm::KanidmProvider;
 use kanidm_unix_common::unix_config::KanidmUnixdConfig;
 use kanidm_unix_common::unix_passwd::{parse_etc_group, parse_etc_passwd};
 use kanidm_unix_common::unix_proto::{ClientRequest, ClientResponse, TaskRequest, TaskResponse};
@@ -182,7 +183,7 @@ async fn handle_task_client(
 
 async fn handle_client(
     sock: UnixStream,
-    cachelayer: Arc<Resolver>,
+    cachelayer: Arc<Resolver<KanidmProvider>>,
     task_channel_tx: &Sender<AsyncTaskRequest>,
 ) -> Result<(), Box<dyn Error>> {
     debug!("Accepted connection");
@@ -372,7 +373,7 @@ async fn handle_client(
     Ok(())
 }
 
-async fn process_etc_passwd_group(cachelayer: &Resolver) -> Result<(), Box<dyn Error>> {
+async fn process_etc_passwd_group(cachelayer: &Resolver<KanidmProvider>) -> Result<(), Box<dyn Error>> {
     let mut file = File::open("/etc/passwd").await?;
     let mut contents = vec![];
     file.read_to_end(&mut contents).await?;

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -27,8 +27,8 @@ use kanidm_client::KanidmClientBuilder;
 use kanidm_proto::constants::DEFAULT_CLIENT_CONFIG_PATH;
 use kanidm_unix_common::constants::DEFAULT_CONFIG_PATH;
 use kanidm_unix_common::db::Db;
-use kanidm_unix_common::resolver::Resolver;
 use kanidm_unix_common::idprovider::kanidm::KanidmProvider;
+use kanidm_unix_common::resolver::Resolver;
 use kanidm_unix_common::unix_config::KanidmUnixdConfig;
 use kanidm_unix_common::unix_passwd::{parse_etc_group, parse_etc_passwd};
 use kanidm_unix_common::unix_proto::{ClientRequest, ClientResponse, TaskRequest, TaskResponse};
@@ -373,7 +373,9 @@ async fn handle_client(
     Ok(())
 }
 
-async fn process_etc_passwd_group(cachelayer: &Resolver<KanidmProvider>) -> Result<(), Box<dyn Error>> {
+async fn process_etc_passwd_group(
+    cachelayer: &Resolver<KanidmProvider>,
+) -> Result<(), Box<dyn Error>> {
     let mut file = File::open("/etc/passwd").await?;
     let mut contents = vec![];
     file.read_to_end(&mut contents).await?;
@@ -662,6 +664,8 @@ async fn main() -> ExitCode {
                 }
             };
 
+            let idprovider = KanidmProvider::new(rsclient);
+
             let db = match Db::new(cfg.db_path.as_str(), &cfg.tpm_policy) {
                 Ok(db) => db,
                 Err(_e) => {
@@ -672,8 +676,8 @@ async fn main() -> ExitCode {
 
             let cl_inner = match Resolver::new(
                 db,
+                idprovider,
                 cfg.cache_timeout,
-                rsclient,
                 cfg.pam_allowed_login_groups.clone(),
                 cfg.default_shell.clone(),
                 cfg.home_prefix.clone(),

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 /// and should be carefully selected to match your expected errors.
 #[derive(Debug)]
 pub enum IdpError {
-    /// An error occured in the underlying communication to the Idp. A timeout or
+    /// An error occurred in the underlying communication to the Idp. A timeout or
     /// or other communication issue exists. The resolver will take this provider
     /// offline.
     Transport,

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Errors that the IdProvider may return. These drive the resolver state machine
+/// and should be carefully selected to match your expected errors.
+#[derive(Debug)]
+pub enum IdpError {
+    /// An error occured in the underlying communication to the Idp. A timeout or
+    /// or other communication issue exists. The resolver will take this provider
+    /// offline.
+    Transport,
+    /// The provider is online but the provider module is not current authorised with
+    /// the idp. After returning this error the operation will be retried after a
+    /// successful authentication.
+    ProviderUnauthorised,
+    /// The provider made an invalid request to the idp, and the result is not able to
+    /// be used by the resolver.
+    BadRequest,
+    /// The idp has indicated that the requested resource does not exist and should
+    /// be considered deleted, removed, or not present.
+    NotFound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Id {
+    Name(String),
+    Gid(u32),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GroupToken {
+    pub name: String,
+    pub spn: String,
+    pub uuid: Uuid,
+    pub gidnumber: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UserToken {
+    pub name: String,
+    pub spn: String,
+    pub uuid: Uuid,
+    pub gidnumber: u32,
+    pub displayname: String,
+    pub shell: Option<String>,
+    pub groups: Vec<GroupToken>,
+    // Could there be a better type here?
+    pub sshkeys: Vec<String>,
+    // Defaults to false.
+    pub valid: bool,
+}
+
+#[async_trait]
+pub trait IdProvider {
+    async fn provider_authenticate(&self) -> Result<(), IdpError>;
+
+    async fn unix_user_get(&self, id: &Id) -> Result<UserToken, IdpError>;
+
+    async fn unix_user_authenticate(
+        &self,
+        id: &Id,
+        cred: &str,
+    ) -> Result<Option<UserToken>, IdpError>;
+
+    async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;
+}

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -33,7 +33,7 @@ impl From<UnixUserToken> for UserToken {
 
         let groups = groups
             .into_iter()
-            .map(|ugt| GroupToken::from(ugt))
+            .map(GroupToken::from)
             .collect();
 
         UserToken {

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -1,0 +1,264 @@
+use async_trait::async_trait;
+use kanidm_client::{ClientError, KanidmClient, StatusCode};
+use kanidm_proto::v1::{OperationError, UnixGroupToken, UnixUserToken};
+use tokio::sync::RwLock;
+
+use super::interface::{GroupToken, Id, IdProvider, IdpError, UserToken};
+
+pub struct KanidmProvider {
+    client: RwLock<KanidmClient>,
+}
+
+impl KanidmProvider {
+    pub fn new(client: KanidmClient) -> Self {
+        KanidmProvider {
+            client: RwLock::new(client),
+        }
+    }
+}
+
+impl From<UnixUserToken> for UserToken {
+    fn from(value: UnixUserToken) -> UserToken {
+        let UnixUserToken {
+            name,
+            spn,
+            displayname,
+            gidnumber,
+            uuid,
+            shell,
+            groups,
+            sshkeys,
+            valid,
+        } = value;
+
+        let groups = groups
+            .into_iter()
+            .map(|ugt| GroupToken::from(ugt))
+            .collect();
+
+        UserToken {
+            name,
+            spn,
+            uuid,
+            gidnumber,
+            displayname,
+            shell,
+            groups,
+            sshkeys,
+            valid,
+        }
+    }
+}
+
+impl From<UnixGroupToken> for GroupToken {
+    fn from(value: UnixGroupToken) -> GroupToken {
+        let UnixGroupToken {
+            name,
+            spn,
+            uuid,
+            gidnumber,
+        } = value;
+
+        GroupToken {
+            name,
+            spn,
+            uuid,
+            gidnumber,
+        }
+    }
+}
+
+#[async_trait]
+impl IdProvider for KanidmProvider {
+    // Needs .read on all types except re-auth.
+
+    async fn provider_authenticate(&self) -> Result<(), IdpError> {
+        match self.client.write().await.auth_anonymous().await {
+            Ok(_uat) => Ok(()),
+            Err(err) => {
+                error!(?err, "Provider authentication failed");
+                Err(IdpError::ProviderUnauthorised)
+            }
+        }
+    }
+
+    async fn unix_user_get(&self, id: &Id) -> Result<UserToken, IdpError> {
+        match self
+            .client
+            .read()
+            .await
+            .idm_account_unix_token_get(id.to_string().as_str())
+            .await
+        {
+            Ok(tok) => Ok(UserToken::from(tok)),
+            Err(ClientError::Transport(err)) => {
+                error!(?err);
+                Err(IdpError::Transport)
+            }
+            Err(ClientError::Http(StatusCode::UNAUTHORIZED, reason, opid)) => {
+                match reason {
+                    Some(OperationError::NotAuthenticated) => warn!(
+                        "session not authenticated - attempting reauthentication - eventid {}",
+                        opid
+                    ),
+                    Some(OperationError::SessionExpired) => warn!(
+                        "session expired - attempting reauthentication - eventid {}",
+                        opid
+                    ),
+                    e => error!(
+                        "authentication error {:?}, moving to offline - eventid {}",
+                        e, opid
+                    ),
+                };
+                Err(IdpError::ProviderUnauthorised)
+            }
+            Err(ClientError::Http(
+                StatusCode::BAD_REQUEST,
+                Some(OperationError::NoMatchingEntries),
+                opid,
+            ))
+            | Err(ClientError::Http(
+                StatusCode::NOT_FOUND,
+                Some(OperationError::NoMatchingEntries),
+                opid,
+            ))
+            | Err(ClientError::Http(
+                StatusCode::BAD_REQUEST,
+                Some(OperationError::InvalidAccountState(_)),
+                opid,
+            )) => {
+                debug!(
+                    ?opid,
+                    "entry has been removed or is no longer a valid posix account"
+                );
+                Err(IdpError::NotFound)
+            }
+            Err(err) => {
+                error!(?err, "client error");
+                Err(IdpError::BadRequest)
+            }
+        }
+    }
+
+    async fn unix_user_authenticate(
+        &self,
+        id: &Id,
+        cred: &str,
+    ) -> Result<Option<UserToken>, IdpError> {
+        match self
+            .client
+            .read()
+            .await
+            .idm_account_unix_cred_verify(id.to_string().as_str(), cred)
+            .await
+        {
+            Ok(Some(n_tok)) => Ok(Some(UserToken::from(n_tok))),
+            Ok(None) => Ok(None),
+            Err(ClientError::Transport(err)) => {
+                error!(?err);
+                Err(IdpError::Transport)
+            }
+            Err(ClientError::Http(StatusCode::UNAUTHORIZED, reason, opid)) => {
+                match reason {
+                    Some(OperationError::NotAuthenticated) => warn!(
+                        "session not authenticated - attempting reauthentication - eventid {}",
+                        opid
+                    ),
+                    Some(OperationError::SessionExpired) => warn!(
+                        "session expired - attempting reauthentication - eventid {}",
+                        opid
+                    ),
+                    e => error!(
+                        "authentication error {:?}, moving to offline - eventid {}",
+                        e, opid
+                    ),
+                };
+                Err(IdpError::ProviderUnauthorised)
+            }
+            Err(ClientError::Http(
+                StatusCode::BAD_REQUEST,
+                Some(OperationError::NoMatchingEntries),
+                opid,
+            ))
+            | Err(ClientError::Http(
+                StatusCode::NOT_FOUND,
+                Some(OperationError::NoMatchingEntries),
+                opid,
+            ))
+            | Err(ClientError::Http(
+                StatusCode::BAD_REQUEST,
+                Some(OperationError::InvalidAccountState(_)),
+                opid,
+            )) => {
+                error!(
+                    "unknown account or is not a valid posix account - eventid {}",
+                    opid
+                );
+                Err(IdpError::NotFound)
+            }
+            Err(err) => {
+                error!(?err, "client error");
+                // Some other unknown processing error?
+                Err(IdpError::BadRequest)
+            }
+        }
+    }
+
+    async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError> {
+        match self
+            .client
+            .read()
+            .await
+            .idm_group_unix_token_get(id.to_string().as_str())
+            .await
+        {
+            Ok(tok) => Ok(GroupToken::from(tok)),
+            Err(ClientError::Transport(err)) => {
+                error!(?err);
+                Err(IdpError::Transport)
+            }
+            Err(ClientError::Http(StatusCode::UNAUTHORIZED, reason, opid)) => {
+                match reason {
+                    Some(OperationError::NotAuthenticated) => warn!(
+                        "session not authenticated - attempting reauthentication - eventid {}",
+                        opid
+                    ),
+                    Some(OperationError::SessionExpired) => warn!(
+                        "session expired - attempting reauthentication - eventid {}",
+                        opid
+                    ),
+                    e => error!(
+                        "authentication error {:?}, moving to offline - eventid {}",
+                        e, opid
+                    ),
+                };
+                Err(IdpError::ProviderUnauthorised)
+            }
+            Err(ClientError::Http(
+                StatusCode::BAD_REQUEST,
+                Some(OperationError::NoMatchingEntries),
+                opid,
+            ))
+            | Err(ClientError::Http(
+                StatusCode::NOT_FOUND,
+                Some(OperationError::NoMatchingEntries),
+                opid,
+            ))
+            | Err(ClientError::Http(
+                StatusCode::BAD_REQUEST,
+                Some(OperationError::InvalidAccountState(_)),
+                opid,
+            )) => {
+                debug!(
+                    ?opid,
+                    "entry has been removed or is no longer a valid posix group"
+                );
+                Err(IdpError::NotFound)
+            }
+            Err(err) => {
+                error!(?err, "client error");
+                Err(IdpError::BadRequest)
+            }
+        }
+    }
+}

--- a/unix_integration/src/idprovider/mod.rs
+++ b/unix_integration/src/idprovider/mod.rs
@@ -1,0 +1,2 @@
+pub mod interface;
+pub mod kanidm;

--- a/unix_integration/src/lib.rs
+++ b/unix_integration/src/lib.rs
@@ -26,6 +26,8 @@ pub mod constants;
 #[cfg(target_family = "unix")]
 pub mod db;
 #[cfg(target_family = "unix")]
+pub mod idprovider;
+#[cfg(target_family = "unix")]
 pub mod resolver;
 #[cfg(all(target_family = "unix", feature = "selinux"))]
 pub mod selinux_util;

--- a/unix_integration/src/ssh_authorizedkeys.rs
+++ b/unix_integration/src/ssh_authorizedkeys.rs
@@ -65,7 +65,7 @@ async fn main() -> ExitCode {
     }
     let req = ClientRequest::SshKey(opt.account_id);
 
-    match call_daemon(cfg.sock_path.as_str(), req).await {
+    match call_daemon(cfg.sock_path.as_str(), req, cfg.unix_sock_timeout).await {
         Ok(r) => match r {
             ClientResponse::SshKeys(sk) => sk.iter().for_each(|k| {
                 println!("{}", k);

--- a/unix_integration/tests/cache_layer_test.rs
+++ b/unix_integration/tests/cache_layer_test.rs
@@ -108,8 +108,8 @@ async fn setup_test(fix_fn: Fixture) -> (Resolver, KanidmClient) {
 
     let cachelayer = Resolver::new(
         db,
-        300,
         rsclient,
+        300,
         vec!["allowed_group".to_string()],
         DEFAULT_SHELL.to_string(),
         DEFAULT_HOME_PREFIX.to_string(),


### PR DESCRIPTION
Break out the Idp layer as the next step to assist @dmulder with himmelblaud. This creates an interface of idprovider that different backends can implement which drives the primary cache and db layers. 

Next up I need to split this to a unix_int_generic library to remove kani specific parts. In that I'll also need to tidy up some of the tpm features too. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
