### PR TITLE
docs: fix miniflux oauth example

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -295,7 +295,7 @@ Miniflux is a feedreader that supports OAuth 2.0 and OpenID connect. It automati
 match the `OAUTH2_PROVIDER` name.
 
 ```
-OAUTH2_PROVIDER = "kanidm";
+OAUTH2_PROVIDER = "oidc";
 OAUTH2_CLIENT_ID = "miniflux";
 OAUTH2_CLIENT_SECRET = "<oauth2_rs_basic_secret>";
 OAUTH2_REDIRECT_URL = "https://feeds.example.com/oauth2/kanidm/callback";


### PR DESCRIPTION
Per miniflux documentation, "oidc" should be used for generic OpenID connect provider.
See https://miniflux.app/docs/configuration.html#oauth2-provider

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
