### PR TITLE
Implement DeviceAuthorizationGrant for MFA

### DIFF
--- a/unix_integration/nss_kanidm/src/implementation.rs
+++ b/unix_integration/nss_kanidm/src/implementation.rs
@@ -20,16 +20,15 @@ impl PasswdHooks for KanidmPasswd {
             };
         let req = ClientRequest::NssAccounts;
 
-        let mut daemon_client =
-            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-                Ok(dc) => dc,
-                Err(_) => {
-                    return Response::Unavail;
-                }
-            };
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str()) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
 
         daemon_client
-            .call_and_wait(&req)
+            .call_and_wait(&req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssAccounts(l) => l.into_iter().map(passwd_from_nssuser).collect(),
                 _ => Vec::new(),
@@ -48,16 +47,15 @@ impl PasswdHooks for KanidmPasswd {
             };
         let req = ClientRequest::NssAccountByUid(uid);
 
-        let mut daemon_client =
-            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-                Ok(dc) => dc,
-                Err(_) => {
-                    return Response::Unavail;
-                }
-            };
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str()) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
 
         daemon_client
-            .call_and_wait(&req)
+            .call_and_wait(&req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -77,16 +75,15 @@ impl PasswdHooks for KanidmPasswd {
                 }
             };
         let req = ClientRequest::NssAccountByName(name);
-        let mut daemon_client =
-            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-                Ok(dc) => dc,
-                Err(_) => {
-                    return Response::Unavail;
-                }
-            };
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str()) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
 
         daemon_client
-            .call_and_wait(&req)
+            .call_and_wait(&req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssAccount(opt) => opt
                     .map(passwd_from_nssuser)
@@ -111,16 +108,15 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroups;
-        let mut daemon_client =
-            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-                Ok(dc) => dc,
-                Err(_) => {
-                    return Response::Unavail;
-                }
-            };
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str()) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
 
         daemon_client
-            .call_and_wait(&req)
+            .call_and_wait(&req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssGroups(l) => l.into_iter().map(group_from_nssgroup).collect(),
                 _ => Vec::new(),
@@ -138,16 +134,15 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByGid(gid);
-        let mut daemon_client =
-            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-                Ok(dc) => dc,
-                Err(_) => {
-                    return Response::Unavail;
-                }
-            };
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str()) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
 
         daemon_client
-            .call_and_wait(&req)
+            .call_and_wait(&req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)
@@ -167,16 +162,15 @@ impl GroupHooks for KanidmGroup {
                 }
             };
         let req = ClientRequest::NssGroupByName(name);
-        let mut daemon_client =
-            match DaemonClientBlocking::new(cfg.sock_path.as_str(), cfg.unix_sock_timeout) {
-                Ok(dc) => dc,
-                Err(_) => {
-                    return Response::Unavail;
-                }
-            };
+        let mut daemon_client = match DaemonClientBlocking::new(cfg.sock_path.as_str()) {
+            Ok(dc) => dc,
+            Err(_) => {
+                return Response::Unavail;
+            }
+        };
 
         daemon_client
-            .call_and_wait(&req)
+            .call_and_wait(&req, cfg.unix_sock_timeout)
             .map(|r| match r {
                 ClientResponse::NssGroup(opt) => opt
                     .map(group_from_nssgroup)

--- a/unix_integration/src/client_sync.rs
+++ b/unix_integration/src/client_sync.rs
@@ -6,33 +6,49 @@ use std::time::{Duration, SystemTime};
 use crate::unix_proto::{ClientRequest, ClientResponse};
 
 pub struct DaemonClientBlocking {
-    timeout: Duration,
     stream: UnixStream,
 }
 
 impl DaemonClientBlocking {
-    pub fn new(path: &str, timeout: u64) -> Result<DaemonClientBlocking, Box<dyn Error>> {
-        let timeout = Duration::from_secs(timeout);
-
-        debug!(%path, ?timeout);
+    pub fn new(path: &str) -> Result<DaemonClientBlocking, Box<dyn Error>> {
+        debug!(%path);
 
         let stream = UnixStream::connect(path)
-            .and_then(|socket| socket.set_read_timeout(Some(timeout)).map(|_| socket))
-            .and_then(|socket| socket.set_write_timeout(Some(timeout)).map(|_| socket))
             .map_err(|e| {
                 error!("stream setup error -> {:?}", e);
                 e
             })
             .map_err(Box::new)?;
 
-        Ok(DaemonClientBlocking { timeout, stream })
+        Ok(DaemonClientBlocking { stream })
     }
 
-    pub fn call_and_wait(&mut self, req: &ClientRequest) -> Result<ClientResponse, Box<dyn Error>> {
+    pub fn call_and_wait(
+        &mut self,
+        req: &ClientRequest,
+        timeout: u64,
+    ) -> Result<ClientResponse, Box<dyn Error>> {
+        let timeout = Duration::from_secs(timeout);
+
         let data = serde_json::to_vec(&req).map_err(|e| {
             error!("socket encoding error -> {:?}", e);
             Box::new(IoError::new(ErrorKind::Other, "JSON encode error"))
         })?;
+
+        match self.stream.set_read_timeout(Some(timeout)) {
+            Ok(()) => {}
+            Err(e) => {
+                error!("stream setup error -> {:?}", e);
+                return Err(Box::new(e));
+            }
+        };
+        match self.stream.set_write_timeout(Some(timeout)) {
+            Ok(()) => {}
+            Err(e) => {
+                error!("stream setup error -> {:?}", e);
+                return Err(Box::new(e));
+            }
+        };
 
         self.stream
             .write_all(data.as_slice())
@@ -52,7 +68,7 @@ impl DaemonClientBlocking {
         loop {
             let mut buffer = [0; 1024];
             let durr = SystemTime::now().duration_since(start).map_err(Box::new)?;
-            if durr > self.timeout {
+            if durr > timeout {
                 error!("Socket timeout");
                 // timed out, not enough activity.
                 break;

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -1,4 +1,4 @@
-use crate::unix_proto::{PamAuthRequest, PamAuthResponse};
+use crate::unix_proto::{DeviceAuthorizationResponse, PamAuthRequest, PamAuthResponse};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -55,10 +55,12 @@ pub struct UserToken {
 #[derive(Debug)]
 pub enum AuthCredHandler {
     Password,
+    DeviceAuthorizationGrant,
 }
 
 pub enum AuthRequest {
     Password,
+    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
 }
 
 #[allow(clippy::from_over_into)]
@@ -66,6 +68,9 @@ impl Into<PamAuthResponse> for AuthRequest {
     fn into(self) -> PamAuthResponse {
         match self {
             AuthRequest::Password => PamAuthResponse::Password,
+            AuthRequest::DeviceAuthorizationGrant { data } => {
+                PamAuthResponse::DeviceAuthorizationGrant { data }
+            }
         }
     }
 }

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -223,13 +223,18 @@ impl IdProvider for KanidmProvider {
                         Err(IdpError::BadRequest)
                     }
                 }
-            } // For future when we have different auth combos/types.
-              /*
-                _ => {
-                    error!("invalid authentication request state");
-                    Err(IdpError::BadRequest)
-                }
-              */
+            }
+            (
+                AuthCredHandler::DeviceAuthorizationGrant,
+                PamAuthRequest::DeviceAuthorizationGrant { .. },
+            ) => {
+                error!("DeviceAuthorizationGrant not implemented!");
+                Err(IdpError::BadRequest)
+            }
+            _ => {
+                error!("invalid authentication request state");
+                Err(IdpError::BadRequest)
+            }
         }
     }
 

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -1047,6 +1047,14 @@ where
                             }
                         }
                     }
+                    (AuthCredHandler::Password, _) => {
+                        // AuthCredHandler::Password is only valid with a cred provided
+                        return Err(());
+                    }
+                    (AuthCredHandler::DeviceAuthorizationGrant, _) => {
+                        // AuthCredHandler::DeviceAuthorizationGrant is invalid for offline auth
+                        return Err(());
+                    }
                 }
 
                 /*
@@ -1113,6 +1121,10 @@ where
     ) -> Result<Option<bool>, ()> {
         let mut auth_session = match self.pam_account_authenticate_init(account_id).await? {
             (auth_session, PamAuthResponse::Password) => {
+                // Can continue!
+                auth_session
+            }
+            (auth_session, PamAuthResponse::DeviceAuthorizationGrant { .. }) => {
                 // Can continue!
                 auth_session
             }

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -16,12 +16,27 @@ pub struct NssGroup {
     pub members: Vec<String>,
 }
 
+/* RFC8628: 3.2. Device Authorization Response */
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct DeviceAuthorizationResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: Option<String>,
+    pub expires_in: u32,
+    pub interval: Option<u32>,
+    /* The message is not part of RFC8628, but an add-on from MS. Listed
+     * optional here to support all implementations. */
+    pub message: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthResponse {
     Unknown,
     Success,
     Denied,
     Password,
+    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
     /*
     MFACode {
     },
@@ -32,11 +47,11 @@ pub enum PamAuthResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthRequest {
     Password { cred: String },
-    /*
-    MFACode {
-        cred: Option<PamCred>
-    }
-    */
+    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse }, /*
+                                                                    MFACode {
+                                                                        cred: Option<PamCred>
+                                                                    }
+                                                                    */
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Himmelblau will use the DeviceAuthorizationGrant
(defined in RFC8628) to perform MFA. This commit
adds the bits to Kanidm to make that possible,
using the new pam state machine code.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
