### PR TITLE
Bump Fedora 36 to Fedora 38

### DIFF
--- a/book/src/installing_client_tools.md
+++ b/book/src/installing_client_tools.md
@@ -13,7 +13,7 @@ Kanidm currently is packaged for the following systems:
 - MacOS
 - Arch Linux
 - NixOS
-- Fedora 36
+- Fedora 38
 - CentOS Stream 9
 
 The `kanidm` client has been built and tested from Windows, but is not (yet) packaged routinely.
@@ -77,7 +77,7 @@ metadata into the correct directory:
 
 ```bash
 # Fedora
-wget https://download.opensuse.org/repositories/network:/idm/Fedora_36/network:idm.repo
+wget https://download.opensuse.org/repositories/network:/idm/Fedora_38/network:idm.repo
 # Centos Stream 9
 wget https://download.opensuse.org/repositories/network:/idm/CentOS_9_Stream/network:idm.repo
 ```


### PR DESCRIPTION
Poking around the repos I found that the Fedora 36 repo no longer exists, only Fedora 38. 

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)