### PR TITLE
bindaddress default doesn't match documentation

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -446,26 +446,27 @@ impl KanidmClientBuilder {
 
 #[test]
 fn test_make_url() {
+    use kanidm_proto::constants::DEFAULT_SERVER_ADDRESS;
     let client: KanidmClient = KanidmClientBuilder::new()
-        .address("https://localhost:8080".to_string())
+        .address(format!("https://{}", DEFAULT_SERVER_ADDRESS))
         .build()
         .unwrap();
     assert_eq!(
         client.get_url(),
-        Url::parse("https://localhost:8080").unwrap()
+        Url::parse(&format!("https://{}", DEFAULT_SERVER_ADDRESS)).unwrap()
     );
     assert_eq!(
         client.make_url("/hello"),
-        Url::parse("https://localhost:8080/hello").unwrap()
+        Url::parse(&format!("https://{}/hello", DEFAULT_SERVER_ADDRESS)).unwrap()
     );
 
     let client: KanidmClient = KanidmClientBuilder::new()
-        .address("https://localhost:8080/cheese/".to_string())
+        .address(format!("https://{}/cheese/", DEFAULT_SERVER_ADDRESS))
         .build()
         .unwrap();
     assert_eq!(
         client.make_url("hello"),
-        Url::parse("https://localhost:8080/cheese/hello").unwrap()
+        Url::parse(&format!("https://{}/cheese/hello", DEFAULT_SERVER_ADDRESS)).unwrap()
     );
 }
 

--- a/proto/src/constants.rs
+++ b/proto/src/constants.rs
@@ -7,6 +7,12 @@ pub const DEFAULT_CLIENT_CONFIG_PATH: &str = "/etc/kanidm/config";
 /// The user-owned path for Kanidm client config
 pub const DEFAULT_CLIENT_CONFIG_PATH_HOME: &str = "~/.config/kanidm";
 
+/// The default bind address for the Kanidm server
+pub const DEFAULT_SERVER_ADDRESS: &str = "127.0.0.1:8443";
+pub const DEFAULT_SERVER_LOCALHOST: &str = "localhost:8443";
+pub const DEFAULT_LDAP_ADDRESS: &str = "127.0.0.1:636";
+pub const DEFAULT_LDAP_LOCALHOST: &str = "localhost:636";
+
 /// IF YOU CHANGE THESE VALUES YOU BREAK EVERYTHING
 pub const ATTR_ACCOUNT_EXPIRE: &str = "account_expire";
 pub const ATTR_ACCOUNT_VALID_FROM: &str = "account_valid_from";

--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 
 use std::str::FromStr;
 
+use kanidm_proto::constants::DEFAULT_SERVER_ADDRESS;
 use kanidm_proto::messages::ConsoleOutputMode;
 use serde::{Deserialize, Serialize};
 use sketching::tracing_subscriber::EnvFilter;
@@ -220,7 +221,7 @@ impl fmt::Display for Configuration {
 impl Configuration {
     pub fn new() -> Self {
         Configuration {
-            address: String::from("127.0.0.1:8080"),
+            address: DEFAULT_SERVER_ADDRESS.to_string(),
             ldapaddress: None,
             adminbindpath: env!("KANIDM_ADMIN_BIND_PATH").to_string(),
             threads: std::thread::available_parallelism()
@@ -304,7 +305,7 @@ impl Configuration {
         self.address = b
             .as_ref()
             .cloned()
-            .unwrap_or_else(|| String::from("127.0.0.1:8080"));
+            .unwrap_or_else(|| DEFAULT_SERVER_ADDRESS.to_string());
     }
 
     pub fn update_ldapbind(&mut self, l: &Option<String>) {

--- a/tools/orca/src/profile.rs
+++ b/tools/orca/src/profile.rs
@@ -1,3 +1,4 @@
+use kanidm_proto::constants::{DEFAULT_LDAP_LOCALHOST, DEFAULT_SERVER_LOCALHOST};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,13 +61,13 @@ pub struct Profile {
 impl Default for Profile {
     fn default() -> Self {
         let kani_http_config = KaniHttpConfig {
-            uri: "https://localhost:8443".to_string(),
+            uri: format!("https://{}", DEFAULT_SERVER_LOCALHOST),
             admin_pw: "".to_string(),
         };
 
         let kani_ldap_config = KaniLdapConfig {
-            uri: "https://localhost:8443".to_string(),
-            ldap_uri: "ldaps://localhost:636".to_string(),
+            uri: format!("https://{}", DEFAULT_SERVER_LOCALHOST),
+            ldap_uri: format!("ldaps://{}", DEFAULT_LDAP_LOCALHOST),
             admin_pw: "".to_string(),
             base_dn: "dn=localhost".to_string(),
         };


### PR DESCRIPTION
Fixes #2147 - changes everything to using a central constant

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes