### PR TITLE
Reduce `pam_kanidm`'s priority in Debian platforms

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@
 - Martin Weinelt (hexa)
 - Samuel Cabrero (scabrero)
 - philipcristiano
+- Jianchen Zhao (bolu61)
 
 ## Acknowledgements
 

--- a/platform/debian/kanidm-unixd/kanidm.pam
+++ b/platform/debian/kanidm-unixd/kanidm.pam
@@ -1,6 +1,6 @@
 Name: Kanidm Authentication
 Default: yes
-Priority: 300
+Priority: 128
 
 Auth-Type: Primary
 Auth:


### PR DESCRIPTION
`pam_kanidm` doesn't set AUTHTOK after reading from user input, so modules down the stack must ask for passwords redundantly. This is only a workaround and might not be the desired behaviour in all cases.

Fixes #2208 

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
