### PR TITLE
68 20230821 replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,8 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "base64urlsafedata"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b3d30abb74120a9d5267463b9e0045fdccc4dd152e7249d966612dc1721384"
 dependencies = [
  "base64 0.21.2",
  "serde",
@@ -438,8 +440,7 @@ dependencies = [
 [[package]]
 name = "base64urlsafedata"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b3d30abb74120a9d5267463b9e0045fdccc4dd152e7249d966612dc1721384"
+source = "git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5#429662e34d6e760af8cff68760567c6b56dbb2d5"
 dependencies = [
  "base64 0.21.2",
  "serde",
@@ -5059,11 +5060,12 @@ dependencies = [
 [[package]]
 name = "webauthn-authenticator-rs"
 version = "0.5.0-dev"
+source = "git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5#429662e34d6e760af8cff68760567c6b56dbb2d5"
 dependencies = [
  "async-stream",
  "async-trait",
  "authenticator-ctap2-2021",
- "base64urlsafedata 0.1.3",
+ "base64urlsafedata 0.1.3 (git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5)",
  "bitflags 1.3.2",
  "futures",
  "hex",
@@ -5090,8 +5092,9 @@ dependencies = [
 [[package]]
 name = "webauthn-rs"
 version = "0.5.0-dev"
+source = "git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5#429662e34d6e760af8cff68760567c6b56dbb2d5"
 dependencies = [
- "base64urlsafedata 0.1.3",
+ "base64urlsafedata 0.1.3 (git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5)",
  "serde",
  "tracing",
  "url",
@@ -5102,9 +5105,10 @@ dependencies = [
 [[package]]
 name = "webauthn-rs-core"
 version = "0.5.0-dev"
+source = "git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5#429662e34d6e760af8cff68760567c6b56dbb2d5"
 dependencies = [
  "base64 0.21.2",
- "base64urlsafedata 0.1.3",
+ "base64urlsafedata 0.1.3 (git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5)",
  "compact_jwt",
  "der-parser",
  "nom",
@@ -5124,8 +5128,9 @@ dependencies = [
 [[package]]
 name = "webauthn-rs-proto"
 version = "0.5.0-dev"
+source = "git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5#429662e34d6e760af8cff68760567c6b56dbb2d5"
 dependencies = [
- "base64urlsafedata 0.1.3",
+ "base64urlsafedata 0.1.3 (git+https://github.com/kanidm/webauthn-rs.git?rev=429662e34d6e760af8cff68760567c6b56dbb2d5)",
  "js-sys",
  "serde",
  "serde-wasm-bindgen 0.4.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +425,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.1.3"
+dependencies = [
+ "base64 0.21.2",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "base64urlsafedata"
@@ -714,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f9032b96a89dd79ffc5f62523d5351ebb40680cbdfc4029393b511b9e971aa"
 dependencies = [
  "base64 0.13.1",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "openssl",
  "serde",
@@ -2165,7 +2196,7 @@ dependencies = [
 name = "kanidm-ipa-sync"
 version = "1.1.0-rc.14-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "clap",
  "clap_complete",
@@ -2189,7 +2220,7 @@ dependencies = [
 name = "kanidm-ldap-sync"
 version = "1.1.0-rc.14-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "clap",
  "clap_complete",
@@ -2242,7 +2273,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "base64 0.21.2",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "kanidm_proto",
  "openssl",
@@ -2267,7 +2298,7 @@ name = "kanidm_proto"
 version = "1.1.0-rc.14-dev"
 dependencies = [
  "base32",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum",
  "scim_proto",
  "serde",
@@ -2315,7 +2346,7 @@ name = "kanidm_unix_int"
 version = "1.1.0-rc.14-dev"
 dependencies = [
  "async-trait",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "clap",
  "clap_complete",
@@ -2404,7 +2435,7 @@ name = "kanidmd_lib"
 version = "1.1.0-rc.14-dev"
 dependencies = [
  "base64 0.21.2",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "compact_jwt",
  "concread",
  "criterion",
@@ -2566,7 +2597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a229cd5ee2a4e5a1a279b6216494aa2a5053a189c5ce37bb31f9156b63b63de"
 dependencies = [
  "base64 0.13.1",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "ldap3_proto",
  "openssl",
@@ -3871,7 +3902,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e53f2c444b72dd7410aa1cdc3c0942349262e84364dc7968dc7402525ea2ca"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "peg",
  "serde",
  "serde_json",
@@ -4528,6 +4559,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5026,32 +5058,40 @@ dependencies = [
 
 [[package]]
 name = "webauthn-authenticator-rs"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603b8602cae2d6c3706b6195765ff582389494d10c442d84a1de2ed5a25679ef"
+version = "0.5.0-dev"
 dependencies = [
+ "async-stream",
+ "async-trait",
  "authenticator-ctap2-2021",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3",
+ "bitflags 1.3.2",
+ "futures",
+ "hex",
  "nom",
+ "num-derive",
+ "num-traits",
  "openssl",
  "rpassword 5.0.1",
  "serde",
+ "serde_bytes",
  "serde_cbor_2",
  "serde_json",
+ "tokio",
+ "tokio-stream",
  "tracing",
+ "unicode-normalization",
  "url",
  "uuid",
+ "webauthn-rs-core",
  "webauthn-rs-proto",
  "windows 0.41.0",
 ]
 
 [[package]]
 name = "webauthn-rs"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db00711c712414e93b019c4596315085792215bc2ac2d5872f9e8913b0a6316"
+version = "0.5.0-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3",
  "serde",
  "tracing",
  "url",
@@ -5061,12 +5101,10 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294c78c83f12153a51e1cf1e6970b5da1397645dada39033a9c3173a8fc4fc2b"
+version = "0.5.0-dev"
 dependencies = [
- "base64 0.13.1",
- "base64urlsafedata",
+ "base64 0.21.2",
+ "base64urlsafedata 0.1.3",
  "compact_jwt",
  "der-parser",
  "nom",
@@ -5085,11 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24e638361a63ba5c0a0be6a60229490fcdf33740ed63df5bb6bdb627b52a138"
+version = "0.5.0-dev"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3",
  "js-sys",
  "serde",
  "serde-wasm-bindgen 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,10 +187,16 @@ wasm-bindgen-test = "0.3.35"
 # webauthn-rs = "0.4.8"
 # webauthn-rs-core = "0.4.8"
 # webauthn-rs-proto = "0.4.8"
-webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs", features = ["softpasskey", "softtoken", "mozilla"] }
-webauthn-rs = { path = "../webauthn-rs/webauthn-rs", features = ["preview-features"] }
-webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
-webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
+# webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs", features = ["softpasskey", "softtoken", "mozilla"] }
+# webauthn-rs = { path = "../webauthn-rs/webauthn-rs", features = ["preview-features"] }
+# webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
+# webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
+
+webauthn-authenticator-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "429662e34d6e760af8cff68760567c6b56dbb2d5", features = ["softpasskey", "softtoken", "mozilla"] }
+webauthn-rs = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "429662e34d6e760af8cff68760567c6b56dbb2d5", features = ["preview-features"] }
+webauthn-rs-core = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "429662e34d6e760af8cff68760567c6b56dbb2d5" }
+webauthn-rs-proto = { git = "https://github.com/kanidm/webauthn-rs.git", rev = "429662e34d6e760af8cff68760567c6b56dbb2d5" }
+
 web-sys = "^0.3.62"
 whoami = "^1.4.1"
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,8 +165,8 @@ tokio-util = "^0.7.8"
 
 toml = "^0.5.11"
 touch = "^0.0.1"
-# tracing = { version = "^0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
-tracing = { version = "^0.1.37" }
+tracing = { version = "^0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
+# tracing = { version = "^0.1.37" }
 tracing-subscriber = { version = "^0.3.17", features = ["env-filter"] }
 
 # tracing-forest = { path = "/Users/william/development/tracing-forest/tracing-forest" }
@@ -183,14 +183,14 @@ wasm-bindgen = "^0.2.86"
 wasm-bindgen-futures = "^0.4.30"
 wasm-bindgen-test = "0.3.35"
 
-webauthn-authenticator-rs = "0.4.8"
-webauthn-rs = "0.4.8"
-webauthn-rs-core = "0.4.8"
-webauthn-rs-proto = "0.4.8"
-# webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs" }
-# webauthn-rs = { path = "../webauthn-rs/webauthn-rs" }
-# webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
-# webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
+# webauthn-authenticator-rs = { version = "0.4.8", features = ["softpasskey", "softtoken"] }
+# webauthn-rs = "0.4.8"
+# webauthn-rs-core = "0.4.8"
+# webauthn-rs-proto = "0.4.8"
+webauthn-authenticator-rs = { path = "../webauthn-rs/webauthn-authenticator-rs", features = ["softpasskey", "softtoken", "mozilla"] }
+webauthn-rs = { path = "../webauthn-rs/webauthn-rs", features = ["preview-features"] }
+webauthn-rs-core = { path = "../webauthn-rs/webauthn-rs-core" }
+webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
 web-sys = "^0.3.62"
 whoami = "^1.4.1"
 walkdir = "2"

--- a/server/lib/src/be/dbvalue.rs
+++ b/server/lib/src/be/dbvalue.rs
@@ -7,9 +7,7 @@ use serde_with::skip_serializing_none;
 use url::Url;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
-    AttestedPasskey as DeviceKeyV4,
-    Passkey as PasskeyV4,
-    SecurityKey as SecurityKeyV4,
+    AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
 };
 use webauthn_rs_core::proto::{COSEKey, UserVerificationPolicy};
 

--- a/server/lib/src/be/dbvalue.rs
+++ b/server/lib/src/be/dbvalue.rs
@@ -7,7 +7,9 @@ use serde_with::skip_serializing_none;
 use url::Url;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
-    DeviceKey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
+    AttestedPasskey as DeviceKeyV4,
+    Passkey as PasskeyV4,
+    SecurityKey as SecurityKeyV4,
 };
 use webauthn_rs_core::proto::{COSEKey, UserVerificationPolicy};
 

--- a/server/lib/src/be/idl_arc_sqlite.rs
+++ b/server/lib/src/be/idl_arc_sqlite.rs
@@ -1086,9 +1086,12 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
     ///
     /// It should only be called internally by the backend in limited and
     /// specific situations.
+    #[instrument(level = "trace", skip_all)]
     pub fn danger_purge_idxs(&mut self) -> Result<(), OperationError> {
+        error!("CLEARING CACHE");
         self.db.danger_purge_idxs().map(|()| {
             self.idl_cache.clear();
+            self.name_cache.clear();
         })
     }
 
@@ -1096,6 +1099,7 @@ impl<'a> IdlArcSqliteWriteTransaction<'a> {
     ///
     /// It should only be called internally by the backend in limited and
     /// specific situations.
+    #[instrument(level = "trace", skip_all)]
     pub fn danger_purge_id2entry(&mut self) -> Result<(), OperationError> {
         self.db.danger_purge_id2entry().map(|()| {
             let mut ids = IDLBitRange::new();

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -1162,7 +1162,7 @@ impl<'a> BackendWriteTransaction<'a> {
                 }
                 Some(idl) => {
                     // BUG - duplicate uuid!
-                    error!(uuid = ?ctx_ent_uuid, "Invalid IDL state, uuid index must have only a single or no values. Contains {}", idl.len());
+                    error!(uuid = ?ctx_ent_uuid, "Invalid IDL state, uuid index must have only a single or no values. Contains {:?}", idl);
                     return Err(OperationError::InvalidDbState);
                 }
                 None => {
@@ -1491,6 +1491,12 @@ impl<'a> BackendWriteTransaction<'a> {
                         match self.idlayer.get_idl(attr, itype, &idx_key)? {
                             Some(mut idl) => {
                                 idl.insert_id(e_id);
+                                if cfg!(debug_assertions) {
+                                    if attr == "uuid" && itype == IndexType::Equality {
+                                        trace!("{:?}", idl);
+                                        debug_assert!(idl.len() <= 1);
+                                    }
+                                }
                                 self.idlayer.write_idl(attr, itype, &idx_key, &idl)
                             }
                             None => {
@@ -1507,6 +1513,12 @@ impl<'a> BackendWriteTransaction<'a> {
                         match self.idlayer.get_idl(attr, itype, &idx_key)? {
                             Some(mut idl) => {
                                 idl.remove_id(e_id);
+                                if cfg!(debug_assertions) {
+                                    if attr == "uuid" && itype == IndexType::Equality {
+                                        trace!("{:?}", idl);
+                                        debug_assert!(idl.len() <= 1);
+                                    }
+                                }
                                 self.idlayer.write_idl(attr, itype, &idx_key, &idl)
                             }
                             None => {

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -1491,11 +1491,10 @@ impl<'a> BackendWriteTransaction<'a> {
                         match self.idlayer.get_idl(attr, itype, &idx_key)? {
                             Some(mut idl) => {
                                 idl.insert_id(e_id);
-                                if cfg!(debug_assertions) {
-                                    if attr == "uuid" && itype == IndexType::Equality {
+                                if cfg!(debug_assertions)
+                                    && attr == "uuid" && itype == IndexType::Equality {
                                         trace!("{:?}", idl);
                                         debug_assert!(idl.len() <= 1);
-                                    }
                                 }
                                 self.idlayer.write_idl(attr, itype, &idx_key, &idl)
                             }
@@ -1513,11 +1512,9 @@ impl<'a> BackendWriteTransaction<'a> {
                         match self.idlayer.get_idl(attr, itype, &idx_key)? {
                             Some(mut idl) => {
                                 idl.remove_id(e_id);
-                                if cfg!(debug_assertions) {
-                                    if attr == "uuid" && itype == IndexType::Equality {
+                                if cfg!(debug_assertions) && attr == "uuid" && itype == IndexType::Equality {
                                         trace!("{:?}", idl);
                                         debug_assert!(idl.len() <= 1);
-                                    }
                                 }
                                 self.idlayer.write_idl(attr, itype, &idx_key, &idl)
                             }

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -42,7 +42,7 @@ use smartstring::alias::String as AttrString;
 use time::OffsetDateTime;
 use tracing::trace;
 use uuid::Uuid;
-use webauthn_rs::prelude::{DeviceKey as DeviceKeyV4, Passkey as PasskeyV4};
+use webauthn_rs::prelude::{AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4};
 
 use crate::be::dbentry::{DbEntry, DbEntryV2, DbEntryVers};
 use crate::be::dbvalue::DbValueSetV2;

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -7,7 +7,7 @@ use kanidm_proto::v1::{
 use time::OffsetDateTime;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
-    AuthenticationResult, CredentialID, AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4,
+    AttestedPasskey as DeviceKeyV4, AuthenticationResult, CredentialID, Passkey as PasskeyV4,
 };
 
 use crate::constants::UUID_ANONYMOUS;

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -7,7 +7,7 @@ use kanidm_proto::v1::{
 use time::OffsetDateTime;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
-    AuthenticationResult, CredentialID, DeviceKey as DeviceKeyV4, Passkey as PasskeyV4,
+    AuthenticationResult, CredentialID, AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4,
 };
 
 use crate::constants::UUID_ANONYMOUS;

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -17,7 +17,6 @@ use kanidm_proto::v1::{
 // use crossbeam::channel::Sender;
 use tokio::sync::mpsc::UnboundedSender as Sender;
 use uuid::Uuid;
-// use webauthn_rs::prelude::DeviceKey as DeviceKeyV4;
 use nonempty::{nonempty, NonEmpty};
 use webauthn_rs::prelude::Passkey as PasskeyV4;
 use webauthn_rs::prelude::{
@@ -1815,7 +1814,7 @@ mod tests {
     ) {
         let webauthn = create_webauthn();
         // Setup a soft token
-        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());
+        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
 
         let uuid = Uuid::new_v4();
 
@@ -1843,7 +1842,7 @@ mod tests {
     ) {
         let webauthn = create_webauthn();
         // Setup a soft token
-        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());
+        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
 
         let uuid = Uuid::new_v4();
 
@@ -1968,7 +1967,7 @@ mod tests {
 
         // Use an incorrect softtoken.
         {
-            let mut inv_wa = WebauthnAuthenticator::new(SoftPasskey::new());
+            let mut inv_wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
             let (chal, reg_state) = webauthn
                 .start_passkey_registration(account.uuid, &account.name, &account.displayname, None)
                 .expect("Failed to setup webauthn rego challenge");

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -15,9 +15,9 @@ use kanidm_proto::v1::{
     AuthAllowed, AuthCredential, AuthIssueSession, AuthMech, OperationError, UserAuthToken,
 };
 // use crossbeam::channel::Sender;
+use nonempty::{nonempty, NonEmpty};
 use tokio::sync::mpsc::UnboundedSender as Sender;
 use uuid::Uuid;
-use nonempty::{nonempty, NonEmpty};
 use webauthn_rs::prelude::Passkey as PasskeyV4;
 use webauthn_rs::prelude::{
     CredentialID, PasskeyAuthentication, RequestChallengeResponse, SecurityKeyAuthentication,

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -12,7 +12,7 @@ use kanidm_proto::v1::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use webauthn_rs::prelude::{
-    CreationChallengeResponse, DeviceKey as DeviceKeyV4, Passkey as PasskeyV4, PasskeyRegistration,
+    CreationChallengeResponse, AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4, PasskeyRegistration,
     RegisterPublicKeyCredential,
 };
 
@@ -2679,7 +2679,7 @@ mod tests {
         let origin = cutxn.get_origin().clone();
 
         // Create a soft passkey
-        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());
+        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
 
         // Start the registration
         let c_status = cutxn

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -12,8 +12,8 @@ use kanidm_proto::v1::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use webauthn_rs::prelude::{
-    CreationChallengeResponse, AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4, PasskeyRegistration,
-    RegisterPublicKeyCredential,
+    AttestedPasskey as DeviceKeyV4, CreationChallengeResponse, Passkey as PasskeyV4,
+    PasskeyRegistration, RegisterPublicKeyCredential,
 };
 
 use crate::credential::totp::{Totp, TOTP_DEFAULT_STEP};

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -134,7 +134,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
             session,
             session_cred_id,
             issue,
-            &self.webauthn,
+            self.webauthn,
             ct,
             source,
         );

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -134,7 +134,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
             session,
             session_cred_id,
             issue,
-            self.webauthn,
+            &self.webauthn,
             ct,
             source,
         );
@@ -230,7 +230,7 @@ mod tests {
         let cutxn = idms.cred_update_transaction().await;
         let origin = cutxn.get_origin().clone();
 
-        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());
+        let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
 
         let c_status = cutxn
             .credential_passkey_init(&cust, ct)

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -2025,6 +2025,8 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
                 .map(|new_cookie_key| {
                     self.domain_keys.cookie_key = new_cookie_key;
                 })?;
+            // If the domain name has changed, we need to update rp-id in
+            // webauthn rs
         }
         // Commit everything.
         self.oauth2rs.commit();

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -86,7 +86,7 @@ pub struct IdmServer {
     async_tx: Sender<DelayedAction>,
     audit_tx: Sender<AuditEvent>,
     /// [Webauthn] verifier/config
-    webauthn: Arc<CowCell<Webauthn>>,
+    webauthn: Webauthn,
     pw_badlist_cache: Arc<CowCell<HashSet<String>>>,
     oauth2rs: Arc<Oauth2ResourceServers>,
     domain_keys: Arc<CowCell<DomainKeys>>,
@@ -104,7 +104,7 @@ pub struct IdmServerAuthTransaction<'a> {
     // For flagging eventual actions.
     pub(crate) async_tx: Sender<DelayedAction>,
     pub(crate) audit_tx: Sender<AuditEvent>,
-    pub(crate) webauthn: CowCellReadTxn<Webauthn>,
+    pub(crate) webauthn: &'a Webauthn,
     pub(crate) pw_badlist_cache: CowCellReadTxn<HashSet<String>>,
     pub(crate) domain_keys: CowCellReadTxn<DomainKeys>,
 }
@@ -112,7 +112,7 @@ pub struct IdmServerAuthTransaction<'a> {
 pub struct IdmServerCredUpdateTransaction<'a> {
     pub(crate) _qs_read: QueryServerReadTransaction<'a>,
     // sid: Sid,
-    pub(crate) webauthn: CowCellReadTxn<Webauthn>,
+    pub(crate) webauthn: &'a Webauthn,
     pub(crate) pw_badlist_cache: CowCellReadTxn<HashSet<String>>,
     pub(crate) cred_update_sessions: BptreeMapReadTxn<'a, Uuid, CredentialUpdateSessionMutex>,
     pub(crate) domain_keys: CowCellReadTxn<DomainKeys>,
@@ -134,7 +134,7 @@ pub struct IdmServerProxyWriteTransaction<'a> {
     pub(crate) cred_update_sessions: BptreeMapWriteTxn<'a, Uuid, CredentialUpdateSessionMutex>,
     pub(crate) sid: Sid,
     crypto_policy: &'a CryptoPolicy,
-    webauthn: CowCellWriteTxn<'a, Webauthn>,
+    webauthn: &'a Webauthn,
     pw_badlist_cache: CowCellWriteTxn<'a, HashSet<String>>,
     pub(crate) domain_keys: CowCellWriteTxn<'a, DomainKeys>,
     pub(crate) oauth2rs: Oauth2ResourceServersWriteTransaction<'a>,
@@ -213,8 +213,6 @@ impl IdmServer {
                 OperationError::InvalidState
             })?;
 
-        let webauthn = Arc::new(CowCell::new(webauthn));
-
         // Setup our auth token signing key.
         let token_enc_key = Fernet::new(&fernet_private_key).ok_or_else(|| {
             admin_error!("Unable to load Fernet encryption key");
@@ -284,7 +282,7 @@ impl IdmServer {
             sid,
             async_tx: self.async_tx.clone(),
             audit_tx: self.audit_tx.clone(),
-            webauthn: self.webauthn.read(),
+            webauthn: &self.webauthn,
             pw_badlist_cache: self.pw_badlist_cache.read(),
             domain_keys: self.domain_keys.read(),
         }
@@ -314,7 +312,7 @@ impl IdmServer {
             qs_write,
             sid,
             crypto_policy: &self.crypto_policy,
-            webauthn: self.webauthn.write(),
+            webauthn: &self.webauthn,
             pw_badlist_cache: self.pw_badlist_cache.write(),
             domain_keys: self.domain_keys.write(),
             oauth2rs: self.oauth2rs.write(),
@@ -325,7 +323,7 @@ impl IdmServer {
         IdmServerCredUpdateTransaction {
             _qs_read: self.qs.read().await,
             // sid: Sid,
-            webauthn: self.webauthn.read(),
+            webauthn: &self.webauthn,
             pw_badlist_cache: self.pw_badlist_cache.read(),
             cred_update_sessions: self.cred_update_sessions.read(),
             domain_keys: self.domain_keys.read(),
@@ -1005,7 +1003,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
                         });
 
                 let (auth_session, state) =
-                    AuthSession::new(account, init.issue, &self.webauthn, ct, source);
+                    AuthSession::new(account, init.issue, self.webauthn, ct, source);
 
                 match auth_session {
                     Some(auth_session) => {
@@ -1129,7 +1127,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
                             ct,
                             &self.async_tx,
                             &self.audit_tx,
-                            &self.webauthn,
+                            self.webauthn,
                             pw_badlist_cache,
                             &self.domain_keys.uat_jwt_signer,
                         )
@@ -2029,6 +2027,11 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
                 })?;
             // If the domain name has changed, we need to update rp-id in
             // webauthn rs
+            //
+            // TODO: I'm not sure actually. because on a domain rename we
+            // might need to update origin too. So this gets a bit tricky.
+            // we might actually need to *not* reload here, and then let the
+            // admin do it inline with their configs too.
         }
         // Commit everything.
         self.oauth2rs.commit();

--- a/server/lib/src/plugins/memberof.rs
+++ b/server/lib/src/plugins/memberof.rs
@@ -230,6 +230,18 @@ impl Plugin for MemberOf {
         Self::post_create_inner(qs, cand, &ident)
     }
 
+    #[instrument(level = "debug", name = "memberof_post_repl_incremental", skip_all)]
+    fn post_repl_incremental(
+        qs: &mut QueryServerWriteTransaction,
+        pre_cand: &[Arc<EntrySealedCommitted>],
+        cand: &[EntrySealedCommitted],
+    ) -> Result<(), OperationError> {
+        // IMPORTANT - we need this for now so that dyngroup doesn't error on us, since
+        // repl is internal and dyngroup has a safety check to prevent external triggers.
+        let ident_internal = Identity::from_internal();
+        Self::post_modify_inner(qs, pre_cand, cand, &ident_internal)
+    }
+
     #[instrument(level = "debug", name = "memberof_post_modify", skip_all)]
     fn post_modify(
         qs: &mut QueryServerWriteTransaction,

--- a/server/lib/src/repl/proto.rs
+++ b/server/lib/src/repl/proto.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 use webauthn_rs::prelude::{
-    DeviceKey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
+    AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4, SecurityKey as SecurityKeyV4,
 };
 
 // Re-export this for our own usage.

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -114,7 +114,7 @@ pub struct QueryServerWriteTransaction<'a> {
     pub(crate) changed_acp: bool,
     pub(crate) changed_oauth2: bool,
     pub(crate) changed_domain: bool,
-    changed_sync_agreement: bool,
+    pub(crate) changed_sync_agreement: bool,
     // Store the list of changed uuids for other invalidation needs?
     pub(crate) changed_uuid: HashSet<Uuid>,
     _db_ticket: SemaphorePermit<'a>,

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -25,7 +25,7 @@ use sshkeys::PublicKey as SshPublicKey;
 use time::OffsetDateTime;
 use url::Url;
 use uuid::Uuid;
-use webauthn_rs::prelude::{DeviceKey as DeviceKeyV4, Passkey as PasskeyV4};
+use webauthn_rs::prelude::{AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4};
 
 use crate::be::dbentry::DbIdentSpn;
 use crate::credential::{totp::Totp, Credential};

--- a/server/lib/src/valueset/cred.rs
+++ b/server/lib/src/valueset/cred.rs
@@ -1,7 +1,7 @@
 use std::collections::btree_map::Entry as BTreeEntry;
 use std::collections::BTreeMap;
 
-use webauthn_rs::prelude::{DeviceKey as DeviceKeyV4, Passkey as PasskeyV4};
+use webauthn_rs::prelude::{AttestedPasskey as DeviceKeyV4, Passkey as PasskeyV4};
 
 use crate::be::dbvalue::{
     DbValueCredV1, DbValueDeviceKeyV1, DbValueIntentTokenStateV1, DbValuePasskeyV1,

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -9,7 +9,7 @@ use openssl::pkey::Public;
 use smolset::SmolSet;
 use time::OffsetDateTime;
 // use std::fmt::Debug;
-use webauthn_rs::prelude::DeviceKey as DeviceKeyV4;
+use webauthn_rs::prelude::AttestedPasskey as DeviceKeyV4;
 use webauthn_rs::prelude::Passkey as PasskeyV4;
 
 use kanidm_proto::v1::Filter as ProtoFilter;

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -1181,7 +1181,7 @@ async fn setup_demo_account_passkey(rsclient: &KanidmClient) -> WebauthnAuthenti
         .unwrap();
 
     // Setup and update the passkey
-    let mut wa = WebauthnAuthenticator::new(SoftPasskey::new());
+    let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
 
     let status = rsclient
         .idm_account_credential_update_passkey_init(&session_token)


### PR DESCRIPTION
Relates #68 - More work on replication. Allows domain renames over replication, importantly fixing spn's of entries that have not been replicated from a consumer side yet. This pr has raised some questions about handling of the webauthn rp-id post domain rename that require future answers. In the mean time it upgrades to latest webauthn-rs dev master branch for us to proceed with testing - important for account policy that @Seba-T just added since we need this for attestation. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
