### PR TITLE
Fighting with zypper, tagging our images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ TESTS ?=
 BOOK_VERSION ?= master
 GIT_COMMIT := $(shell git rev-parse HEAD)
 
-
-
 .DEFAULT: help
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ buildx/kanidmd:
 		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
-		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.git-commit=$(GIT_COMMIT)" \
 		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 
@@ -50,7 +50,7 @@ buildx/kanidm_tools:
 		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
-		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.git-commit=$(GIT_COMMIT)" \
 		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 
@@ -61,7 +61,7 @@ buildx/radiusd:
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f rlm_python/Dockerfile \
 		--progress $(BUILDKIT_PROGRESS) \
-		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.git-commit=$(GIT_COMMIT)" \
 		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_EXT_VERSION) .
@@ -76,7 +76,7 @@ build/kanidmd:
 		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
-		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.git-commit=$(GIT_COMMIT)" \
 		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 
@@ -85,7 +85,7 @@ build/radiusd:	## Build the radiusd docker image locally
 build/radiusd:
 	@$(CONTAINER_TOOL) build $(CONTAINER_TOOL_ARGS) \
 		-f rlm_python/Dockerfile \
-		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.git-commit=$(GIT_COMMIT)" \
 		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) .
 
@@ -99,7 +99,7 @@ test/kanidmd:
 		$(CONTAINER_TOOL_ARGS) -f server/Dockerfile \
 		--target builder \
 		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION)-builder \
-		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.git-commit=$(GIT_COMMIT)" \
 		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 	@$(CONTAINER_TOOL) run --rm $(IMAGE_BASE)/server:$(IMAGE_VERSION)-builder cargo test

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ CONTAINER_TOOL ?= docker
 BUILDKIT_PROGRESS ?= plain
 TESTS ?=
 BOOK_VERSION ?= master
+GIT_COMMIT := $(shell git rev-parse HEAD)
+
+
 
 .DEFAULT: help
 .PHONY: help
@@ -32,6 +35,8 @@ buildx/kanidmd:
 		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 
 .PHONY: buildx/kanidm_tools
@@ -45,6 +50,8 @@ buildx/kanidm_tools:
 		--progress $(BUILDKIT_PROGRESS) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 
 .PHONY: buildx/radiusd
@@ -54,6 +61,8 @@ buildx/radiusd:
 		--pull --push --platform $(IMAGE_ARCH) \
 		-f rlm_python/Dockerfile \
 		--progress $(BUILDKIT_PROGRESS) \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_EXT_VERSION) .
 
@@ -65,17 +74,19 @@ build/kanidmd:	## Build the kanidmd docker image locally
 build/kanidmd:
 	@$(CONTAINER_TOOL) build $(CONTAINER_TOOL_ARGS) -f server/Dockerfile \
 		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION) \
-		--platform $(IMAGE_ARCH) \
 		--build-arg "KANIDM_BUILD_PROFILE=container_generic" \
 		--build-arg "KANIDM_FEATURES=" \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 
 .PHONY: build/radiusd
 build/radiusd:	## Build the radiusd docker image locally
 build/radiusd:
 	@$(CONTAINER_TOOL) build $(CONTAINER_TOOL_ARGS) \
-		--platform $(IMAGE_ARCH) \
 		-f rlm_python/Dockerfile \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		-t $(IMAGE_BASE)/radius:$(IMAGE_VERSION) .
 
 .PHONY: build
@@ -88,6 +99,8 @@ test/kanidmd:
 		$(CONTAINER_TOOL_ARGS) -f server/Dockerfile \
 		--target builder \
 		-t $(IMAGE_BASE)/server:$(IMAGE_VERSION)-builder \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--label "com.kanidm.version=$(IMAGE_EXT_VERSION)" \
 		$(CONTAINER_BUILD_ARGS) .
 	@$(CONTAINER_TOOL) run --rm $(IMAGE_BASE)/server:$(IMAGE_VERSION)-builder cargo test
 

--- a/examples/apache_oauth/Dockerfile
+++ b/examples/apache_oauth/Dockerfile
@@ -1,3 +1,5 @@
+ARG GIT_COMMIT=""
+
 FROM ubuntu/apache2:latest
 
 RUN apt-get update
@@ -10,3 +12,5 @@ RUN a2enmod ssl
 RUN rm /etc/apache2/sites-enabled/000-default.conf
 COPY index.html /var/www/html/index.html
 COPY oauth2.conf /etc/apache2/sites-enabled/oauth2.conf
+
+LABEL "com.kanidm.git-commit"=${GIT_COMMIT}

--- a/examples/apache_oauth/Dockerfile
+++ b/examples/apache_oauth/Dockerfile
@@ -1,5 +1,3 @@
-ARG GIT_COMMIT=""
-
 FROM ubuntu/apache2:latest
 
 RUN apt-get update
@@ -13,4 +11,3 @@ RUN rm /etc/apache2/sites-enabled/000-default.conf
 COPY index.html /var/www/html/index.html
 COPY oauth2.conf /etc/apache2/sites-enabled/oauth2.conf
 
-LABEL "com.kanidm.git-commit"=${GIT_COMMIT}

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -7,7 +7,6 @@ RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 FROM repos
 EXPOSE 1812 1813
 ARG RADIUS_USER=radiusd
-ARG GIT_COMMIT=""
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
@@ -61,7 +60,5 @@ ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
 RUN chmod a+r /etc/raddb/certs/ -R
 USER $RADIUS_USER
-
-LABEL "com.kanidm.git-commit"=${GIT_COMMIT}
 
 CMD [ "/usr/bin/python3", "/radius_entrypoint.py" ]

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -11,19 +11,19 @@ ARG RADIUS_USER=radiusd
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
-    freeradius-client \
-    freeradius-server \
-    freeradius-server-python3 \
-    freeradius-server-utils \
-    hostname \
-    python3 \
-    python3-devel \
-    python3-pip \
-    timezone \
-    iproute2 \
-    iputils \
-    openssl \
-    curl
+        freeradius-client \
+        freeradius-server \
+        freeradius-server-python3 \
+        freeradius-server-utils \
+        hostname \
+        python3 \
+        python3-devel \
+        python3-pip \
+        timezone \
+        iproute2 \
+        iputils \
+        openssl \
+        curl
 
 # Don't put in the TZ at build time - it needs to be bind mounted at runtime
 # else we are forcing things on people.

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -1,17 +1,13 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
-RUN \
-    --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper mr -k repo-oss; \
-    zypper mr -k repo-non-oss; \
-    zypper mr -k repo-update; \
-    zypper ref --force; \
-    zypper -v dup -y
+ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
+RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
 # ======================
 FROM repos
 EXPOSE 1812 1813
 ARG RADIUS_USER=radiusd
+ARG GIT_COMMIT=""
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
@@ -34,7 +30,7 @@ RUN \
 # else we are forcing things on people.
 # RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-ADD  rlm_python/mods-available/ /etc/raddb/mods-available/
+ADD rlm_python/mods-available/ /etc/raddb/mods-available/
 COPY rlm_python/sites-available/ /etc/raddb/sites-available/
 
 # Set a working directory of /etc/raddb
@@ -65,5 +61,7 @@ ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
 RUN chmod a+r /etc/raddb/certs/ -R
 USER $RADIUS_USER
+
+LABEL "com.kanidm.git-commit"=${GIT_COMMIT}
 
 CMD [ "/usr/bin/python3", "/radius_entrypoint.py" ]

--- a/scripts/zypper_fixing.sh
+++ b/scripts/zypper_fixing.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# makes sure the repos are configured because the containers are derpy sometimes
+
+#disable the openh264 repo
+if [ "$(zypper lr | grep -ci 'repo-openh264')" -eq 1 ]; then
+    zypper mr -d -f -n 'repo-openh264'
+fi
+
+# add the non-oss repo if it doesn't exist
+if [ "$(zypper lr | grep -c 'repo-non-oss')" -eq 0 ]; then
+    zypper ar -f -n 'Non-OSS' http://download.opensuse.org/tumbleweed/repo/non-oss/ repo-non-oss
+fi
+
+# update the repos and make sure the ones we want are enabled
+zypper mr -k repo-oss
+zypper mr -k repo-non-oss
+zypper mr -k repo-update
+zypper ref --force
+zypper -v dup -y

--- a/scripts/zypper_fixing.sh
+++ b/scripts/zypper_fixing.sh
@@ -16,5 +16,7 @@ fi
 zypper mr -k repo-oss
 zypper mr -k repo-non-oss
 zypper mr -k repo-update
+# force the refresh because zypper is too silly to work out it needs to do it itself
 zypper ref --force
+# show which mirror is failing if an error occurs (otherwise zypper shows the wrong mirror url)
 zypper -v dup -y

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,8 +21,11 @@ RUN \
         sccache \
         cargo \
         clang \
-        make automake autoconf \
-        libopenssl-3-devel pam-devel \
+        make \
+        automake \
+        autoconf \
+        libopenssl-3-devel \
+        pam-devel \
         sqlite3-devel \
         rsync \
         findutils \
@@ -50,9 +53,10 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
     export RUSTC_WRAPPER=/usr/bin/sccache && \
     export CC="/usr/bin/clang" && \
     cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release && sccache -s
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release; \
+    sccache -s
 
 # ======================
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,16 +18,16 @@ ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
-    sccache \
-    cargo \
-    clang \
-    make automake autoconf \
-    libopenssl-3-devel pam-devel \
-    sqlite3-devel \
-    rsync \
-    findutils \
-    which \
-    mold
+        sccache \
+        cargo \
+        clang \
+        make automake autoconf \
+        libopenssl-3-devel pam-devel \
+        sqlite3-devel \
+        rsync \
+        findutils \
+        which \
+        mold
 
 COPY . /usr/src/kanidm
 
@@ -60,10 +60,10 @@ FROM repos
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
-    timezone \
-    openssl-3 \
-    sqlite3 \
-    pam
+        timezone \
+        openssl-3 \
+        sqlite3 \
+        pam
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidmd /sbin/
 COPY --from=builder /usr/src/kanidm/server/web_ui/pkg /pkg

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,13 +1,9 @@
 # Build the main Kanidmd server
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
+
 FROM ${BASE_IMAGE} AS repos
-RUN \
-    --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper mr -k repo-oss; \
-    zypper mr -k repo-non-oss; \
-    zypper mr -k repo-update; \
-    zypper ref --force ; \
-    zypper -v dup -y
+ADD scripts/zypper_fixing.sh /zypper_fixing.sh
+RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
 # ======================
 FROM repos AS builder
@@ -22,16 +18,16 @@ ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
-        sccache \
-        cargo \
-        clang \
-        make automake autoconf \
-        libopenssl-3-devel pam-devel \
-        sqlite3-devel \
-        rsync \
-        findutils \
-        which \
-        mold
+    sccache \
+    cargo \
+    clang \
+    make automake autoconf \
+    libopenssl-3-devel pam-devel \
+    sqlite3-devel \
+    rsync \
+    findutils \
+    which \
+    mold
 
 COPY . /usr/src/kanidm
 
@@ -47,30 +43,28 @@ COPY . /usr/src/kanidm
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
 # Exports don't persist through RUN statements.
-RUN \
---mount=type=cache,id=cargo,target=/cargo \
---mount=type=cache,id=sccache,target=/sccache \
-export CARGO_HOME=/cargo; \
-export SCCACHE_DIR=/sccache; \
-export RUSTC_WRAPPER=/usr/bin/sccache; \
-export CC="/usr/bin/clang"; \
+RUN --mount=type=cache,id=cargo,target=/cargo \
+    --mount=type=cache,id=sccache,target=/sccache \
+    export CARGO_HOME=/cargo && \
+    export SCCACHE_DIR=/sccache && \
+    export RUSTC_WRAPPER=/usr/bin/sccache && \
+    export CC="/usr/bin/clang" && \
     cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
-        --target-dir="/usr/src/kanidm/target/" \
-        --features="${KANIDM_FEATURES}" \
-        --release; \
-    sccache -s
+    --target-dir="/usr/src/kanidm/target/" \
+    --features="${KANIDM_FEATURES}" \
+    --release && sccache -s
 
 # ======================
 
 FROM repos
-
+ARG GIT_COMMIT=""
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
-        timezone \
-        openssl-3 \
-        sqlite3 \
-        pam
+    timezone \
+    openssl-3 \
+    sqlite3 \
+    pam
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidmd /sbin/
 COPY --from=builder /usr/src/kanidm/server/web_ui/pkg /pkg
@@ -80,4 +74,7 @@ EXPOSE 8443 3636
 VOLUME /data
 
 ENV RUST_BACKTRACE 1
+
+LABEL "com.kanidm.git-commit"=${GIT_COMMIT}
+
 CMD [ "/sbin/kanidmd", "server", "-c", "/data/server.toml"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -57,7 +57,6 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
 # ======================
 
 FROM repos
-ARG GIT_COMMIT=""
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
@@ -74,7 +73,5 @@ EXPOSE 8443 3636
 VOLUME /data
 
 ENV RUST_BACKTRACE 1
-
-LABEL "com.kanidm.git-commit"=${GIT_COMMIT}
 
 CMD [ "/sbin/kanidmd", "server", "-c", "/data/server.toml"]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -16,16 +16,16 @@ ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
-    sccache \
-    cargo \
-    clang \
-    make automake autoconf \
-    libopenssl-3-devel \
-    pam-devel \
-    libudev-devel \
-    sqlite3-devel \
-    rsync \
-    mold
+        sccache \
+        cargo \
+        clang \
+        make automake autoconf \
+        libopenssl-3-devel \
+        pam-devel \
+        libudev-devel \
+        sqlite3-devel \
+        rsync \
+        mold
 
 COPY . /usr/src/kanidm
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -51,7 +51,6 @@ RUN \
 
 # == Construct the tools container
 FROM repos
-ARG GIT_COMMIT=""
 
 ENV RUST_BACKTRACE 1
 
@@ -69,7 +68,5 @@ RUN adduser -D -H kanidm && \
     touch /etc/kanidm/config
 
 USER kanidm
-
-LABEL "com.kanidm.git-commit"=${GIT_COMMIT}
 
 CMD [ "/sbin/kanidm", "-h" ]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,13 +1,8 @@
 # This builds the kanidm CLI tools
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
 FROM ${BASE_IMAGE} AS repos
-RUN \
-    --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper mr -k repo-oss; \
-    zypper mr -k repo-non-oss; \
-    zypper mr -k repo-update; \
-    zypper ref --force; \
-    zypper -v dup -y
+ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
+RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
 FROM repos AS builder
 ARG KANIDM_FEATURES
@@ -21,16 +16,16 @@ ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=/usr/bin/ld.mold"
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
-        sccache \
-        cargo \
-        clang \
-        make automake autoconf \
-        libopenssl-3-devel \
-        pam-devel \
-        libudev-devel \
-        sqlite3-devel \
-        rsync \
-        mold
+    sccache \
+    cargo \
+    clang \
+    make automake autoconf \
+    libopenssl-3-devel \
+    pam-devel \
+    libudev-devel \
+    sqlite3-devel \
+    rsync \
+    mold
 
 COPY . /usr/src/kanidm
 
@@ -38,24 +33,25 @@ WORKDIR /usr/src/kanidm/
 
 # build the CLI
 RUN \
---mount=type=cache,id=cargo,target=/cargo \
---mount=type=cache,id=sccache,target=/sccache \
-export CARGO_HOME=/cargo; \
-export SCCACHE_DIR=/sccache; \
-export RUSTC_WRAPPER=/usr/bin/sccache; \
-export CC="/usr/bin/clang"; \
+    --mount=type=cache,id=cargo,target=/cargo \
+    --mount=type=cache,id=sccache,target=/sccache \
+    export CARGO_HOME=/cargo
+    export SCCACHE_DIR=/sccache
+    export RUSTC_WRAPPER=/usr/bin/sccache
+    export CC="/usr/bin/clang"
     cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
-        --release; \
+        --release
     cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
-        --release; \
+        --release
     sccache -s
 
 # == Construct the tools container
 FROM repos
+ARG GIT_COMMIT=""
 
 ENV RUST_BACKTRACE 1
 
@@ -74,5 +70,6 @@ RUN adduser -D -H kanidm && \
 
 USER kanidm
 
-CMD [ "/sbin/kanidm", "-h" ]
+LABEL "com.kanidm.git-commit"=${GIT_COMMIT}
 
+CMD [ "/sbin/kanidm", "-h" ]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -35,18 +35,18 @@ WORKDIR /usr/src/kanidm/
 RUN \
     --mount=type=cache,id=cargo,target=/cargo \
     --mount=type=cache,id=sccache,target=/sccache \
-    export CARGO_HOME=/cargo
-    export SCCACHE_DIR=/sccache
-    export RUSTC_WRAPPER=/usr/bin/sccache
-    export CC="/usr/bin/clang"
+    export CARGO_HOME=/cargo; \
+    export SCCACHE_DIR=/sccache; \
+    export RUSTC_WRAPPER=/usr/bin/sccache; \
+    export CC="/usr/bin/clang"; \
     cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
-        --release
+        --release && \
     cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
-        --release
+        --release  && \
     sccache -s
 
 # == Construct the tools container

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -19,7 +19,9 @@ RUN \
         sccache \
         cargo \
         clang \
-        make automake autoconf \
+        make \
+        automake \
+        autoconf \
         libopenssl-3-devel \
         pam-devel \
         libudev-devel \
@@ -56,7 +58,10 @@ ENV RUST_BACKTRACE 1
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper install -y timezone busybox-adduser openssl-3
+    zypper install -y \
+        timezone \
+        busybox-adduser \
+        openssl-3
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/


### PR DESCRIPTION
* Zypper loves to break on ARM builds, so I'm adding a script to do more checking and fixing.
* Tagging containers with 
  * `com.kanidm.git-commit` to show when they were built.
  * `com.kanidm.version` to show the current version as far as the build's  concerned. 

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
