### PR TITLE
68 20230829 replication referential integrity

### DIFF
--- a/server/lib/src/plugins/attrunique.rs
+++ b/server/lib/src/plugins/attrunique.rs
@@ -256,6 +256,29 @@ impl Plugin for AttrUnique {
         r
     }
 
+    fn pre_repl_incremental(
+        _qs: &mut QueryServerWriteTransaction,
+        _cand: &mut [(EntryIncrementalCommitted, Arc<EntrySealedCommitted>)],
+    ) -> Result<(), OperationError> {
+        admin_error!(
+            "plugin {} has an unimplemented pre_repl_incremental!",
+            Self::id()
+        );
+
+        // Important! We need to also have a list of uuids that we conflicted AGAINST so that both
+        // this candidate *and* the existing item both move to conflict. This is because if we don't
+        // do it this way, then some nodes will conflict on potentially the inverse entries, which
+        // could end up pretty bad.
+
+        // We also can't realllllyyyy rely on the cid here since it could have changed multiple times
+        // and may not truly reflect the accurate change times, so we have to conflict on both
+        // itemsthat hit the attrunique.
+
+        // debug_assert!(false);
+        // Err(OperationError::InvalidState)
+        Ok(())
+    }
+
     #[instrument(level = "debug", name = "attrunique::verify", skip_all)]
     fn verify(qs: &mut QueryServerReadTransaction) -> Vec<Result<(), ConsistencyError>> {
         // Only check live entries, not recycled.

--- a/server/lib/src/plugins/memberof.rs
+++ b/server/lib/src/plugins/memberof.rs
@@ -235,6 +235,7 @@ impl Plugin for MemberOf {
         qs: &mut QueryServerWriteTransaction,
         pre_cand: &[Arc<EntrySealedCommitted>],
         cand: &[EntrySealedCommitted],
+        _conflict_uuids: &[Uuid],
     ) -> Result<(), OperationError> {
         // IMPORTANT - we need this for now so that dyngroup doesn't error on us, since
         // repl is internal and dyngroup has a safety check to prevent external triggers.

--- a/server/lib/src/plugins/mod.rs
+++ b/server/lib/src/plugins/mod.rs
@@ -157,15 +157,15 @@ trait Plugin {
             "plugin {} has an unimplemented pre_repl_incremental!",
             Self::id()
         );
-        // debug_assert!(false);
-        // Err(OperationError::InvalidState)
-        Ok(())
+        debug_assert!(false);
+        Err(OperationError::InvalidState)
     }
 
     fn post_repl_incremental(
         _qs: &mut QueryServerWriteTransaction,
         _pre_cand: &[Arc<EntrySealedCommitted>],
         _cand: &[EntrySealedCommitted],
+        _conflict_uuids: &[Uuid],
     ) -> Result<(), OperationError> {
         admin_error!(
             "plugin {} has an unimplemented post_repl_incremental!",
@@ -352,11 +352,12 @@ impl Plugins {
         qs: &mut QueryServerWriteTransaction,
         pre_cand: &[Arc<EntrySealedCommitted>],
         cand: &[EntrySealedCommitted],
+        conflict_uuids: &[Uuid],
     ) -> Result<(), OperationError> {
-        domain::Domain::post_repl_incremental(qs, pre_cand, cand)?;
-        spn::Spn::post_repl_incremental(qs, pre_cand, cand)?;
-        refint::ReferentialIntegrity::post_repl_incremental(qs, pre_cand, cand)?;
-        memberof::MemberOf::post_repl_incremental(qs, pre_cand, cand)
+        domain::Domain::post_repl_incremental(qs, pre_cand, cand, conflict_uuids)?;
+        spn::Spn::post_repl_incremental(qs, pre_cand, cand, conflict_uuids)?;
+        refint::ReferentialIntegrity::post_repl_incremental(qs, pre_cand, cand, conflict_uuids)?;
+        memberof::MemberOf::post_repl_incremental(qs, pre_cand, cand, conflict_uuids)
     }
 
     #[instrument(level = "debug", name = "plugins::run_verify", skip_all)]

--- a/server/lib/src/plugins/spn.rs
+++ b/server/lib/src/plugins/spn.rs
@@ -77,6 +77,7 @@ impl Plugin for Spn {
         qs: &mut QueryServerWriteTransaction,
         pre_cand: &[Arc<EntrySealedCommitted>],
         cand: &[EntrySealedCommitted],
+        _conflict_uuids: &[Uuid],
     ) -> Result<(), OperationError> {
         Self::post_modify_inner(qs, pre_cand, cand)
     }

--- a/server/lib/src/repl/tests.rs
+++ b/server/lib/src/repl/tests.rs
@@ -2080,12 +2080,210 @@ async fn test_repl_increment_schema_dynamic(server_a: &QueryServer, server_b: &Q
     drop(server_a_txn);
 }
 
+// Test memberof over replication boundaries.
+#[qs_pair_test]
+async fn test_repl_increment_memberof_basic(server_a: &QueryServer, server_b: &QueryServer) {
+    let ct = duration_from_epoch_now();
+
+    let mut server_a_txn = server_a.write(ct).await;
+    let mut server_b_txn = server_b.read().await;
+
+    assert!(repl_initialise(&mut server_b_txn, &mut server_a_txn)
+        .and_then(|_| server_a_txn.commit())
+        .is_ok());
+    drop(server_b_txn);
+
+    // Since memberof isn't replicated, we have to check that when a group with
+    // a member is sent over, it's re-calced on the other side.
+
+    let mut server_a_txn = server_a.write(duration_from_epoch_now()).await;
+    let t_uuid = Uuid::new_v4();
+    assert!(server_a_txn
+        .internal_create(vec![entry_init!(
+            (Attribute::Class.as_ref(), EntryClass::Object.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Account.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Person.to_value()),
+            (Attribute::Name.as_ref(), Value::new_iname("testperson1")),
+            (Attribute::Uuid.as_ref(), Value::Uuid(t_uuid)),
+            (
+                Attribute::Description.as_ref(),
+                Value::new_utf8s("testperson1")
+            ),
+            (
+                Attribute::DisplayName.as_ref(),
+                Value::new_utf8s("testperson1")
+            )
+        ),])
+        .is_ok());
+
+    let g_uuid = Uuid::new_v4();
+    assert!(server_a_txn
+        .internal_create(vec![entry_init!(
+            (Attribute::Class.as_ref(), EntryClass::Object.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Group.to_value()),
+            (Attribute::Name.as_ref(), Value::new_iname("testgroup1")),
+            (Attribute::Uuid.as_ref(), Value::Uuid(g_uuid)),
+            (Attribute::Member.as_ref(), Value::Refer(t_uuid))
+        ),])
+        .is_ok());
+
+    server_a_txn.commit().expect("Failed to commit");
+
+    // Now replicated A -> B
+
+    let mut server_a_txn = server_a.read().await;
+    let mut server_b_txn = server_b.write(ct).await;
+
+    trace!("========================================");
+    repl_incremental(&mut server_a_txn, &mut server_b_txn);
+
+    let e1 = server_a_txn
+        .internal_search_all_uuid(g_uuid)
+        .expect("Unable to access new entry.");
+    let e2 = server_b_txn
+        .internal_search_all_uuid(g_uuid)
+        .expect("Unable to access entry.");
+
+    assert!(e1 == e2);
+
+    let e1 = server_a_txn
+        .internal_search_all_uuid(t_uuid)
+        .expect("Unable to access new entry.");
+    let e2 = server_b_txn
+        .internal_search_all_uuid(t_uuid)
+        .expect("Unable to access entry.");
+
+    assert!(e1 == e2);
+    assert!(e1.attribute_equality(Attribute::MemberOf.as_ref(), &PartialValue::Refer(g_uuid)));
+    // We should also check dyngroups too here :)
+    assert!(e1.attribute_equality(
+        Attribute::MemberOf.as_ref(),
+        &PartialValue::Refer(UUID_IDM_ALL_ACCOUNTS)
+    ));
+
+    server_b_txn.commit().expect("Failed to commit");
+    drop(server_a_txn);
+}
+
 // Test when a group has a member A, and then the group is conflicted, that when
-// group is moved to conflict the memberShip of A is removed.
+// group is moved to conflict the memberShip of A is removed. The conflict must be
+// a non group, or a group that doesn't have the member A.
+#[qs_pair_test]
+async fn test_repl_increment_memberof_conflict(server_a: &QueryServer, server_b: &QueryServer) {
+    let ct = duration_from_epoch_now();
+
+    let mut server_a_txn = server_a.write(ct).await;
+    let mut server_b_txn = server_b.read().await;
+
+    assert!(repl_initialise(&mut server_b_txn, &mut server_a_txn)
+        .and_then(|_| server_a_txn.commit())
+        .is_ok());
+    drop(server_b_txn);
+
+    // First, we need to create a group on b that will conflict
+    let mut server_b_txn = server_b.write(duration_from_epoch_now()).await;
+    let g_uuid = Uuid::new_v4();
+
+    assert!(server_b_txn
+        .internal_create(vec![entry_init!(
+            (Attribute::Class.as_ref(), EntryClass::Object.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Group.to_value()),
+            (
+                Attribute::Name.as_ref(),
+                Value::new_iname("testgroup_conflict")
+            ),
+            (Attribute::Uuid.as_ref(), Value::Uuid(g_uuid))
+        ),])
+        .is_ok());
+
+    server_b_txn.commit().expect("Failed to commit");
+
+    // Now on a, use the same uuid, make the user and a group as it's member.
+    let mut server_a_txn = server_a.write(duration_from_epoch_now()).await;
+    let t_uuid = Uuid::new_v4();
+    assert!(server_a_txn
+        .internal_create(vec![entry_init!(
+            (Attribute::Class.as_ref(), EntryClass::Object.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Account.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Person.to_value()),
+            (Attribute::Name.as_ref(), Value::new_iname("testperson1")),
+            (Attribute::Uuid.as_ref(), Value::Uuid(t_uuid)),
+            (
+                Attribute::Description.as_ref(),
+                Value::new_utf8s("testperson1")
+            ),
+            (
+                Attribute::DisplayName.as_ref(),
+                Value::new_utf8s("testperson1")
+            )
+        ),])
+        .is_ok());
+
+    assert!(server_a_txn
+        .internal_create(vec![entry_init!(
+            (Attribute::Class.as_ref(), EntryClass::Object.to_value()),
+            (Attribute::Class.as_ref(), EntryClass::Group.to_value()),
+            (Attribute::Name.as_ref(), Value::new_iname("testgroup1")),
+            (Attribute::Uuid.as_ref(), Value::Uuid(g_uuid)),
+            (Attribute::Member.as_ref(), Value::Refer(t_uuid))
+        ),])
+        .is_ok());
+
+    server_a_txn.commit().expect("Failed to commit");
+
+    // Now do A -> B. B should show that the second group was a conflict and
+    // the membership drops.
+    let mut server_a_txn = server_a.read().await;
+    let mut server_b_txn = server_b.write(ct).await;
+
+    trace!("========================================");
+    repl_incremental(&mut server_a_txn, &mut server_b_txn);
+
+    let e = server_b_txn
+        .internal_search_all_uuid(g_uuid)
+        .expect("Unable to access entry.");
+    assert!(!e.attribute_equality(Attribute::Member.as_ref(), &PartialValue::Refer(t_uuid)));
+
+    let e = server_b_txn
+        .internal_search_all_uuid(t_uuid)
+        .expect("Unable to access entry.");
+    assert!(!e.attribute_equality(Attribute::MemberOf.as_ref(), &PartialValue::Refer(g_uuid)));
+
+    server_b_txn.commit().expect("Failed to commit");
+    drop(server_a_txn);
+
+    // Now B -> A. A will now reflect the conflict as well.
+    let mut server_b_txn = server_b.read().await;
+    let mut server_a_txn = server_a.write(ct).await;
+
+    trace!("========================================");
+    repl_incremental(&mut server_b_txn, &mut server_a_txn);
+
+    let e1 = server_a_txn
+        .internal_search_all_uuid(g_uuid)
+        .expect("Unable to access entry.");
+    let e2 = server_b_txn
+        .internal_search_all_uuid(g_uuid)
+        .expect("Unable to access entry.");
+
+    assert!(e1 == e2);
+    assert!(!e1.attribute_equality(Attribute::Member.as_ref(), &PartialValue::Refer(t_uuid)));
+
+    let e1 = server_a_txn
+        .internal_search_all_uuid(t_uuid)
+        .expect("Unable to access entry.");
+    let e2 = server_b_txn
+        .internal_search_all_uuid(t_uuid)
+        .expect("Unable to access entry.");
+
+    assert!(e1 == e2);
+    assert!(!e1.attribute_equality(Attribute::MemberOf.as_ref(), &PartialValue::Refer(g_uuid)));
+
+    server_a_txn.commit().expect("Failed to commit");
+    drop(server_b_txn);
+}
 
 // Ref int deletes references when tombstone is replicated over. May need consumer
 // to have some extra groups that need cleanup
-
-// Test memberof over replication boundaries.
 
 // Test change of domain version over incremental.


### PR DESCRIPTION
Relates #68 - implements referential integrity over replication. This adds tests for some of the super gnarly edge cases and ensures that everything is all consistent and nice. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
