### PR TITLE
Removing default features from git2 package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,8 +1722,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -2739,9 +2737,7 @@ checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -2773,20 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ fs2 = "^0.4.3"
 futures = "^0.3.28"
 futures-concurrency = "^3.1.0"
 futures-util = { version = "^0.3.21", features = ["sink"] }
-git2 = "0.17.2"
+git2 = { version = "0.17.2", default-features = false }
 gloo = "^0.8.1"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 hex = "^0.4.3"
@@ -185,7 +185,10 @@ tokio-util = "^0.7.8"
 
 toml = "^0.5.11"
 touch = "^0.0.1"
-tracing = { version = "^0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
+tracing = { version = "^0.1.37", features = [
+    "max_level_trace",
+    "release_max_level_debug",
+] }
 # tracing = { version = "^0.1.37" }
 tracing-subscriber = { version = "^0.3.17", features = ["env-filter"] }
 tracing-forest = "^0.1.6"
@@ -201,7 +204,11 @@ wasm-bindgen = "^0.2.86"
 wasm-bindgen-futures = "^0.4.30"
 wasm-bindgen-test = "0.3.35"
 
-webauthn-authenticator-rs = { version = "0.5.0-dev", features = ["softpasskey", "softtoken", "mozilla"] }
+webauthn-authenticator-rs = { version = "0.5.0-dev", features = [
+    "softpasskey",
+    "softtoken",
+    "mozilla",
+] }
 webauthn-rs = { version = "0.5.0-dev", features = ["preview-features"] }
 webauthn-rs-core = "0.5.0-dev"
 webauthn-rs-proto = "0.5.0-dev"

--- a/server/lib/src/plugins/refint.rs
+++ b/server/lib/src/plugins/refint.rs
@@ -248,7 +248,7 @@ impl Plugin for ReferentialIntegrity {
             }
         }
 
-        // We can now combine this with the confict uuids from the incoming set.
+        // We can now combine this with the conflict uuids from the incoming set.
 
         // In a conflict case, we need to also add these uuids to the delete logic
         // since on the originator node the original uuid will still persist

--- a/server/lib/src/repl/tests.rs
+++ b/server/lib/src/repl/tests.rs
@@ -2491,7 +2491,7 @@ async fn test_repl_increment_refint_conflict(server_a: &QueryServer, server_b: &
     // the true intent of the situation now.
     //
     // In this example, the users created on server A was intended to be a member of
-    // the group, but the user on server B *was not* intended to be a member. Therfore
+    // the group, but the user on server B *was not* intended to be a member. Therefore
     // it's wrong that we retain the user from Server B *while* also the membership
     // that was intended for the user on A.
     let e = server_b_txn


### PR DESCRIPTION
Saves 51s on a clean release build because git2 is only used for parsing the log to get the version out 😄 

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes