### PR TITLE
Replication tweaks - try the most recent successful one and error less

### DIFF
--- a/book/src/authentication.md
+++ b/book/src/authentication.md
@@ -120,7 +120,8 @@ kanidm self whoami --name demo_user
 {{#template templates/kani-warning.md
 imagepath=images
 title=Warning!
-text=Don't use the direct credential reset to lock or invalidate an account. You should expire the account instead. }}
+text=Don't use the direct credential reset to lock or invalidate an account. You should expire the account instead.
+}}
 
 <!-- deno-fmt-ignore-end -->
 

--- a/book/src/authentication.md
+++ b/book/src/authentication.md
@@ -115,8 +115,14 @@ kanidm login --name demo_user
 kanidm self whoami --name demo_user
 ```
 
-{{#template templates/kani-warning.md imagepath=images title=Warning! text=Don't use the direct
-credential reset to lock or invalidate an account. You should expire the account instead. }}
+<!-- deno-fmt-ignore-start -->
+
+{{#template templates/kani-warning.md
+imagepath=images
+title=Warning!
+text=Don't use the direct credential reset to lock or invalidate an account. You should expire the account instead. }}
+
+<!-- deno-fmt-ignore-end -->
 
 ## Reauthentication / Privilege Access Mode
 

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -392,7 +392,7 @@ pub(crate) async fn handle_conn(
                 .serve_connection(tls_stream, svc)
                 .await
                 .map_err(|e| {
-                    error!("Failed to complete connection: {:?}", e);
+                    debug!("Failed to complete connection: {:?}", e);
                     std::io::Error::from(ErrorKind::ConnectionAborted)
                 })
         }

--- a/server/core/src/repl/mod.rs
+++ b/server/core/src/repl/mod.rs
@@ -180,12 +180,10 @@ async fn repl_run_consumer_refresh(
     }
 
     // okay, we need to proceed.
-    let Some((addr, mut supplier_conn)) =
+    let (addr, mut supplier_conn) =
         repl_consumer_connect_supplier(domain, sock_addrs, tls_connector, consumer_conn_settings)
             .await
-    else {
-        return Err(());
-    };
+            .ok_or(())?;
 
     // If we fail at any point, just RETURN because this leaves the next task to attempt, or
     // the channel drops and that tells the caller this failed.

--- a/server/core/src/repl/mod.rs
+++ b/server/core/src/repl/mod.rs
@@ -468,7 +468,11 @@ async fn repl_task(
             Some(addr) => vec![addr],
             None => vec![],
         };
-        sorted_socket_addrs.extend(socket_addrs.iter().cloned());
+        socket_addrs.iter().cloned().for_each(|addr| {
+            if !sorted_socket_addrs.contains(&addr) {
+                sorted_socket_addrs.push(addr);
+            }
+        });
 
         tokio::select! {
             Ok(task) = task_rx.recv() => {

--- a/server/lib/src/filter.rs
+++ b/server/lib/src/filter.rs
@@ -661,7 +661,7 @@ impl FilterComp {
                 // * If all filters are okay, return Ok(Filter::Or())
                 // * Any filter is invalid, return the error.
                 // * An empty "or" is a valid filter in mathematical terms, but we throw an
-                //   error to warn the user because it's super unlikey they want that
+                //   error to warn the user because it's super unlikely they want that
                 if filters.is_empty() {
                     return Err(SchemaError::EmptyFilter);
                 };
@@ -676,7 +676,7 @@ impl FilterComp {
                 // * If all filters are okay, return Ok(Filter::Or())
                 // * Any filter is invalid, return the error.
                 // * An empty "and" is a valid filter in mathematical terms, but we throw an
-                //   error to warn the user because it's super unlikey they want that
+                //   error to warn the user because it's super unlikely they want that
                 if filters.is_empty() {
                     return Err(SchemaError::EmptyFilter);
                 };


### PR DESCRIPTION
* When a peer connection is successful, try it first next time.
* Don't throw errors until we can't connect to *any* peers - it was erroring on each connection.

Somewhere in the socket code something's throwing a *LOT* of debug messages that it'd be good to filter out.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
