### PR TITLE
fix: output an array in json mode for `kanidm group list`

### DIFF
--- a/tools/cli/src/cli/group.rs
+++ b/tools/cli/src/cli/group.rs
@@ -25,16 +25,16 @@ impl GroupOpt {
             GroupOpt::List(copt) => {
                 let client = copt.to_client(OpType::Read).await;
                 match client.idm_group_list().await {
-                    Ok(r) => r.iter().for_each(|ent| match copt.output_mode {
+                    Ok(r) => match copt.output_mode {
                         OutputMode::Json => {
+                            let r_attrs: Vec<_> = r.iter().map(|entry| &entry.attrs).collect();
                             println!(
                                 "{}",
-                                serde_json::to_string(&ent.attrs)
-                                    .expect("Failed to serialise json")
+                                serde_json::to_string(&r_attrs).expect("Failed to serialise json")
                             );
                         }
-                        OutputMode::Text => println!("{}", ent),
-                    }),
+                        OutputMode::Text => r.iter().for_each(|ent| println!("{}", ent)),
+                    },
                     Err(e) => error!("Error -> {:?}", e),
                 }
             }


### PR DESCRIPTION
Currently `kanidm group list --output=json` outputs one separate json object per line, which is hard to work with.

This PR changes this to output a json array instead, which IMO is more consistent and allows for easier consumption of the output.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
