### PR TITLE
fixing requested session type on CLI read commands

### DIFF
--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -280,7 +280,7 @@ impl PersonOpt {
                 }
             }
             PersonOpt::Get(aopt) => {
-                let client = aopt.copt.to_client(OpType::Write).await;
+                let client = aopt.copt.to_client(OpType::Read).await;
                 match client
                     .idm_person_account_get(aopt.aopts.account_id.as_str())
                     .await

--- a/tools/cli/src/cli/recycle.rs
+++ b/tools/cli/src/cli/recycle.rs
@@ -20,7 +20,7 @@ impl RecycleOpt {
                 }
             }
             RecycleOpt::Get(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = nopt.copt.to_client(OpType::Read).await;
                 match client.recycle_bin_get(nopt.name.as_str()).await {
                     Ok(Some(e)) => println!("{}", e),
                     Ok(None) => println!("No matching entries"),


### PR DESCRIPTION
Fixes #2151 - we were asking for a "write" session, which forced accounts to try and reauth unnecessarily - setting it to read means you can do a read with anonymous OK 😄 

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes