### PR TITLE
Allow one-character usernames

### DIFF
--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -53,7 +53,7 @@ lazy_static! {
     /// Only lowercase+numbers, with limited chars.
     pub static ref INAME_RE: Regex = {
         #[allow(clippy::expect_used)]
-        Regex::new("^[a-z][a-z0-9-_\\.]+$").expect("Invalid Iname regex found")
+        Regex::new("^[a-z][a-z0-9-_\\.]*$").expect("Invalid Iname regex found")
     };
 
     pub static ref EXTRACT_VAL_DN: Regex = {


### PR DESCRIPTION
Previously, usernames had to be at least two characters because of this regex. I'm not aware of any issues around one-character usernames and happen to have one in my environment. This seems fine, e.g. adduser uses a validation regex that allows them (but I'd be happy to hear if there's a reason not to allow them). This just changes the regex to make a single letter a valid username.

Checklist

- [X] This pr contains no AI generated code
- [X] cargo fmt has been run
- [X] cargo clippy has been run
- [X] cargo test has been run and passes
- [X] book chapter included (if relevant)
- [X] design document included (if relevant)
