### PR TITLE
resolver: Himmelblau needs old token for refresh

### DIFF
--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -55,7 +55,7 @@ pub struct UserToken {
 pub trait IdProvider {
     async fn provider_authenticate(&self) -> Result<(), IdpError>;
 
-    async fn unix_user_get(&self, id: &Id) -> Result<UserToken, IdpError>;
+    async fn unix_user_get(&self, id: &Id, old_token: Option<UserToken>) -> Result<UserToken, IdpError>;
 
     async fn unix_user_authenticate(
         &self,

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -79,7 +79,7 @@ impl IdProvider for KanidmProvider {
         }
     }
 
-    async fn unix_user_get(&self, id: &Id) -> Result<UserToken, IdpError> {
+    async fn unix_user_get(&self, id: &Id, _old_token: Option<UserToken>) -> Result<UserToken, IdpError> {
         match self
             .client
             .read()

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -393,7 +393,7 @@ where
         account_id: &Id,
         token: Option<UserToken>,
     ) -> Result<Option<UserToken>, ()> {
-        match self.client.unix_user_get(account_id).await {
+        match self.client.unix_user_get(account_id, token.clone()).await {
             Ok(mut n_tok) => {
                 if self.check_nxset(&n_tok.name, n_tok.gidnumber).await {
                     // Refuse to release the token, it's in the denied set.


### PR DESCRIPTION
Himmelblau needs access to the old token during
a refresh otherwise the GECOS is lost (AAD
responds with everything we need except GECOS).

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
