### PR TITLE
Bearer should send with same caps we accept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,6 +3504,8 @@ dependencies = [
 [[package]]
 name = "ldap3_client"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec3fe7dd2cd58ea17bf49e794dd89b7773bff180300fc8667a8ca8f38e4aed0"
 dependencies = [
  "base64 0.21.5",
  "base64urlsafedata",
@@ -3522,6 +3524,8 @@ dependencies = [
 [[package]]
 name = "ldap3_proto"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4598dd32dbd16d4fd06a1eb423bf569563d7c65e808ceae5ef3c12179134bc36"
 dependencies = [
  "base64 0.21.5",
  "bytes",

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -1182,7 +1182,7 @@ impl<'a> IdmServerProxyWriteTransaction<'a> {
 
         Ok(AccessTokenResponse {
             access_token,
-            token_type: "bearer".to_string(),
+            token_type: "Bearer".to_string(),
             expires_in,
             refresh_token: Some(refresh_token),
             scope,
@@ -2428,7 +2428,7 @@ mod tests {
             .expect("Failed to perform OAuth2 token exchange");
 
         // 🎉 We got a token! In the future we can then check introspection from this point.
-        assert!(token_response.token_type == "bearer");
+        assert!(token_response.token_type == "Bearer");
 
         assert!(idms_prox_write.commit().is_ok());
     }
@@ -2494,7 +2494,7 @@ mod tests {
             .expect("Failed to perform OAuth2 token exchange");
 
         // 🎉 We got a token! In the future we can then check introspection from this point.
-        assert!(token_response.token_type == "bearer");
+        assert!(token_response.token_type == "Bearer");
 
         assert!(idms_prox_write.commit().is_ok());
     }
@@ -3574,7 +3574,7 @@ mod tests {
             .expect("Failed to perform OAuth2 token exchange");
 
         // 🎉 We got a token!
-        assert!(token_response.token_type == "bearer");
+        assert!(token_response.token_type == "Bearer");
 
         let id_token = token_response.id_token.expect("No id_token in response!");
         let access_token = token_response.access_token;
@@ -4013,7 +4013,7 @@ mod tests {
             .expect("Failed to perform OAuth2 token exchange");
 
         // 🎉 We got a token!
-        assert!(token_response.token_type == "bearer");
+        assert!(token_response.token_type == "Bearer");
         let id_token = token_response.id_token.expect("No id_token in response!");
 
         let jws_validator =


### PR DESCRIPTION
Fixes #2344 - we should send "Bearer" with the same casing we expect, as there are a lot of "poorly implemented client applications" that just yolo-echo this value back at us. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
