### PR TITLE
adding service account patch methods

### DIFF
--- a/server/core/src/https/apidocs/mod.rs
+++ b/server/core/src/https/apidocs/mod.rs
@@ -114,6 +114,7 @@ impl Modify for SecurityAddon {
         super::v1::service_account_post,
         super::v1::service_account_id_get,
         super::v1::service_account_id_delete,
+        super::v1::service_account_id_patch,
         super::v1::service_account_id_get_attr,
         super::v1::service_account_id_put_attr,
         super::v1::service_account_id_post_attr,

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -1536,11 +1536,11 @@ async fn test_server_api_token_lifecycle(rsclient: KanidmClient) {
         .await
         .is_err());
 
-    // updating the username
+    // updating the service account details
     assert!(rsclient
         .idm_service_account_update(
             test_service_account_username,
-            None, // Some(&format!("{}lol", test_service_account_username)),
+            None,
             Some(&format!("{}displayzzzz", test_service_account_username)),
             Some(&[format!("{}@example.crabs", test_service_account_username)]),
         )

--- a/server/testkit/tests/proto_v1_test.rs
+++ b/server/testkit/tests/proto_v1_test.rs
@@ -1535,16 +1535,17 @@ async fn test_server_api_token_lifecycle(rsclient: KanidmClient) {
         .idm_service_account_update(test_service_account_username, None, None, None)
         .await
         .is_err());
+
+    // updating the username
     assert!(rsclient
         .idm_service_account_update(
             test_service_account_username,
-            Some(&format!("{}lol", test_service_account_username)),
+            None, // Some(&format!("{}lol", test_service_account_username)),
             Some(&format!("{}displayzzzz", test_service_account_username)),
             Some(&[format!("{}@example.crabs", test_service_account_username)]),
         )
         .await
-        .is_err());
-
+        .is_ok());
     let pw = rsclient
         .idm_service_account_generate_password(test_service_account_username)
         .await
@@ -1581,8 +1582,6 @@ async fn test_server_api_token_lifecycle(rsclient: KanidmClient) {
     //     .idm_person_account_delete(test_service_account_username)
     //     .await
     //     .is_ok());
-
-    // No need to test expiry, that's validated in the server internal tests.
 }
 
 #[kanidmd_testkit::test]


### PR DESCRIPTION
Fixes #2253

Turns out we didn't actually add a PATCH method for service accounts

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes