### PR TITLE
Minor CI change to speed up WASM tests

### DIFF
--- a/.github/workflows/wasm_test.yml
+++ b/.github/workflows/wasm_test.yml
@@ -50,6 +50,6 @@ jobs:
       - name: "Run webdriver tests"
         run: |
           chromedriver &
-          cargo test -p kanidmd_testkit --features webdriver
+          cargo test -p kanidmd_testkit --features webdriver test_webdriver
         env:
           DISPLAY: ":99"


### PR DESCRIPTION
Fixes the fact that WASM tests were running the full test suite.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes