### PR TITLE
Resolve incorrect time units on timeout

### DIFF
--- a/unix_integration/src/client.rs
+++ b/unix_integration/src/client.rs
@@ -81,12 +81,12 @@ pub async fn call_daemon(
     req: ClientRequest,
     timeout: u64,
 ) -> Result<ClientResponse, Box<dyn Error>> {
-    let sleep = time::sleep(Duration::from_millis(timeout));
+    let sleep = time::sleep(Duration::from_secs(timeout));
     tokio::pin!(sleep);
 
     tokio::select! {
         _ = &mut sleep => {
-            error!("Timed out making request to kanidm_unixd");
+            error!(?timeout, "Timed out making request to kanidm_unixd");
             Err(Box::new(IoError::new(ErrorKind::Other, "timeout")))
         }
         res = call_daemon_inner(path, req) => {


### PR DESCRIPTION
Fixes #1995 - Timeout was incorrectly set to millis instead of seconds. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
