### PR TITLE
Yak hassling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ vendor.tar.*
 tools/orca/example_profiles/small/orca-edited.toml
 /docs/
 .vscode/
+# webui things we don't need
+*.d.ts
 
 # kanidm simple packaging
 deployment-config/

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -638,7 +638,7 @@ async fn main() -> ExitCode {
                     client = match &sconfig.tls_chain {
                         None => client,
                         Some(ca_cert) => {
-                            debug!("Trying to load {}", ca_cert);
+                            debug!("Trying to load {} to build a CA cert path", ca_cert);
                             // if the ca_cert file exists, then we'll use it
                             let ca_cert_path = PathBuf::from(ca_cert);
                             match ca_cert_path.exists() {
@@ -666,7 +666,7 @@ async fn main() -> ExitCode {
                                     let ca_cert_parsed = match reqwest::Certificate::from_pem(content.as_bytes()) {
                                         Ok(val) => val,
                                         Err(e) =>{
-                                            error!("Failed to parse {} as a valid certificate!\nError: {:?}", ca_cert, e);
+                                            error!("Failed to parse {} into CA certificate!\nError: {:?}", ca_cert, e);
                                         return ExitCode::FAILURE
                                         }
                                     };

--- a/server/lib/Cargo.toml
+++ b/server/lib/Cargo.toml
@@ -50,6 +50,8 @@ regex = { workspace = true, features = [
     "unicode",
     "unicode-gencat",
 ] }
+rusqlite = { workspace = true, features = ["array", "bundled"] }
+
 serde = { workspace = true, features = ["derive"] }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
@@ -80,11 +82,9 @@ serde_with = { workspace = true }
 
 # because windows really can't build without the bundled one
 [target.'cfg(target_family = "windows")'.dependencies]
-rusqlite = { workspace = true, features = ["array", "bundled", "vtab"] }
 whoami = { workspace = true }
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
-rusqlite = { workspace = true }
 kanidm_utils_users = { workspace = true }
 
 [features]

--- a/server/lib/Cargo.toml
+++ b/server/lib/Cargo.toml
@@ -80,7 +80,7 @@ serde_with = { workspace = true }
 
 # because windows really can't build without the bundled one
 [target.'cfg(target_family = "windows")'.dependencies]
-rusqlite = { workspace = true, features = ["bundled"] }
+rusqlite = { workspace = true, features = ["array", "bundled", "vtab"] }
 whoami = { workspace = true }
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]

--- a/server/lib/src/be/idl_arc_sqlite.rs
+++ b/server/lib/src/be/idl_arc_sqlite.rs
@@ -565,7 +565,7 @@ impl<'a> IdlArcSqliteTransaction for IdlArcSqliteWriteTransaction<'a> {
 }
 
 impl<'a> IdlArcSqliteWriteTransaction<'a> {
-    #[cfg(debug_assertions)]
+    #[cfg(any(test, debug_assertions))]
     #[instrument(level = "debug", name = "idl_arc_sqlite::clear_cache", skip_all)]
     pub fn clear_cache(&mut self) -> Result<(), OperationError> {
         // I'm not sure rn if I want to reload these? If we reload these we kind of

--- a/server/lib/src/be/idl_sqlite.rs
+++ b/server/lib/src/be/idl_sqlite.rs
@@ -206,7 +206,7 @@ pub trait IdlSqliteTransaction {
                         }
                         // TODO: make this a better error
                         Err(e) => {
-                            admin_error!(?e, "SQLite Error");
+                            admin_error!(?e, "SQLite Error in get_identry_raw");
                             return Err(OperationError::SqliteError);
                         }
                     }
@@ -1712,14 +1712,19 @@ impl IdlSqlite {
                 match conn {
                     Ok(conn) => {
                         rusqlite::vtab::array::load_module(&conn).map_err(|e| {
-                            panic!("Failed to load rarray virtual module: {:?}", e);
-                            // sqlite_error(e)
+                            admin_error!(
+                                "Failed to load rarray virtual module for sqlite, cannot start! {:?}", e
+                            );
+                            sqlite_error(e)
                         })?;
                         Ok(conn)
                     }
                     Err(err) => {
-                        panic!("Failed to open connection: {:?}", err);
-                        // Err(err)
+                        admin_error!(
+                            "Failed to start database connection, cannot start! {:?}",
+                            err
+                        );
+                        Err(err)
                     }
                 }
             })

--- a/server/lib/src/be/idl_sqlite.rs
+++ b/server/lib/src/be/idl_sqlite.rs
@@ -167,8 +167,6 @@ pub trait IdlSqliteTransaction {
                     ))
                     .map_err(sqlite_error)?;
 
-                // TODO #258: I have no idea how to make this an iterator chain ... so what
-
                 // turn them into i64's
                 let mut id_list: Vec<i64> = vec![];
                 for id in idli {
@@ -1711,6 +1709,7 @@ impl IdlSqlite {
                     Connection::open_with_flags(cfg.path.as_str(), flags).map_err(sqlite_error);
                 match conn {
                     Ok(conn) => {
+                        // load the rusqlite vtab module to allow for virtual tables
                         rusqlite::vtab::array::load_module(&conn).map_err(|e| {
                             admin_error!(
                                 "Failed to load rarray virtual module for sqlite, cannot start! {:?}", e
@@ -1733,24 +1732,6 @@ impl IdlSqlite {
                 error!(err = ?e, "Failed to build connection pool");
                 e
             })?;
-
-        // // load the rarray virtual module for each pooled connection
-        // let pool = pool
-        //     .into_iter()
-        //     .map(
-        //         |p| match rusqlite::vtab::array::load_module(&p).map_err(sqlite_error) {
-        //             Ok(_) => Ok(p),
-        //             Err(_) => {
-        //                 error!("Failed to load rarray virtual module");
-        //                 Err(OperationError::SqliteError)
-        //             }
-        //         },
-        //     )
-        //     .collect::<Result<VecDeque<Connection>, OperationError>>()
-        //     .map_err(|e| {
-        //         error!(err = ?e, "Failed to build connection pool");
-        //         e
-        //     })?;
 
         let pool = Arc::new(Mutex::new(pool));
 

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -1792,7 +1792,7 @@ impl<'a> BackendWriteTransaction<'a> {
         self.set_db_index_version(0)
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(test, debug_assertions))]
     pub fn clear_cache(&mut self) -> Result<(), OperationError> {
         self.get_idlayer().clear_cache()
     }

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -1220,7 +1220,7 @@ impl QueryServer {
         }
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(test, debug_assertions))]
     pub async fn clear_cache(&self) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut w_txn = self.write(ct).await;
@@ -1608,7 +1608,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         Ok(())
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(test, debug_assertions))]
     #[instrument(level = "debug", skip_all)]
     pub fn clear_cache(&mut self) -> Result<(), OperationError> {
         self.be_txn.clear_cache()

--- a/server/web_ui/build_wasm.sh
+++ b/server/web_ui/build_wasm.sh
@@ -29,7 +29,7 @@ fi
 
 # we can disable this since we want it to expand
 # shellcheck disable=SC2086
-wasm-pack build ${BUILD_FLAGS} --target web --mode no-install --no-pack || exit 1
+wasm-pack build ${BUILD_FLAGS} --target web --mode no-install --no-pack
 
 touch ./pkg/ANYTHING_HERE_WILL_BE_DELETED_ADD_TO_SRC && \
     rsync --delete-after -r --copy-links -v ./static/* ./pkg/ && \
@@ -37,6 +37,8 @@ touch ./pkg/ANYTHING_HERE_WILL_BE_DELETED_ADD_TO_SRC && \
     cp ../../LICENSE.md ./pkg/
     rm ./pkg/.gitignore
 
-# updates the brotli-compressed files
-echo "brotli-compressing the WASM file..."
-find ./pkg -name '*.wasm' -exec ./find_best_brotli.sh "{}" \; || exit 1
+if [ -z "${SKIP_BROTLI}" ]; then
+    # updates the brotli-compressed files
+    echo "brotli-compressing the WASM file..."
+    find ./pkg -name '*.wasm' -exec ./find_best_brotli.sh "{}" \; || exit 1
+fi

--- a/server/web_ui/src/views/mod.rs
+++ b/server/web_ui/src/views/mod.rs
@@ -1,3 +1,4 @@
+#[allow(non_camel_case_types)]
 use gloo::console;
 use kanidm_proto::v1::{UiHint, UserAuthToken};
 use serde::{Deserialize, Serialize};

--- a/server/web_ui/src/views/mod.rs
+++ b/server/web_ui/src/views/mod.rs
@@ -1,4 +1,4 @@
-#[allow(non_camel_case_types)]
+#![allow(non_camel_case_types)]
 use gloo::console;
 use kanidm_proto::v1::{UiHint, UserAuthToken};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Fixes #258 

- adds the vtab plugin from rusqlite to the database to allow for dynamic "where in" things - is only used when using the `rarray` function in queries
- updates the error message for the healthcheck when failing to load a cert for CA trust, ref #2047 
- clippy lint about camelcase types

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
