### PR TITLE
error handling and web server logging fixes

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -204,7 +204,7 @@ impl KanidmClientBuilder {
         let verify_ca = kcc.verify_ca.unwrap_or(verify_ca);
         let verify_hostnames = kcc.verify_hostnames.unwrap_or(verify_hostnames);
         let ca = match kcc.ca_path {
-            Some(ca_path) => Some(Self::parse_certificate(ca_path.as_str())?),
+            Some(ca_path) => Some(Self::parse_certificate(&ca_path)?),
             None => ca,
         };
 
@@ -271,7 +271,7 @@ impl KanidmClientBuilder {
             ClientError::ConfigParseIssue(format!("{:?}", e))
         })?;
 
-        let config: KanidmClientConfig = toml::from_str(contents.as_str()).map_err(|e| {
+        let config: KanidmClientConfig = toml::from_str(&contents).map_err(|e| {
             error!("{:?}", e);
             ClientError::ConfigParseIssue(format!("{:?}", e))
         })?;
@@ -396,7 +396,7 @@ impl KanidmClientBuilder {
             }
         };
 
-        self.display_warnings(address.as_str());
+        self.display_warnings(&address);
 
         let client_builder = reqwest::Client::builder()
             .user_agent(KanidmClientBuilder::user_agent())
@@ -447,8 +447,14 @@ impl KanidmClient {
         &self.origin
     }
 
+    /// Returns the base URL of the server
     pub fn get_url(&self) -> &str {
-        self.addr.as_str()
+        &self.addr
+    }
+
+    /// Get a URL based on adding an endpoint to the base URL of the server
+    pub fn make_url(&self, endpoint: &impl ToString) -> String {
+        format!("{}{}", self.get_url(), endpoint.to_string())
     }
 
     pub async fn set_token(&self, new_token: String) {
@@ -474,6 +480,7 @@ impl KanidmClient {
         Ok(())
     }
 
+    /// Check that we're getting the right version back from the server.
     async fn expect_version(&self, response: &reqwest::Response) {
         let mut guard = self.check_version.lock().await;
 
@@ -508,13 +515,11 @@ impl KanidmClient {
         dest: &str,
         request: &R,
     ) -> Result<T, ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-
         let req_string = serde_json::to_string(request).map_err(ClientError::JsonEncode)?;
 
         let response = self
             .client
-            .post(dest.as_str())
+            .post(self.make_url(&dest))
             .body(req_string)
             .header(CONTENT_TYPE, APPLICATION_JSON);
 
@@ -552,13 +557,12 @@ impl KanidmClient {
         dest: &str,
         request: R,
     ) -> Result<T, ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
         trace!("perform_auth_post_request connecting to {}", dest);
         let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
 
         let response = self
             .client
-            .post(dest.as_str())
+            .post(self.make_url(&dest))
             .body(req_string)
             .header(CONTENT_TYPE, APPLICATION_JSON);
 
@@ -626,12 +630,10 @@ impl KanidmClient {
         dest: &str,
         request: R,
     ) -> Result<T, ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-
         let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
         let response = self
             .client
-            .post(dest.as_str())
+            .post(self.make_url(&dest))
             .body(req_string)
             .header(CONTENT_TYPE, APPLICATION_JSON);
 
@@ -678,13 +680,11 @@ impl KanidmClient {
         dest: &str,
         request: R,
     ) -> Result<T, ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-
         let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
 
         let response = self
             .client
-            .put(dest.as_str())
+            .put(self.make_url(&dest))
             .header(CONTENT_TYPE, APPLICATION_JSON);
         let response = {
             let tguard = self.bearer_token.read().await;
@@ -734,12 +734,10 @@ impl KanidmClient {
         dest: &str,
         request: R,
     ) -> Result<T, ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-
         let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
         let response = self
             .client
-            .patch(dest.as_str())
+            .patch(self.make_url(&dest))
             .body(req_string)
             .header(CONTENT_TYPE, APPLICATION_JSON);
 
@@ -782,10 +780,11 @@ impl KanidmClient {
     }
 
     #[instrument(level = "debug", skip(self))]
-    async fn perform_get_request<T: DeserializeOwned>(&self, dest: &str) -> Result<T, ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-        let response = self.client.get(dest.as_str());
-
+    pub async fn perform_get_request<T: DeserializeOwned>(
+        &self,
+        dest: &str,
+    ) -> Result<T, ClientError> {
+        let response = self.client.get(self.make_url(&dest));
         let response = {
             let tguard = self.bearer_token.read().await;
             if let Some(token) = &(*tguard) {
@@ -826,11 +825,9 @@ impl KanidmClient {
     }
 
     async fn perform_delete_request(&self, dest: &str) -> Result<(), ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-
         let response = self
             .client
-            .delete(dest.as_str())
+            .delete(self.make_url(&dest))
             .header(CONTENT_TYPE, APPLICATION_JSON);
 
         let response = {
@@ -876,12 +873,10 @@ impl KanidmClient {
         dest: &str,
         request: R,
     ) -> Result<(), ClientError> {
-        let dest = format!("{}{}", self.get_url(), dest);
-
         let req_string = serde_json::to_string(&request).map_err(ClientError::JsonEncode)?;
         let response = self
             .client
-            .delete(dest.as_str())
+            .delete(self.make_url(&dest))
             .body(req_string)
             .header(CONTENT_TYPE, APPLICATION_JSON);
 
@@ -1352,10 +1347,7 @@ impl KanidmClient {
     }
 
     pub async fn whoami(&self) -> Result<Option<Entry>, ClientError> {
-        let whoami_dest = [self.addr.as_str(), "/v1/self"].concat();
-        // format!("{}/v1/self", self.addr);
-        debug!("{:?}", whoami_dest);
-        let response = self.client.get(whoami_dest.as_str());
+        let response = self.client.get(self.make_url(&"/v1/self"));
 
         let response = {
             let tguard = self.bearer_token.read().await;
@@ -1429,15 +1421,14 @@ impl KanidmClient {
     }
 
     pub async fn idm_group_get(&self, id: &str) -> Result<Option<Entry>, ClientError> {
-        self.perform_get_request(format!("/v1/group/{}", id).as_str())
-            .await
+        self.perform_get_request(&format!("/v1/group/{}", id)).await
     }
 
     pub async fn idm_group_get_members(
         &self,
         id: &str,
     ) -> Result<Option<Vec<String>>, ClientError> {
-        self.perform_get_request(format!("/v1/group/{}/_attr/member", id).as_str())
+        self.perform_get_request(&format!("/v1/group/{}/_attr/member", id))
             .await
     }
 
@@ -1457,7 +1448,7 @@ impl KanidmClient {
         members: &[&str],
     ) -> Result<(), ClientError> {
         let m: Vec<_> = members.iter().map(|v| (*v).to_string()).collect();
-        self.perform_put_request(format!("/v1/group/{}/_attr/member", id).as_str(), m)
+        self.perform_put_request(&format!("/v1/group/{}/_attr/member", id), m)
             .await
     }
 
@@ -1467,7 +1458,7 @@ impl KanidmClient {
         members: &[&str],
     ) -> Result<(), ClientError> {
         let m: Vec<_> = members.iter().map(|v| (*v).to_string()).collect();
-        self.perform_post_request(["/v1/group/", id, "/_attr/member"].concat().as_str(), m)
+        self.perform_post_request(&format!("/v1/group/{}/_attr/member", id), m)
             .await
     }
 
@@ -1477,24 +1468,19 @@ impl KanidmClient {
         members: &[&str],
     ) -> Result<(), ClientError> {
         debug!(
-            "{}",
-            &[
-                "Asked to remove members ",
-                &members.join(","),
-                " from ",
-                group
-            ]
-            .concat()
+            "Asked to remove members {} from {}",
+            &members.join(","),
+            group
         );
         self.perform_delete_request_with_body(
-            ["/v1/group/", group, "/_attr/member"].concat().as_str(),
+            &format!("/v1/group/{}/_attr/member", group),
             &members,
         )
         .await
     }
 
     pub async fn idm_group_purge_members(&self, id: &str) -> Result<(), ClientError> {
-        self.perform_delete_request(format!("/v1/group/{}/_attr/member", id).as_str())
+        self.perform_delete_request(&format!("/v1/group/{}/_attr/member", id))
             .await
     }
 
@@ -1504,26 +1490,24 @@ impl KanidmClient {
         gidnumber: Option<u32>,
     ) -> Result<(), ClientError> {
         let gx = GroupUnixExtend { gidnumber };
-        self.perform_post_request(format!("/v1/group/{}/_unix", id).as_str(), gx)
+        self.perform_post_request(&format!("/v1/group/{}/_unix", id), gx)
             .await
     }
 
     pub async fn idm_group_unix_token_get(&self, id: &str) -> Result<UnixGroupToken, ClientError> {
-        self.perform_get_request(["/v1/group/", id, "/_unix/_token"].concat().as_str())
+        self.perform_get_request(&format!("/v1/group/{}/_unix/_token", id))
             .await
     }
 
     pub async fn idm_group_delete(&self, id: &str) -> Result<(), ClientError> {
-        self.perform_delete_request(["/v1/group/", id].concat().as_str())
+        self.perform_delete_request(&format!("/v1/group/{}", id))
             .await
     }
 
     // ==== ACCOUNTS
 
     pub async fn idm_account_unix_token_get(&self, id: &str) -> Result<UnixUserToken, ClientError> {
-        // Format doesn't work in async
-        // format!("/v1/account/{}/_unix/_token", id).as_str()
-        self.perform_get_request(["/v1/account/", id, "/_unix/_token"].concat().as_str())
+        self.perform_get_request(&format!("/v1/account/{}/_unix/_token", id))
             .await
     }
 
@@ -1535,15 +1519,14 @@ impl KanidmClient {
         ttl: Option<u32>,
     ) -> Result<CUIntentToken, ClientError> {
         if let Some(ttl) = ttl {
-            self.perform_get_request(
-                format!("/v1/person/{}/_credential/_update_intent?ttl={}", id, ttl).as_str(),
-            )
+            self.perform_get_request(&format!(
+                "/v1/person/{}/_credential/_update_intent?ttl={}",
+                id, ttl
+            ))
             .await
         } else {
-            self.perform_get_request(
-                format!("/v1/person/{}/_credential/_update_intent", id).as_str(),
-            )
-            .await
+            self.perform_get_request(&format!("/v1/person/{}/_credential/_update_intent", id))
+                .await
         }
     }
 
@@ -1551,7 +1534,7 @@ impl KanidmClient {
         &self,
         id: &str,
     ) -> Result<(CUSessionToken, CUStatus), ClientError> {
-        self.perform_get_request(format!("/v1/person/{}/_credential/_update", id).as_str())
+        self.perform_get_request(&format!("/v1/person/{}/_credential/_update", id))
             .await
     }
 
@@ -1692,7 +1675,7 @@ impl KanidmClient {
         &self,
         id: &str,
     ) -> Result<RadiusAuthToken, ClientError> {
-        self.perform_get_request(format!("/v1/account/{}/_radius/_token", id).as_str())
+        self.perform_get_request(&format!("/v1/account/{}/_radius/_token", id))
             .await
     }
 
@@ -1704,7 +1687,7 @@ impl KanidmClient {
         let req = SingleStringRequest {
             value: cred.to_string(),
         };
-        self.perform_post_request(["/v1/account/", id, "/_unix/_auth"].concat().as_str(), req)
+        self.perform_post_request(&format!("/v1/account/{}/_unix/_auth", id), req)
             .await
     }
 
@@ -1714,12 +1697,12 @@ impl KanidmClient {
         id: &str,
         tag: &str,
     ) -> Result<Option<String>, ClientError> {
-        self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
+        self.perform_get_request(&format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag))
             .await
     }
 
     pub async fn idm_account_get_ssh_pubkeys(&self, id: &str) -> Result<Vec<String>, ClientError> {
-        self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys", id).as_str())
+        self.perform_get_request(&format!("/v1/account/{}/_ssh_pubkeys", id))
             .await
     }
 
@@ -1783,7 +1766,7 @@ impl KanidmClient {
         &self,
         id: &str,
     ) -> Result<Option<Entry>, ClientError> {
-        self.perform_get_request(format!("/v1/schema/attributetype/{}", id).as_str())
+        self.perform_get_request(&format!("/v1/schema/attributetype/{}", id))
             .await
     }
 
@@ -1792,7 +1775,7 @@ impl KanidmClient {
     }
 
     pub async fn idm_schema_classtype_get(&self, id: &str) -> Result<Option<Entry>, ClientError> {
-        self.perform_get_request(format!("/v1/schema/classtype/{}", id).as_str())
+        self.perform_get_request(&format!("/v1/schema/classtype/{}", id))
             .await
     }
 
@@ -1802,12 +1785,12 @@ impl KanidmClient {
     }
 
     pub async fn recycle_bin_get(&self, id: &str) -> Result<Option<Entry>, ClientError> {
-        self.perform_get_request(format!("/v1/recycle_bin/{}", id).as_str())
+        self.perform_get_request(&format!("/v1/recycle_bin/{}", id))
             .await
     }
 
     pub async fn recycle_bin_revive(&self, id: &str) -> Result<(), ClientError> {
-        self.perform_post_request(format!("/v1/recycle_bin/{}/_revive", id).as_str(), ())
+        self.perform_post_request(&format!("/v1/recycle_bin/{}/_revive", id), ())
             .await
     }
 }

--- a/libs/profiles/build.rs
+++ b/libs/profiles/build.rs
@@ -6,7 +6,7 @@ use base64::{engine::general_purpose, Engine as _};
 // We do this here so it's only actually run and checked once.
 fn determine_git_rev() -> Option<String> {
     let path = PathBuf::from("../../");
-    let repo = git2::Repository::open(&path).ok()?;
+    let repo = git2::Repository::open(path).ok()?;
     let head = repo.head().ok()?;
     let commit = head.peel_to_commit().ok()?;
     let mut commit_id = commit.id().to_string();

--- a/proto/src/v1.rs
+++ b/proto/src/v1.rs
@@ -1,3 +1,5 @@
+#![allow(non_upper_case_globals)]
+
 use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -293,14 +295,6 @@ pub struct Claim {
     // some may even need requesting.
     // pub expiry: DateTime
 }
-
-/*
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Application {
-    pub name: String,
-    pub uuid: String,
-}
-*/
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 #[serde(rename_all = "lowercase")]

--- a/scripts/setup_dev_environment.sh
+++ b/scripts/setup_dev_environment.sh
@@ -30,6 +30,11 @@ if [ ! -f run_insecure_dev_server.sh ]; then
     exit 1
 fi
 
+# defaults
+KANIDM_CONFIG_FILE="../../examples/insecure_server.toml"
+KANIDM_URL="$(rg origin "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')"
+KANIDM_CA_PATH="/tmp/kanidm/ca.pem"
+
 # wait for them to shut down the server if it's running...
 while true; do
     if [ "$(pgrep kanidmd | wc -l)" -eq 1 ]; then
@@ -43,11 +48,6 @@ while true; do
         sleep 2
     done
 done
-
-# defaults
-KANIDM_CONFIG_FILE="../../examples/insecure_server.toml"
-KANIDM_URL="$(rg origin "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')"
-KANIDM_CA_PATH="/tmp/kanidm/ca.pem"
 
 # needed for the CLI tools to do their thing
 export KANIDM_URL

--- a/scripts/zypper_fixing.sh
+++ b/scripts/zypper_fixing.sh
@@ -2,12 +2,16 @@
 
 # makes sure the repos are configured because the containers are derpy sometimes
 
+set -e
+
 #disable the openh264 repo
 if [ "$(zypper lr | grep -ci 'repo-openh264')" -eq 1 ]; then
-    zypper mr -d -f -n 'repo-openh264'
+    echo "Disabling openh264 repo"
+    zypper mr -d -f repo-openh264
 fi
 
 # add the non-oss repo if it doesn't exist
+echo "Adding the non-oss repo"
 if [ "$(zypper lr | grep -c 'repo-non-oss')" -eq 0 ]; then
     zypper ar -f -n 'Non-OSS' http://download.opensuse.org/tumbleweed/repo/non-oss/ repo-non-oss
 fi

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -618,10 +618,15 @@ impl QueryServerReadV1 {
             .qs_read
             .name_to_uuid(uuid_or_name.as_str())
             .map_err(|e| {
+                // sometimes it comes back as empty which is bad
+                let uuid_or_name_val = match uuid_or_name.is_empty() {
+                    true => "<empty uuid_or_name>",
+                    false => &uuid_or_name,
+                };
                 admin_info!(
                     err = ?e,
                     "Error resolving {} as gidnumber continuing ...",
-                    uuid_or_name
+                    uuid_or_name_val
                 );
                 e
             })?;

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -618,7 +618,8 @@ impl QueryServerReadV1 {
             .qs_read
             .name_to_uuid(uuid_or_name.as_str())
             .map_err(|e| {
-                // sometimes it comes back as empty which is bad
+                // sometimes it comes back as empty which is bad, it's safe to start with `<empty` here
+                // because a valid username/uuid can never start with that and we're only logging it
                 let uuid_or_name_val = match uuid_or_name.is_empty() {
                     true => "<empty uuid_or_name>",
                     false => &uuid_or_name,

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -70,7 +70,7 @@ pub async fn are_we_json_yet<B>(request: Request<B>, next: Next<B>) -> Response 
 }
 
 /// This runs at the start of the request, adding an extension with `KOpId` which has useful things inside it.
-#[instrument(name = "request", skip_all)]
+#[instrument(name = "kopid_middleware", skip_all, level = "DEBUG")]
 pub async fn kopid_middleware<B>(
     auth: Option<TypedHeader<Authorization<Bearer>>>,
     mut request: Request<B>,
@@ -86,10 +86,11 @@ pub async fn kopid_middleware<B>(
     request.extensions_mut().insert(KOpId { eventid, uat });
     let mut response = next.run(request).await;
 
-    #[allow(clippy::unwrap_used)]
+    #[allow(clippy::expect_used)]
     response.headers_mut().insert(
         "X-KANIDM-OPID",
-        HeaderValue::from_str(&eventid.as_hyphenated().to_string()).unwrap(),
+        HeaderValue::from_str(&eventid.as_hyphenated().to_string())
+            .expect("Failed to set X-KANIDM-OPID header in response!"),
     );
 
     response

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -252,19 +252,19 @@ pub async fn create_https_server(
         .layer(from_fn(middleware::version_middleware))
         .layer(from_fn(
             middleware::hsts_header::strict_transport_security_layer,
-        ))
-        .layer(from_fn(middleware::kopid_middleware));
+        ));
 
     // layer which checks the responses have a content-type of JSON when we're in debug mode
     #[cfg(debug_assertions)]
     let app = app.layer(from_fn(middleware::are_we_json_yet));
 
     let app = app
+        .layer(trace_layer)
         // This must be the LAST middleware.
         // This is because the last middleware here is the first to be entered and the last
         // to be exited, and this middleware sets up ids' and other bits for for logging
         // coherence to be maintained.
-        .layer(trace_layer)
+        .layer(from_fn(middleware::kopid_middleware))
         .with_state(state)
         // the connect_info bit here lets us pick up the remote address of the client
         .into_make_service_with_connect_info::<SocketAddr>();

--- a/server/core/src/https/trace.rs
+++ b/server/core/src/https/trace.rs
@@ -1,0 +1,37 @@
+//! Reimplementation of [`tower-http`]'s [`DefaultMakeSpan`] that only runs at "INFO" level for our own needs.
+
+use http::Request;
+use tracing::{Level, Span};
+
+/// The default way [`Span`]s will be created for [`Trace`].
+///
+/// [`Span`]: tracing::Span
+/// [`Trace`]: super::Trace
+#[derive(Debug, Clone)]
+pub struct DefaultMakeSpanKanidmd {}
+
+impl DefaultMakeSpanKanidmd {
+    /// Create a new `DefaultMakeSpanKanidmd`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for DefaultMakeSpanKanidmd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<B> tower_http::trace::MakeSpan<B> for DefaultMakeSpanKanidmd {
+    #[instrument(name = "handle_request", skip_all)]
+    fn make_span(&mut self, request: &Request<B>) -> Span {
+        tracing::span!(
+            Level::INFO,
+            "request",
+            method = %request.method(),
+            uri = %request.uri(),
+            version = ?request.version(),
+        )
+    }
+}

--- a/server/testkit/src/lib.rs
+++ b/server/testkit/src/lib.rs
@@ -99,25 +99,24 @@ pub async fn create_user(rsclient: &KanidmClient, id: &str, group_name: &str) {
         .expect("Failed to create the user");
 
     // Create group and add to user to test read attr: member_of
-    #[allow(clippy::expect_used)]
+    #[allow(clippy::panic)]
     if rsclient
         .idm_group_get(group_name)
         .await
-        .expect("Failed to get group")
+        .unwrap_or_else(|_| panic!("Failed to get group {}", group_name))
         .is_none()
     {
-        #[allow(clippy::expect_used)]
+        #[allow(clippy::panic)]
         rsclient
             .idm_group_create(group_name)
             .await
-            .expect("Failed to create group");
+            .unwrap_or_else(|_| panic!("Failed to create group {}", group_name));
     }
-
-    #[allow(clippy::expect_used)]
+    #[allow(clippy::panic)]
     rsclient
         .idm_group_add_members(group_name, &[id])
         .await
-        .expect("Failed to set group membership for user");
+        .unwrap_or_else(|_| panic!("Failed to add user {} to group {}", id, group_name));
 }
 
 pub async fn create_user_with_all_attrs(

--- a/server/testkit/tests/default_entries.rs
+++ b/server/testkit/tests/default_entries.rs
@@ -554,12 +554,15 @@ async fn test_self_write_mail_priv_people(rsclient: KanidmClient) {
 #[kanidmd_testkit::test]
 async fn test_https_robots_txt(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
 
-    let response = match reqwest::get(format!("{}/robots.txt", &addr)).await {
+    let response = match reqwest::get(rsclient.make_url("/robots.txt")).await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/robots.txt"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);
@@ -577,9 +580,7 @@ async fn test_https_robots_txt(rsclient: KanidmClient) {
 // #[kanidmd_testkit::test]
 // async fn test_https_routemap(rsclient: KanidmClient) {
 //     // We need to do manual reqwests here.
-//     let addr = rsclient.get_url();
-
-//     let response = match reqwest::get(format!("{}/v1/routemap", &addr)).await {
+//     let response = match reqwest::get(rsclient.make_url("/v1/routemap")).await {
 //         Ok(value) => value,
 //         Err(error) => {
 //             panic!("Failed to query {:?} : {:#?}", addr, error);
@@ -598,7 +599,7 @@ async fn test_https_robots_txt(rsclient: KanidmClient) {
 #[kanidmd_testkit::test]
 async fn test_v1_raw_delete(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
+
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
@@ -607,7 +608,7 @@ async fn test_v1_raw_delete(rsclient: KanidmClient) {
     let post_body = serde_json::json!({"filter": "self"}).to_string();
 
     let response = match client
-        .post(format!("{}/v1/raw/delete", &addr))
+        .post(rsclient.make_url("/v1/raw/delete"))
         .header(CONTENT_TYPE, APPLICATION_JSON)
         .body(post_body)
         .send()
@@ -615,7 +616,11 @@ async fn test_v1_raw_delete(rsclient: KanidmClient) {
     {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/v1/raw/delete"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);
@@ -629,16 +634,19 @@ async fn test_v1_raw_delete(rsclient: KanidmClient) {
 #[kanidmd_testkit::test]
 async fn test_v1_raw_logout(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap();
 
-    let response = match client.get(format!("{}/v1/logout", &addr)).send().await {
+    let response = match client.get(rsclient.make_url("/v1/logout")).send().await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/v1/logout"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);
@@ -652,16 +660,19 @@ async fn test_v1_raw_logout(rsclient: KanidmClient) {
 #[kanidmd_testkit::test]
 async fn test_status_endpoint(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap();
 
-    let response = match client.get(format!("{}/status", &addr)).send().await {
+    let response = match client.get(rsclient.make_url("/status")).send().await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/status"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/http_manifest.rs
+++ b/server/testkit/tests/http_manifest.rs
@@ -3,13 +3,16 @@ use kanidm_client::KanidmClient;
 #[kanidmd_testkit::test]
 async fn test_https_manifest(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
 
     // here we test the /ui/ endpoint which should have the headers
-    let response = match reqwest::get(format!("{}/manifest.webmanifest", &addr)).await {
+    let response = match reqwest::get(rsclient.make_url("/manifest.webmanifest")).await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/manifest.webmanifest"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/https_middleware.rs
+++ b/server/testkit/tests/https_middleware.rs
@@ -3,13 +3,16 @@ use kanidm_client::KanidmClient;
 #[kanidmd_testkit::test]
 async fn test_https_middleware_headers(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
 
     // here we test the /ui/ endpoint which should have the headers
-    let response = match reqwest::get(format!("{}/ui", &addr)).await {
+    let response = match reqwest::get(rsclient.make_url("/ui")).await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/ui"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);
@@ -21,10 +24,14 @@ async fn test_https_middleware_headers(rsclient: KanidmClient) {
     assert_ne!(response.headers().get("content-security-policy"), None);
 
     // here we test the /ui/login endpoint which should have the headers
-    let response = match reqwest::get(format!("{}/ui/login", &addr)).await {
+    let response = match reqwest::get(rsclient.make_url("/ui/login")).await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/ui/login"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/integration.rs
+++ b/server/testkit/tests/integration.rs
@@ -82,7 +82,7 @@ async fn test_webdriver_user_login(rsclient: kanidm_client::KanidmClient) {
 
     handle_error!(
         c,
-        c.goto(rsclient.get_url().to_string()).await,
+        c.goto(&rsclient.get_url().into()).await,
         "Couldn't get URL"
     );
 

--- a/server/testkit/tests/integration.rs
+++ b/server/testkit/tests/integration.rs
@@ -82,7 +82,7 @@ async fn test_webdriver_user_login(rsclient: kanidm_client::KanidmClient) {
 
     handle_error!(
         c,
-        c.goto(&rsclient.get_url().into()).await,
+        c.goto(&rsclient.get_url().to_string()).await,
         "Couldn't get URL"
     );
 

--- a/server/testkit/tests/person.rs
+++ b/server/testkit/tests/person.rs
@@ -6,7 +6,6 @@ use reqwest::header::CONTENT_TYPE;
 #[kanidmd_testkit::test]
 async fn test_v1_person_patch(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
@@ -15,7 +14,7 @@ async fn test_v1_person_patch(rsclient: KanidmClient) {
     let post_body = serde_json::json!({"attrs": { "email" : "crab@example.com"}}).to_string();
 
     let response = match client
-        .patch(format!("{}/v1/person/foo", &addr))
+        .patch(rsclient.make_url("/v1/person/foo"))
         .header(CONTENT_TYPE, APPLICATION_JSON)
         .body(post_body)
         .send()
@@ -23,7 +22,11 @@ async fn test_v1_person_patch(rsclient: KanidmClient) {
     {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/v1/person/foo"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -120,6 +120,7 @@ async fn test_server_search(rsclient: KanidmClient) {
     // First show we are un-authenticated.
     let pre_res = rsclient.whoami().await;
     // This means it was okay whoami, but no uat attached.
+    println!("Response: {:?}", pre_res);
     assert!(pre_res.unwrap().is_none());
 
     let res = rsclient

--- a/server/testkit/tests/scim_test.rs
+++ b/server/testkit/tests/scim_test.rs
@@ -93,7 +93,6 @@ async fn test_sync_account_lifecycle(rsclient: KanidmClient) {
 #[kanidmd_testkit::test]
 async fn test_scim_sync_get(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
 
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
@@ -107,10 +106,14 @@ async fn test_scim_sync_get(rsclient: KanidmClient) {
         .build()
         .unwrap();
     // here we test the /ui/ endpoint which should have the headers
-    let response = match client.get(format!("{}/scim/v1/Sync", addr)).send().await {
+    let response = match client.get(rsclient.make_url("/scim/v1/Sync")).send().await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/scim/v1/Sync"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/self.rs
+++ b/server/testkit/tests/self.rs
@@ -4,20 +4,23 @@ use kanidm_client::KanidmClient;
 #[kanidmd_testkit::test]
 async fn test_v1_self_applinks(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap();
 
     let response = match client
-        .get(format!("{}/v1/self/_applinks", &addr))
+        .get(rsclient.make_url("/v1/self/_applinks"))
         .send()
         .await
     {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/v1/self/_applinks"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);
@@ -31,16 +34,19 @@ async fn test_v1_self_applinks(rsclient: KanidmClient) {
 #[kanidmd_testkit::test]
 async fn test_v1_self_whoami_uat(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap();
 
-    let response = match client.get(format!("{}/v1/self/_uat", &addr)).send().await {
+    let response = match client.get(rsclient.make_url("/v1/self/_uat")).send().await {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/v1/self/_uat"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/service_account.rs
+++ b/server/testkit/tests/service_account.rs
@@ -4,7 +4,6 @@ use kanidm_client::KanidmClient;
 #[kanidmd_testkit::test]
 async fn test_v1_service_account_id_attr_attr_delete(rsclient: KanidmClient) {
     // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
@@ -13,13 +12,17 @@ async fn test_v1_service_account_id_attr_attr_delete(rsclient: KanidmClient) {
     // let post_body = serde_json::json!({"filter": "self"}).to_string();
 
     let response = match client
-        .delete(format!("{}/v1/service_account/admin/_attr/email", &addr))
+        .delete(rsclient.make_url("/v1/service_account/admin/_attr/email"))
         .send()
         .await
     {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("/v1/service_account/admin/_attr/email"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/system.rs
+++ b/server/testkit/tests/system.rs
@@ -3,22 +3,24 @@ use kanidm_client::KanidmClient;
 /// This literally tests that the thing exists and responds in a way we expect, probably worth testing it better...
 #[kanidmd_testkit::test]
 async fn test_v1_system_post_attr(rsclient: KanidmClient) {
-    // We need to do manual reqwests here.
-    let addr = rsclient.get_url();
     let client = reqwest::ClientBuilder::new()
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap();
 
     let response = match client
-        .post(format!("{}/v1/system/_attr/domain_name", &addr))
+        .post(rsclient.make_url("/v1/system/_attr/domain_name"))
         .json(&serde_json::json!({"filter": "self"}))
         .send()
         .await
     {
         Ok(value) => value,
         Err(error) => {
-            panic!("Failed to query {:?} : {:#?}", addr, error);
+            panic!(
+                "Failed to query {:?} : {:#?}",
+                rsclient.make_url("v1/system/_attr/domain_name"),
+                error
+            );
         }
     };
     eprintln!("response: {:#?}", response);

--- a/server/testkit/tests/unix.rs
+++ b/server/testkit/tests/unix.rs
@@ -1,0 +1,46 @@
+use kanidm_client::KanidmClient;
+use kanidmd_testkit::*;
+
+#[kanidmd_testkit::test]
+async fn account_id_unix_token(rsclient: KanidmClient) {
+    login_put_admin_idm_admins(&rsclient).await;
+
+    create_user(&rsclient, "group_manager", "idm_group_manage_priv").await;
+    // create test user without creating new groups
+    create_user(&rsclient, NOT_ADMIN_TEST_USERNAME, "idm_admins").await;
+    login_account(&rsclient, "group_manager").await;
+
+    let response = rsclient
+        .idm_account_unix_token_get(NOT_ADMIN_TEST_USERNAME)
+        .await;
+    assert!(response.is_err());
+    if let Err(val) = response {
+        assert!(format!("{:?}", val).contains("404"));
+    }
+
+    let response = rsclient.idm_account_unix_token_get("lol").await;
+    assert!(response.is_err());
+    if let Err(val) = response {
+        assert!(format!("{:?}", val).contains("404"));
+    }
+
+    // testing empty results
+    let response = rsclient.idm_account_unix_token_get("").await;
+    assert!(response.is_err());
+    if let Err(val) = response {
+        assert!(format!("{:?}", val).contains("400"));
+    }
+
+    login_put_admin_idm_admins(&rsclient).await;
+
+    rsclient
+        .idm_person_account_unix_extend(NOT_ADMIN_TEST_USERNAME, None, None)
+        .await
+        .unwrap();
+
+    // testing NOT_ADMIN_TEST_USERNAME has a token result, since we just added one
+    assert!(rsclient
+        .idm_account_unix_token_get(NOT_ADMIN_TEST_USERNAME)
+        .await
+        .is_ok());
+}

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -16,7 +16,6 @@ use qrcode::render::unicode;
 use qrcode::QrCode;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use url::Url;
 use uuid::Uuid;
 
 use crate::webauthn::get_authenticator;
@@ -603,14 +602,7 @@ impl AccountCredential {
                     .await
                 {
                     Ok(cuintent_token) => {
-                        let mut url = match Url::parse(client.get_url()) {
-                            Ok(u) => u,
-                            Err(e) => {
-                                error!("Unable to parse url - {:?}", e);
-                                return;
-                            }
-                        };
-                        url.set_path("/ui/reset");
+                        let mut url = client.make_url("/ui/reset");
                         url.query_pairs_mut()
                             .append_pair("token", cuintent_token.token.as_str());
 


### PR DESCRIPTION
* Fixes #1958
* adds some tests relating to #1958
* Cleans up some URL-generation in the client code
* chases some clippy lints
* fixes the setup_dev_environment script to support the new UNIX socket system


Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
