### PR TITLE
Bug chasing

### DIFF
--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -1336,12 +1336,22 @@ pub async fn service_account_id_credential_status_get(
     Extension(kopid): Extension<KOpId>,
     Path(id): Path<String>,
 ) -> Result<Json<CredentialStatus>, WebError> {
-    state
+    match state
         .qe_r_ref
-        .handle_idmcredentialstatus(kopid.uat, id, kopid.eventid)
+        .handle_idmcredentialstatus(kopid.uat, id.clone(), kopid.eventid)
         .await
         .map(Json::from)
-        .map_err(WebError::from)
+    {
+        Ok(val) => Ok(val),
+        Err(err) => {
+            if let OperationError::NoMatchingAttributes = err {
+                debug!("No credentials set on account {}, returning empty list", id);
+                Ok(Json(CredentialStatus { creds: Vec::new() }))
+            } else {
+                Err(WebError::from(err))
+            }
+        }
+    }
 }
 
 #[utoipa::path(
@@ -1362,12 +1372,22 @@ pub async fn person_get_id_credential_status(
     Extension(kopid): Extension<KOpId>,
     Path(id): Path<String>,
 ) -> Result<Json<CredentialStatus>, WebError> {
-    state
+    match state
         .qe_r_ref
-        .handle_idmcredentialstatus(kopid.uat, id, kopid.eventid)
+        .handle_idmcredentialstatus(kopid.uat, id.clone(), kopid.eventid)
         .await
         .map(Json::from)
-        .map_err(WebError::from)
+    {
+        Ok(val) => Ok(val),
+        Err(err) => {
+            if let OperationError::NoMatchingAttributes = err {
+                debug!("No credentials set on person {}, returning empty list", id);
+                Ok(Json(CredentialStatus { creds: Vec::new() }))
+            } else {
+                Err(WebError::from(err))
+            }
+        }
+    }
 }
 
 #[utoipa::path(

--- a/tools/cli/src/cli/common.rs
+++ b/tools/cli/src/cli/common.rs
@@ -379,30 +379,33 @@ pub fn prompt_for_username_get_token() -> Result<String, String> {
 */
 
 /// This parses the input for the person/service-account expire-at CLI commands
-pub(crate) fn try_expire_at_from_string(input: &str) -> Option<String> {
+///
+/// If it fails, return error, if it needs to *clear* the result, return Ok(None),
+/// otherwise return Ok(Some(String)) which is the new value to set.
+pub(crate) fn try_expire_at_from_string(input: &str) -> Result<Option<String>, ()> {
     match input {
-        "any" | "never" | "clear" => None,
+        "any" | "never" | "clear" => Ok(None),
         "now" => match OffsetDateTime::now_utc().format(&Rfc3339) {
-            Ok(s) => Some(s),
+            Ok(s) => Ok(Some(s)),
             Err(e) => {
                 error!(err = ?e, "Unable to format current time to rfc3339");
-                None
+                Err(())
             }
         },
         "epoch" => match OffsetDateTime::UNIX_EPOCH.format(&Rfc3339) {
-            Ok(val) => Some(val),
+            Ok(val) => Ok(Some(val)),
             Err(err) => {
                 error!("Failed to format epoch timestamp as RFC3339: {:?}", err);
-                None
+                Err(())
             }
         },
         _ => {
             // fall back to parsing it as a date
             match OffsetDateTime::parse(input, &Rfc3339) {
-                Ok(_) => Some(input.to_string()),
+                Ok(_) => Ok(Some(input.to_string())),
                 Err(err) => {
                     error!("Failed to parse supplied timestamp: {:?}", err);
-                    None
+                    Err(())
                 }
             }
         }

--- a/tools/cli/src/cli/group/account_policy.rs
+++ b/tools/cli/src/cli/group/account_policy.rs
@@ -14,7 +14,7 @@ impl GroupAccountPolicyOpt {
         match self {
             GroupAccountPolicyOpt::Enable { name, copt } => {
                 let client = copt.to_client(OpType::Write).await;
-                if let Err(e) = client.group_account_policy_enable(&name).await {
+                if let Err(e) = client.group_account_policy_enable(name).await {
                     handle_client_error(e, &copt.output_mode);
                 } else {
                     println!("Group enabled for account policy.");
@@ -23,7 +23,7 @@ impl GroupAccountPolicyOpt {
             GroupAccountPolicyOpt::AuthSessionExpiry { name, expiry, copt } => {
                 let client = copt.to_client(OpType::Write).await;
                 if let Err(e) = client
-                    .group_account_policy_authsession_expiry_set(&name, *expiry)
+                    .group_account_policy_authsession_expiry_set(name, *expiry)
                     .await
                 {
                     handle_client_error(e, &copt.output_mode);
@@ -34,7 +34,7 @@ impl GroupAccountPolicyOpt {
             GroupAccountPolicyOpt::PrivilegedSessionExpiry { name, expiry, copt } => {
                 let client = copt.to_client(OpType::Write).await;
                 if let Err(e) = client
-                    .group_account_policy_privilege_expiry_set(&name, *expiry)
+                    .group_account_policy_privilege_expiry_set(name, *expiry)
                     .await
                 {
                     handle_client_error(e, &copt.output_mode);

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -411,7 +411,10 @@ impl PersonOpt {
                 }
                 AccountValidity::ExpireAt(ano) => {
                     let client = ano.copt.to_client(OpType::Write).await;
-                    let validity = try_expire_at_from_string(ano.datetime.as_str());
+                    let validity = match try_expire_at_from_string(ano.datetime.as_str()) {
+                        Ok(val) => val,
+                        Err(()) => return,
+                    };
                     let res = match validity {
                         None => {
                             client

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -1,4 +1,4 @@
-use crate::common::OpType;
+use crate::common::{try_expire_at_from_string, OpType};
 use std::fmt::{self, Debug};
 use std::str::FromStr;
 
@@ -411,78 +411,30 @@ impl PersonOpt {
                 }
                 AccountValidity::ExpireAt(ano) => {
                     let client = ano.copt.to_client(OpType::Write).await;
-                    if matches!(ano.datetime.as_str(), "never" | "clear") {
-                        // Unset the value
-                        match client
-                            .idm_person_account_purge_attr(
-                                ano.aopts.account_id.as_str(),
-                                ATTR_ACCOUNT_EXPIRE,
-                            )
-                            .await
-                        {
-                            Err(e) => handle_client_error(e, &ano.copt.output_mode),
-                            _ => println!("Success"),
+                    let validity = try_expire_at_from_string(ano.datetime.as_str());
+                    let res = match validity {
+                        None => {
+                            client
+                                .idm_person_account_purge_attr(
+                                    ano.aopts.account_id.as_str(),
+                                    ATTR_ACCOUNT_EXPIRE,
+                                )
+                                .await
                         }
-                    } else if matches!(ano.datetime.as_str(), "now") {
-                        // set the expiry to *now*
-                        let now = match OffsetDateTime::now_utc().format(&Rfc3339) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                error!(err = ?e, "Unable to format current time to rfc3339");
-                                return;
-                            }
-                        };
-                        debug!("Setting expiry to {}", now);
-                        match client
-                            .idm_person_account_set_attr(
-                                ano.aopts.account_id.as_str(),
-                                ATTR_ACCOUNT_EXPIRE,
-                                &[&now],
-                            )
-                            .await
-                        {
-                            Err(e) => error!("Error setting expiry to 'now' -> {:?}", e),
-                            _ => println!("Success"),
+                        Some(new_expiry) => {
+                            client
+                                .idm_person_account_set_attr(
+                                    ano.aopts.account_id.as_str(),
+                                    ATTR_ACCOUNT_EXPIRE,
+                                    &[&new_expiry],
+                                )
+                                .await
                         }
-                    } else if matches!(ano.datetime.as_str(), "epoch") {
-                        // set the expiry to the epoch
-                        let epoch_str = match OffsetDateTime::UNIX_EPOCH.format(&Rfc3339) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                error!(err = ?e, "Unable to format unix epoch to rfc3339");
-                                return;
-                            }
-                        };
-                        debug!("Setting expiry to {}", epoch_str);
-                        match client
-                            .idm_person_account_set_attr(
-                                ano.aopts.account_id.as_str(),
-                                ATTR_ACCOUNT_EXPIRE,
-                                &[&epoch_str],
-                            )
-                            .await
-                        {
-                            Err(e) => error!("Error setting expiry to 'epoch' -> {:?}", e),
-                            _ => println!("Success"),
-                        }
-                    } else {
-                        if let Err(e) = OffsetDateTime::parse(ano.datetime.as_str(), &Rfc3339) {
-                            error!("Error -> {:?}", e);
-                            return;
-                        }
-
-                        match client
-                            .idm_person_account_set_attr(
-                                ano.aopts.account_id.as_str(),
-                                ATTR_ACCOUNT_EXPIRE,
-                                &[ano.datetime.as_str()],
-                            )
-                            .await
-                        {
-                            Err(e) => handle_client_error(e, &ano.copt.output_mode),
-                            _ => println!("Success"),
-                        }
-                    }
+                    };
+                    match res {
+                        Err(e) => handle_client_error(e, &ano.copt.output_mode),
+                        _ => println!("Success"),
+                    };
                 }
                 AccountValidity::BeginFrom(ano) => {
                     let client = ano.copt.to_client(OpType::Write).await;

--- a/tools/cli/src/cli/serviceaccount.rs
+++ b/tools/cli/src/cli/serviceaccount.rs
@@ -430,7 +430,10 @@ impl ServiceAccountOpt {
                 }
                 AccountValidity::ExpireAt(ano) => {
                     let client = ano.copt.to_client(OpType::Write).await;
-                    let validity = try_expire_at_from_string(ano.datetime.as_str());
+                    let validity = match try_expire_at_from_string(ano.datetime.as_str()) {
+                        Ok(val) => val,
+                        Err(()) => return,
+                    };
                     let res = match validity {
                         None => {
                             client


### PR DESCRIPTION
Fixes #2153
Fixes #2156 

* Brought all the handling for the user input into a single function which means we only handle it one way.
* Returning an empty set when querying accounts without credentials, instead of a 500 error.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
