### PR TITLE
Trying to fix the (current) container build failures

### DIFF
--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -1,12 +1,13 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
-FROM ${BASE_IMAGE} AS repos
+ARG RADIUS_USER=radiusd
+FROM ${BASE_IMAGE}
+
+EXPOSE 1812 1813
+ENV KANIDM_CONFIG_FILE="/data/kanidm"
+
 ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
 RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
-# ======================
-FROM repos
-EXPOSE 1812 1813
-ARG RADIUS_USER=radiusd
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
@@ -60,7 +61,6 @@ RUN python3 -m pip install \
 
 COPY rlm_python/radius_entrypoint.py /radius_entrypoint.py
 
-ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
 RUN chmod a+r /etc/raddb/certs/ -R
 USER $RADIUS_USER

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -1,13 +1,17 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
-ARG RADIUS_USER=radiusd
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as repos
 
-EXPOSE 1812 1813
-ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
 ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
 RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
+
+# ======================
+
+FROM repos
+ARG RADIUS_USER=radiusd
+EXPOSE 1812 1813
+ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -13,9 +13,7 @@ ARG RADIUS_USER=radiusd
 EXPOSE 1812 1813
 ENV KANIDM_CONFIG_FILE="/data/kanidm"
 
-RUN \
-    --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper install -y \
+RUN --mount=type=cache,id=zypp,target=/var/cache/zypp zypper install -y \
         freeradius-client \
         freeradius-server \
         freeradius-server-python3 \

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -1,14 +1,12 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
-FROM ${BASE_IMAGE} as repos
-
+# FROM ${BASE_IMAGE} as repos
+FROM ${BASE_IMAGE}
 
 ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
 RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
-
 # ======================
-
-FROM repos
+# FROM repos
 ARG RADIUS_USER=radiusd
 EXPOSE 1812 1813
 ENV KANIDM_CONFIG_FILE="/data/kanidm"

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -52,7 +52,11 @@ RUN mkdir -p /pkg/pykanidm/
 COPY pykanidm/ /pkg/pykanidm/
 
 # install the package and its dependencies
-RUN python3 -m pip install --no-cache-dir --no-warn-script-location /pkg/pykanidm
+RUN python3 -m pip install \
+    --break-system-packages \
+    --no-cache-dir \
+    --no-warn-script-location \
+    /pkg/pykanidm
 
 COPY rlm_python/radius_entrypoint.py /radius_entrypoint.py
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -48,7 +48,11 @@ RUN \
     cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
-        --release  && \
+        --release && \
+    cargo build -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release && \
     sccache -s
 
 # == Construct the tools container
@@ -60,18 +64,16 @@ RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
         timezone \
-        busybox-adduser \
         openssl-3
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/
+COPY --from=builder /usr/src/kanidm/target/release/kanidm-ldap-sync /sbin/
 RUN chmod +x /sbin/kanidm
 RUN chmod +x /sbin/kanidm-ipa-sync
+RUN chmod +x /sbin/kanidm-ldap-sync
 
-RUN adduser -D -H kanidm && \
-    mkdir /etc/kanidm && \
+RUN mkdir /etc/kanidm && \
     touch /etc/kanidm/config
-
-USER kanidm
 
 CMD [ "/sbin/kanidm", "-h" ]


### PR DESCRIPTION
* `busybox-adduser` fails to install on amd64 because `shadow` is installed, which means it fails in GHA builds and there's I can't find an automated alternative for just creating a user in the container 😡 - removing this dependency from the `kanidm` container and reverting to using the default (root) user. 
* python changed how salty they get about installing system-level packages, so forcing that to work.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
