### PR TITLE
feat: add json output modes for `person list` and `system oauth2 list`

### DIFF
--- a/tools/cli/src/cli/oauth2.rs
+++ b/tools/cli/src/cli/oauth2.rs
@@ -34,7 +34,16 @@ impl Oauth2Opt {
             Oauth2Opt::List(copt) => {
                 let client = copt.to_client(OpType::Read).await;
                 match client.idm_oauth2_rs_list().await {
-                    Ok(r) => r.iter().for_each(|ent| println!("{}", ent)),
+                    Ok(r) => match copt.output_mode {
+                        OutputMode::Json => {
+                            let r_attrs: Vec<_> = r.iter().map(|entry| &entry.attrs).collect();
+                            println!(
+                                "{}",
+                                serde_json::to_string(&r_attrs).expect("Failed to serialise json")
+                            );
+                        }
+                        OutputMode::Text => r.iter().for_each(|ent| println!("{}", ent)),
+                    },
                     Err(e) => error!("Error -> {:?}", e),
                 }
             }


### PR DESCRIPTION
This implements json output for `kanidm person list` and  `kanidm system oauth2 list`, so that the argument `--output=json` is no longer ignored.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
