### PR TITLE
CLI and kanidm_client changes to handle errors and TLS validation changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,12 +1457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exitcode"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2843,7 @@ dependencies = [
 name = "kanidm_client"
 version = "1.1.0-rc.14-dev"
 dependencies = [
+ "hyper",
  "kanidm_proto",
  "reqwest",
  "serde",
@@ -2917,7 +2912,6 @@ dependencies = [
  "compact_jwt",
  "cursive",
  "dialoguer",
- "exitcode",
  "futures-concurrency",
  "kanidm_build_profiles",
  "kanidm_client",

--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -18,9 +18,16 @@ kanidm_proto = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 time = { workspace = true, features = ["serde", "std"] }
-tokio = { workspace = true, features = ["rt", "net", "time", "macros", "sync", "signal"] }
+tokio = { workspace = true, features = [
+    "rt",
+    "net",
+    "time",
+    "macros",
+    "sync",
+    "signal",
+] }
 toml = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 url = { workspace = true, features = ["serde"] }
 webauthn-rs-proto = { workspace = true, features = ["wasm"] }
-
+hyper = { workspace = true }

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -4,13 +4,13 @@ default-run = "kanidm"
 description = "Kanidm Client Tools"
 documentation = "https://kanidm.github.io/kanidm/stable/"
 
-version = { workspace=true }
-authors = { workspace=true }
-rust-version = { workspace=true }
-edition = { workspace=true }
-license = { workspace=true }
-homepage = { workspace=true }
-repository = { workspace=true }
+version = { workspace = true }
+authors = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 [features]
 default = ["unix"]
@@ -34,26 +34,25 @@ path = "src/ssh_authorizedkeys.rs"
 async-recursion = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 compact_jwt = { workspace = true, features = ["openssl"] }
-dialoguer = { workspace=true }
-futures-concurrency = { workspace=true }
-libc = { workspace=true }
-kanidm_client = { workspace=true }
-kanidm_proto = { workspace=true }
+dialoguer = { workspace = true }
+futures-concurrency = { workspace = true }
+libc = { workspace = true }
+kanidm_client = { workspace = true }
+kanidm_proto = { workspace = true }
 qrcode = { workspace = true }
-rpassword = { workspace=true }
+rpassword = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace=true }
-shellexpand = { workspace=true }
+serde_json = { workspace = true }
+shellexpand = { workspace = true }
 time = { workspace = true, features = ["serde", "std"] }
-tracing = { workspace=true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
 url = { workspace = true, features = ["serde"] }
-uuid = { workspace=true }
-zxcvbn = { workspace=true }
+uuid = { workspace = true }
+zxcvbn = { workspace = true }
 lazy_static.workspace = true
 regex.workspace = true
-exitcode = "1.1.2"
 
 [dependencies.cursive]
 version = "0.20.0"
@@ -63,9 +62,9 @@ features = ["crossterm-backend"]
 
 [build-dependencies]
 clap = { workspace = true, features = ["derive"] }
-clap_complete = { workspace=true }
+clap_complete = { workspace = true }
 kanidm_build_profiles = { workspace = true }
-uuid = { workspace=true }
+uuid = { workspace = true }
 url = { workspace = true }
 
 [target."cfg(target_os = \"windows\")".dependencies.webauthn-authenticator-rs]

--- a/tools/cli/src/cli/lib.rs
+++ b/tools/cli/src/cli/lib.rs
@@ -56,12 +56,20 @@ pub(crate) fn handle_client_error(response: ClientError, _output_mode: &OutputMo
                     "Internal Server Error in response:{:?} {:?}",
                     error_msg, message
                 );
-                std::process::exit(exitcode::SOFTWARE);
+                std::process::exit(1);
             } else if status == StatusCode::NOT_FOUND {
                 error!("Item not found:{:?} {:?}", error_msg, message)
             } else {
                 error!("HTTP Error: {}{} {:?}", status, error_msg, message);
             }
+        }
+        ClientError::Transport(e) => {
+            error!("HTTP-Transport Related Error: {:?}", e);
+            std::process::exit(1);
+        }
+        ClientError::UntrustedCertificate(e) => {
+            error!("Untrusted Certificate Error: {:?}", e);
+            std::process::exit(1);
         }
         _ => {
             eprintln!("{:?}", response);

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -49,6 +49,13 @@ pub struct CommonOpt {
     /// Log format (still in very early development)
     #[clap(short, long = "output", env = "KANIDM_OUTPUT", default_value = "text")]
     output_mode: OutputMode,
+    /// Skip hostname verification
+    #[clap(
+        long = "skip-hostname-verification",
+        env = "KANIDM_SKIP_HOSTNAME_VERIFICATION",
+        default_value_t = false
+    )]
+    skip_hostname_verification: bool,
 }
 
 #[derive(Debug, Args)]


### PR DESCRIPTION
Changes

* Adds new `ClientError` value `UntrustedCertificate(String)` - the String is because hyper comes back with all sorts of random things based on the underlying libraries, which can't be relied upon.
* Adds the option to explicitly skip hostname verification on the command line instead of in-config. 
* Removes `exitcode` as a dependency because it's a waste of code.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
