### PR TITLE
Check in missing users crate for SELinux integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "toml",
  "tracing",
  "tss-esapi",
+ "users",
  "uuid",
  "walkdir",
 ]
@@ -5038,6 +5039,16 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,7 @@ tss-esapi = "^7.2.0"
 
 url = "^2.4.0"
 urlencoding = "2.1.3"
+users = "^0.11.0"
 uuid = "^1.4.1"
 
 wasm-bindgen = "^0.2.86"

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -69,6 +69,7 @@ tokio = { workspace = true, features = ["rt", "fs", "macros", "sync", "time", "n
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tss-esapi = { workspace = true, optional = true }
+users = { workspace = true }
 uuid = { workspace = true }
 walkdir = { workspace = true }
 


### PR DESCRIPTION
Looks like I forgot to include this a while back for some reason. With this commit, the SELinux feature builds again.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
