### PR TITLE
Orca tweaks

### DIFF
--- a/scripts/setup_dev_environment.sh
+++ b/scripts/setup_dev_environment.sh
@@ -25,25 +25,21 @@ if [ -z "${REMOVE_TEST_DB}" ]; then
     fi
 fi
 
+
 if [ ! -f run_insecure_dev_server.sh ]; then
     echo "Please run from the server/daemon dir!"
     exit 1
 fi
 
 # wait for them to shut down the server if it's running...
-if [ "$REMOVE_TEST_DB" -eq 1 ]; then
-    echo "Removing the existing DB!"
-    while true; do
-        echo "Checking if kanidmd's running..."
-        if [ "$(pgrep kanidmd | wc -l)" -eq 0 ]; then
-            break
-        fi
-        echo "Stop the kanidmd server first please!"
-        sleep 1
-    done
-    rm /tmp/kanidm/kanidm.db || true
-    exit 1
-fi
+while true
+do
+    if [ "$(pgrep kanidmd | wc -l )" -eq 0 ]; then
+        break
+    fi
+    echo "Stop the kanidmd server first please!"
+    sleep 1
+done
 
 # defaults
 KANIDM_CONFIG="../../examples/insecure_server.toml"
@@ -66,29 +62,24 @@ OAUTH2_RP_DISPLAY="test_oauth2"
 KANIDM="cargo run --manifest-path ../../Cargo.toml --bin kanidm -- "
 KANIDMD="cargo run -p daemon --bin kanidmd -- "
 
-while true; do
-    echo "Waiting for you to start the server... testing ${KANIDM_URL}"
-    curl --cacert "${KANIDM_CA_PATH}" -fs "${KANIDM_URL}" >/dev/null && break
-    sleep 2
-done
+if [ "${REMOVE_TEST_DB}" -eq 1 ]; then
+    echo "Removing the existing DB!"
+    rm /tmp/kanidm/kanidm.db || true
+fi
 
 echo "Reset the admin user"
-ADMIN_PASS=$(${KANIDMD} recover-account admin -o json 2>&1 | rg password | jq -r '.password')
-if [ -z "${ADMIN_PASS}" ]; then
-    echo "Failed to reset admin password!"
-    exit 1
-else
-    echo "admin pass: '${ADMIN_PASS}'"
-fi
-
+ADMIN_PASS=$(${KANIDMD} recover-account admin -o json 2>&1 | rg recovery | rg result | jq -r .result )
+echo "admin pass: '${ADMIN_PASS}'"
 echo "Reset the idm_admin user"
-IDM_ADMIN_PASS=$(${KANIDMD} recover-account idm_admin -o json 2>&1 | rg password | jq -r '.password')
-if [ -z "${ADMIN_PASS}" ]; then
-    echo "Failed to reset admin password!"
-    exit 1
-else
-    echo "idm_admin pass: '${IDM_ADMIN_PASS}'"
-fi
+IDM_ADMIN_PASS=$(${KANIDMD} recover-account idm_admin -o json 2>&1 | rg recovery | rg result | jq -r .result)
+echo "idm_admin pass: '${IDM_ADMIN_PASS}'"
+
+while true
+do
+    echo "Waiting for you to start the server... testing ${KANIDM_URL}"
+    curl --cacert "${KANIDM_CA_PATH}" -fs "${KANIDM_URL}" > /dev/null && break
+    sleep 2
+done
 
 echo "login with admin"
 ${KANIDM} login -D admin --password "${ADMIN_PASS}"
@@ -105,7 +96,7 @@ echo "Adding ${TEST_USER_NAME} to ${TEST_GROUP}"
 ${KANIDM} group add-members "${TEST_GROUP}" "${TEST_USER_NAME}" -D idm_admin
 
 echo "Enable experimental UI for admin idm_admin ${TEST_USER_NAME}"
-${KANIDM} group add-members idm_ui_enable_experimental_features admin idm_admin "${TEST_USER_NAME}" -D idm_admin
+${KANIDM} group add-members  idm_ui_enable_experimental_features admin idm_admin "${TEST_USER_NAME}" -D idm_admin
 
 # create oauth2 rp
 echo "Creating the OAuth2 RP"

--- a/scripts/setup_dev_environment.sh
+++ b/scripts/setup_dev_environment.sh
@@ -25,21 +25,25 @@ if [ -z "${REMOVE_TEST_DB}" ]; then
     fi
 fi
 
-
 if [ ! -f run_insecure_dev_server.sh ]; then
     echo "Please run from the server/daemon dir!"
     exit 1
 fi
 
 # wait for them to shut down the server if it's running...
-while true
-do
-    if [ "$(pgrep kanidmd | wc -l )" -eq 0 ]; then
-        break
-    fi
-    echo "Stop the kanidmd server first please!"
-    sleep 1
-done
+if [ "$REMOVE_TEST_DB" -eq 1 ]; then
+    echo "Removing the existing DB!"
+    while true; do
+        echo "Checking if kanidmd's running..."
+        if [ "$(pgrep kanidmd | wc -l)" -eq 0 ]; then
+            break
+        fi
+        echo "Stop the kanidmd server first please!"
+        sleep 1
+    done
+    rm /tmp/kanidm/kanidm.db || true
+    exit 1
+fi
 
 # defaults
 KANIDM_CONFIG="../../examples/insecure_server.toml"
@@ -62,24 +66,29 @@ OAUTH2_RP_DISPLAY="test_oauth2"
 KANIDM="cargo run --manifest-path ../../Cargo.toml --bin kanidm -- "
 KANIDMD="cargo run -p daemon --bin kanidmd -- "
 
-if [ "${REMOVE_TEST_DB}" -eq 1 ]; then
-    echo "Removing the existing DB!"
-    rm /tmp/kanidm/kanidm.db || true
-fi
-
-echo "Reset the admin user"
-ADMIN_PASS=$(${KANIDMD} recover-account admin -o json 2>&1 | rg recovery | rg result | jq -r .result )
-echo "admin pass: '${ADMIN_PASS}'"
-echo "Reset the idm_admin user"
-IDM_ADMIN_PASS=$(${KANIDMD} recover-account idm_admin -o json 2>&1 | rg recovery | rg result | jq -r .result)
-echo "idm_admin pass: '${IDM_ADMIN_PASS}'"
-
-while true
-do
+while true; do
     echo "Waiting for you to start the server... testing ${KANIDM_URL}"
-    curl --cacert "${KANIDM_CA_PATH}" -fs "${KANIDM_URL}" > /dev/null && break
+    curl --cacert "${KANIDM_CA_PATH}" -fs "${KANIDM_URL}" >/dev/null && break
     sleep 2
 done
+
+echo "Reset the admin user"
+ADMIN_PASS=$(${KANIDMD} recover-account admin -o json 2>&1 | rg password | jq -r '.password')
+if [ -z "${ADMIN_PASS}" ]; then
+    echo "Failed to reset admin password!"
+    exit 1
+else
+    echo "admin pass: '${ADMIN_PASS}'"
+fi
+
+echo "Reset the idm_admin user"
+IDM_ADMIN_PASS=$(${KANIDMD} recover-account idm_admin -o json 2>&1 | rg password | jq -r '.password')
+if [ -z "${ADMIN_PASS}" ]; then
+    echo "Failed to reset admin password!"
+    exit 1
+else
+    echo "idm_admin pass: '${IDM_ADMIN_PASS}'"
+fi
 
 echo "login with admin"
 ${KANIDM} login -D admin --password "${ADMIN_PASS}"
@@ -96,7 +105,7 @@ echo "Adding ${TEST_USER_NAME} to ${TEST_GROUP}"
 ${KANIDM} group add-members "${TEST_GROUP}" "${TEST_USER_NAME}" -D idm_admin
 
 echo "Enable experimental UI for admin idm_admin ${TEST_USER_NAME}"
-${KANIDM} group add-members  idm_ui_enable_experimental_features admin idm_admin "${TEST_USER_NAME}" -D idm_admin
+${KANIDM} group add-members idm_ui_enable_experimental_features admin idm_admin "${TEST_USER_NAME}" -D idm_admin
 
 # create oauth2 rp
 echo "Creating the OAuth2 RP"

--- a/tools/orca/setup_orca.sh
+++ b/tools/orca/setup_orca.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f "$0" ]; then
+    echo "This script must be run from the tools/orca directory."
+    exit 1
+fi
+
+MYDIR="$(pwd)"
+
+echo "Running this will run the setup_dev_environment script"
+echo "which resets the local dev environment to a default state."
+echo ""
+echo "Also, you'll need to start the server in another tab."
+echo ""
+echo "Hit ctrl-c to quit now if that's not what you intend!"
+
+# read -rp "Press Enter to continue"
+
+cd ../../server/daemon/ || exit 1
+
+KANI_TEMP="$(mktemp -d)"
+echo "Running the script..."
+../../scripts/setup_dev_environment.sh | tee "${KANI_TEMP}/kanifile"
+
+echo "#########################"
+echo "Back to orca now..."
+echo "#########################"
+
+if [ -z "${KANIDM_CONFIG}" ]; then
+    KANIDM_CONFIG="../../examples/insecure_server.toml"
+fi
+
+ADMIN_PW=$(grep -E "^admin password" "${KANI_TEMP}/kanifile" | awk '{print $NF}')
+IDM_ADMIN_PW=$(grep -E "^idm_admin password" "${KANI_TEMP}/kanifile" | awk '{print $NF}')
+rm "${KANI_TEMP}/kanifile"
+
+if [ -n "${DEBUG}" ]; then
+    echo "Admin pw: ${ADMIN_PW}"
+    echo "IDM Admin pw: ${IDM_ADMIN_PW}"
+fi
+
+cd "$MYDIR" || exit 1
+
+LDAP_DN="DN=$(grep domain "${KANIDM_CONFIG}" | awk '{print $NF}' | tr -d '"' | sed -E 's/\./,DN=/g')"
+
+cargo run --bin orca -- configure \
+    --profile /tmp/kanidm/orca.toml \
+    --admin-password "${ADMIN_PW}" \
+    --kanidm-uri "$(grep origin "${KANIDM_CONFIG}" | awk '{print $NF}' | tr -d '"')" \
+    --ldap-uri "ldaps://$(grep domain "${KANIDM_CONFIG}" | awk '{print $NF}' | tr -d '"'):636" \
+    --ldap-base-dn "${LDAP_DN}"

--- a/tools/orca/src/main.rs
+++ b/tools/orca/src/main.rs
@@ -252,64 +252,76 @@ async fn main() {
             // load the related data (if any) or generate it
             // run the test!
         }
-        OrcaOpt::Configure(opt) => {
-            let mut profile = match opt.profile.exists() {
-                true => {
-                    let file_contents = std::fs::read_to_string(&opt.profile).unwrap();
-                    toml::from_str(&file_contents).unwrap()
-                }
-
-                false => Profile::default(),
-            };
-            println!("Current profile:\n{}", toml::to_string(&profile).unwrap());
-
-            if let Some(name) = opt.name {
-                println!("Updating config name.");
-                profile.name = name;
-            };
-
-            if let Some(new_password) = opt.admin_password {
-                println!("Updating admin password.");
-                profile.kani_http_config.as_mut().unwrap().admin_pw = new_password.clone();
-                profile.kani_ldap_config.as_mut().unwrap().admin_pw = new_password;
-            };
-
-            if let Some(kani_uri) = opt.kanidm_uri {
-                println!("Updating kanidm uri.");
-                profile.kani_http_config.as_mut().unwrap().uri = kani_uri.clone();
-                profile.kani_ldap_config.as_mut().unwrap().uri = kani_uri;
-            };
-
-            if let Some(ldap_uri) = opt.ldap_uri {
-                println!("Updating ldap uri.");
-                profile.kani_ldap_config.as_mut().unwrap().ldap_uri = ldap_uri;
-            };
-
-            if let Some(base_dn) = opt.ldap_base_dn {
-                println!("Updating base DN.");
-                profile.kani_ldap_config.as_mut().unwrap().base_dn = base_dn;
-            };
-
-            let file_contents = match toml::to_string(&profile) {
-                Err(err) => {
-                    error!("Failed to serialize the config file: {:?}", err);
-                    return;
-                }
-                Ok(val) => val,
-            };
-
-            match std::fs::write(&opt.profile, &file_contents) {
-                Err(err) => {
-                    eprintln!("Failed to write the config file: {:?}", err);
-                    return;
-                }
-                Ok(_) => {
-                    println!("Wrote out the new config file");
-                }
-            };
-
-            println!("New config:\n{}", file_contents);
-        }
+        OrcaOpt::Configure(opt) => update_config_file(opt),
     };
     debug!("Exit");
+}
+
+fn update_config_file(opt: ConfigOpt) {
+    let mut profile = match opt.profile.exists() {
+        true => {
+            let file_contents = std::fs::read_to_string(&opt.profile).unwrap();
+            toml::from_str(&file_contents).unwrap()
+        }
+
+        false => Profile::default(),
+    };
+    println!("Current profile:\n{}", toml::to_string(&profile).unwrap());
+
+    if let Some(name) = opt.name {
+        println!("Updating config name.");
+        profile.name = name;
+    };
+
+    if let Some(new_password) = opt.admin_password {
+        println!("Updating admin password.");
+        profile.kani_http_config.as_mut().unwrap().admin_pw = new_password.clone();
+        profile.kani_ldap_config.as_mut().unwrap().admin_pw = new_password;
+    };
+
+    if let Some(kani_uri) = opt.kanidm_uri {
+        println!("Updating kanidm uri.");
+        profile.kani_http_config.as_mut().unwrap().uri = kani_uri.clone();
+        profile.kani_ldap_config.as_mut().unwrap().uri = kani_uri;
+    };
+
+    if let Some(ldap_uri) = opt.ldap_uri {
+        println!("Updating ldap uri.");
+        profile.kani_ldap_config.as_mut().unwrap().ldap_uri = ldap_uri;
+    };
+
+    if let Some(base_dn) = opt.ldap_base_dn {
+        println!("Updating base DN.");
+        profile.kani_ldap_config.as_mut().unwrap().base_dn = base_dn;
+    };
+
+    if let Some(data_file) = opt.data_file {
+        println!("Updating data_file path.");
+        profile.data = data_file;
+    };
+
+    if let Some(results) = opt.results {
+        println!("Updating results path.");
+        profile.results = results.to_str().unwrap().to_string();
+    };
+
+    let file_contents = match toml::to_string(&profile) {
+        Err(err) => {
+            error!("Failed to serialize the config file: {:?}", err);
+            return;
+        }
+        Ok(val) => val,
+    };
+
+    match std::fs::write(&opt.profile, &file_contents) {
+        Err(err) => {
+            eprintln!("Failed to write the config file: {:?}", err);
+            return;
+        }
+        Ok(_) => {
+            println!("Wrote out the new config file");
+        }
+    };
+
+    println!("New config:\n{}", file_contents);
 }

--- a/tools/orca/src/opt.rs
+++ b/tools/orca/src/opt.rs
@@ -53,6 +53,33 @@ struct RunOpt {
     pub profile_path: PathBuf,
 }
 
+#[derive(Debug, Parser)]
+/// Configuration options
+struct ConfigOpt {
+    #[clap(flatten)]
+    pub copt: CommonOpt,
+    #[clap(value_parser, short, long)]
+    /// Update the admin password
+    pub admin_password: Option<String>,
+    #[clap(value_parser, short, long)]
+    /// Update the Kanidm URI
+    pub kanidm_uri: Option<String>,
+    #[clap(value_parser, short, long)]
+    /// Update the LDAP URI
+    pub ldap_uri: Option<String>,
+    #[clap(value_parser, short = 'D', long)]
+    /// Update the LDAP base DN
+    pub ldap_base_dn: Option<String>,
+
+    #[clap(value_parser, short = 'D', long)]
+    /// Set the configuration name
+    pub name: Option<String>,
+
+    #[clap(value_parser, short, long)]
+    /// The configuration file path to update (or create)
+    pub profile: PathBuf,
+}
+
 #[derive(Debug, Subcommand, Clone)]
 /// The target to run against
 pub(crate) enum TargetOpt {
@@ -150,5 +177,8 @@ enum OrcaOpt {
     Run(RunOpt),
     #[clap(name = "version")]
     /// Print version info and exit
-    Version(CommonOpt)
+    Version(CommonOpt),
+    #[clap(name = "configure")]
+    /// Update a config file
+    Configure(ConfigOpt),
 }

--- a/tools/orca/src/opt.rs
+++ b/tools/orca/src/opt.rs
@@ -76,6 +76,14 @@ struct ConfigOpt {
     pub name: Option<String>,
 
     #[clap(value_parser, short, long)]
+    /// The data file path to update (or create)
+    pub data_file: Option<String>,
+
+    #[clap(value_parser, short, long)]
+    /// The place we'll drop the results
+    pub results: Option<PathBuf>,
+
+    #[clap(value_parser, short, long)]
     /// The configuration file path to update (or create)
     pub profile: PathBuf,
 }

--- a/tools/orca/src/profile.rs
+++ b/tools/orca/src/profile.rs
@@ -73,8 +73,8 @@ impl Default for Profile {
 
         Self {
             name: "orca default profile".to_string(),
-            data: "".to_string(),
-            results: "".to_string(),
+            data: "/tmp/kanidm/orcatest".to_string(),
+            results: "/tmp/kanidm/orca-results/".to_string(),
             ds_config: None,
             ipa_config: None,
             kani_http_config: Some(kani_http_config),

--- a/tools/orca/src/profile.rs
+++ b/tools/orca/src/profile.rs
@@ -1,26 +1,26 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DsConfig {
     pub uri: String,
     pub dm_pw: String,
     pub base_dn: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct IpaConfig {
     pub uri: String,
     pub realm: String,
     pub admin_pw: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct KaniHttpConfig {
     pub uri: String,
     pub admin_pw: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct KaniLdapConfig {
     pub uri: String,
     pub ldap_uri: String,
@@ -28,7 +28,7 @@ pub struct KaniLdapConfig {
     pub base_dn: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SearchBasicConfig {
     // Could consider fn for this #[serde(default = "Priority::lowest")]
     pub warmup_seconds: u32,
@@ -44,7 +44,7 @@ impl Default for SearchBasicConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Profile {
     pub name: String,
     pub data: String,
@@ -55,4 +55,31 @@ pub struct Profile {
     pub kani_ldap_config: Option<KaniLdapConfig>,
     #[serde(default)]
     pub search_basic_config: SearchBasicConfig,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        let kani_http_config = KaniHttpConfig {
+            uri: "https://localhost:8443".to_string(),
+            admin_pw: "".to_string(),
+        };
+
+        let kani_ldap_config = KaniLdapConfig {
+            uri: "https://localhost:8443".to_string(),
+            ldap_uri: "ldaps://localhost:636".to_string(),
+            admin_pw: "".to_string(),
+            base_dn: "dn=localhost".to_string(),
+        };
+
+        Self {
+            name: "orca default profile".to_string(),
+            data: "".to_string(),
+            results: "".to_string(),
+            ds_config: None,
+            ipa_config: None,
+            kani_http_config: Some(kani_http_config),
+            kani_ldap_config: Some(kani_ldap_config),
+            search_basic_config: SearchBasicConfig::default(),
+        }
+    }
 }

--- a/tools/orca/src/setup.rs
+++ b/tools/orca/src/setup.rs
@@ -84,7 +84,7 @@ pub(crate) fn config(
     debug!("Target server info -> {}", server.info());
 
     // load the related data (if any) or generate it if that is what we have.
-    let data_file = File::open(data_path).map_err(|e| {
+    let data_file = File::open(&data_path).map_err(|e| {
         error!("Unable to open data file [{:?}] 🥺", e);
     })?;
 
@@ -92,7 +92,8 @@ pub(crate) fn config(
 
     let data: TestData = serde_json::from_reader(data_reader).map_err(|e| {
         error!(
-            "Unable to process data file. You may need to preprocess it again: {:?}",
+            "Unable to process data file {}. You may need to preprocess it again: {:?}",
+            data_path.display(),
             e
         );
     })?;


### PR DESCRIPTION
This really needs to be merged after #1960 (because it fixes `setup_dev_environment.sh`).

* allows one to configure an `orca` profile largely from the command line
* adds a script that works with `setup_dev_environment.sh` to do the setup

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
