### PR TITLE
docs: miniflux added pkce support

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -303,10 +303,6 @@ OAUTH2_REDIRECT_URL = "https://feeds.example.com/oauth2/kanidm/callback";
 OAUTH2_OIDC_DISCOVERY_ENDPOINT = "https://idm.example.com/oauth2/openid/<oauth2_rs_name>";
 ```
 
-Currently Miniflux [does not support PKCE](https://github.com/miniflux/v2/issues/1910) and Kanidm
-will prevent logins until you [disable PKCE](#extended-options-for-legacy-clients) for the resource
-server.
-
 ### Nextcloud
 
 Install the module [from the nextcloud market place](https://apps.nextcloud.com/apps/user_oidc) - it


### PR DESCRIPTION
From Miniflux 2.0.48, released in September 2023, it added support for Oauth2 PKCE.

https://github.com/miniflux/v2/releases/tag/2.0.48

Fixes n/a

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
