### PR TITLE
68 20230912 session consistency

### DIFF
--- a/server/lib/src/be/dbvalue.rs
+++ b/server/lib/src/be/dbvalue.rs
@@ -390,6 +390,16 @@ pub enum DbValueIdentityId {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub enum DbValueSessionStateV1 {
+    #[serde(rename = "ea")]
+    ExpiresAt(String),
+    #[serde(rename = "nv")]
+    Never,
+    #[serde(rename = "ra")]
+    RevokedAt(DbCidV1),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub enum DbValueSession {
     V1 {
         #[serde(rename = "u")]
@@ -412,6 +422,22 @@ pub enum DbValueSession {
         label: String,
         #[serde(rename = "e")]
         expiry: Option<String>,
+        #[serde(rename = "i")]
+        issued_at: String,
+        #[serde(rename = "b")]
+        issued_by: DbValueIdentityId,
+        #[serde(rename = "c")]
+        cred_id: Uuid,
+        #[serde(rename = "s", default)]
+        scope: DbValueAccessScopeV1,
+    },
+    V3 {
+        #[serde(rename = "u")]
+        refer: Uuid,
+        #[serde(rename = "l")]
+        label: String,
+        #[serde(rename = "e")]
+        state: DbValueSessionStateV1,
         #[serde(rename = "i")]
         issued_at: String,
         #[serde(rename = "b")]
@@ -461,6 +487,18 @@ pub enum DbValueOauth2Session {
         parent: Uuid,
         #[serde(rename = "e")]
         expiry: Option<String>,
+        #[serde(rename = "i")]
+        issued_at: String,
+        #[serde(rename = "r")]
+        rs_uuid: Uuid,
+    },
+    V2 {
+        #[serde(rename = "u")]
+        refer: Uuid,
+        #[serde(rename = "p")]
+        parent: Uuid,
+        #[serde(rename = "e")]
+        state: DbValueSessionStateV1,
         #[serde(rename = "i")]
         issued_at: String,
         #[serde(rename = "r")]

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -77,7 +77,8 @@ pub const MFAREG_SESSION_TIMEOUT: u64 = 300;
 pub const PW_MIN_LENGTH: usize = 10;
 
 // Default - sessions last for 1 hour.
-pub const DEFAULT_AUTH_SESSION_EXPIRY: u32 = 3600;
+pub const DEFAULT_AUTH_SESSION_EXPIRY: u32 = 86400;
+pub const DEFAULT_AUTH_SESSION_LIMITED_EXPIRY: u32 = 3600;
 // Default - privileges last for 10 minutes.
 pub const DEFAULT_AUTH_PRIVILEGE_EXPIRY: u32 = 600;
 // Default - oauth refresh tokens last for 16 hours.

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -3047,6 +3047,16 @@ where
         }
     }
 
+    /// Unlike pop or purge, this does NOT respect the attributes purge settings, meaning
+    /// that this can break replication by force clearing the state of an attribute. It's
+    /// useful for things like "session" to test the grace window by removing the revoked
+    /// sessions from the value set that you otherwise, could not.
+    #[cfg(test)]
+    pub(crate) fn force_trim_ava(&mut self, attr: &str) -> Option<ValueSet> {
+        self.valid.ecstate.change_ava(&self.valid.cid, attr);
+        self.attrs.remove(attr)
+    }
+
     /// Replace the content of this attribute with the values from this
     /// iterator. If the iterator is empty, the attribute is purged.
     pub fn set_ava<T>(&mut self, attr: &str, iter: T)

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -230,6 +230,8 @@ impl Account {
         // ns value which breaks some checks.
         let ct = ct - Duration::from_nanos(ct.subsec_nanos() as u64);
         let issued_at = OffsetDateTime::UNIX_EPOCH + ct;
+        // Note that currently the auth_session time comes from policy, but the already-privileged
+        // session bound is hardcoded.
         let expiry =
             Some(OffsetDateTime::UNIX_EPOCH + ct + Duration::from_secs(auth_session_expiry as u64));
         let limited_expiry = Some(
@@ -251,13 +253,7 @@ impl Account {
                 // These sessions are always rw, and so have limited life.
                 (UatPurpose::ReadWrite { expiry }, limited_expiry)
             }
-            SessionScope::PrivilegeCapable =>
-            // Return a rw capable session with the expiry currently invalid.
-            // These sessions COULD live forever since they can re-auth properly.
-            // Today I'm setting this to 24hr though.
-            {
-                (UatPurpose::ReadWrite { expiry: None }, expiry)
-            }
+            SessionScope::PrivilegeCapable => (UatPurpose::ReadWrite { expiry: None }, expiry),
         };
 
         Some(UserAuthToken {

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -484,6 +484,7 @@ impl<'a> Oauth2ResourceServersWriteTransaction<'a> {
 }
 
 impl<'a> IdmServerProxyWriteTransaction<'a> {
+    #[instrument(level = "debug", skip_all)]
     pub fn oauth2_token_revoke(
         &mut self,
         client_authz: &str,
@@ -575,6 +576,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_token_exchange(
         &mut self,
         client_authz: Option<&str>,
@@ -659,6 +661,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_authorise_permit(
         &mut self,
         ident: &Identity,
@@ -750,6 +753,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         })
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn check_oauth2_token_exchange_authorization_code(
         &mut self,
         o2rs: &Oauth2RS,
@@ -849,6 +853,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         )
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn check_oauth2_token_refresh(
         &mut self,
         o2rs: &Oauth2RS,
@@ -1139,7 +1144,9 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
 
         // We need to update (replace) this session id if present.
         let modlist = ModifyList::new_list(vec![
-            Modify::Removed("oauth2_session".into(), PartialValue::Refer(session_id)),
+            // NOTE: Oauth2_session has special handling that allows update in place without
+            // the remove step needing to be carried out.
+            // Modify::Removed("oauth2_session".into(), PartialValue::Refer(session_id)),
             Modify::Present("oauth2_session".into(), session),
         ]);
 
@@ -1208,6 +1215,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
 }
 
 impl<'a> IdmServerProxyReadTransaction<'a> {
+    #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_authorisation(
         &self,
         ident: &Identity,
@@ -1499,6 +1507,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_authorise_reject(
         &self,
         ident: &Identity,
@@ -1550,6 +1559,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         Ok(consent_req.redirect_uri)
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_token_introspect(
         &mut self,
         client_authz: &str,
@@ -1659,6 +1669,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn oauth2_openid_userinfo(
         &mut self,
         client_id: &str,
@@ -1765,6 +1776,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn oauth2_openid_discovery(
         &self,
         client_id: &str,
@@ -1848,6 +1860,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         })
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn oauth2_openid_publickey(&self, client_id: &str) -> Result<JwkKeySet, OperationError> {
         let o2rs = self.oauth2rs.inner.rs_set.get(client_id).ok_or_else(|| {
             admin_warn!(
@@ -1974,6 +1987,7 @@ mod tests {
     use crate::idm::oauth2::{AuthoriseResponse, Oauth2Error};
     use crate::idm::server::{IdmServer, IdmServerTransaction};
     use crate::prelude::*;
+    use crate::value::SessionState;
 
     use crate::credential::Credential;
     use kanidm_lib_crypto::CryptoPolicy;
@@ -2129,8 +2143,8 @@ mod tests {
         // Need the uat first for expiry.
         let state = uat
             .expiry
-            .map(crate::value::SessionState::ExpiresAt)
-            .unwrap_or(crate::value::SessionState::NeverExpires);
+            .map(SessionState::ExpiresAt)
+            .unwrap_or(SessionState::NeverExpires);
 
         let p = CryptoPolicy::minimum();
         let cred = Credential::new_password_only(&p, "test_password").unwrap();
@@ -2251,8 +2265,8 @@ mod tests {
         // Need the uat first for expiry.
         let state = uat
             .expiry
-            .map(crate::value::SessionState::ExpiresAt)
-            .unwrap_or(crate::value::SessionState::NeverExpires);
+            .map(SessionState::ExpiresAt)
+            .unwrap_or(SessionState::NeverExpires);
 
         let p = CryptoPolicy::minimum();
         let cred = Credential::new_password_only(&p, "test_password").unwrap();
@@ -3089,18 +3103,6 @@ mod tests {
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
 
-        // Check it is still valid - this is because we are still in the GRACE window.
-        let mut idms_prox_read = idms.proxy_read().await;
-        let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
-            .expect("Failed to inspect token");
-
-        assert!(intr_response.active);
-        drop(idms_prox_read);
-
-        // Check after the grace window, it will be invalid.
-        let ct = ct + GRACE_WINDOW;
-
         // Assert it is now invalid.
         let mut idms_prox_read = idms.proxy_read().await;
         let intr_response = idms_prox_read
@@ -3108,6 +3110,39 @@ mod tests {
             .expect("Failed to inspect token");
 
         assert!(!intr_response.active);
+        drop(idms_prox_read);
+
+        // Force trim the session and wait for the grace window to pass. The token will be invalidated
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        let filt = filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(uat.uuid)));
+        let mut work_set = idms_prox_write
+            .qs_write
+            .internal_search_writeable(&filt)
+            .expect("Failed to perform internal search writeable");
+        for (_, entry) in work_set.iter_mut() {
+            let _ = entry.force_trim_ava(Attribute::OAuth2Session.into());
+        }
+        assert!(idms_prox_write
+            .qs_write
+            .internal_apply_writable(work_set)
+            .is_ok());
+
+        assert!(idms_prox_write.commit().is_ok());
+
+        let mut idms_prox_read = idms.proxy_read().await;
+        // Grace window in effect.
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+        assert!(intr_response.active);
+
+        // Grace window passed, it will now be invalid.
+        let ct = ct + GRACE_WINDOW;
+        let intr_response = idms_prox_read
+            .check_oauth2_token_introspect(client_authz.as_deref().unwrap(), &intr_request, ct)
+            .expect("Failed to inspect token");
+        assert!(!intr_response.active);
+
         drop(idms_prox_read);
 
         // A second invalidation of the token "does nothing".
@@ -3207,17 +3242,19 @@ mod tests {
 
         assert!(idms_prox_write.qs_write.delete(&de).is_ok());
 
-        // Assert the session is gone. This is cleaned up as an artifact of the referential
-        // integrity plugin.
+        // Assert the session is revoked. This is cleaned up as an artifact of the referential
+        // integrity plugin. Remember, refint doesn't consider revoked sessions once they are
+        // revoked.
         let entry = idms_prox_write
             .qs_write
             .internal_search_uuid(UUID_ADMIN)
             .expect("failed");
-        let valid = entry
+        let revoked = entry
             .get_ava_as_oauth2session_map("oauth2_session")
-            .map(|map| map.get(&session_id).is_some())
+            .and_then(|sessions| sessions.get(&session_id))
+            .map(|session| matches!(session.state, SessionState::RevokedAt(_)))
             .unwrap_or(false);
-        assert!(!valid);
+        assert!(revoked);
 
         assert!(idms_prox_write.commit().is_ok());
     }
@@ -4769,13 +4806,12 @@ mod tests {
             .expect("failed");
         let valid = entry
             .get_ava_as_oauth2session_map("oauth2_session")
-            .map(|map| {
-                trace!(?map);
-                map.is_empty()
-            })
-            // If there is no map, it must be empty
-            .unwrap_or(true);
-        assert!(valid);
+            .and_then(|sessions| sessions.first_key_value())
+            .map(|(_, session)| !matches!(session.state, SessionState::RevokedAt(_)))
+            // If there is no map, then something is wrong.
+            .unwrap();
+        // The session should be invalid at this point.
+        assert!(!valid);
 
         assert!(idms_prox_write.commit().is_ok());
     }
@@ -4846,8 +4882,10 @@ mod tests {
 
         // Success!
     }
-    #[test] // I know this looks kinda dumb but at some point someone pointed out that our scope syntax wasn't compliant with rfc6749
-            //(https://datatracker.ietf.org/doc/html/rfc6749#section-3.3), so I'm just making sure that we don't break it again.
+
+    #[test]
+    // I know this looks kinda dumb but at some point someone pointed out that our scope syntax wasn't compliant with rfc6749
+    //(https://datatracker.ietf.org/doc/html/rfc6749#section-3.3), so I'm just making sure that we don't break it again.
     fn compliant_serialization_test() {
         let token_req: Result<AccessTokenRequest, serde_json::Error> = serde_json::from_str(
             r#"

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -701,23 +701,21 @@ pub trait IdmServerTransaction<'a> {
                     );
                     return Ok(None);
                 }
+            } else if grace_valid {
+                security_info!(
+                    "The token grace window is in effect. Assuming parent session valid."
+                );
             } else {
-                if grace_valid {
-                    security_info!(
-                        "The token grace window is in effect. Assuming parent session valid."
-                    );
-                } else {
-                    security_info!("The token grace window has passed and no entry parent sessions exist. Assuming invalid.");
-                    return Ok(None);
-                }
-            }
-        } else {
-            if grace_valid {
-                security_info!("The token grace window is in effect. Assuming valid.");
-            } else {
-                security_info!("The token grace window has passed and no entry sessions exist. Assuming invalid.");
+                security_info!("The token grace window has passed and no entry parent sessions exist. Assuming invalid.");
                 return Ok(None);
             }
+        } else if grace_valid {
+            security_info!("The token grace window is in effect. Assuming valid.");
+        } else {
+            security_info!(
+                "The token grace window has passed and no entry sessions exist. Assuming invalid."
+            );
+            return Ok(None);
         }
 
         Ok(Some(entry))

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -536,10 +536,12 @@ pub trait IdmServerTransaction<'a> {
                 .map(|t: Jws<UserAuthToken>| t.into_inner())?;
 
             if let Some(exp) = uat.expiry {
-                if time::OffsetDateTime::UNIX_EPOCH + ct >= exp {
-                    security_info!("Session expired");
+                let ct_odt = time::OffsetDateTime::UNIX_EPOCH + ct;
+                if ct_odt >= exp {
+                    security_info!(?ct_odt, ?exp, "Session expired");
                     Err(OperationError::SessionExpired)
                 } else {
+                    trace!(?ct_odt, ?exp, "Session not yet expired");
                     Ok(Token::UserAuthToken(uat))
                 }
             } else {
@@ -667,28 +669,56 @@ pub trait IdmServerTransaction<'a> {
             return Ok(None);
         }
 
-        if ct >= Duration::from_secs(iat as u64) + GRACE_WINDOW {
-            // We are past the grace window. Enforce session presence.
-            // We enforce both sessions are present in case of inconsistency
-            // that may occur with replication.
-            let oauth2_session_valid = entry
-                .get_ava_as_oauth2session_map(Attribute::OAuth2Session.as_ref())
-                .map(|map| map.get(&session_id).is_some())
-                .unwrap_or(false);
-            let uat_session_valid = entry
-                .get_ava_as_session_map(Attribute::UserAuthTokenSession.as_ref())
-                .map(|map| map.get(&parent_session_id).is_some())
-                .unwrap_or(false);
+        // We are past the grace window. Enforce session presence.
+        // We enforce both sessions are present in case of inconsistency
+        // that may occur with replication.
 
-            if oauth2_session_valid && uat_session_valid {
-                security_info!("A valid session value exists for this token");
-            } else {
-                security_info!(%uat_session_valid, %oauth2_session_valid, "The token grace window has passed and no sessions exist. Assuming invalid.");
+        let grace_valid = ct < (Duration::from_secs(iat as u64) + GRACE_WINDOW);
+
+        let oauth2_session = entry
+            .get_ava_as_oauth2session_map(Attribute::OAuth2Session.as_ref())
+            .and_then(|sessions| sessions.get(&session_id));
+        let uat_session = entry
+            .get_ava_as_session_map(Attribute::UserAuthTokenSession.as_ref())
+            .and_then(|sessions| sessions.get(&parent_session_id));
+
+        if let Some(oauth2_session) = oauth2_session {
+            // We have the oauth2 session, lets check it.
+            let oauth2_session_valid = !matches!(oauth2_session.state, SessionState::RevokedAt(_));
+
+            if !oauth2_session_valid {
+                security_info!("The oauth2 session associated to this token is revoked.");
                 return Ok(None);
             }
+
+            if let Some(uat_session) = uat_session {
+                let parent_session_valid = !matches!(uat_session.state, SessionState::RevokedAt(_));
+                if parent_session_valid {
+                    security_info!("A valid parent and oauth2 session value exists for this token");
+                } else {
+                    security_info!(
+                        "The parent oauth2 session associated to this token is revoked."
+                    );
+                    return Ok(None);
+                }
+            } else {
+                if grace_valid {
+                    security_info!(
+                        "The token grace window is in effect. Assuming parent session valid."
+                    );
+                } else {
+                    security_info!("The token grace window has passed and no entry parent sessions exist. Assuming invalid.");
+                    return Ok(None);
+                }
+            }
         } else {
-            security_info!("The token grace window is in effect. Assuming valid.");
-        };
+            if grace_valid {
+                security_info!("The token grace window is in effect. Assuming valid.");
+            } else {
+                security_info!("The token grace window has passed and no entry sessions exist. Assuming invalid.");
+                return Ok(None);
+            }
+        }
 
         Ok(Some(entry))
     }
@@ -1792,6 +1822,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn recover_account(
         &mut self,
         name: &str,
@@ -1836,6 +1867,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         Ok(cleartext)
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn regenerate_radius_secret(
         &mut self,
         rrse: &RegenerateRadiusSecretEvent,
@@ -1874,6 +1906,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
     }
 
     // -- delayed action processing --
+    #[instrument(level = "debug", skip_all)]
     fn process_pwupgrade(&mut self, pwu: &PasswordUpgrade) -> Result<(), OperationError> {
         // get the account
         let account = self.target_to_account(pwu.target_uuid)?;
@@ -1898,6 +1931,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn process_unixpwupgrade(&mut self, pwu: &UnixPasswordUpgrade) -> Result<(), OperationError> {
         info!(session_id = %pwu.target_uuid, "Processing unix password hash upgrade");
 
@@ -1926,6 +1960,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub(crate) fn process_webauthncounterinc(
         &mut self,
         wci: &WebauthnCounterIncrement,
@@ -1954,6 +1989,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub(crate) fn process_backupcoderemoval(
         &mut self,
         bcr: &BackupCodeRemoval,
@@ -1975,6 +2011,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         )
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub(crate) fn process_authsessionrecord(
         &mut self,
         asr: &AuthSessionRecord,
@@ -2020,6 +2057,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
         // Done!
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn process_delayedaction(
         &mut self,
         da: DelayedAction,
@@ -2139,6 +2177,7 @@ mod tests {
     use crate::modify::{Modify, ModifyList};
     use crate::prelude::*;
     use crate::utils::duration_from_epoch_now;
+    use crate::value::SessionState;
     use kanidm_lib_crypto::CryptoPolicy;
 
     const TEST_PASSWORD: &str = "ntaoeuntnaoeuhraohuercahu😍";
@@ -3471,13 +3510,13 @@ mod tests {
         let da = idms_delayed.try_recv().expect("invalid");
         assert!(matches!(da, DelayedAction::AuthSessionRecord(_)));
         // Persist it.
-        let r = idms.delayed_action(duration_from_epoch_now(), da).await;
+        let r = idms.delayed_action(ct, da).await;
         assert!(Ok(true) == r);
         idms_delayed.check_is_empty_or_panic();
 
         let mut idms_prox_read = idms.proxy_read().await;
 
-        // Check it's valid.
+        // Check it's valid - This is within the time window so will pass.
         idms_prox_read
             .validate_and_parse_token_to_ident(Some(token.as_str()), ct)
             .expect("Failed to validate");
@@ -3540,16 +3579,12 @@ mod tests {
             .get_ava_as_session_map("user_auth_token_session")
             .expect("Sessions must be present!");
         assert!(sessions.len() == 1);
-        let session_id_a = sessions
-            .keys()
-            .copied()
-            .next()
-            .expect("Could not access session id");
-        assert!(session_id_a == session_a);
+        let session_data_a = sessions.get(&session_a).expect("Session A is missing!");
+        assert!(matches!(session_data_a.state, SessionState::ExpiresAt(_)));
 
         drop(idms_prox_read);
 
-        // When we re-auth, this is what triggers the session cleanup via the delayed action.
+        // When we re-auth, this is what triggers the session revoke via the delayed action.
 
         let da = DelayedAction::AuthSessionRecord(AuthSessionRecord {
             target_uuid: UUID_ADMIN,
@@ -3574,15 +3609,14 @@ mod tests {
             .get_ava_as_session_map("user_auth_token_session")
             .expect("Sessions must be present!");
         trace!(?sessions);
-        assert!(sessions.len() == 1);
-        let session_id_b = sessions
-            .keys()
-            .copied()
-            .next()
-            .expect("Could not access session id");
-        assert!(session_id_b == session_b);
+        assert!(sessions.len() == 2);
 
-        assert!(session_id_a != session_id_b);
+        let session_data_a = sessions.get(&session_a).expect("Session A is missing!");
+        assert!(matches!(session_data_a.state, SessionState::RevokedAt(_)));
+
+        let session_data_b = sessions.get(&session_b).expect("Session B is missing!");
+        assert!(matches!(session_data_b.state, SessionState::ExpiresAt(_)));
+        // Now show that sessions trim!
     }
 
     #[idm_test]
@@ -3644,7 +3678,32 @@ mod tests {
         // Now check again with the session destroyed.
         let mut idms_prox_read = idms.proxy_read().await;
 
-        // Now, within gracewindow, it's still valid.
+        // Now, within gracewindow, it's NOT valid because the session entry exists and is in
+        // the revoked state!
+        match idms_prox_read.validate_and_parse_token_to_ident(Some(token.as_str()), post_grace) {
+            Err(OperationError::SessionExpired) => {}
+            _ => assert!(false),
+        }
+        drop(idms_prox_read);
+
+        // Force trim the session out so that we can check the grate handling.
+        let mut idms_prox_write = idms.proxy_write(ct).await;
+        let filt = filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(uat_inner.uuid)));
+        let mut work_set = idms_prox_write
+            .qs_write
+            .internal_search_writeable(&filt)
+            .expect("Failed to perform internal search writeable");
+        for (_, entry) in work_set.iter_mut() {
+            let _ = entry.force_trim_ava(Attribute::UserAuthTokenSession.into());
+        }
+        assert!(idms_prox_write
+            .qs_write
+            .internal_apply_writable(work_set)
+            .is_ok());
+
+        assert!(idms_prox_write.commit().is_ok());
+
+        let mut idms_prox_read = idms.proxy_read().await;
         idms_prox_read
             .validate_and_parse_token_to_ident(Some(token.as_str()), ct)
             .expect("Failed to validate");

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -92,6 +92,7 @@ pub mod prelude {
     pub use crate::modify::{
         m_assert, m_pres, m_purge, m_remove, Modify, ModifyInvalid, ModifyList, ModifyValid,
     };
+    pub use crate::repl::cid::Cid;
     pub use crate::server::access::AccessControlsTransaction;
     pub use crate::server::batch_modify::BatchModifyEvent;
     pub use crate::server::identity::{

--- a/server/lib/src/macros.rs
+++ b/server/lib/src/macros.rs
@@ -486,9 +486,11 @@ macro_rules! mergemaps {
         $b:expr
     ) => {{
         $b.iter().for_each(|(k, v)| {
-            if !$a.contains_key(k) {
-                $a.insert(k.clone(), v.clone());
-            }
+            // I think to be consistent, we need the content of b to always
+            // the content of a
+            // if !$a.contains_key(k) {
+            $a.insert(k.clone(), v.clone());
+            // }
         });
         Ok(())
     }};

--- a/server/lib/src/plugins/namehistory.rs
+++ b/server/lib/src/plugins/namehistory.rs
@@ -128,6 +128,7 @@ mod tests {
     use crate::prelude::{uuid, EntryClass};
     use crate::repl::cid::Cid;
     use crate::value::Value;
+    use crate::valueset::AUDIT_LOG_STRING_CAPACITY;
 
     #[test]
     fn name_purge_and_set() {
@@ -216,10 +217,10 @@ mod tests {
     #[test]
     fn name_purge_and_set_with_filled_history() {
         let mut cids: Vec<Cid> = Vec::new();
-        for i in 1..8 {
+        for i in 1..AUDIT_LOG_STRING_CAPACITY {
             cids.push(Cid::new(
                 uuid!("d2b496bd-8493-47b7-8142-f568b5cf47e1"),
-                Duration::new(20 + i, 0),
+                Duration::new(20 + i as u64, 0),
             ))
         }
         // Add another uuid to a type
@@ -257,10 +258,10 @@ mod tests {
                 let e = qs
                     .internal_search_uuid(uuid!("d2b496bd-8493-47b7-8142-f568b5cf47ee"))
                     .expect("failed to get entry");
-                trace!("{:?}", e.get_ava());
                 let c = e
                     .get_ava_set(Attribute::NameHistory.as_ref())
                     .expect("failed to get name_history ava :/");
+                trace!(?c);
                 assert!(
                     !c.contains(&PartialValue::new_utf8s("old_name1"))
                         && c.contains(&PartialValue::new_utf8s("new_name"))

--- a/server/lib/src/plugins/refint.rs
+++ b/server/lib/src/plugins/refint.rs
@@ -435,7 +435,7 @@ mod tests {
 
     use crate::event::CreateEvent;
     use crate::prelude::*;
-    use crate::value::{Oauth2Session, Session};
+    use crate::value::{Oauth2Session, Session, SessionState};
     use time::OffsetDateTime;
     use uuid::uuid;
 
@@ -1066,7 +1066,7 @@ mod tests {
                     Oauth2Session {
                         parent,
                         // Note we set the exp to None so we are not removing based on exp
-                        expiry: None,
+                        state: SessionState::NeverExpires,
                         issued_at,
                         rs_uuid,
                     },
@@ -1079,7 +1079,7 @@ mod tests {
                     Session {
                         label: "label".to_string(),
                         // Note we set the exp to None so we are not removing based on removal of the parent.
-                        expiry: None,
+                        state: SessionState::NeverExpires,
                         // Need the other inner bits?
                         // for the gracewindow.
                         issued_at,

--- a/server/lib/src/plugins/refint.rs
+++ b/server/lib/src/plugins/refint.rs
@@ -1051,8 +1051,8 @@ mod tests {
         let session_id = Uuid::new_v4();
         let pv_session_id = PartialValue::Refer(session_id);
 
-        let parent = Uuid::new_v4();
-        let pv_parent_id = PartialValue::Refer(parent);
+        let parent_id = Uuid::new_v4();
+        let pv_parent_id = PartialValue::Refer(parent_id);
         let issued_at = curtime_odt;
         let issued_by = IdentityId::User(tuuid);
         let scope = SessionScope::ReadOnly;
@@ -1064,7 +1064,7 @@ mod tests {
                 Value::Oauth2Session(
                     session_id,
                     Oauth2Session {
-                        parent,
+                        parent: parent_id,
                         // Note we set the exp to None so we are not removing based on exp
                         state: SessionState::NeverExpires,
                         issued_at,
@@ -1075,7 +1075,7 @@ mod tests {
             Modify::Present(
                 Attribute::UserAuthTokenSession.into(),
                 Value::Session(
-                    parent,
+                    parent_id,
                     Session {
                         label: "label".to_string(),
                         // Note we set the exp to None so we are not removing based on removal of the parent.
@@ -1114,11 +1114,18 @@ mod tests {
         let entry = server_txn.internal_search_uuid(tuuid).expect("failed");
 
         // Note the uat is present still.
-        assert!(entry.attribute_equality(Attribute::UserAuthTokenSession.as_ref(), &pv_parent_id));
-        // The oauth2 session is removed.
-        dbg!(&entry);
-        dbg!(&pv_session_id);
-        assert!(!entry.attribute_equality(Attribute::OAuth2Session.as_ref(), &pv_session_id));
+        let session = entry
+            .get_ava_as_session_map(Attribute::UserAuthTokenSession.into())
+            .and_then(|sessions| sessions.get(&parent_id))
+            .expect("No session map found");
+        assert!(matches!(session.state, SessionState::NeverExpires));
+
+        // The oauth2 session is revoked.
+        let session = entry
+            .get_ava_as_oauth2session_map(Attribute::OAuth2Session.into())
+            .and_then(|sessions| sessions.get(&session_id))
+            .expect("No session map found");
+        assert!(matches!(session.state, SessionState::RevokedAt(_)));
 
         assert!(server_txn.commit().is_ok());
     }

--- a/server/lib/src/repl/consumer.rs
+++ b/server/lib/src/repl/consumer.rs
@@ -104,7 +104,8 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 // their attribute sets/states per the change state rules.
 
                 // This must create an EntryInvalidCommitted
-                let merge_ent = ctx_ent.merge_state(db_ent.as_ref(), &self.schema);
+                let merge_ent =
+                    ctx_ent.merge_state(db_ent.as_ref(), &self.schema, &self.trim_cid());
                 (merge_ent, db_ent)
             })
             .collect();

--- a/server/lib/src/repl/consumer.rs
+++ b/server/lib/src/repl/consumer.rs
@@ -104,8 +104,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 // their attribute sets/states per the change state rules.
 
                 // This must create an EntryInvalidCommitted
-                let merge_ent =
-                    ctx_ent.merge_state(db_ent.as_ref(), &self.schema, &self.trim_cid());
+                let merge_ent = ctx_ent.merge_state(db_ent.as_ref(), &self.schema, self.trim_cid());
                 (merge_ent, db_ent)
             })
             .collect();

--- a/server/lib/src/repl/proto.rs
+++ b/server/lib/src/repl/proto.rs
@@ -397,7 +397,7 @@ pub enum ReplAttrV1 {
         set: Vec<(String, ReplTotpV1)>,
     },
     AuditLogString {
-        set: Vec<(Cid, String)>,
+        map: Vec<(Cid, String)>,
     },
     EcKeyPrivate {
         key: Vec<u8>,

--- a/server/lib/src/repl/proto.rs
+++ b/server/lib/src/repl/proto.rs
@@ -229,7 +229,8 @@ pub struct ReplOauthScopeMapV1 {
 pub struct ReplOauth2SessionV1 {
     pub refer: Uuid,
     pub parent: Uuid,
-    pub expiry: Option<String>,
+    pub state: ReplSessionStateV1,
+    // pub expiry: Option<String>,
     pub issued_at: String,
     pub rs_uuid: Uuid,
 }
@@ -262,11 +263,19 @@ pub enum ReplIdentityIdV1 {
 pub struct ReplSessionV1 {
     pub refer: Uuid,
     pub label: String,
-    pub expiry: Option<String>,
+    pub state: ReplSessionStateV1,
+    // pub expiry: Option<String>,
     pub issued_at: String,
     pub issued_by: ReplIdentityIdV1,
     pub cred_id: Uuid,
     pub scope: ReplSessionScopeV1,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum ReplSessionStateV1 {
+    ExpiresAt(String),
+    Never,
+    RevokedAt(ReplCidV1),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/server/lib/src/server/batch_modify.rs
+++ b/server/lib/src/server/batch_modify.rs
@@ -106,7 +106,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
             .iter()
             .map(|er| {
                 let u = er.get_uuid();
-                let mut ent_mut = er.as_ref().clone().invalidate(self.cid.clone());
+                let mut ent_mut = er
+                    .as_ref()
+                    .clone()
+                    .invalidate(self.cid.clone(), &self.trim_cid);
 
                 me.modset
                     .get(&u)

--- a/server/lib/src/server/delete.rs
+++ b/server/lib/src/server/delete.rs
@@ -51,7 +51,11 @@ impl<'a> QueryServerWriteTransaction<'a> {
         let mut candidates: Vec<Entry<EntryInvalid, EntryCommitted>> = pre_candidates
             .iter()
             // Invalidate and assign change id's
-            .map(|er| er.as_ref().clone().invalidate(self.cid.clone()))
+            .map(|er| {
+                er.as_ref()
+                    .clone()
+                    .invalidate(self.cid.clone(), &self.trim_cid)
+            })
             .collect();
 
         trace!(?candidates, "delete: candidates");

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -223,7 +223,11 @@ impl<'a> QueryServerWriteTransaction<'a> {
         // Change the value type.
         let mut candidates: Vec<Entry<EntryInvalid, EntryCommitted>> = pre_candidates
             .iter()
-            .map(|er| er.as_ref().clone().invalidate(self.cid.clone()))
+            .map(|er| {
+                er.as_ref()
+                    .clone()
+                    .invalidate(self.cid.clone(), &self.trim_cid)
+            })
             .collect();
 
         candidates.iter_mut().try_for_each(|er| {

--- a/server/lib/src/server/modify.rs
+++ b/server/lib/src/server/modify.rs
@@ -29,6 +29,8 @@ impl<'a> QueryServerWriteTransaction<'a> {
         &mut self,
         me: &'x ModifyEvent,
     ) -> Result<Option<ModifyPartial<'x>>, OperationError> {
+        trace!(?me);
+
         // Get the candidates.
         // Modify applies a modlist to a filter, so we need to internal search
         // then apply.

--- a/server/lib/src/server/modify.rs
+++ b/server/lib/src/server/modify.rs
@@ -97,7 +97,11 @@ impl<'a> QueryServerWriteTransaction<'a> {
         // and the new modified ents.
         let mut candidates: Vec<Entry<EntryInvalid, EntryCommitted>> = pre_candidates
             .iter()
-            .map(|er| er.as_ref().clone().invalidate(self.cid.clone()))
+            .map(|er| {
+                er.as_ref()
+                    .clone()
+                    .invalidate(self.cid.clone(), &self.trim_cid)
+            })
             .collect();
 
         candidates.iter_mut().try_for_each(|er| {
@@ -275,7 +279,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
         self.search(&se).map(|vs| {
             vs.into_iter()
                 .map(|e| {
-                    let writeable = e.as_ref().clone().invalidate(self.cid.clone());
+                    let writeable = e
+                        .as_ref()
+                        .clone()
+                        .invalidate(self.cid.clone(), &self.trim_cid);
                     (e, writeable)
                 })
                 .collect()

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -817,10 +817,18 @@ impl TryInto<UatPurposeStatus> for SessionScope {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionState {
+    ExpiresAt(OffsetDateTime),
+    NeverExpires,
+    RevokedAt(Cid),
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct Session {
     pub label: String,
-    pub expiry: Option<OffsetDateTime>,
+    // pub expiry: Option<OffsetDateTime>,
+    pub state: SessionState,
     pub issued_at: OffsetDateTime,
     pub issued_by: IdentityId,
     pub cred_id: Uuid,
@@ -834,13 +842,14 @@ impl fmt::Debug for Session {
             IdentityId::Synch(u) => format!("Synch - {}", uuid_to_proto_string(u)),
             IdentityId::Internal => "Internal".to_string(),
         };
-        let expiry = match self.expiry {
-            Some(e) => e.to_string(),
-            None => "never".to_string(),
+        let expiry = match self.state {
+            SessionState::ExpiresAt(e) => e.to_string(),
+            SessionState::NeverExpires => "never".to_string(),
+            SessionState::RevokedAt(_) => "revoked".to_string(),
         };
         write!(
             f,
-            "expiry: {}, issued at: {}, issued by: {}, credential id: {}, scope: {:?}",
+            "state: {}, issued at: {}, issued by: {}, credential id: {}, scope: {:?}",
             expiry, self.issued_at, issuer, self.cred_id, self.scope
         )
     }
@@ -849,7 +858,8 @@ impl fmt::Debug for Session {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Oauth2Session {
     pub parent: Uuid,
-    pub expiry: Option<OffsetDateTime>,
+    // pub expiry: Option<OffsetDateTime>,
+    pub state: SessionState,
     pub issued_at: OffsetDateTime,
     pub rs_uuid: Uuid,
 }

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -817,11 +817,14 @@ impl TryInto<UatPurposeStatus> for SessionScope {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum SessionState {
+    // IMPORTANT - this order allows sorting by
+    // lowest to highest, we always want to take
+    // the lowest value!
+    RevokedAt(Cid),
     ExpiresAt(OffsetDateTime),
     NeverExpires,
-    RevokedAt(Cid),
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/server/lib/src/valueset/address.rs
+++ b/server/lib/src/valueset/address.rs
@@ -104,7 +104,7 @@ impl ValueSetT for ValueSetAddress {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Address(_) => {
                 unreachable!()
@@ -325,7 +325,7 @@ impl ValueSetT for ValueSetEmailAddress {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::EmailAddress(a) => {
                 let r = self.set.remove(a);
@@ -463,6 +463,7 @@ pub struct ValueSetPhoneNumber {
 #[cfg(test)]
 mod tests {
     use super::ValueSetEmailAddress;
+    use crate::repl::cid::Cid;
     use crate::value::{PartialValue, Value};
     use crate::valueset::{self, ValueSet};
 
@@ -501,7 +502,10 @@ mod tests {
         assert!(vs.to_email_address_primary_str() == vs2.to_email_address_primary_str());
 
         // Remove primary, assert it's gone and that the "first" address is assigned.
-        assert!(vs.remove(&PartialValue::new_email_address_s("primary@example.com")));
+        assert!(vs.remove(
+            &PartialValue::new_email_address_s("primary@example.com"),
+            &Cid::new_zero()
+        ));
         assert!(vs.len() == 2);
         assert!(vs.to_email_address_primary_str() == Some("alice@example.com"));
 

--- a/server/lib/src/valueset/auditlogstring.rs
+++ b/server/lib/src/valueset/auditlogstring.rs
@@ -146,6 +146,12 @@ impl ValueSetT for ValueSetAuditLogString {
             Err(OperationError::InvalidValueState)
         }
     }
+
+    #[allow(clippy::todo)]
+    fn repl_merge_valueset(&self, _older: &ValueSet) -> Option<ValueSet> {
+        todo!();
+    }
+
     fn as_audit_log_string(&self) -> Option<&SmolSet<[(Cid, String); 8]>> {
         Some(&self.set)
     }

--- a/server/lib/src/valueset/auditlogstring.rs
+++ b/server/lib/src/valueset/auditlogstring.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 type AuditLogStringType = (Cid, String);
 
-const AUDIT_LOG_STRING_CAPACITY: usize = 9;
+pub const AUDIT_LOG_STRING_CAPACITY: usize = 9;
 
 #[derive(Debug, Clone)]
 pub struct ValueSetAuditLogString {

--- a/server/lib/src/valueset/auditlogstring.rs
+++ b/server/lib/src/valueset/auditlogstring.rs
@@ -163,7 +163,7 @@ impl ValueSetT for ValueSetAuditLogString {
     }
 
     #[allow(clippy::todo)]
-    fn repl_merge_valueset(&self, older: &ValueSet) -> Option<ValueSet> {
+    fn repl_merge_valueset(&self, older: &ValueSet, _trim_cid: &Cid) -> Option<ValueSet> {
         if let Some(mut map) = older.as_audit_log_string().cloned() {
             // Merge maps is right-preferencing, so this means that
             // newer content always wins over.
@@ -274,6 +274,7 @@ mod tests {
 
     #[test]
     fn test_valueset_auditlogstring_repl_merge() {
+        let zero_cid = Cid::new_zero();
         let mut vs: ValueSet = ValueSetAuditLogString::new((Cid::new_count(1), "A".to_string()));
         assert!(vs.len() == 1);
 
@@ -296,7 +297,7 @@ mod tests {
 
         // Merge. The content of other_vs should be dropped.
         let r_vs = vs
-            .repl_merge_valueset(&other_vs)
+            .repl_merge_valueset(&other_vs, &zero_cid)
             .expect("merge did not occur");
 
         // No change in the state of the set.
@@ -321,7 +322,7 @@ mod tests {
         assert!(other_vs.len() == 1);
 
         let r_vs = vs
-            .repl_merge_valueset(&other_vs)
+            .repl_merge_valueset(&other_vs, &zero_cid)
             .expect("merge did not occur");
 
         // New value has pushed out the next oldest.

--- a/server/lib/src/valueset/auditlogstring.rs
+++ b/server/lib/src/valueset/auditlogstring.rs
@@ -1,44 +1,47 @@
-use smolset::SmolSet;
-
 use crate::prelude::*;
 use crate::repl::cid::Cid;
 use crate::repl::proto::ReplAttrV1;
 use crate::schema::SchemaAttribute;
 use crate::valueset::{DbValueSetV2, ValueSet};
+use std::collections::BTreeMap;
 
 type AuditLogStringType = (Cid, String);
 
+const AUDIT_LOG_STRING_CAPACITY: usize = 9;
+
 #[derive(Debug, Clone)]
 pub struct ValueSetAuditLogString {
-    set: SmolSet<[AuditLogStringType; 8]>,
+    map: BTreeMap<Cid, String>,
 }
 
 impl ValueSetAuditLogString {
     fn remove_oldest(&mut self) {
-        let oldest = self.set.iter().min().cloned();
-        if let Some(oldest_value) = oldest {
-            self.set.remove(&oldest_value);
+        // pop to size.
+        while self.map.len() > AUDIT_LOG_STRING_CAPACITY {
+            self.map.pop_first();
         }
     }
 
-    pub fn new(s: AuditLogStringType) -> Box<Self> {
-        let mut set = SmolSet::new();
-        set.insert(s);
-        Box::new(ValueSetAuditLogString { set })
+    pub fn new((c, s): AuditLogStringType) -> Box<Self> {
+        let mut map = BTreeMap::new();
+        map.insert(c, s);
+        Box::new(ValueSetAuditLogString { map })
     }
 
-    pub fn push(&mut self, s: AuditLogStringType) -> bool {
-        self.set.insert(s)
+    /*
+    pub fn push(&mut self, (c, s): AuditLogStringType) -> bool {
+        self.map.insert(c, s).is_none()
     }
+    */
 
     pub fn from_dbvs2(data: Vec<AuditLogStringType>) -> Result<ValueSet, OperationError> {
-        let set = data.into_iter().collect();
-        Ok(Box::new(ValueSetAuditLogString { set }))
+        let map = data.into_iter().collect();
+        Ok(Box::new(ValueSetAuditLogString { map }))
     }
 
     pub fn from_repl_v1(data: &[AuditLogStringType]) -> Result<ValueSet, OperationError> {
-        let set = data.iter().map(|e| (e.0.clone(), e.1.clone())).collect();
-        Ok(Box::new(ValueSetAuditLogString { set }))
+        let map = data.iter().map(|e| (e.0.clone(), e.1.clone())).collect();
+        Ok(Box::new(ValueSetAuditLogString { map }))
     }
 }
 
@@ -46,10 +49,10 @@ impl ValueSetT for ValueSetAuditLogString {
     fn insert_checked(&mut self, value: Value) -> Result<bool, OperationError> {
         match value {
             Value::AuditLogString(c, s) => {
-                if self.set.len() >= 8 {
-                    self.remove_oldest();
-                }
-                Ok(self.push((c, s)))
+                let r = self.map.insert(c, s);
+                self.remove_oldest();
+                // true if insert was a new value.
+                Ok(r.is_none())
             }
             _ => {
                 debug_assert!(false);
@@ -59,7 +62,7 @@ impl ValueSetT for ValueSetAuditLogString {
     }
 
     fn clear(&mut self) {
-        self.set.clear();
+        self.map.clear();
     }
 
     fn remove(&mut self, _pv: &PartialValue, _cid: &Cid) -> bool {
@@ -68,7 +71,8 @@ impl ValueSetT for ValueSetAuditLogString {
 
     fn contains(&self, pv: &PartialValue) -> bool {
         match pv {
-            PartialValue::Utf8(s) => self.set.iter().any(|(_, current)| s.eq(current)),
+            PartialValue::Utf8(s) => self.map.values().any(|current| s.eq(current)),
+            PartialValue::Cid(c) => self.map.contains_key(c),
             _ => {
                 debug_assert!(false);
                 true
@@ -85,11 +89,11 @@ impl ValueSetT for ValueSetAuditLogString {
     }
 
     fn len(&self) -> usize {
-        self.set.len()
+        self.map.len()
     }
 
     fn generate_idx_eq_keys(&self) -> Vec<String> {
-        self.set.iter().map(|(d, s)| format!("{d}-{s}")).collect()
+        self.map.iter().map(|(d, s)| format!("{d}-{s}")).collect()
     }
 
     fn syntax(&self) -> SyntaxType {
@@ -97,33 +101,42 @@ impl ValueSetT for ValueSetAuditLogString {
     }
 
     fn validate(&self, _schema_attr: &SchemaAttribute) -> bool {
-        self.set
+        self.map
             .iter()
             .all(|(_, s)| Value::validate_str_escapes(s) && Value::validate_singleline(s))
-            && self.set.len() <= 8
+            && self.map.len() <= AUDIT_LOG_STRING_CAPACITY
     }
 
     fn to_proto_string_clone_iter(&self) -> Box<dyn Iterator<Item = String> + '_> {
-        Box::new(self.set.iter().map(|(d, s)| format!("{d}-{s}")))
+        Box::new(self.map.iter().map(|(d, s)| format!("{d}-{s}")))
     }
 
     fn to_db_valueset_v2(&self) -> DbValueSetV2 {
-        DbValueSetV2::AuditLogString(self.set.iter().cloned().collect())
+        DbValueSetV2::AuditLogString(
+            self.map
+                .iter()
+                .map(|(c, s)| (c.clone(), s.clone()))
+                .collect(),
+        )
     }
 
     fn to_repl_v1(&self) -> ReplAttrV1 {
         ReplAttrV1::AuditLogString {
-            set: self.set.iter().cloned().collect(),
+            map: self
+                .map
+                .iter()
+                .map(|(c, s)| (c.clone(), s.clone()))
+                .collect(),
         }
     }
 
     fn to_partialvalue_iter(&self) -> Box<dyn Iterator<Item = PartialValue> + '_> {
-        Box::new(self.set.iter().map(|(_, s)| PartialValue::Utf8(s.clone())))
+        Box::new(self.map.keys().map(|c| PartialValue::Cid(c.clone())))
     }
 
     fn to_value_iter(&self) -> Box<dyn Iterator<Item = Value> + '_> {
         Box::new(
-            self.set
+            self.map
                 .iter()
                 .map(|(c, s)| Value::AuditLogString(c.clone(), s.clone())),
         )
@@ -131,7 +144,7 @@ impl ValueSetT for ValueSetAuditLogString {
 
     fn equal(&self, other: &ValueSet) -> bool {
         if let Some(other) = other.as_audit_log_string() {
-            &self.set == other
+            &self.map == other
         } else {
             debug_assert!(false);
             false
@@ -140,7 +153,9 @@ impl ValueSetT for ValueSetAuditLogString {
 
     fn merge(&mut self, other: &ValueSet) -> Result<(), OperationError> {
         if let Some(b) = other.as_audit_log_string() {
-            mergesets!(self.set, b)
+            mergemaps!(self.map, b)?;
+            self.remove_oldest();
+            Ok(())
         } else {
             debug_assert!(false);
             Err(OperationError::InvalidValueState)
@@ -148,11 +163,176 @@ impl ValueSetT for ValueSetAuditLogString {
     }
 
     #[allow(clippy::todo)]
-    fn repl_merge_valueset(&self, _older: &ValueSet) -> Option<ValueSet> {
-        todo!();
+    fn repl_merge_valueset(&self, older: &ValueSet) -> Option<ValueSet> {
+        if let Some(mut map) = older.as_audit_log_string().cloned() {
+            // Merge maps is right-preferencing, so this means that
+            // newer content always wins over.
+            mergemaps!(map, self.map)
+                .map_err(|_: OperationError| ())
+                .ok()?;
+            let mut new_vs = Box::new(ValueSetAuditLogString { map });
+            new_vs.remove_oldest();
+            Some(new_vs)
+        } else {
+            debug_assert!(false);
+            None
+        }
     }
 
-    fn as_audit_log_string(&self) -> Option<&SmolSet<[(Cid, String); 8]>> {
-        Some(&self.set)
+    fn as_audit_log_string(&self) -> Option<&BTreeMap<Cid, String>> {
+        Some(&self.map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ValueSetAuditLogString, AUDIT_LOG_STRING_CAPACITY};
+    use crate::repl::cid::Cid;
+    use crate::value::Value;
+    use crate::valueset::ValueSet;
+    use std::time::Duration;
+
+    #[test]
+    fn test_valueset_auditlogstring_merge() {
+        let mut vs: ValueSet = ValueSetAuditLogString::new((Cid::new_count(0), "A".to_string()));
+        assert!(vs.len() == 1);
+
+        for i in 1..AUDIT_LOG_STRING_CAPACITY {
+            vs.insert_checked(Value::AuditLogString(
+                Cid::new_count(i as u64),
+                "A".to_string(),
+            ))
+            .unwrap();
+        }
+
+        assert!(vs.len() == AUDIT_LOG_STRING_CAPACITY);
+
+        // Add one extra
+        vs.insert_checked(Value::AuditLogString(
+            Cid::new_count(AUDIT_LOG_STRING_CAPACITY as u64),
+            "A".to_string(),
+        ))
+        .unwrap();
+
+        assert!(vs.len() == AUDIT_LOG_STRING_CAPACITY);
+
+        let mut v_iter = vs.to_value_iter();
+        let Some(Value::AuditLogString(c, _s)) = v_iter.next() else {
+            unreachable!();
+        };
+        // Should always be '1' since the set merge would have pushed '0' (ring-buffer);
+        assert!(c.ts == Duration::from_secs(1));
+        println!("{:?}", c);
+        drop(v_iter);
+
+        // Make a second set.
+        let other_vs: ValueSet = ValueSetAuditLogString::new(
+            // Notice that 0 here is older than our other set items.
+            (Cid::new_count(0), "A".to_string()),
+        );
+        assert!(other_vs.len() == 1);
+
+        // Merge. The content of other_vs should be dropped.
+        vs.merge(&other_vs)
+            .expect("Failed to merge, incorrect types");
+
+        // No change in the state of the set.
+        assert!(vs.len() == AUDIT_LOG_STRING_CAPACITY);
+        let mut v_iter = vs.to_value_iter();
+        let Some(Value::AuditLogString(c, _s)) = v_iter.next() else {
+            unreachable!();
+        };
+        // Should always be '1' since the set merge would have pushed '0' (ring-buffer);
+        assert!(c.ts == Duration::from_secs(1));
+        println!("{:?}", c);
+        drop(v_iter);
+
+        // Now merge in with a set that has a value that is newer.
+
+        assert!(100 > AUDIT_LOG_STRING_CAPACITY);
+
+        let other_vs: ValueSet = ValueSetAuditLogString::new(
+            // Notice that 0 here is older than our other set items.
+            (Cid::new_count(100), "A".to_string()),
+        );
+        assert!(other_vs.len() == 1);
+
+        vs.merge(&other_vs)
+            .expect("Failed to merge, incorrect types");
+
+        // New value has pushed out the next oldest.
+        assert!(vs.len() == AUDIT_LOG_STRING_CAPACITY);
+        let mut v_iter = vs.to_value_iter();
+        let Some(Value::AuditLogString(c, _s)) = v_iter.next() else {
+            unreachable!();
+        };
+        // Should always be '1' since the set merge would have pushed '0' (ring-buffer);
+        println!("{:?}", c);
+        assert!(c.ts == Duration::from_secs(2));
+        drop(v_iter);
+    }
+
+    #[test]
+    fn test_valueset_auditlogstring_repl_merge() {
+        let mut vs: ValueSet = ValueSetAuditLogString::new((Cid::new_count(1), "A".to_string()));
+        assert!(vs.len() == 1);
+
+        for i in 2..(AUDIT_LOG_STRING_CAPACITY + 1) {
+            vs.insert_checked(Value::AuditLogString(
+                Cid::new_count(i as u64),
+                "A".to_string(),
+            ))
+            .unwrap();
+        }
+
+        assert!(vs.len() == AUDIT_LOG_STRING_CAPACITY);
+
+        // Make a second set.
+        let other_vs: ValueSet = ValueSetAuditLogString::new(
+            // Notice that 0 here is older than our other set items.
+            (Cid::new_count(0), "A".to_string()),
+        );
+        assert!(other_vs.len() == 1);
+
+        // Merge. The content of other_vs should be dropped.
+        let r_vs = vs
+            .repl_merge_valueset(&other_vs)
+            .expect("merge did not occur");
+
+        // No change in the state of the set.
+        assert!(r_vs.len() == AUDIT_LOG_STRING_CAPACITY);
+        let mut v_iter = r_vs.to_value_iter();
+        let Some(Value::AuditLogString(c, _s)) = v_iter.next() else {
+            unreachable!();
+        };
+        // Should always be '1' since the set merge would have pushed '0' (ring-buffer);
+        assert!(c.ts == Duration::from_secs(1));
+        println!("{:?}", c);
+        drop(v_iter);
+
+        // Now merge in with a set that has a value that is newer.
+
+        assert!(100 > AUDIT_LOG_STRING_CAPACITY);
+
+        let other_vs: ValueSet = ValueSetAuditLogString::new(
+            // Notice that 0 here is older than our other set items.
+            (Cid::new_count(100), "A".to_string()),
+        );
+        assert!(other_vs.len() == 1);
+
+        let r_vs = vs
+            .repl_merge_valueset(&other_vs)
+            .expect("merge did not occur");
+
+        // New value has pushed out the next oldest.
+        assert!(r_vs.len() == AUDIT_LOG_STRING_CAPACITY);
+        let mut v_iter = r_vs.to_value_iter();
+        let Some(Value::AuditLogString(c, _s)) = v_iter.next() else {
+            unreachable!();
+        };
+        // Should always be '1' since the set merge would have pushed '0' (ring-buffer);
+        println!("{:?}", c);
+        assert!(c.ts == Duration::from_secs(2));
+        drop(v_iter);
     }
 }

--- a/server/lib/src/valueset/auditlogstring.rs
+++ b/server/lib/src/valueset/auditlogstring.rs
@@ -62,7 +62,7 @@ impl ValueSetT for ValueSetAuditLogString {
         self.set.clear();
     }
 
-    fn remove(&mut self, _pv: &PartialValue) -> bool {
+    fn remove(&mut self, _pv: &PartialValue, _cid: &Cid) -> bool {
         false
     }
 

--- a/server/lib/src/valueset/binary.rs
+++ b/server/lib/src/valueset/binary.rs
@@ -62,7 +62,7 @@ impl ValueSetT for ValueSetPrivateBinary {
         self.set.clear();
     }
 
-    fn remove(&mut self, _pv: &PartialValue) -> bool {
+    fn remove(&mut self, _pv: &PartialValue, _cid: &Cid) -> bool {
         true
     }
 
@@ -209,7 +209,7 @@ impl ValueSetT for ValueSetPublicBinary {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::PublicBinary(t) => self.map.remove(t.as_str()).is_some(),
             _ => false,

--- a/server/lib/src/valueset/bool.rs
+++ b/server/lib/src/valueset/bool.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetBool {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Bool(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/cid.rs
+++ b/server/lib/src/valueset/cid.rs
@@ -65,7 +65,7 @@ impl ValueSetT for ValueSetCid {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Cid(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/cred.rs
+++ b/server/lib/src/valueset/cred.rs
@@ -83,7 +83,7 @@ impl ValueSetT for ValueSetCredential {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Cred(t) => self.map.remove(t.as_str()).is_some(),
             _ => false,
@@ -338,11 +338,16 @@ impl ValueSetT for ValueSetIntentToken {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::IntentToken(u) => self.map.remove(u).is_some(),
             _ => false,
         }
+    }
+
+    fn purge(&mut self, _cid: &Cid) -> bool {
+        // Could consider making this a TS capable entry.
+        true
     }
 
     fn contains(&self, pv: &PartialValue) -> bool {
@@ -587,7 +592,7 @@ impl ValueSetT for ValueSetPasskey {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Passkey(u) => self.map.remove(u).is_some(),
             _ => false,
@@ -771,7 +776,7 @@ impl ValueSetT for ValueSetDeviceKey {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::DeviceKey(u) => self.map.remove(u).is_some(),
             _ => false,

--- a/server/lib/src/valueset/cred.rs
+++ b/server/lib/src/valueset/cred.rs
@@ -511,6 +511,11 @@ impl ValueSetT for ValueSetIntentToken {
         }
     }
 
+    #[allow(clippy::todo)]
+    fn repl_merge_valueset(&self, _older: &ValueSet) -> Option<ValueSet> {
+        todo!();
+    }
+
     fn as_intenttoken_map(&self) -> Option<&BTreeMap<String, IntentTokenState>> {
         Some(&self.map)
     }

--- a/server/lib/src/valueset/cred.rs
+++ b/server/lib/src/valueset/cred.rs
@@ -516,9 +516,9 @@ impl ValueSetT for ValueSetIntentToken {
         }
     }
 
-    #[allow(clippy::todo)]
-    fn repl_merge_valueset(&self, _older: &ValueSet) -> Option<ValueSet> {
-        todo!();
+    fn repl_merge_valueset(&self, _older: &ValueSet, _trim_cid: &Cid) -> Option<ValueSet> {
+        // Im not sure this actually needs repl handling ...
+        None
     }
 
     fn as_intenttoken_map(&self) -> Option<&BTreeMap<String, IntentTokenState>> {

--- a/server/lib/src/valueset/datetime.rs
+++ b/server/lib/src/valueset/datetime.rs
@@ -73,7 +73,7 @@ impl ValueSetT for ValueSetDateTime {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::DateTime(u) => self.set.remove(u),
             _ => false,

--- a/server/lib/src/valueset/eckey.rs
+++ b/server/lib/src/valueset/eckey.rs
@@ -1,7 +1,7 @@
 use std::iter::{self};
 
 use crate::be::dbvalue::DbValueSetV2;
-use crate::prelude::ValueSetT;
+use crate::prelude::*;
 use crate::repl::proto::ReplAttrV1;
 use crate::value::{PartialValue, SyntaxType, Value};
 use kanidm_proto::v1::OperationError;
@@ -90,7 +90,7 @@ impl ValueSetT for ValueSetEcKeyPrivate {
         self.set = None;
     }
 
-    fn remove(&mut self, _pv: &crate::value::PartialValue) -> bool {
+    fn remove(&mut self, _pv: &crate::value::PartialValue, _cid: &Cid) -> bool {
         false
     }
 

--- a/server/lib/src/valueset/iname.rs
+++ b/server/lib/src/valueset/iname.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetIname {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Iname(s) => self.set.remove(s),
             _ => {

--- a/server/lib/src/valueset/index.rs
+++ b/server/lib/src/valueset/index.rs
@@ -59,7 +59,7 @@ impl ValueSetT for ValueSetIndex {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Index(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/iutf8.rs
+++ b/server/lib/src/valueset/iutf8.rs
@@ -59,7 +59,7 @@ impl ValueSetT for ValueSetIutf8 {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Iutf8(s) => self.set.remove(s),
             _ => {

--- a/server/lib/src/valueset/json.rs
+++ b/server/lib/src/valueset/json.rs
@@ -65,7 +65,7 @@ impl ValueSetT for ValueSetJsonFilter {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::JsonFilt(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/jws.rs
+++ b/server/lib/src/valueset/jws.rs
@@ -79,7 +79,7 @@ impl ValueSetT for ValueSetJwsKeyEs256 {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Iutf8(kid) => {
                 let x = self.set.len();
@@ -263,7 +263,7 @@ impl ValueSetT for ValueSetJwsKeyRs256 {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Iutf8(kid) => {
                 let x = self.set.len();

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -87,7 +87,12 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
 
     fn clear(&mut self);
 
-    fn remove(&mut self, pv: &PartialValue) -> bool;
+    fn remove(&mut self, pv: &PartialValue, cid: &Cid) -> bool;
+
+    fn purge(&mut self, _cid: &Cid) -> bool {
+        // Default handling is true.
+        true
+    }
 
     fn contains(&self, pv: &PartialValue) -> bool;
 

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -21,9 +21,9 @@ use crate::prelude::*;
 use crate::repl::{cid::Cid, proto::ReplAttrV1};
 use crate::schema::SchemaAttribute;
 use crate::value::{Address, ApiToken, IntentTokenState, Oauth2Session, Session};
-use crate::valueset::auditlogstring::ValueSetAuditLogString;
 
 pub use self::address::{ValueSetAddress, ValueSetEmailAddress};
+pub use self::auditlogstring::{ValueSetAuditLogString, AUDIT_LOG_STRING_CAPACITY};
 pub use self::binary::{ValueSetPrivateBinary, ValueSetPublicBinary};
 pub use self::bool::ValueSetBool;
 pub use self::cid::ValueSetCid;

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -94,6 +94,10 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
         true
     }
 
+    fn trim(&mut self, _trim_cid: &Cid) {
+        // default to a no-op
+    }
+
     fn contains(&self, pv: &PartialValue) -> bool;
 
     fn substring(&self, pv: &PartialValue) -> bool;
@@ -561,7 +565,7 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
     fn repl_merge_valueset(
         &self,
         _older: &ValueSet,
-        // schema_attr: &SchemaAttribute
+        _trim_cid: &Cid, // schema_attr: &SchemaAttribute
     ) -> Option<ValueSet> {
         // Self is the "latest" content. Older contains the earlier
         // state of the attribute.

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -548,7 +548,7 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
         None
     }
 
-    fn as_audit_log_string(&self) -> Option<&SmolSet<[(Cid, String); 8]>> {
+    fn as_audit_log_string(&self) -> Option<&BTreeMap<Cid, String>> {
         debug_assert!(false);
         None
     }
@@ -795,7 +795,7 @@ pub fn from_repl_v1(rv1: &ReplAttrV1) -> Result<ValueSet, OperationError> {
         ReplAttrV1::Session { set } => ValueSetSession::from_repl_v1(set),
         ReplAttrV1::ApiToken { set } => ValueSetApiToken::from_repl_v1(set),
         ReplAttrV1::TotpSecret { set } => ValueSetTotpSecret::from_repl_v1(set),
-        ReplAttrV1::AuditLogString { set } => ValueSetAuditLogString::from_repl_v1(set),
+        ReplAttrV1::AuditLogString { map } => ValueSetAuditLogString::from_repl_v1(map),
         ReplAttrV1::EcKeyPrivate { key } => ValueSetEcKeyPrivate::from_repl_v1(key),
     }
 }

--- a/server/lib/src/valueset/nsuniqueid.rs
+++ b/server/lib/src/valueset/nsuniqueid.rs
@@ -59,7 +59,7 @@ impl ValueSetT for ValueSetNsUniqueId {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Nsuniqueid(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/oauth.rs
+++ b/server/lib/src/valueset/oauth.rs
@@ -61,7 +61,7 @@ impl ValueSetT for ValueSetOauthScope {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::OauthScope(s) => self.set.remove(s.as_str()),
             _ => {
@@ -233,7 +233,7 @@ impl ValueSetT for ValueSetOauthScopeMap {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Refer(u) => self.map.remove(u).is_some(),
             _ => false,

--- a/server/lib/src/valueset/restricted.rs
+++ b/server/lib/src/valueset/restricted.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetRestricted {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::RestrictedString(s) => self.set.remove(s),
             _ => {

--- a/server/lib/src/valueset/secret.rs
+++ b/server/lib/src/valueset/secret.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetSecret {
         self.set.clear();
     }
 
-    fn remove(&mut self, _pv: &PartialValue) -> bool {
+    fn remove(&mut self, _pv: &PartialValue, _cid: &Cid) -> bool {
         false
     }
 

--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -386,7 +386,7 @@ impl ValueSetT for ValueSetSession {
             PartialValue::Refer(u) => {
                 if let Some(session) = self.map.get_mut(u) {
                     if !matches!(session.state, SessionState::RevokedAt(_)) {
-                        session.state = SessionState::RevokedAt(cid.clone())
+                        session.state = SessionState::RevokedAt(cid.clone());
                         true
                     } else {
                         false
@@ -1450,17 +1450,24 @@ impl ValueSetT for ValueSetApiToken {
 
 #[cfg(test)]
 mod tests {
+    use time::OffsetDateTime;
     use super::ValueSetSession;
+    use crate::prelude::{Uuid, SessionScope, IdentityId};
     use crate::repl::cid::Cid;
-    use crate::value::{Session, Value};
+    use crate::value::{Session, SessionState};
     use crate::valueset::ValueSet;
-    use std::time::Duration;
 
     #[test]
     fn test_valueset_session_purge() {
         let mut vs: ValueSet = ValueSetSession::new(
             Uuid::new_v4(),
             Session {
+                label: "hacks".to_string(),
+                state: SessionState::NeverExpires,
+                issued_at: OffsetDateTime::now_utc(),
+                issued_by: IdentityId::Internal,
+                cred_id: Uuid::new_v4(),
+                scope: SessionScope::ReadOnly,
             }
         );
 
@@ -1468,5 +1475,41 @@ mod tests {
 
         // Simulate session revocation.
         vs.purge(&zero_cid);
+    }
+
+    #[test]
+    fn test_valueset_session_merge() {
+    }
+
+    #[test]
+    fn test_valueset_session_repl_merge() {
+    }
+
+    #[test]
+    fn test_valueset_oauth2_session_purge() {
+        let mut vs: ValueSet = ValueSetSession::new(
+            Uuid::new_v4(),
+            Session {
+                label: "hacks".to_string(),
+                state: SessionState::NeverExpires,
+                issued_at: OffsetDateTime::now_utc(),
+                issued_by: IdentityId::Internal,
+                cred_id: Uuid::new_v4(),
+                scope: SessionScope::ReadOnly,
+            }
+        );
+
+        let zero_cid = Cid::new_zero();
+
+        // Simulate session revocation.
+        vs.purge(&zero_cid);
+    }
+
+    #[test]
+    fn test_valueset_oauth2_session_merge() {
+    }
+
+    #[test]
+    fn test_valueset_oauth2_session_repl_merge() {
     }
 }

--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -1451,10 +1451,10 @@ impl ValueSetT for ValueSetApiToken {
 #[cfg(test)]
 mod tests {
     use time::OffsetDateTime;
-    use super::ValueSetSession;
+    use super::{ValueSetSession, ValueSetOauth2Session};
     use crate::prelude::{Uuid, SessionScope, IdentityId};
     use crate::repl::cid::Cid;
-    use crate::value::{Session, SessionState};
+    use crate::value::{Oauth2Session, Session, SessionState};
     use crate::valueset::ValueSet;
 
     #[test]
@@ -1475,21 +1475,25 @@ mod tests {
 
         // Simulate session revocation.
         vs.purge(&zero_cid);
+
+        todo!();
     }
 
     #[test]
     fn test_valueset_session_merge() {
+        todo!();
     }
 
     #[test]
     fn test_valueset_session_repl_merge() {
+        todo!();
     }
 
     #[test]
     fn test_valueset_oauth2_session_purge() {
-        let mut vs: ValueSet = ValueSetSession::new(
+        let mut vs: ValueSet = ValueSetOauth2Session::new(
             Uuid::new_v4(),
-            Session {
+            Oauth2Session {
                 label: "hacks".to_string(),
                 state: SessionState::NeverExpires,
                 issued_at: OffsetDateTime::now_utc(),
@@ -1503,13 +1507,17 @@ mod tests {
 
         // Simulate session revocation.
         vs.purge(&zero_cid);
+
+        todo!();
     }
 
     #[test]
     fn test_valueset_oauth2_session_merge() {
+        todo!();
     }
 
     #[test]
     fn test_valueset_oauth2_session_repl_merge() {
+        todo!();
     }
 }

--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -589,7 +589,7 @@ impl ValueSetT for ValueSetSession {
                     }
                 } else {
                     // Not present, just insert.
-                    self.map.insert(k_other.clone(), v_other.clone());
+                    self.map.insert(*k_other, v_other.clone());
                 }
             }
             Ok(())
@@ -635,7 +635,7 @@ impl ValueSetT for ValueSetSession {
                         *u,
                         ApiToken {
                             label: label.clone(),
-                            expiry: expiry,
+                            expiry,
                             issued_at: *issued_at,
                             issued_by: issued_by.clone(),
                             scope: match scope {
@@ -666,7 +666,7 @@ impl ValueSetT for ValueSetSession {
                     }
                 } else {
                     // Not present, just insert.
-                    map.insert(k_other.clone(), v_other.clone());
+                    map.insert(*k_other, v_other.clone());
                 }
             }
             // There might be a neater way to do this with less iterations. The problem
@@ -1180,7 +1180,7 @@ impl ValueSetT for ValueSetOauth2Session {
                     // Update the rs_filter!
                     self.rs_filter |= v_other.rs_uuid.as_u128();
                     // Not present, just insert.
-                    self.map.insert(k_other.clone(), v_other.clone());
+                    self.map.insert(*k_other, v_other.clone());
                 }
             }
             Ok(())
@@ -1217,7 +1217,7 @@ impl ValueSetT for ValueSetOauth2Session {
                 } else {
                     // Not present, just insert.
                     rs_filter |= v_other.rs_uuid.as_u128();
-                    map.insert(k_other.clone(), v_other.clone());
+                    map.insert(*k_other, v_other.clone());
                 }
             }
             // There might be a neater way to do this with less iterations. The problem

--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -388,7 +388,14 @@ impl ValueSetT for ValueSetSession {
         }
     }
 
-    fn purge(&mut self, _cid: &Cid) -> bool {
+    fn purge(&mut self, cid: &Cid) -> bool {
+        for (_uuid, session) in self.map.iter_mut() {
+            // Send them all to the shadow realm
+            if !matches!(session.state, SessionState::RevokedAt(_)) {
+                session.state = SessionState::RevokedAt(cid.clone())
+            }
+        }
+        // Can't be purged since we need the cid's of revoked to persist.
         false
     }
 
@@ -886,7 +893,14 @@ impl ValueSetT for ValueSetOauth2Session {
         }
     }
 
-    fn purge(&mut self, _cid: &Cid) -> bool {
+    fn purge(&mut self, cid: &Cid) -> bool {
+        for (_uuid, session) in self.map.iter_mut() {
+            // Send them all to the shadow realm
+            if !matches!(session.state, SessionState::RevokedAt(_)) {
+                session.state = SessionState::RevokedAt(cid.clone())
+            }
+        }
+        // Can't be purged since we need the cid's of revoked to persist.
         false
     }
 

--- a/server/lib/src/valueset/spn.rs
+++ b/server/lib/src/valueset/spn.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetSpn {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Spn(n, d) => self.set.remove(&(n.clone(), d.clone())),
             _ => {

--- a/server/lib/src/valueset/ssh.rs
+++ b/server/lib/src/valueset/ssh.rs
@@ -69,7 +69,7 @@ impl ValueSetT for ValueSetSshKey {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::SshKey(t) => self.map.remove(t.as_str()).is_some(),
             _ => false,

--- a/server/lib/src/valueset/syntax.rs
+++ b/server/lib/src/valueset/syntax.rs
@@ -59,7 +59,7 @@ impl ValueSetT for ValueSetSyntax {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Syntax(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/totp.rs
+++ b/server/lib/src/valueset/totp.rs
@@ -80,7 +80,7 @@ impl ValueSetT for ValueSetTotpSecret {
         self.map.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Utf8(l) => self.map.remove(l.as_str()).is_some(),
             _ => false,

--- a/server/lib/src/valueset/uihint.rs
+++ b/server/lib/src/valueset/uihint.rs
@@ -48,7 +48,7 @@ impl ValueSetT for ValueSetUiHint {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::UiHint(s) => self.set.remove(s),
             _ => {

--- a/server/lib/src/valueset/uint32.rs
+++ b/server/lib/src/valueset/uint32.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetUint32 {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Uint32(u) => self.set.remove(u),
             _ => {

--- a/server/lib/src/valueset/url.rs
+++ b/server/lib/src/valueset/url.rs
@@ -58,7 +58,7 @@ impl ValueSetT for ValueSetUrl {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Url(u) => self.set.remove(u),
             _ => false,

--- a/server/lib/src/valueset/utf8.rs
+++ b/server/lib/src/valueset/utf8.rs
@@ -44,7 +44,7 @@ impl ValueSetT for ValueSetUtf8 {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Utf8(s) => self.set.remove(s),
             _ => {

--- a/server/lib/src/valueset/uuid.rs
+++ b/server/lib/src/valueset/uuid.rs
@@ -60,7 +60,7 @@ impl ValueSetT for ValueSetUuid {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Uuid(u) => self.set.remove(u),
             _ => {
@@ -220,7 +220,7 @@ impl ValueSetT for ValueSetRefer {
         self.set.clear();
     }
 
-    fn remove(&mut self, pv: &PartialValue) -> bool {
+    fn remove(&mut self, pv: &PartialValue, _cid: &Cid) -> bool {
         match pv {
             PartialValue::Refer(u) => self.set.remove(u),
             _ => {

--- a/server/testkit/tests/default_entries.rs
+++ b/server/testkit/tests/default_entries.rs
@@ -28,9 +28,10 @@ static SELF_WRITEABLE_ATTRS: [&str; 7] = [
     "displayname",
     "legalname",
     "radius_secret",
-    "primary_credential",
     ATTR_LDAP_SSH_PUBLICKEY,
     "unix_password",
+    // Must be last - changing credential invalidates auth sessions!
+    "primary_credential",
 ];
 static DEFAULT_HP_GROUP_NAMES: [&str; 24] = [
     "idm_admins",
@@ -117,9 +118,10 @@ async fn test_default_entries_rbac_account_managers(rsclient: KanidmClient) {
     static ACCOUNT_MANAGER_ATTRS: [&str; 5] = [
         "name",
         "displayname",
-        "primary_credential",
         ATTR_LDAP_SSH_PUBLICKEY,
         "mail",
+        // Must be last, writing to this invalidates sessions.
+        "primary_credential",
     ];
     test_write_attrs(
         &rsclient,
@@ -420,7 +422,7 @@ async fn test_default_entries_rbac_people_managers(rsclient: KanidmClient) {
 
     static PEOPLE_MANAGER_ATTRS: [&str; 2] = ["legalname", "mail"];
 
-    static TECHNICAL_ATTRS: [&str; 3] = ["primary_credential", "radius_secret", "unix_password"];
+    static TECHNICAL_ATTRS: [&str; 3] = ["radius_secret", "unix_password", "primary_credential"];
     test_read_attrs(
         &rsclient,
         NOT_ADMIN_TEST_USERNAME,

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -1447,6 +1447,12 @@ async fn test_server_user_auth_token_lifecycle(rsclient: KanidmClient) {
         .await
         .expect("Failed to destroy user auth token");
 
+    // Since the session is revoked, check with the admin.
+    let res = rsclient
+        .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
     let tokens = rsclient
         .idm_service_account_list_api_token("demo_account")
         .await


### PR DESCRIPTION
Relates #68 - This adds support for special-casing sessions in replication to allow them to internally trim and merge so that session revocations and creations are not lost between replicas. This is important for security and user experience. As usual this adds extensive tests of all the states and trimming related to how it will work under replication. Since this also tidies up some internal state about sessions it also allows better handling of logouts and revocations in some edge cases (login with immediate logout would fall in the grace window meaning the session had a tiny valid window. This is now closed). 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
