### PR TITLE
Add test for password min length checking

### DIFF
--- a/server/lib/src/utils.rs
+++ b/server/lib/src/utils.rs
@@ -31,9 +31,15 @@ pub fn uuid_from_duration(d: Duration, sid: Sid) -> Uuid {
     uuid_from_u64_u32(d.as_secs(), d.subsec_nanos(), sid)
 }
 
+pub(crate) fn password_from_random_len(len: u32) -> String {
+    thread_rng()
+        .sample_iter(&DistinctAlpha)
+        .take(len as usize)
+        .collect::<String>()
+}
+
 pub fn password_from_random() -> String {
-    let rand_string: String = thread_rng().sample_iter(&DistinctAlpha).take(48).collect();
-    rand_string
+    password_from_random_len(48)
 }
 
 pub fn backup_code_from_random() -> HashSet<String> {


### PR DESCRIPTION
Fixes #2321 - This adds a test to show that we support passwords of the exact length of the min pw policy, and only a password of len 1 fewer will cause an error.

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
