### PR TITLE
Himmelblau requires a mechanism to send pam_prompt

### DIFF
--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -282,6 +282,9 @@ async fn handle_client(
                     .map(ClientResponse::PamStatus)
                     .unwrap_or(ClientResponse::Error)
             }
+            ClientRequest::PamAuthenticateContinue(_account_id, _resp, _data) => {
+                ClientResponse::PamStatus(false)
+            }
             ClientRequest::PamAccountAllowed(account_id) => {
                 debug!("pam account allowed");
                 cachelayer

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -20,6 +20,9 @@ pub enum IdpError {
     /// The idp has indicated that the requested resource does not exist and should
     /// be considered deleted, removed, or not present.
     NotFound,
+    /// The idp is requesting an authentication continuation, and the resolver must
+    /// forward this information back to pam.
+    Continue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -62,6 +65,18 @@ pub trait IdProvider {
         id: &Id,
         cred: &str,
     ) -> Result<Option<UserToken>, IdpError>;
+
+    async fn unix_user_authenticate_continue(
+        &self,
+        id: &Id,
+        resp: &str,
+        data: Option<String>,
+    ) -> Result<Option<UserToken>, IdpError>;
+
+    async fn unix_user_authenticate_initiate_continue(
+        &self,
+        id: &Id,
+    ) -> Result<(Option<String>, Option<String>), IdpError>;
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;
 }

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -201,6 +201,22 @@ impl IdProvider for KanidmProvider {
         }
     }
 
+    async fn unix_user_authenticate_continue(
+        &self,
+        id: &Id,
+        resp: &str,
+        data: Option<String>,
+    ) -> Result<Option<UserToken>, IdpError> {
+        Err(IdpError::BadRequest)
+    }
+
+    async fn unix_user_authenticate_initiate_continue(
+        &self,
+        id: &Id,
+    ) -> Result<(Option<String>, Option<String>), IdpError> {
+        Err(IdpError::BadRequest)
+    }
+
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError> {
         match self
             .client

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -26,6 +26,7 @@ pub enum ClientRequest {
     NssGroupByGid(u32),
     NssGroupByName(String),
     PamAuthenticate(String, String),
+    PamAuthenticateContinue(String, String, Option<String>),
     PamAccountAllowed(String),
     PamAccountBeginSession(String),
     InvalidateCache,
@@ -41,6 +42,7 @@ pub enum ClientResponse {
     NssGroups(Vec<NssGroup>),
     NssGroup(Option<NssGroup>),
     PamStatus(Option<bool>),
+    PamPrompt(String, Option<String>),
     Ok,
     Error,
 }


### PR DESCRIPTION
In Himmelblau I need a mechanism for sending an additional pam prompt (for performing 2FA via a browser window on another device). I've implemented that here by providing a pam continue feature, which sends a message with some optional data back to pam for an additional prompt. The purpose of the additional data is simply for continuing the authentication later (in my case, it's a json string).

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
