### PR TITLE
Thread naming and display

### DIFF
--- a/server/core/src/admin.rs
+++ b/server/core/src/admin.rs
@@ -168,7 +168,7 @@ impl AdminActor {
                     }
                 }
             }
-            info!("Stopped AdminActor");
+            info!("Stopped {}", super::TaskName::AdminSocket);
         });
         Ok(handle)
     }

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -312,7 +312,7 @@ pub async fn create_https_server(
         };
         #[cfg(feature = "otel")]
         opentelemetry::global::shutdown_tracer_provider();
-        info!("Stopped WebAcceptorActor");
+        info!("Stopped {}", super::TaskName::HttpsServer);
     }))
 }
 

--- a/server/core/src/interval.rs
+++ b/server/core/src/interval.rs
@@ -47,7 +47,7 @@ impl IntervalActor {
                 }
             }
 
-            info!("Stopped IntervalActor");
+            info!("Stopped {}", super::TaskName::IntervalActor);
         })
     }
 
@@ -149,7 +149,7 @@ impl IntervalActor {
                     }
                 }
             }
-            info!("Stopped OnlineBackupActor");
+            info!("Stopped {}", super::TaskName::BackupActor);
         });
 
         Ok(handle)

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -150,7 +150,7 @@ async fn tls_acceptor(
             }
         }
     }
-    info!("Stopped LdapAcceptorActor");
+    info!("Stopped {}", super::TaskName::LdapActor);
 }
 
 pub(crate) async fn create_ldap_server(

--- a/server/core/src/repl/mod.rs
+++ b/server/core/src/repl/mod.rs
@@ -904,5 +904,5 @@ async fn repl_acceptor(
         }
     }
 
-    info!("Stopped Replication Acceptor");
+    info!("Stopped {}", super::TaskName::Replication);
 }

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -78,7 +78,7 @@ macro_rules! try_from_entry {
         let mail = $value
             .get_ava_iter_mail(Attribute::Mail)
             .map(|i| i.map(str::to_string).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let valid_from = $value.get_ava_single_datetime(Attribute::AccountValidFrom);
 

--- a/server/lib/src/idm/unix.rs
+++ b/server/lib/src/idm/unix.rs
@@ -96,7 +96,7 @@ macro_rules! try_from_entry {
         let sshkeys = $value
             .get_ava_iter_sshpubkeys(Attribute::SshPublicKey)
             .map(|i| i.map(|s| s.to_string()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let cred = $value
             .get_ava_single_credential(Attribute::UnixPassword)
@@ -109,7 +109,7 @@ macro_rules! try_from_entry {
         let mail = $value
             .get_ava_iter_mail(Attribute::Mail)
             .map(|i| i.map(str::to_string).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let valid_from = $value.get_ava_single_datetime(Attribute::AccountValidFrom);
 

--- a/server/lib/src/schema.rs
+++ b/server/lib/src/schema.rs
@@ -444,36 +444,36 @@ impl SchemaClass {
         let systemmay = value
             .get_ava_iter_iutf8(Attribute::SystemMay)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
         let systemmust = value
             .get_ava_iter_iutf8(Attribute::SystemMust)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
         let may = value
             .get_ava_iter_iutf8(Attribute::May)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
         let must = value
             .get_ava_iter_iutf8(Attribute::Must)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let systemsupplements = value
             .get_ava_iter_iutf8(Attribute::SystemSupplements)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
         let supplements = value
             .get_ava_iter_iutf8(Attribute::Supplements)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
         let systemexcludes = value
             .get_ava_iter_iutf8(Attribute::SystemExcludes)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
         let excludes = value
             .get_ava_iter_iutf8(Attribute::Excludes)
             .map(|i| i.map(|v| v.into()).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         Ok(SchemaClass {
             name,

--- a/server/lib/src/server/access/profiles.rs
+++ b/server/lib/src/server/access/profiles.rs
@@ -129,12 +129,12 @@ impl AccessControlCreate {
         let attrs = value
             .get_ava_iter_iutf8(Attribute::AcpCreateAttr)
             .map(|i| i.map(AttrString::from).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let classes = value
             .get_ava_iter_iutf8(Attribute::AcpCreateClass)
             .map(|i| i.map(AttrString::from).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         Ok(AccessControlCreate {
             acp: AccessControlProfile::try_from(qs, value)?,
@@ -190,17 +190,17 @@ impl AccessControlModify {
         let presattrs = value
             .get_ava_iter_iutf8(Attribute::AcpModifyPresentAttr)
             .map(|i| i.map(AttrString::from).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let remattrs = value
             .get_ava_iter_iutf8(Attribute::AcpModifyRemovedAttr)
             .map(|i| i.map(AttrString::from).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let classes = value
             .get_ava_iter_iutf8(Attribute::AcpModifyClass)
             .map(|i| i.map(AttrString::from).collect())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         Ok(AccessControlModify {
             acp: AccessControlProfile::try_from(qs, value)?,

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -1167,7 +1167,7 @@ where
             aliases: self
                 .token_homedirectory_alias(tok)
                 .map(|s| vec![s])
-                .unwrap_or_else(Vec::new),
+                .unwrap_or_default(),
         }))
     }
 


### PR DESCRIPTION
I found a thread was `panic`'ing and it wasn't showing which one or why, so this stores a name for the thread on startup and then can show it when we're shutting down.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
