### PR TITLE
Fix handling of TPM in some trait contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,9 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm-hsm-crypto"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d325d5f7a3978ad1451f8bad2fdea1cc70a7b33dcaa8bbff7617a80d4c36c449"
+version = "0.1.4"
 dependencies = [
  "argon2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ kanidmd_lib_macros = { path = "./server/lib-macros", version = "1.1.0-rc.15-dev"
 kanidmd_testkit = { path = "./server/testkit", version = "1.1.0-rc.15-dev" }
 kanidm_build_profiles = { path = "./libs/profiles", version = "1.1.0-rc.15-dev" }
 kanidm_client = { path = "./libs/client", version = "1.1.0-rc.15-dev" }
-kanidm-hsm-crypto = "^0.1.3"
+kanidm-hsm-crypto = "^0.1.5"
 kanidm_lib_crypto = { path = "./libs/crypto", version = "1.1.0-rc.15-dev" }
 kanidm_lib_file_permissions = { path = "./libs/file_permissions", version = "1.1.0-rc.15-dev" }
 kanidm_proto = { path = "./proto", version = "1.1.0-rc.15-dev" }
@@ -115,7 +115,7 @@ clap = { version = "^4.4.8", features = ["derive", "env"] }
 clap_complete = "^4.4.4"
 # Forced by saffron/cron
 chrono = "^0.4.31"
-compact_jwt = { version = "^0.3.2", default-features = false }
+compact_jwt = { version = "^0.3.3", default-features = false }
 concread = "^0.4.3"
 cron = "0.12.0"
 crossbeam = "0.8.1"

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -49,7 +49,7 @@ use tokio::sync::oneshot;
 use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
-use kanidm_hsm_crypto::{soft::SoftTpm, AuthValue, Tpm};
+use kanidm_hsm_crypto::{soft::SoftTpm, AuthValue, BoxedDynTpm, Tpm};
 
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, notify::Watcher};
 
@@ -791,9 +791,9 @@ async fn main() -> ExitCode {
                 }
             };
 
-            let mut hsm: Box<dyn Tpm + Send> = match cfg.hsm_type {
+            let mut hsm: BoxedDynTpm = match cfg.hsm_type {
                 HsmType::Soft => {
-                    Box::new(SoftTpm::new())
+                    BoxedDynTpm::new(SoftTpm::new())
                 }
                 HsmType::Tpm => {
                     error!("TPM not supported ... yet");

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -98,7 +98,7 @@ pub trait IdProvider {
     async fn configure_hsm_keys<D: KeyStoreTxn + Send>(
         &self,
         _keystore: &mut D,
-        _tpm: &mut (dyn tpm::Tpm + Send),
+        _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
     ) -> Result<(), IdpError> {
         Ok(())
@@ -117,21 +117,20 @@ pub trait IdProvider {
     }
     */
 
-    async fn provider_authenticate(&self, _tpm: &mut (dyn tpm::Tpm + Send))
-        -> Result<(), IdpError>;
+    async fn provider_authenticate(&self, _tpm: &mut tpm::BoxedDynTpm) -> Result<(), IdpError>;
 
     async fn unix_user_get(
         &self,
         _id: &Id,
         _token: Option<&UserToken>,
-        _tpm: &mut (dyn tpm::Tpm + Send),
+        _tpm: &mut tpm::BoxedDynTpm,
     ) -> Result<UserToken, IdpError>;
 
     async fn unix_user_online_auth_init(
         &self,
         _account_id: &str,
         _token: Option<&UserToken>,
-        _tpm: &mut (dyn tpm::Tpm + Send),
+        _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;
 
@@ -140,7 +139,7 @@ pub trait IdProvider {
         _account_id: &str,
         _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
-        _tpm: &mut (dyn tpm::Tpm + Send),
+        _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError>;
 
@@ -177,6 +176,6 @@ pub trait IdProvider {
     async fn unix_group_get(
         &self,
         id: &Id,
-        _tpm: &mut (dyn tpm::Tpm + Send),
+        _tpm: &mut tpm::BoxedDynTpm,
     ) -> Result<GroupToken, IdpError>;
 }

--- a/unix_integration/tests/cache_layer_test.rs
+++ b/unix_integration/tests/cache_layer_test.rs
@@ -20,7 +20,7 @@ use kanidmd_testkit::{is_free_port, PORT_ALLOC};
 use tokio::task;
 use tracing::log::{debug, trace};
 
-use kanidm_hsm_crypto::{soft::SoftTpm, AuthValue, Tpm};
+use kanidm_hsm_crypto::{soft::SoftTpm, AuthValue, BoxedDynTpm, Tpm};
 
 const ADMIN_TEST_USER: &str = "admin";
 const ADMIN_TEST_PASSWORD: &str = "integration test admin password";
@@ -109,7 +109,7 @@ async fn setup_test(fix_fn: Fixture) -> (Resolver<KanidmProvider>, KanidmClient)
         .and_then(|_| dbtxn.commit())
         .expect("Unable to migrate cache db");
 
-    let mut hsm: Box<dyn Tpm + Send> = Box::new(SoftTpm::new());
+    let mut hsm = BoxedDynTpm::new(SoftTpm::new());
 
     let auth_value = AuthValue::ephemeral().unwrap();
 


### PR DESCRIPTION
Allows the dyn tpm type to work with compact jwt

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
