### PR TITLE
idprovider: Share lifetime with machine key

### DIFF
--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -94,12 +94,12 @@ pub enum AuthCacheAction {
 }
 
 #[async_trait]
-pub trait IdProvider {
+pub trait IdProvider<'a> {
     async fn configure_hsm_keys<D: KeyStoreTxn + Send>(
         &self,
         _keystore: &mut D,
         _tpm: &mut (dyn tpm::Tpm + Send),
-        _machine_key: &tpm::MachineKey,
+        _machine_key: &'a tpm::MachineKey,
     ) -> Result<(), IdpError> {
         Ok(())
     }

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -82,12 +82,12 @@ impl From<UnixGroupToken> for GroupToken {
 }
 
 #[async_trait]
-impl IdProvider for KanidmProvider {
+impl<'a> IdProvider<'a> for KanidmProvider {
     async fn configure_hsm_keys<D: KeyStoreTxn + Send>(
         &self,
         keystore: &mut D,
         tpm: &mut (dyn tpm::Tpm + Send),
-        machine_key: &tpm::MachineKey,
+        machine_key: &'a tpm::MachineKey,
     ) -> Result<(), IdpError> {
         let id_key: Option<tpm::LoadableIdentityKey> =
             keystore.get_tagged_hsm_key(TAG_IDKEY).map_err(|ks_err| {

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -54,7 +54,7 @@ pub enum AuthSession {
 
 pub struct Resolver<I>
 where
-    I: IdProvider + Sync,
+    I: for<'a> IdProvider<'a> + Sync,
 {
     // Generic / modular types.
     db: Db,
@@ -88,7 +88,7 @@ impl ToString for Id {
 
 impl<I> Resolver<I>
 where
-    I: IdProvider + Sync,
+    I: for<'a> IdProvider<'a> + Sync,
 {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(


### PR DESCRIPTION
Himmelblau needs access to the machine key during
authentication (so it can join the machine if
necessary), so I added it to my idprovider after
the call to `configure_hsm_keys`. This requires
they share a lifetime.

Is this the correct approach?

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [ ] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
