### PR TITLE
daemon: kanidmd version requires a config file to run (#1959)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@
 - Minh Phan (MinhPhan8803)
 - Kenton Groombridge (0xC0ncord)
 - Martin Weinelt (hexa)
+- Samuel Cabrero (scabrero)
 
 ## Acknowledgements
 

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -146,6 +146,12 @@ async fn main() -> ExitCode {
     // Read CLI args, determine what the user has asked us to do.
     let opt = KanidmdParser::parse();
 
+    // print the app version and bail
+    if let KanidmdOpt::Version(_) = &opt.commands {
+        println!("kanidmd {}", env!("KANIDM_PKG_VERSION"));
+        return ExitCode::SUCCESS;
+    };
+
     //we set up a list of these so we can set the log config THEN log out the errors.
     let mut config_error: Vec<String> = Vec::new();
     let mut config = Configuration::new();
@@ -232,12 +238,6 @@ async fn main() -> ExitCode {
                     return ExitCode::FAILURE
                 }
                 (cuid, ceuid)
-            };
-
-            // print the app version and bail
-            if let KanidmdOpt::Version(_) = &opt.commands {
-                println!("kanidmd {}",  env!("KANIDM_PKG_VERSION"));
-                return ExitCode::SUCCESS
             };
 
             let sconfig = match sconfig {


### PR DESCRIPTION
Fixes #1959 

Checklist

- [X] This pr contains no AI generated code
- [X] cargo fmt has been run
- [X] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
