### PR TITLE
Dmulder/pam state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,8 @@ dependencies = [
  "kanidm_unix_int",
  "libc",
  "pkg-config",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/server/lib/src/be/idl_sqlite.rs
+++ b/server/lib/src/be/idl_sqlite.rs
@@ -601,11 +601,11 @@ pub trait IdlSqliteTransaction {
     #[allow(clippy::let_and_return)]
     fn verify(&self) -> Vec<Result<(), ConsistencyError>> {
         let Ok(conn) = self.get_conn() else {
-            return vec![Err(ConsistencyError::SqliteIntegrityFailure)]
+            return vec![Err(ConsistencyError::SqliteIntegrityFailure)];
         };
 
         let Ok(mut stmt) = conn.prepare("PRAGMA integrity_check;") else {
-            return vec![Err(ConsistencyError::SqliteIntegrityFailure)]
+            return vec![Err(ConsistencyError::SqliteIntegrityFailure)];
         };
 
         // Allow this as it actually extends the life of stmt

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -432,9 +432,7 @@ pub trait BackendTransaction {
                 for f in f_andnot.iter() {
                     f_rem_count -= 1;
                     let FilterResolved::AndNot(f_in, _) = f else {
-                        filter_error!(
-                            "Invalid server state, a cand filter leaked to andnot set!"
-                        );
+                        filter_error!("Invalid server state, a cand filter leaked to andnot set!");
                         return Err(OperationError::InvalidState);
                     };
                     let (inter, fp) = self.filter2idl(f_in, thres)?;

--- a/server/lib/src/idm/identityverification.rs
+++ b/server/lib/src/idm/identityverification.rs
@@ -266,7 +266,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         let other_user_public_key = self.get_other_user_public_key(target, ident)?;
         let mut shared_key = self.derive_shared_key(self_private, other_user_public_key)?;
         let Some(self_uuid) = ident.get_uuid() else {
-            return Err(OperationError::NotAuthenticated)
+            return Err(OperationError::NotAuthenticated);
         };
         shared_key.extend_from_slice(self_uuid.as_bytes());
         Ok(shared_key)
@@ -509,8 +509,8 @@ mod test {
         );
 
         let Ok(IdentifyUserResponse::ProvideCode { totp, .. }) = res_higher_user else {
-                return assert!(false);
-            };
+            return assert!(false);
+        };
 
         let res_lower_user_wrong = idms_prox_read.handle_identify_user_submit_code(
             &IdentifyUserSubmitCodeEvent::new(higher_user_uuid, lower_user.clone(), totp + 1),
@@ -532,9 +532,9 @@ mod test {
 
         // now we need to get the code from the lower_user and submit it to the higher_user
 
-        let Ok(IdentifyUserResponse::ProvideCode{totp, ..}) = res_lower_user_correct else {
-                return assert!(false);
-            };
+        let Ok(IdentifyUserResponse::ProvideCode { totp, .. }) = res_lower_user_correct else {
+            return assert!(false);
+        };
 
         let res_higher_user_2_wrong = idms_prox_read.handle_identify_user_submit_code(
             &IdentifyUserSubmitCodeEvent::new(lower_user_uuid, higher_user.clone(), totp + 1),
@@ -596,9 +596,13 @@ mod test {
             &IdentifyUserStartEvent::new(lower_user_uuid, higher_user.clone()),
         );
 
-        let Ok(IdentifyUserResponse::ProvideCode { totp: higher_user_totp, .. }) = res_higher_user else {
-                return assert!(false);
-            };
+        let Ok(IdentifyUserResponse::ProvideCode {
+            totp: higher_user_totp,
+            ..
+        }) = res_higher_user
+        else {
+            return assert!(false);
+        };
 
         // then we get the lower user code
 

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -3763,9 +3763,10 @@ mod tests {
             .proxy_read()
             .await
             .validate_and_parse_token_to_token(Some(&token), ct)
-            .expect("Must not fail") else {
+            .expect("Must not fail")
+        else {
             panic!("Unexpected auth token type for anonymous auth");
-            };
+        };
 
         debug!(?uat);
 

--- a/server/lib/src/plugins/spn.rs
+++ b/server/lib/src/plugins/spn.rs
@@ -186,7 +186,7 @@ impl Spn {
         });
 
         let Some(domain_name) = domain_name_changed else {
-            return Ok(())
+            return Ok(());
         };
 
         // IMPORTANT - we have to *pre-emptively reload the domain info here*

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -162,7 +162,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         trace!("internal_migrate_or_create operating on {:?}", e.get_uuid());
 
         let Some(filt) = e.filter_from_attrs(&[Attribute::Uuid.into()]) else {
-            return Err(OperationError::FilterGeneration)
+            return Err(OperationError::FilterGeneration);
         };
 
         trace!("internal_migrate_or_create search {:?}", filt);

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -830,7 +830,10 @@ pub trait QueryServerTransaction<'a> {
                 }
             })
             .map_err(|e| {
-                admin_error!(?e, "Failed to retrieve authsession_expiry from system configuration");
+                admin_error!(
+                    ?e,
+                    "Failed to retrieve authsession_expiry from system configuration"
+                );
                 e
             })
     }
@@ -845,7 +848,10 @@ pub trait QueryServerTransaction<'a> {
                 }
             })
             .map_err(|e| {
-                admin_error!(?e, "Failed to retrieve privilege_expiry from system configuration");
+                admin_error!(
+                    ?e,
+                    "Failed to retrieve privilege_expiry from system configuration"
+                );
                 e
             })
     }

--- a/server/testkit/tests/identity_verification_tests.rs
+++ b/server/testkit/tests/identity_verification_tests.rs
@@ -206,9 +206,9 @@ async fn test_full_identification_flow(rsclient: KanidmClient) {
     // we check that the user A got a WaitForCode
 
     let IdentifyUserResponse::ProvideCode { step: _, totp } = higher_user_req_1 else {
-            return assert!(false);
-            // we check that the user B got the code
-        };
+        return assert!(false);
+        // we check that the user B got the code
+    };
     // we now try to submit the wrong code and we check that we get CodeFailure
     // we now submit the received totp as the user A
 
@@ -233,8 +233,8 @@ async fn test_full_identification_flow(rsclient: KanidmClient) {
         .unwrap();
     // if the totp was correct we must get a ProvideCode
     let IdentifyUserResponse::ProvideCode { step: _, totp } = lower_user_req_2_right else {
-                return assert!(false)
-        };
+        return assert!(false);
+    };
     // we now try to do the same thing with user B: we first submit the wrong code expecting CodeFailure,
     // and then we submit the right one expecting Success
 

--- a/server/web_ui/src/components/totpdisplay.rs
+++ b/server/web_ui/src/components/totpdisplay.rs
@@ -55,10 +55,9 @@ impl TotpDisplayApp {
     async fn renew_totp(other_id: String) -> Msg {
         let uri = format!("/v1/person/{}/_identify_user", other_id);
         let request = IdentifyUserRequest::DisplayCode;
-        let Ok(state_as_jsvalue) = serde_json::to_string(&request)
-            .map(|s| JsValue::from(&s))
-             else {
-            return Msg::Cancel
+        let Ok(state_as_jsvalue) = serde_json::to_string(&request).map(|s| JsValue::from(&s))
+        else {
+            return Msg::Cancel;
         };
         let response = match do_request(&uri, RequestMethod::POST, Some(state_as_jsvalue)).await {
             Ok((_, _, response, _)) => response,

--- a/unix_integration/nss_kanidm/src/implementation.rs
+++ b/unix_integration/nss_kanidm/src/implementation.rs
@@ -20,14 +20,16 @@ impl PasswdHooks for KanidmPasswd {
             };
         let req = ClientRequest::NssAccounts;
 
-        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-            Ok(dc) => dc,
-            Err(_) => {
-                return Response::Unavail;
-            }
-        };
+        let mut daemon_client =
+            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+                Ok(dc) => dc,
+                Err(_) => {
+                    return Response::Unavail;
+                }
+            };
 
-        daemon_client.call_and_wait(&req)
+        daemon_client
+            .call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssAccounts(l) => l.into_iter().map(passwd_from_nssuser).collect(),
                 _ => Vec::new(),
@@ -46,14 +48,16 @@ impl PasswdHooks for KanidmPasswd {
             };
         let req = ClientRequest::NssAccountByUid(uid);
 
-        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-            Ok(dc) => dc,
-            Err(_) => {
-                return Response::Unavail;
-            }
-        };
+        let mut daemon_client =
+            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+                Ok(dc) => dc,
+                Err(_) => {
+                    return Response::Unavail;
+                }
+            };
 
-        daemon_client.call_and_wait(&req)
+        daemon_client
+            .call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -73,14 +77,16 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByName(name);
-        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-            Ok(dc) => dc,
-            Err(_) => {
-                return Response::Unavail;
-            }
-        };
+        let mut daemon_client =
+            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+                Ok(dc) => dc,
+                Err(_) => {
+                    return Response::Unavail;
+                }
+            };
 
-        daemon_client.call_and_wait(&req)
+        daemon_client
+            .call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -105,14 +111,16 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroups;
-        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-            Ok(dc) => dc,
-            Err(_) => {
-                return Response::Unavail;
-            }
-        };
+        let mut daemon_client =
+            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+                Ok(dc) => dc,
+                Err(_) => {
+                    return Response::Unavail;
+                }
+            };
 
-        daemon_client.call_and_wait(&req)
+        daemon_client
+            .call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssGroups(l) => l.into_iter().map(group_from_nssgroup).collect(),
                 _ => Vec::new(),
@@ -130,14 +138,16 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByGid(gid);
-        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-            Ok(dc) => dc,
-            Err(_) => {
-                return Response::Unavail;
-            }
-        };
+        let mut daemon_client =
+            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+                Ok(dc) => dc,
+                Err(_) => {
+                    return Response::Unavail;
+                }
+            };
 
-        daemon_client.call_and_wait(&req)
+        daemon_client
+            .call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)
@@ -157,14 +167,16 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByName(name);
-        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-            Ok(dc) => dc,
-            Err(_) => {
-                return Response::Unavail;
-            }
-        };
+        let mut daemon_client =
+            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+                Ok(dc) => dc,
+                Err(_) => {
+                    return Response::Unavail;
+                }
+            };
 
-        daemon_client.call_and_wait(&req)
+        daemon_client
+            .call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)

--- a/unix_integration/nss_kanidm/src/implementation.rs
+++ b/unix_integration/nss_kanidm/src/implementation.rs
@@ -1,4 +1,4 @@
-use kanidm_unix_common::client_sync::call_daemon_blocking;
+use kanidm_unix_common::client_sync::DaemonClientBlocking;
 use kanidm_unix_common::constants::DEFAULT_CONFIG_PATH;
 use kanidm_unix_common::unix_config::KanidmUnixdConfig;
 use kanidm_unix_common::unix_proto::{ClientRequest, ClientResponse, NssGroup, NssUser};
@@ -19,7 +19,15 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccounts;
-        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
+
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
+
+        daemon_client.call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssAccounts(l) => l.into_iter().map(passwd_from_nssuser).collect(),
                 _ => Vec::new(),
@@ -37,7 +45,15 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByUid(uid);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
+
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
+
+        daemon_client.call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -57,7 +73,14 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByName(name);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
+
+        daemon_client.call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -82,7 +105,14 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroups;
-        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
+
+        daemon_client.call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssGroups(l) => l.into_iter().map(group_from_nssgroup).collect(),
                 _ => Vec::new(),
@@ -100,7 +130,14 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByGid(gid);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
+
+        daemon_client.call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)
@@ -120,7 +157,14 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByName(name);
-        call_daemon_blocking(cfg.sock_path.as_str(), &req, cfg.unix_sock_timeout)
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
+
+        daemon_client.call_and_wait(&req)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)

--- a/unix_integration/pam_kanidm/Cargo.toml
+++ b/unix_integration/pam_kanidm/Cargo.toml
@@ -18,6 +18,8 @@ path =  "src/lib.rs"
 [dependencies]
 kanidm_unix_int = { workspace = true }
 libc = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 pkg-config = { workspace = true }

--- a/unix_integration/pam_kanidm/src/pam/constants.rs
+++ b/unix_integration/pam_kanidm/src/pam/constants.rs
@@ -47,9 +47,9 @@ pub const _PAM_AUTHTOK_TYPE: PamItemType = 13;
 
 // Message styles
 pub const PAM_PROMPT_ECHO_OFF: PamMessageStyle = 1;
-pub const _PAM_PROMPT_ECHO_ON: PamMessageStyle = 2;
-pub const _PAM_ERROR_MSG: PamMessageStyle = 3;
-pub const _PAM_TEXT_INFO: PamMessageStyle = 4;
+pub const PAM_PROMPT_ECHO_ON: PamMessageStyle = 2;
+pub const PAM_ERROR_MSG: PamMessageStyle = 3;
+pub const PAM_TEXT_INFO: PamMessageStyle = 4;
 /// yes/no/maybe conditionals
 pub const _PAM_RADIO_TYPE: PamMessageStyle = 5;
 pub const _PAM_BINARY_PROMPT: PamMessageStyle = 7;

--- a/unix_integration/pam_kanidm/src/pam/mod.rs
+++ b/unix_integration/pam_kanidm/src/pam/mod.rs
@@ -286,10 +286,16 @@ impl PamHooks for PamKanidm {
                     };
                     match prompt.cred_type {
                         Some(CredType::Password) => {
-                            req = ClientRequest::PamAuthenticateStep(Some(PamCred::Password(resp)));
+                            req = ClientRequest::PamAuthenticateStep(
+                                Some(PamCred::Password(resp)),
+                                prompt.data,
+                            );
                         }
                         _ => {
-                            req = ClientRequest::PamAuthenticateStep(Some(PamCred::MFACode(resp)));
+                            req = ClientRequest::PamAuthenticateStep(
+                                Some(PamCred::MFACode(resp)),
+                                prompt.data,
+                            );
                         }
                     }
                     // We've consumed any authtok, delete it
@@ -305,7 +311,7 @@ impl PamHooks for PamKanidm {
                             return err;
                         }
                     }
-                    req = ClientRequest::PamAuthenticateStep(None);
+                    req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                 }
                 _ => {
                     return PamResultCode::PAM_IGNORE;

--- a/unix_integration/pam_kanidm/src/pam/mod.rs
+++ b/unix_integration/pam_kanidm/src/pam/mod.rs
@@ -165,7 +165,7 @@ impl PamHooks for PamKanidm {
                 }
                 _ => {
                     // unexpected response.
-                    error!(err = ?r, "PamResultCode::PAM_IGNORE");
+                    error!(err = ?r, "PAM_IGNORE, unexpected resolver response");
                     PamResultCode::PAM_IGNORE
                 }
             },
@@ -287,7 +287,7 @@ impl PamHooks for PamKanidm {
                     }
                     _ => {
                         // unexpected response.
-                        error!(err = ?r, "PAM_IGNORE");
+                        error!(err = ?r, "PAM_IGNORE, unexpected resolver response");
                         return PamResultCode::PAM_IGNORE;
                     }
                 },

--- a/unix_integration/pam_kanidm/src/pam/mod.rs
+++ b/unix_integration/pam_kanidm/src/pam/mod.rs
@@ -68,10 +68,10 @@ fn install_subscriber(debug: bool) {
         LevelFilter::ERROR
     };
 
-    tracing_subscriber::registry()
+    let _ = tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt_layer)
-        .init();
+        .try_init();
 }
 
 #[derive(Debug)]

--- a/unix_integration/src/client_sync.rs
+++ b/unix_integration/src/client_sync.rs
@@ -5,95 +5,101 @@ use std::time::{Duration, SystemTime};
 
 use crate::unix_proto::{ClientRequest, ClientResponse};
 
-pub fn call_daemon_blocking(
-    path: &str,
-    req: &ClientRequest,
-    timeout: u64,
-) -> Result<ClientResponse, Box<dyn Error>> {
-    let timeout = Duration::from_secs(timeout);
+pub struct DaemonClientBlocking {
+    timeout: Duration,
+    stream: UnixStream,
+}
 
-    let mut stream = UnixStream::connect(path)
-        .and_then(|socket| socket.set_read_timeout(Some(timeout)).map(|_| socket))
-        .and_then(|socket| socket.set_write_timeout(Some(timeout)).map(|_| socket))
-        .map_err(|e| {
-            error!("stream setup error -> {:?}", e);
-            e
-        })
-        .map_err(Box::new)?;
+impl DaemonClientBlocking {
+    pub fn new(path: &str, timeout: u64) -> Result<DaemonClientBlocking, Box<dyn Error>> {
+        let timeout = Duration::from_secs(timeout);
 
-    let data = serde_json::to_vec(&req).map_err(|e| {
-        error!("socket encoding error -> {:?}", e);
-        Box::new(IoError::new(ErrorKind::Other, "JSON encode error"))
-    })?;
-    //  .map_err(Box::new)?;
+        let stream = UnixStream::connect(path)
+            .and_then(|socket| socket.set_read_timeout(Some(timeout)).map(|_| socket))
+            .and_then(|socket| socket.set_write_timeout(Some(timeout)).map(|_| socket))
+            .map_err(|e| {
+                error!("stream setup error -> {:?}", e);
+                e
+            })
+            .map_err(Box::new)?;
 
-    stream
-        .write_all(data.as_slice())
-        .and_then(|_| stream.flush())
-        .map_err(|e| {
-            error!("stream write error -> {:?}", e);
-            e
-        })
-        .map_err(Box::new)?;
-
-    // Now wait on the response.
-    let start = SystemTime::now();
-    let mut read_started = false;
-    let mut data = Vec::with_capacity(1024);
-    let mut counter = 0;
-
-    loop {
-        let mut buffer = [0; 1024];
-        let durr = SystemTime::now().duration_since(start).map_err(Box::new)?;
-        if durr > timeout {
-            error!("Socket timeout");
-            // timed out, not enough activity.
-            break;
-        }
-        // Would be a lot easier if we had peek ...
-        // https://github.com/rust-lang/rust/issues/76923
-        match stream.read(&mut buffer) {
-            Ok(0) => {
-                if read_started {
-                    debug!("read_started true, we have completed");
-                    // We're done, no more bytes.
-                    break;
-                } else {
-                    debug!("Waiting ...");
-                    // Still can wait ...
-                    continue;
-                }
-            }
-            Ok(count) => {
-                data.extend_from_slice(&buffer);
-                counter += count;
-                if count == 1024 {
-                    debug!("Filled 1024 bytes, looping ...");
-                    // We have filled the buffer, we need to copy and loop again.
-                    read_started = true;
-                    continue;
-                } else {
-                    debug!("Filled {} bytes, complete", count);
-                    // We have a partial read, so we are complete.
-                    break;
-                }
-            }
-            Err(e) => {
-                error!("Steam read failure -> {:?}", e);
-                // Failure!
-                return Err(Box::new(e));
-            }
-        }
+        Ok(DaemonClientBlocking { timeout, stream })
     }
 
-    // Extend from slice fills with 0's, so we need to truncate now.
-    data.truncate(counter);
+    pub fn call_and_wait(&mut self, req: &ClientRequest) -> Result<ClientResponse, Box<dyn Error>> {
+        let data = serde_json::to_vec(&req).map_err(|e| {
+            error!("socket encoding error -> {:?}", e);
+            Box::new(IoError::new(ErrorKind::Other, "JSON encode error"))
+        })?;
 
-    // Now attempt to decode.
-    let cr = serde_json::from_slice::<ClientResponse>(data.as_slice()).map_err(|e| {
-        error!("socket encoding error -> {:?}", e);
-        Box::new(IoError::new(ErrorKind::Other, "JSON decode error"))
-    })?;
+        self.stream
+            .write_all(data.as_slice())
+            .and_then(|_| self.stream.flush())
+            .map_err(|e| {
+                error!("stream write error -> {:?}", e);
+                e
+            })
+            .map_err(Box::new)?;
 
-    Ok(cr)
+        // Now wait on the response.
+        let start = SystemTime::now();
+        let mut read_started = false;
+        let mut data = Vec::with_capacity(1024);
+        let mut counter = 0;
+
+        loop {
+            let mut buffer = [0; 1024];
+            let durr = SystemTime::now().duration_since(start).map_err(Box::new)?;
+            if durr > self.timeout {
+                error!("Socket timeout");
+                // timed out, not enough activity.
+                break;
+            }
+            // Would be a lot easier if we had peek ...
+            // https://github.com/rust-lang/rust/issues/76923
+            match self.stream.read(&mut buffer) {
+                Ok(0) => {
+                    if read_started {
+                        debug!("read_started true, we have completed");
+                        // We're done, no more bytes.
+                        break;
+                    } else {
+                        debug!("Waiting ...");
+                        // Still can wait ...
+                        continue;
+                    }
+                }
+                Ok(count) => {
+                    data.extend_from_slice(&buffer);
+                    counter += count;
+                    if count == 1024 {
+                        debug!("Filled 1024 bytes, looping ...");
+                        // We have filled the buffer, we need to copy and loop again.
+                        read_started = true;
+                        continue;
+                    } else {
+                        debug!("Filled {} bytes, complete", count);
+                        // We have a partial read, so we are complete.
+                        break;
+                    }
+                }
+                Err(e) => {
+                    error!("Steam read failure -> {:?}", e);
+                    // Failure!
+                    return Err(Box::new(e));
+                }
+            }
+        }
+
+        // Extend from slice fills with 0's, so we need to truncate now.
+        data.truncate(counter);
+
+        // Now attempt to decode.
+        let cr = serde_json::from_slice::<ClientResponse>(data.as_slice()).map_err(|e| {
+            error!("socket encoding error -> {:?}", e);
+            Box::new(IoError::new(ErrorKind::Other, "JSON decode error"))
+        })?;
+
+        Ok(cr)
+    }
 }

--- a/unix_integration/src/client_sync.rs
+++ b/unix_integration/src/client_sync.rs
@@ -14,6 +14,8 @@ impl DaemonClientBlocking {
     pub fn new(path: &str, timeout: u64) -> Result<DaemonClientBlocking, Box<dyn Error>> {
         let timeout = Duration::from_secs(timeout);
 
+        debug!(%path, ?timeout);
+
         let stream = UnixStream::connect(path)
             .and_then(|socket| socket.set_read_timeout(Some(timeout)).map(|_| socket))
             .and_then(|socket| socket.set_write_timeout(Some(timeout)).map(|_| socket))

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -281,15 +281,15 @@ async fn handle_client(
                 debug!("pam authenticate init");
                 pam_state = PamState::Step(account_id.clone());
                 cachelayer
-                    .pam_account_authenticate_step(account_id.as_str(), None)
+                    .pam_account_authenticate_step(account_id.as_str(), None, None)
                     .await
                     .unwrap_or(ClientResponse::Error)
             }
-            ClientRequest::PamAuthenticateStep(cred) => {
+            ClientRequest::PamAuthenticateStep(cred, data) => {
                 debug!("pam authenticate step");
                 match &pam_state {
                     PamState::Step(account_id) => match cachelayer
-                        .pam_account_authenticate_step(account_id.as_str(), cred)
+                        .pam_account_authenticate_step(account_id.as_str(), cred, data)
                         .await
                         .unwrap_or(ClientResponse::Error)
                     {

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -190,7 +190,10 @@ async fn handle_client(
     debug!("Accepted connection");
 
     let Ok(ucred) = sock.peer_cred() else {
-        return Err(Box::new(IoError::new(ErrorKind::Other, "Unable to verify peer credentials.")));
+        return Err(Box::new(IoError::new(
+            ErrorKind::Other,
+            "Unable to verify peer credentials.",
+        )));
     };
 
     let mut reqs = Framed::new(sock, ClientCodec);

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -61,6 +61,7 @@ pub enum AuthRequest {
     Password,
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<PamAuthResponse> for AuthRequest {
     fn into(self) -> PamAuthResponse {
         match self {
@@ -96,12 +97,6 @@ pub trait IdProvider {
         _token: Option<&UserToken>,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;
 
-    async fn unix_user_offline_auth_init(
-        &self,
-        _account_id: &str,
-        _token: Option<&UserToken>,
-    ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;
-
     async fn unix_user_online_auth_step(
         &self,
         _account_id: &str,
@@ -109,6 +104,27 @@ pub trait IdProvider {
         _pam_next_req: PamAuthRequest,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError>;
 
+    async fn unix_user_offline_auth_init(
+        &self,
+        _account_id: &str,
+        _token: Option<&UserToken>,
+    ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;
+
+    /*
+    // I thought about this part of the interface a lot. we could have the
+    // provider actually need to check the password or credentials, but then
+    // we need to rework the tpm/crypto engine to be an argument to pass here
+    // as well the cached credentials.
+    //
+    // As well, since this is "offline auth" the provider isn't really "doing"
+    // anything special here - when you say you want offline password auth, the
+    // resolver can just do it for you for all the possible implementations.
+    // This is similar for offline ctap2 as well, or even offline totp.
+    //
+    // I think in the future we could reconsider this and let the provider be
+    // involved if there is some "custom logic" or similar that is needed but
+    // for now I think making it generic is a good first step and we can change
+    // it later.
     async fn unix_user_offline_auth_step(
         &self,
         _account_id: &str,
@@ -116,6 +132,7 @@ pub trait IdProvider {
         _pam_next_req: PamAuthRequest,
         _online_at_init: bool,
     ) -> Result<AuthResult, IdpError>;
+    */
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;
 }

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -73,7 +73,7 @@ impl AuthSession {
 
 pub enum AuthCacheAction {
     None,
-    PasswordHashUpdate,
+    PasswordHashUpdate { a_uuid: Uuid, cred: String },
 }
 
 #[async_trait]
@@ -107,7 +107,7 @@ pub trait IdProvider {
         _auth_session: &mut AuthSession,
         _pam_next_req: PamAuthRequest,
     ) -> Result<AuthCacheAction, IdpError> {
-        Ok((AuthSession::Unknown, AuthCacheAction::None))
+        Ok(AuthCacheAction::None)
     }
 
     async fn unix_user_offline_auth_step(
@@ -115,7 +115,7 @@ pub trait IdProvider {
         _auth_session: &mut AuthSession,
         _pam_next_req: PamAuthRequest,
     ) -> Result<(), IdpError> {
-        Ok(AuthSession::Unknown)
+        Ok(())
     }
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -1,3 +1,4 @@
+use crate::unix_proto::ProviderResult;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -61,11 +62,11 @@ pub trait IdProvider {
         old_token: Option<UserToken>,
     ) -> Result<UserToken, IdpError>;
 
-    async fn unix_user_authenticate(
+    async fn unix_user_authenticate_step(
         &self,
         id: &Id,
-        cred: &str,
-    ) -> Result<Option<UserToken>, IdpError>;
+        cred: Option<&str>,
+    ) -> Result<ProviderResult, IdpError>;
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;
 }

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -114,6 +114,7 @@ pub trait IdProvider {
         _account_id: &str,
         _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
+        _online_at_init: bool,
     ) -> Result<AuthResult, IdpError>;
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -1,3 +1,4 @@
+use crate::pam_data::PamData;
 use crate::unix_proto::ProviderResult;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -66,6 +67,7 @@ pub trait IdProvider {
         &self,
         id: &Id,
         cred: Option<&str>,
+        data: Option<PamData>,
     ) -> Result<ProviderResult, IdpError>;
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError>;

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -4,7 +4,8 @@ use kanidm_proto::v1::{OperationError, UnixGroupToken, UnixUserToken};
 use tokio::sync::RwLock;
 
 use super::interface::{
-    AuthCacheAction, AuthSession, GroupToken, Id, IdProvider, IdpError, UserToken,
+    AuthCacheAction, AuthCredHandler, AuthRequest, AuthResult, GroupToken, Id, IdProvider,
+    IdpError, UserToken,
 };
 use crate::unix_proto::PamAuthRequest;
 
@@ -84,7 +85,7 @@ impl IdProvider for KanidmProvider {
     async fn unix_user_get(
         &self,
         id: &Id,
-        _old_token: Option<UserToken>,
+        _token: Option<&UserToken>,
     ) -> Result<UserToken, IdpError> {
         match self
             .client
@@ -145,33 +146,108 @@ impl IdProvider for KanidmProvider {
 
     async fn unix_user_online_auth_init(
         &self,
-        _id: &Id,
-        _token: Option<UserToken>,
-    ) -> Result<AuthSession, IdpError> {
-        todo!();
-    }
-
-    async fn unix_user_offline_auth_init(
-        &self,
-        _id: &Id,
-        _token: Option<UserToken>,
-    ) -> Result<AuthSession, IdpError> {
-        todo!();
+        _account_id: &str,
+        _token: Option<&UserToken>,
+    ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
+        // Not sure that I need to do much here?
+        Ok((AuthRequest::Password, AuthCredHandler::Password))
     }
 
     async fn unix_user_online_auth_step(
         &self,
-        _auth_session: &mut AuthSession,
-        _pam_next_req: PamAuthRequest,
-    ) -> Result<AuthCacheAction, IdpError> {
-        todo!();
+        account_id: &str,
+        cred_handler: &mut AuthCredHandler,
+        pam_next_req: PamAuthRequest,
+    ) -> Result<(AuthResult, AuthCacheAction), IdpError> {
+        match (cred_handler, pam_next_req) {
+            (AuthCredHandler::Password, PamAuthRequest::Password { cred }) => {
+                match self
+                    .client
+                    .read()
+                    .await
+                    .idm_account_unix_cred_verify(&account_id, &cred)
+                    .await
+                {
+                    Ok(Some(n_tok)) => Ok((
+                        AuthResult::Success {
+                            token: UserToken::from(n_tok),
+                        },
+                        AuthCacheAction::PasswordHashUpdate { cred },
+                    )),
+                    Ok(None) => Ok((AuthResult::Denied, AuthCacheAction::None)),
+                    Err(ClientError::Transport(err)) => {
+                        error!(?err);
+                        Err(IdpError::Transport)
+                    }
+                    Err(ClientError::Http(StatusCode::UNAUTHORIZED, reason, opid)) => {
+                        match reason {
+                            Some(OperationError::NotAuthenticated) => warn!(
+                                "session not authenticated - attempting reauthentication - eventid {}",
+                                opid
+                            ),
+                            Some(OperationError::SessionExpired) => warn!(
+                                "session expired - attempting reauthentication - eventid {}",
+                                opid
+                            ),
+                            e => error!(
+                                "authentication error {:?}, moving to offline - eventid {}",
+                                e, opid
+                            ),
+                        };
+                        Err(IdpError::ProviderUnauthorised)
+                    }
+                    Err(ClientError::Http(
+                        StatusCode::BAD_REQUEST,
+                        Some(OperationError::NoMatchingEntries),
+                        opid,
+                    ))
+                    | Err(ClientError::Http(
+                        StatusCode::NOT_FOUND,
+                        Some(OperationError::NoMatchingEntries),
+                        opid,
+                    ))
+                    | Err(ClientError::Http(
+                        StatusCode::BAD_REQUEST,
+                        Some(OperationError::InvalidAccountState(_)),
+                        opid,
+                    )) => {
+                        error!(
+                            "unknown account or is not a valid posix account - eventid {}",
+                            opid
+                        );
+                        Err(IdpError::NotFound)
+                    }
+                    Err(err) => {
+                        error!(?err, "client error");
+                        // Some other unknown processing error?
+                        Err(IdpError::BadRequest)
+                    }
+                }
+            } /*
+              _ => {
+                  error!("invalid authentication request state");
+                  Err(IdpError::BadRequest)
+              }
+              */
+        }
+    }
+
+    async fn unix_user_offline_auth_init(
+        &self,
+        _account_id: &str,
+        _token: Option<&UserToken>,
+    ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
+        // Not sure that I need to do much here?
+        Ok((AuthRequest::Password, AuthCredHandler::Password))
     }
 
     async fn unix_user_offline_auth_step(
         &self,
-        _auth_session: &mut AuthSession,
+        _account_id: &str,
+        _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
-    ) -> Result<(), IdpError> {
+    ) -> Result<AuthResult, IdpError> {
+        // We need any cached credentials here.
         todo!();
     }
 

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -3,7 +3,10 @@ use kanidm_client::{ClientError, KanidmClient, StatusCode};
 use kanidm_proto::v1::{OperationError, UnixGroupToken, UnixUserToken};
 use tokio::sync::RwLock;
 
-use super::interface::{GroupToken, Id, IdProvider, IdpError, UserToken};
+use super::interface::{
+    AuthCacheAction, AuthSession, GroupToken, Id, IdProvider, IdpError, UserToken,
+};
+use crate::unix_proto::PamAuthRequest;
 
 pub struct KanidmProvider {
     client: RwLock<KanidmClient>,
@@ -68,7 +71,6 @@ impl From<UnixGroupToken> for GroupToken {
 #[async_trait]
 impl IdProvider for KanidmProvider {
     // Needs .read on all types except re-auth.
-
     async fn provider_authenticate(&self) -> Result<(), IdpError> {
         match self.client.write().await.auth_anonymous().await {
             Ok(_uat) => Ok(()),
@@ -139,6 +141,38 @@ impl IdProvider for KanidmProvider {
                 Err(IdpError::BadRequest)
             }
         }
+    }
+
+    async fn unix_user_online_auth_init(
+        &self,
+        _id: &Id,
+        _token: Option<UserToken>,
+    ) -> Result<AuthSession, IdpError> {
+        todo!();
+    }
+
+    async fn unix_user_offline_auth_init(
+        &self,
+        _id: &Id,
+        _token: Option<UserToken>,
+    ) -> Result<AuthSession, IdpError> {
+        todo!();
+    }
+
+    async fn unix_user_online_auth_step(
+        &self,
+        _auth_session: &mut AuthSession,
+        _pam_next_req: PamAuthRequest,
+    ) -> Result<AuthCacheAction, IdpError> {
+        todo!();
+    }
+
+    async fn unix_user_offline_auth_step(
+        &self,
+        _auth_session: &mut AuthSession,
+        _pam_next_req: PamAuthRequest,
+    ) -> Result<(), IdpError> {
+        todo!();
     }
 
     /*

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -165,7 +165,7 @@ impl IdProvider for KanidmProvider {
                     .client
                     .read()
                     .await
-                    .idm_account_unix_cred_verify(&account_id, &cred)
+                    .idm_account_unix_cred_verify(account_id, &cred)
                     .await
                 {
                     Ok(Some(n_tok)) => Ok((
@@ -223,11 +223,12 @@ impl IdProvider for KanidmProvider {
                         Err(IdpError::BadRequest)
                     }
                 }
-            } /*
-              _ => {
-                  error!("invalid authentication request state");
-                  Err(IdpError::BadRequest)
-              }
+            } // For future when we have different auth combos/types.
+              /*
+                _ => {
+                    error!("invalid authentication request state");
+                    Err(IdpError::BadRequest)
+                }
               */
         }
     }
@@ -241,6 +242,7 @@ impl IdProvider for KanidmProvider {
         Ok((AuthRequest::Password, AuthCredHandler::Password))
     }
 
+    /*
     async fn unix_user_offline_auth_step(
         &self,
         _account_id: &str,
@@ -250,78 +252,6 @@ impl IdProvider for KanidmProvider {
     ) -> Result<AuthResult, IdpError> {
         // We need any cached credentials here.
         todo!();
-    }
-
-    /*
-    async fn unix_user_authenticate_step(
-        &self,
-        id: &Id,
-        cred: Option<&str>,
-        _data: Option<PamData>,
-    ) -> Result<ProviderResult, IdpError> {
-        let cred = match cred {
-            Some(cred) => cred,
-            None => {
-                return Ok(ProviderResult::PamPrompt(PamPrompt::passwd_prompt()));
-            }
-        };
-        match self
-            .client
-            .read()
-            .await
-            .idm_account_unix_cred_verify(id.to_string().as_str(), cred)
-            .await
-        {
-            Ok(Some(n_tok)) => Ok(ProviderResult::UserToken(Some(UserToken::from(n_tok)))),
-            Ok(None) => Ok(ProviderResult::UserToken(None)),
-            Err(ClientError::Transport(err)) => {
-                error!(?err);
-                Err(IdpError::Transport)
-            }
-            Err(ClientError::Http(StatusCode::UNAUTHORIZED, reason, opid)) => {
-                match reason {
-                    Some(OperationError::NotAuthenticated) => warn!(
-                        "session not authenticated - attempting reauthentication - eventid {}",
-                        opid
-                    ),
-                    Some(OperationError::SessionExpired) => warn!(
-                        "session expired - attempting reauthentication - eventid {}",
-                        opid
-                    ),
-                    e => error!(
-                        "authentication error {:?}, moving to offline - eventid {}",
-                        e, opid
-                    ),
-                };
-                Err(IdpError::ProviderUnauthorised)
-            }
-            Err(ClientError::Http(
-                StatusCode::BAD_REQUEST,
-                Some(OperationError::NoMatchingEntries),
-                opid,
-            ))
-            | Err(ClientError::Http(
-                StatusCode::NOT_FOUND,
-                Some(OperationError::NoMatchingEntries),
-                opid,
-            ))
-            | Err(ClientError::Http(
-                StatusCode::BAD_REQUEST,
-                Some(OperationError::InvalidAccountState(_)),
-                opid,
-            )) => {
-                error!(
-                    "unknown account or is not a valid posix account - eventid {}",
-                    opid
-                );
-                Err(IdpError::NotFound)
-            }
-            Err(err) => {
-                error!(?err, "client error");
-                // Some other unknown processing error?
-                Err(IdpError::BadRequest)
-            }
-        }
     }
     */
 

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -4,8 +4,6 @@ use kanidm_proto::v1::{OperationError, UnixGroupToken, UnixUserToken};
 use tokio::sync::RwLock;
 
 use super::interface::{GroupToken, Id, IdProvider, IdpError, UserToken};
-use crate::pam_data::PamData;
-use crate::unix_proto::{PamPrompt, ProviderResult};
 
 pub struct KanidmProvider {
     client: RwLock<KanidmClient>,
@@ -143,6 +141,7 @@ impl IdProvider for KanidmProvider {
         }
     }
 
+    /*
     async fn unix_user_authenticate_step(
         &self,
         id: &Id,
@@ -213,6 +212,7 @@ impl IdProvider for KanidmProvider {
             }
         }
     }
+    */
 
     async fn unix_group_get(&self, id: &Id) -> Result<GroupToken, IdpError> {
         match self

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -246,6 +246,7 @@ impl IdProvider for KanidmProvider {
         _account_id: &str,
         _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
+        _online_at_init: bool,
     ) -> Result<AuthResult, IdpError> {
         // We need any cached credentials here.
         todo!();

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -4,6 +4,7 @@ use kanidm_proto::v1::{OperationError, UnixGroupToken, UnixUserToken};
 use tokio::sync::RwLock;
 
 use super::interface::{GroupToken, Id, IdProvider, IdpError, UserToken};
+use crate::pam_data::PamData;
 use crate::unix_proto::{PamPrompt, ProviderResult};
 
 pub struct KanidmProvider {
@@ -146,6 +147,7 @@ impl IdProvider for KanidmProvider {
         &self,
         id: &Id,
         cred: Option<&str>,
+        _data: Option<PamData>,
     ) -> Result<ProviderResult, IdpError> {
         let cred = match cred {
             Some(cred) => cred,

--- a/unix_integration/src/lib.rs
+++ b/unix_integration/src/lib.rs
@@ -28,6 +28,8 @@ pub mod db;
 #[cfg(target_family = "unix")]
 pub mod idprovider;
 #[cfg(target_family = "unix")]
+pub mod pam_data;
+#[cfg(target_family = "unix")]
 pub mod resolver;
 #[cfg(all(target_family = "unix", feature = "selinux"))]
 pub mod selinux_util;

--- a/unix_integration/src/pam_data.rs
+++ b/unix_integration/src/pam_data.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+/* This is the definition for extra data to be sent along with a pam_prompt
+ * request. It will be sent back to the idprovider to continue an auth attempt.
+ */
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PamData {}

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -949,7 +949,7 @@ where
 
                 Ok((auth_session, next_req.into()))
             }
-            Err(IdpError::NotFound) => Ok(PamAuthResponse::Unknown),
+            Err(IdpError::NotFound) => Ok((AuthSession::Denied, PamAuthResponse::Unknown)),
             Err(IdpError::ProviderUnauthorised) | Err(IdpError::Transport) => {
                 error!("transport error, moving to offline");
                 // Something went wrong, mark offline.
@@ -1039,7 +1039,12 @@ where
                 // contained to the resolver so that it has generic offline-paths
                 // that are possible?
                 self.client
-                    .unix_user_offline_auth_step(&account_id, cred_handler, pam_next_req, online_at_init)
+                    .unix_user_offline_auth_step(
+                        &account_id,
+                        cred_handler,
+                        pam_next_req,
+                        online_at_init,
+                    )
                     .await
             }
             (&mut AuthSession::Success, _) | (&mut AuthSession::Denied, _) => {

--- a/unix_integration/src/tool.rs
+++ b/unix_integration/src/tool.rs
@@ -110,14 +110,16 @@ async fn main() -> ExitCode {
                         };
                         match prompt.cred_type {
                             Some(CredType::Password) => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::Password(
-                                    password,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::Password(password)),
+                                    prompt.data,
+                                );
                             }
                             _ => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::MFACode(
-                                    password,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::MFACode(password)),
+                                    prompt.data,
+                                );
                             }
                         }
                     }
@@ -133,24 +135,26 @@ async fn main() -> ExitCode {
                         passcode = passcode.trim_end_matches('\n').to_string();
                         match prompt.cred_type {
                             Some(CredType::Password) => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::Password(
-                                    passcode,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::Password(passcode)),
+                                    prompt.data,
+                                );
                             }
                             _ => {
-                                req = ClientRequest::PamAuthenticateStep(Some(PamCred::MFACode(
-                                    passcode,
-                                )));
+                                req = ClientRequest::PamAuthenticateStep(
+                                    Some(PamCred::MFACode(passcode)),
+                                    prompt.data,
+                                );
                             }
                         }
                     }
                     PamMessageStyle::PamErrorMsg => {
                         error!(prompt.msg);
-                        req = ClientRequest::PamAuthenticateStep(None);
+                        req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                     }
                     PamMessageStyle::PamTextInfo => {
                         info!(prompt.msg);
-                        req = ClientRequest::PamAuthenticateStep(None);
+                        req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                     }
                 }
             }

--- a/unix_integration/src/tool.rs
+++ b/unix_integration/src/tool.rs
@@ -54,11 +54,11 @@ async fn main() -> ExitCode {
         } => {
             debug!("Starting PAM auth tester tool ...");
 
-            let Ok(cfg) = KanidmUnixdConfig::new()
-                .read_options_from_optional_config(DEFAULT_CONFIG_PATH)
+            let Ok(cfg) =
+                KanidmUnixdConfig::new().read_options_from_optional_config(DEFAULT_CONFIG_PATH)
             else {
                 error!("Failed to parse {}", DEFAULT_CONFIG_PATH);
-                return ExitCode::FAILURE
+                return ExitCode::FAILURE;
             };
 
             let mut req = ClientRequest::PamAuthenticateInit(account_id.clone());

--- a/unix_integration/src/tool.rs
+++ b/unix_integration/src/tool.rs
@@ -20,9 +20,11 @@ use kanidm_unix_common::client::call_daemon;
 use kanidm_unix_common::constants::DEFAULT_CONFIG_PATH;
 use kanidm_unix_common::unix_config::KanidmUnixdConfig;
 use kanidm_unix_common::unix_proto::{
-    ClientRequest, ClientResponse, CredType, PamCred, PamMessageStyle, PamPrompt,
+    ClientRequest,
+    ClientResponse,
+    // CredType, PamCred, PamMessageStyle, PamPrompt,
 };
-use std::io;
+// use std::io;
 use std::path::PathBuf;
 
 include!("./opt/tool.rs");
@@ -61,19 +63,16 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE
         };
 
-            let mut req = ClientRequest::PamAuthenticateInit(account_id.clone());
+            let req = ClientRequest::PamAuthenticateInit(account_id.clone());
             let sereq = ClientRequest::PamAccountAllowed(account_id);
-            let mut prompt: PamPrompt = Default::default();
+            // let mut prompt: PamPrompt = Default::default();
 
             loop {
-                let timeout = match prompt.timeout {
-                    Some(timeout) => timeout,
-                    None => cfg.unix_sock_timeout,
-                };
-                match call_daemon(cfg.sock_path.as_str(), req, timeout).await {
+                match call_daemon(cfg.sock_path.as_str(), req, cfg.unix_sock_timeout).await {
                     Ok(r) => match r {
-                        ClientResponse::PamPrompt(resp) => {
-                            prompt = resp;
+                        ClientResponse::PamPrompt(_resp) => {
+                            // prompt = resp;
+                            todo!();
                         }
                         ClientResponse::PamStatus(Some(true)) => {
                             println!("auth success!");
@@ -99,6 +98,7 @@ async fn main() -> ExitCode {
                     }
                 }
 
+                /*
                 match prompt.style {
                     PamMessageStyle::PamPromptEchoOff => {
                         let password = match rpassword::prompt_password(prompt.msg) {
@@ -157,6 +157,7 @@ async fn main() -> ExitCode {
                         req = ClientRequest::PamAuthenticateStep(None, prompt.data);
                     }
                 }
+                */
             }
 
             match call_daemon(cfg.sock_path.as_str(), sereq, cfg.unix_sock_timeout).await {

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -74,6 +74,28 @@ pub enum PamCred {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub enum PamAuthResponse {
+    Unknown,
+    Success,
+    Deny,
+    Password,
+    /*
+    MFACode {
+    },
+    */
+    // CTAP2
+}
+
+pub enum PamAuthRequest {
+    Password { cred: Option<PamCred> },
+    /*
+    MFACode {
+        cred: Option<PamCred>
+    }
+    */
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub enum ClientRequest {
     SshKey(String),
     NssAccounts,
@@ -98,10 +120,23 @@ pub enum ClientResponse {
     NssAccount(Option<NssUser>),
     NssGroups(Vec<NssGroup>),
     NssGroup(Option<NssGroup>),
+
     PamStatus(Option<bool>),
     PamPrompt(PamPrompt),
     Ok,
     Error,
+}
+
+impl From<PamAuthResponse> for ClientResponse {
+    fn from(par: PamAuthResponse) -> Self {
+        match par {
+            PamAuthResponse::Unknown => ClientResponse::PamStatus(None),
+            PamAuthResponse::Success => ClientResponse::PamStatus(Some(true)),
+            PamAuthResponse::Deny => ClientResponse::PamStatus(Some(false)),
+            // For now
+            PamAuthResponse::Password => ClientResponse::PamStatus(None),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -1,4 +1,5 @@
 use crate::idprovider::interface::UserToken;
+use crate::pam_data::PamData;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -50,6 +51,7 @@ pub struct PamPrompt {
     pub msg: String,
     pub timeout: Option<u64>, // timeout of None means use the config default
     pub cred_type: Option<CredType>,
+    pub data: Option<PamData>,
 }
 
 impl PamPrompt {
@@ -60,6 +62,7 @@ impl PamPrompt {
             msg: "Password: ".to_string(),
             timeout: None,
             cred_type: Some(CredType::Password),
+            data: None,
         }
     }
 }
@@ -80,7 +83,7 @@ pub enum ClientRequest {
     NssGroupByGid(u32),
     NssGroupByName(String),
     PamAuthenticateInit(String),
-    PamAuthenticateStep(Option<PamCred>),
+    PamAuthenticateStep(Option<PamCred>, Option<PamData>),
     PamAccountAllowed(String),
     PamAccountBeginSession(String),
     InvalidateCache,

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -1,4 +1,3 @@
-use crate::idprovider::interface::UserToken;
 use crate::pam_data::PamData;
 use serde::{Deserialize, Serialize};
 
@@ -71,7 +70,7 @@ impl PamPrompt {
 pub enum PamAuthResponse {
     Unknown,
     Success,
-    Deny,
+    Denied,
     Password,
     /*
     MFACode {
@@ -82,7 +81,7 @@ pub enum PamAuthResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthRequest {
-    Password { cred: Option<String> },
+    Password { cred: String },
     /*
     MFACode {
         cred: Option<PamCred>
@@ -127,7 +126,7 @@ impl From<PamAuthResponse> for ClientResponse {
         match par {
             PamAuthResponse::Unknown => ClientResponse::PamStatus(None),
             PamAuthResponse::Success => ClientResponse::PamStatus(Some(true)),
-            PamAuthResponse::Deny => ClientResponse::PamStatus(Some(false)),
+            PamAuthResponse::Denied => ClientResponse::PamStatus(Some(false)),
             // For now
             PamAuthResponse::Password => ClientResponse::PamStatus(None),
         }
@@ -150,10 +149,4 @@ pub enum TaskRequest {
 pub enum TaskResponse {
     Success,
     Error(String),
-}
-
-#[derive(Debug)]
-pub enum ProviderResult {
-    PamPrompt(PamPrompt),
-    UserToken(Option<UserToken>),
 }

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -68,12 +68,6 @@ impl PamPrompt {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub enum PamCred {
-    Password(String), // Will be stored in the cache
-    MFACode(String),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthResponse {
     Unknown,
     Success,
@@ -86,8 +80,9 @@ pub enum PamAuthResponse {
     // CTAP2
 }
 
+#[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthRequest {
-    Password { cred: Option<PamCred> },
+    Password { cred: Option<String> },
     /*
     MFACode {
         cred: Option<PamCred>
@@ -105,7 +100,7 @@ pub enum ClientRequest {
     NssGroupByGid(u32),
     NssGroupByName(String),
     PamAuthenticateInit(String),
-    PamAuthenticateStep(Option<PamCred>, Option<PamData>),
+    PamAuthenticateStep(PamAuthRequest),
     PamAccountAllowed(String),
     PamAccountBeginSession(String),
     InvalidateCache,
@@ -161,9 +156,4 @@ pub enum TaskResponse {
 pub enum ProviderResult {
     PamPrompt(PamPrompt),
     UserToken(Option<UserToken>),
-}
-
-pub enum PamState {
-    Uninitialized,
-    Step(String),
 }


### PR DESCRIPTION
> In Himmelblau I need a mechanism for sending an additional pam prompt (for performing 2FA via a browser window on another device). I've implemented that here by causing pam to operate like a state machine, with the daemon requesting prompts only as required.
This replaces MR https://github.com/kanidm/kanidm/pull/1970 and https://github.com/kanidm/kanidm/pull/1994

The goal of my rework is to make pam-resolver interactions generic beyond just pam prompts. We need to actually specify mechanisms for pam to know how to make choices, for example CTAP2 where the pin entry may need to be prompted multiple times and then require a prompt with *no* entry for the touch interaction. To do this I'll clean up the clientResponse messages to match precise auth steps, and the authSession type will be a "cache" of the details to proceed. We'll need to also handle the difference between online/offline. 

In the future that will make it easier to extend new auth types with pam as well in a way we haven't previously been able to. We can also then use pam auth init to send extended metadata about the session to then make auth session decisions.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
