### PR TITLE
Fixing default for OAuth2 request_parameter_supported metadata

### DIFF
--- a/proto/src/oauth2.rs
+++ b/proto/src/oauth2.rs
@@ -276,7 +276,7 @@ fn request_parameter_supported_default() -> bool {
 }
 
 fn request_uri_parameter_supported_default() -> bool {
-    true
+    false
 }
 
 fn require_request_uri_parameter_supported_default() -> bool {
@@ -330,14 +330,17 @@ pub struct OidcDiscoveryResponse {
     // Default false.
     #[serde(default = "claims_parameter_supported_default")]
     pub claims_parameter_supported: bool,
+
+    pub op_policy_uri: Option<Url>,
+    pub op_tos_uri: Option<Url>,
+
+    // these are related to RFC9101 JWT-Secured Authorization Request support
     #[serde(default = "request_parameter_supported_default")]
     pub request_parameter_supported: bool,
     #[serde(default = "request_uri_parameter_supported_default")]
     pub request_uri_parameter_supported: bool,
     #[serde(default = "require_request_uri_parameter_supported_default")]
     pub require_request_uri_registration: bool,
-    pub op_policy_uri: Option<Url>,
-    pub op_tos_uri: Option<Url>,
 }
 
 #[skip_serializing_none]

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -1879,9 +1879,11 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
             claims_locales_supported: None,
             ui_locales_supported: None,
             claims_parameter_supported: false,
-            // I think?
-            request_parameter_supported: true,
+            // TODO: once we support RFC9101 this can be true again
+            request_parameter_supported: false,
+            // TODO: if we support RFC9101 request_uri methods this can be true
             request_uri_parameter_supported: false,
+            // TODO: if we support RFC9101 request_uri methods this should be true
             require_request_uri_registration: false,
             op_policy_uri: None,
             op_tos_uri: None,
@@ -3518,7 +3520,7 @@ mod tests {
         assert!(!discovery.claims_parameter_supported);
         assert!(!discovery.request_uri_parameter_supported);
         assert!(!discovery.require_request_uri_registration);
-        assert!(discovery.request_parameter_supported);
+        assert!(!discovery.request_parameter_supported);
     }
 
     #[idm_test]


### PR DESCRIPTION
Refers #2377 - don't say we do a thing if we don't 😄 

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
