### PR TITLE
Himmelblau requires a mechanism to send pam_prompt

### DIFF
--- a/unix_integration/pam_kanidm/src/pam/constants.rs
+++ b/unix_integration/pam_kanidm/src/pam/constants.rs
@@ -47,9 +47,9 @@ pub const _PAM_AUTHTOK_TYPE: PamItemType = 13;
 
 // Message styles
 pub const PAM_PROMPT_ECHO_OFF: PamMessageStyle = 1;
-pub const _PAM_PROMPT_ECHO_ON: PamMessageStyle = 2;
-pub const _PAM_ERROR_MSG: PamMessageStyle = 3;
-pub const _PAM_TEXT_INFO: PamMessageStyle = 4;
+pub const PAM_PROMPT_ECHO_ON: PamMessageStyle = 2;
+pub const PAM_ERROR_MSG: PamMessageStyle = 3;
+pub const PAM_TEXT_INFO: PamMessageStyle = 4;
 /// yes/no/maybe conditionals
 pub const _PAM_RADIO_TYPE: PamMessageStyle = 5;
 pub const _PAM_BINARY_PROMPT: PamMessageStyle = 7;

--- a/unix_integration/pam_kanidm/src/pam/mod.rs
+++ b/unix_integration/pam_kanidm/src/pam/mod.rs
@@ -286,10 +286,16 @@ impl PamHooks for PamKanidm {
                     };
                     match prompt.cred_type {
                         Some(CredType::Password) => {
-                            req = ClientRequest::PamAuthenticateStep(Some(PamCred::Password(resp)));
+                            req = ClientRequest::PamAuthenticateStep(
+                                Some(PamCred::Password(resp)),
+                                prompt.data,
+                            );
                         }
                         _ => {
-                            req = ClientRequest::PamAuthenticateStep(Some(PamCred::MFACode(resp)));
+                            req = ClientRequest::PamAuthenticateStep(
+                                Some(PamCred::MFACode(resp)),
+                                prompt.data,
+                            );
                         }
                     }
                     // We've consumed any authtok, delete it
@@ -305,7 +311,7 @@ impl PamHooks for PamKanidm {
                             return err;
                         }
                     }
-                    req = ClientRequest::PamAuthenticateStep(None);
+                    req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                 }
                 _ => {
                     return PamResultCode::PAM_IGNORE;

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -281,15 +281,15 @@ async fn handle_client(
                 debug!("pam authenticate init");
                 pam_state = PamState::Step(account_id.clone());
                 cachelayer
-                    .pam_account_authenticate_step(account_id.as_str(), None)
+                    .pam_account_authenticate_step(account_id.as_str(), None, None)
                     .await
                     .unwrap_or(ClientResponse::Error)
             }
-            ClientRequest::PamAuthenticateStep(cred) => {
+            ClientRequest::PamAuthenticateStep(cred, data) => {
                 debug!("pam authenticate step");
                 match &pam_state {
                     PamState::Step(account_id) => match cachelayer
-                        .pam_account_authenticate_step(account_id.as_str(), cred)
+                        .pam_account_authenticate_step(account_id.as_str(), cred, data)
                         .await
                         .unwrap_or(ClientResponse::Error)
                     {

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -1,3 +1,4 @@
+use crate::unix_proto::ProviderResult;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -61,11 +62,11 @@ pub trait IdProvider {
         old_token: Option<UserToken>,
     ) -> Result<UserToken, IdpError>;
 
-    async fn unix_user_authenticate(
+    async fn unix_user_authenticate_step(
         &self,
         id: &Id,
-        cred: &str,
-    ) -> Result<Option<UserToken>, IdpError>;
+        cred: Option<&str>,
+    ) -> Result<ProviderResult, IdpError>;
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;
 }

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -1,3 +1,4 @@
+use crate::pam_data::PamData;
 use crate::unix_proto::ProviderResult;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -66,6 +67,7 @@ pub trait IdProvider {
         &self,
         id: &Id,
         cred: Option<&str>,
+        data: Option<PamData>,
     ) -> Result<ProviderResult, IdpError>;
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -4,6 +4,7 @@ use kanidm_proto::v1::{OperationError, UnixGroupToken, UnixUserToken};
 use tokio::sync::RwLock;
 
 use super::interface::{GroupToken, Id, IdProvider, IdpError, UserToken};
+use crate::pam_data::PamData;
 use crate::unix_proto::{PamPrompt, ProviderResult};
 
 pub struct KanidmProvider {
@@ -146,6 +147,7 @@ impl IdProvider for KanidmProvider {
         &self,
         id: &Id,
         cred: Option<&str>,
+        _data: Option<PamData>,
     ) -> Result<ProviderResult, IdpError> {
         let cred = match cred {
             Some(cred) => cred,

--- a/unix_integration/src/lib.rs
+++ b/unix_integration/src/lib.rs
@@ -28,6 +28,8 @@ pub mod db;
 #[cfg(target_family = "unix")]
 pub mod idprovider;
 #[cfg(target_family = "unix")]
+pub mod pam_data;
+#[cfg(target_family = "unix")]
 pub mod resolver;
 #[cfg(all(target_family = "unix", feature = "selinux"))]
 pub mod selinux_util;

--- a/unix_integration/src/pam_data.rs
+++ b/unix_integration/src/pam_data.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+/* This is the definition for extra data to be sent along with a pam_prompt
+ * request. It will be sent back to the idprovider to continue an auth attempt.
+ */
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PamData {}

--- a/unix_integration/src/tool.rs
+++ b/unix_integration/src/tool.rs
@@ -110,14 +110,16 @@ async fn main() -> ExitCode {
                         };
                         match prompt.cred_type {
                             Some(CredType::Password) => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::Password(
-                                    password,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::Password(password)),
+                                    prompt.data,
+                                );
                             }
                             _ => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::MFACode(
-                                    password,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::MFACode(password)),
+                                    prompt.data,
+                                );
                             }
                         }
                     }
@@ -133,24 +135,26 @@ async fn main() -> ExitCode {
                         passcode = passcode.trim_end_matches('\n').to_string();
                         match prompt.cred_type {
                             Some(CredType::Password) => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::Password(
-                                    passcode,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::Password(passcode)),
+                                    prompt.data,
+                                );
                             }
                             _ => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::MFACode(
-                                    passcode,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::MFACode(passcode)),
+                                    prompt.data,
+                                );
                             }
                         }
                     }
                     PamMessageStyle::PamErrorMsg => {
                         error!(prompt.msg);
-                        req = ClientRequest::PamAuthenticateStep(None);
+                        req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                     }
                     PamMessageStyle::PamTextInfo => {
                         info!(prompt.msg);
-                        req = ClientRequest::PamAuthenticateStep(None);
+                        req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                     }
                 }
             }

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -1,4 +1,5 @@
 use crate::idprovider::interface::UserToken;
+use crate::pam_data::PamData;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -50,6 +51,7 @@ pub struct PamPrompt {
     pub msg: String,
     pub timeout: Option<u64>, // timeout of None means use the config default
     pub cred_type: Option<CredType>,
+    pub data: Option<PamData>,
 }
 
 impl PamPrompt {
@@ -60,6 +62,7 @@ impl PamPrompt {
             msg: "Password: ".to_string(),
             timeout: None,
             cred_type: Some(CredType::Password),
+            data: None,
         }
     }
 }
@@ -80,7 +83,7 @@ pub enum ClientRequest {
     NssGroupByGid(u32),
     NssGroupByName(String),
     PamAuthenticateInit(String),
-    PamAuthenticateStep(Option<PamCred>),
+    PamAuthenticateStep(Option<PamCred>, Option<PamData>),
     PamAccountAllowed(String),
     PamAccountBeginSession(String),
     InvalidateCache,


### PR DESCRIPTION
In Himmelblau I need a mechanism for sending an additional pam prompt (for performing 2FA via a browser window on another device). I've implemented that here by causing pam to operate like a state machine, with the daemon requesting prompts only as required.
This replaces MR #1970.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
