### PR TITLE
Update compact jwt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,9 +731,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compact_jwt"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f9032b96a89dd79ffc5f62523d5351ebb40680cbdfc4029393b511b9e971aa"
+checksum = "7aa76ef19968577838a34d02848136bb9b6bdbfd7675fb968fe9c931bc434b33"
 dependencies = [
  "base64 0.13.1",
  "base64urlsafedata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ clap = { version = "^4.4.0", features = ["derive", "env"] }
 clap_complete = "^4.4.0"
 # Forced by saffron/cron
 chrono = "^0.4.26"
-compact_jwt = { version = "^0.2.3", default-features = false }
+compact_jwt = { version = "^0.2.10", default-features = false }
 concread = "^0.4.1"
 cron = "0.12.0"
 crossbeam = "0.8.1"


### PR DESCRIPTION
An oidc client was erroring with auth-time "invalid json type". This was due to compact-jwt having auth-time without a skip-if-null on serde.

Update compact jwt to the version with the fix. 


- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
