### PR TITLE
1982 service account access

### DIFF
--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -477,7 +477,7 @@ pub async fn service_account_id_delete(
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
 ) -> impl IntoResponse {
-    let filter = filter_all!(f_eq("class", PartialValue::new_class("service_accont")));
+    let filter = filter_all!(f_eq("class", PartialValue::new_class("service_account")));
     json_rest_event_delete_id(state, id, filter, kopid).await
 }
 

--- a/server/lib/src/server/delete.rs
+++ b/server/lib/src/server/delete.rs
@@ -163,7 +163,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         self.delete(&de)
     }
 
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "debug", skip(self))]
     pub fn internal_delete_uuid_if_exists(
         &mut self,
         target_uuid: Uuid,

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -55,7 +55,11 @@ pub struct UserToken {
 pub trait IdProvider {
     async fn provider_authenticate(&self) -> Result<(), IdpError>;
 
-    async fn unix_user_get(&self, id: &Id, old_token: Option<UserToken>) -> Result<UserToken, IdpError>;
+    async fn unix_user_get(
+        &self,
+        id: &Id,
+        old_token: Option<UserToken>,
+    ) -> Result<UserToken, IdpError>;
 
     async fn unix_user_authenticate(
         &self,

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -79,7 +79,11 @@ impl IdProvider for KanidmProvider {
         }
     }
 
-    async fn unix_user_get(&self, id: &Id, _old_token: Option<UserToken>) -> Result<UserToken, IdpError> {
+    async fn unix_user_get(
+        &self,
+        id: &Id,
+        _old_token: Option<UserToken>,
+    ) -> Result<UserToken, IdpError> {
         match self
             .client
             .read()


### PR DESCRIPTION
Fixes #1982 - service account was misspelt in the endpoint, preventing account delete. 

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
