### PR TITLE
Authentication shortcut to get a RW session

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -955,6 +955,7 @@ impl KanidmClient {
             step: AuthStep::Init2 {
                 username: ident.to_string(),
                 issue: AuthIssueSession::Token,
+                privileged: false,
             },
         };
 

--- a/proto/src/v1.rs
+++ b/proto/src/v1.rs
@@ -919,6 +919,7 @@ pub enum AuthStep {
     Init2 {
         username: String,
         issue: AuthIssueSession,
+        #[serde(default)]
         privileged: bool,
     },
     // We want to talk to you like this.

--- a/proto/src/v1.rs
+++ b/proto/src/v1.rs
@@ -919,6 +919,7 @@ pub enum AuthStep {
     Init2 {
         username: String,
         issue: AuthIssueSession,
+        privileged: bool,
     },
     // We want to talk to you like this.
     Begin(AuthMech),

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -1355,9 +1355,7 @@ mod tests {
         }};
     }
 
-    #[test]
-    fn test_idm_authsession_simple_password_mech() {
-        sketching::test_init();
+    fn start_session_simple_password_mech(privileged: bool) -> () {
         let webauthn = create_webauthn();
         // create the ent
         let mut account = entry_to_account!(E_ADMIN_V1.clone());
@@ -1396,7 +1394,7 @@ mod tests {
         // === Now begin a new session, and use a good pw.
 
         let (mut session, pw_badlist_cache) =
-            start_password_session!(&mut audit, account, &webauthn, false);
+            start_password_session!(&mut audit, account, &webauthn, privileged);
 
         let attempt = AuthCredential::Password("test_password".to_string());
         match session.validate_creds(
@@ -1421,6 +1419,12 @@ mod tests {
         assert!(async_rx.blocking_recv().is_none());
         drop(audit_tx);
         assert!(audit_rx.blocking_recv().is_none());
+    }
+
+    #[test]
+    fn test_idm_authsession_simple_password_mech() {
+        sketching::test_init();
+        start_session_simple_password_mech(false);
     }
 
     #[test]

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -1445,6 +1445,19 @@ mod tests {
     }
 
     #[test]
+    fn test_idm_authsession_simple_password_mech_priv_shortcut() {
+        sketching::test_init();
+        let uat = start_session_simple_password_mech(true);
+        match uat.purpose {
+            UatPurpose::ReadOnly => panic!("Unexpected UatPurpose::ReadOnly"),
+            UatPurpose::ReadWrite { expiry } => {
+                // Short lived RW session
+                assert!(expiry.is_some())
+            }
+        }
+    }
+
+    #[test]
     fn test_idm_authsession_simple_password_badlist() {
         sketching::test_init();
         let jws_signer = create_jwt_signer();

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -1320,12 +1320,13 @@ mod tests {
         (
             $audit:expr,
             $account:expr,
-            $webauthn:expr
+            $webauthn:expr,
+            $privileged:expr
         ) => {{
             let (session, state) = AuthSession::new(
                 $account.clone(),
                 AuthIssueSession::Token,
-                Some(false),
+                $privileged,
                 $webauthn,
                 duration_from_epoch_now(),
                 Source::Internal,
@@ -1370,7 +1371,7 @@ mod tests {
 
         // now check
         let (mut session, pw_badlist_cache) =
-            start_password_session!(&mut audit, account, &webauthn);
+            start_password_session!(&mut audit, account, &webauthn, false);
 
         let attempt = AuthCredential::Password("bad_password".to_string());
         let jws_signer = create_jwt_signer();
@@ -1395,7 +1396,7 @@ mod tests {
         // === Now begin a new session, and use a good pw.
 
         let (mut session, pw_badlist_cache) =
-            start_password_session!(&mut audit, account, &webauthn);
+            start_password_session!(&mut audit, account, &webauthn, false);
 
         let attempt = AuthCredential::Password("test_password".to_string());
         match session.validate_creds(
@@ -1439,7 +1440,7 @@ mod tests {
 
         // now check, even though the password is correct, Auth should be denied since it is in badlist
         let (mut session, pw_badlist_cache) =
-            start_password_session!(&mut audit, account, &webauthn);
+            start_password_session!(&mut audit, account, &webauthn, false);
 
         let attempt = AuthCredential::Password("list@no3IBTyqHu$bad".to_string());
         match session.validate_creds(
@@ -1474,7 +1475,7 @@ mod tests {
             let (session, state) = AuthSession::new(
                 $account.clone(),
                 AuthIssueSession::Token,
-                Some(false),
+                false,
                 $webauthn,
                 duration_from_epoch_now(),
                 Source::Internal,
@@ -1801,7 +1802,7 @@ mod tests {
             let (session, state) = AuthSession::new(
                 $account.clone(),
                 AuthIssueSession::Token,
-                Some(false),
+                false,
                 $webauthn,
                 duration_from_epoch_now(),
                 Source::Internal,

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -1120,7 +1120,11 @@ impl AuthSession {
                     AuthType::UnixPassword | AuthType::Anonymous => SessionScope::ReadOnly,
                     AuthType::GeneratedPassword => SessionScope::ReadWrite,
                     AuthType::Password | AuthType::PasswordMfa | AuthType::Passkey => {
-                        SessionScope::PrivilegeCapable
+                        if privileged {
+                            SessionScope::ReadWrite
+                        } else {
+                            SessionScope::PrivilegeCapable
+                        }
                     }
                 };
 
@@ -1286,7 +1290,7 @@ mod tests {
         let (session, state) = AuthSession::new(
             anon_account,
             AuthIssueSession::Token,
-            Some(false),
+            false,
             &webauthn,
             duration_from_epoch_now(),
             Source::Internal,

--- a/server/lib/src/idm/event.rs
+++ b/server/lib/src/idm/event.rs
@@ -352,7 +352,7 @@ impl AuthEventStep {
         AuthEventStep::Init(AuthEventStepInit {
             username: "anonymous".to_string(),
             issue: AuthIssueSession::Token,
-            privileged: Some(false),
+            privileged: false,
         })
     }
 
@@ -361,7 +361,7 @@ impl AuthEventStep {
         AuthEventStep::Init(AuthEventStepInit {
             username: name.to_string(),
             issue: AuthIssueSession::Token,
-            privileged: Some(false),
+            privileged: false,
         })
     }
 

--- a/server/lib/src/idm/event.rs
+++ b/server/lib/src/idm/event.rs
@@ -280,6 +280,7 @@ impl LdapTokenAuthEvent {
 pub struct AuthEventStepInit {
     pub username: String,
     pub issue: AuthIssueSession,
+    pub privileged: bool,
 }
 
 #[derive(Debug)]
@@ -311,14 +312,23 @@ impl AuthEventStep {
                     Ok(AuthEventStep::Init(AuthEventStepInit {
                         username,
                         issue: AuthIssueSession::Token,
+                        privileged: false,
                     }))
                 }
             }
-            AuthStep::Init2 { username, issue } => {
+            AuthStep::Init2 {
+                username,
+                issue,
+                privileged,
+            } => {
                 if username.trim().is_empty() {
                     Err(OperationError::EmptyRequest)
                 } else {
-                    Ok(AuthEventStep::Init(AuthEventStepInit { username, issue }))
+                    Ok(AuthEventStep::Init(AuthEventStepInit {
+                        username,
+                        issue,
+                        privileged,
+                    }))
                 }
             }
 
@@ -342,6 +352,7 @@ impl AuthEventStep {
         AuthEventStep::Init(AuthEventStepInit {
             username: "anonymous".to_string(),
             issue: AuthIssueSession::Token,
+            privileged: Some(false),
         })
     }
 
@@ -350,6 +361,7 @@ impl AuthEventStep {
         AuthEventStep::Init(AuthEventStepInit {
             username: name.to_string(),
             issue: AuthIssueSession::Token,
+            privileged: Some(false),
         })
     }
 

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1006,6 +1006,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
                 security_info!(
                     username = %init.username,
                     issue = ?init.issue,
+                    privileged = ?init.privileged,
                     uuid = %euuid,
                     "Initiating Authentication Session",
                 );
@@ -1048,8 +1049,14 @@ impl<'a> IdmServerAuthTransaction<'a> {
                             slock_ref
                         });
 
-                let (auth_session, state) =
-                    AuthSession::new(account, init.issue, self.webauthn, ct, source);
+                let (auth_session, state) = AuthSession::new(
+                    account,
+                    init.issue,
+                    init.privileged,
+                    self.webauthn,
+                    ct,
+                    source,
+                );
 
                 match auth_session {
                     Some(auth_session) => {

--- a/server/web_ui/src/login/mod.rs
+++ b/server/web_ui/src/login/mod.rs
@@ -100,6 +100,7 @@ impl LoginApp {
             step: AuthStep::Init2 {
                 username,
                 issue: AuthIssueSession::Token,
+                privileged: false,
             },
         };
         let req_jsvalue = serde_json::to_string(&authreq)


### PR DESCRIPTION
What do you think about this approach? I am not convinced about the `privileged` name.

Do we also want to expose this functionality in the client library? E.g.:
`$ kanidm login --privileged`

Fixes #1940 

Checklist

- [X] This pr contains no AI generated code
- [X] cargo fmt has been run
- [X] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
