### PR TITLE
bumping action version for WASM testing

### DIFF
--- a/.github/workflows/wasm_test.yml
+++ b/.github/workflows/wasm_test.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           chrome-version: latest
       # https://github.com/marketplace/actions/setup-chromedriver
-      - uses: nanasess/setup-chromedriver@v1
+      - uses: nanasess/setup-chromedriver@v2
       # with:
       # Optional: do not specify to match Chrome's version
       # chromedriver-version: '88.0.4324.96'


### PR DESCRIPTION
Fixes failed builds due to the chrome driver going missing for the v1 action:
https://github.com/kanidm/kanidm/actions/runs/5678551696/job/15390791824

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
