### PR TITLE
idprovider: Provide the keystore during auth

### DIFF
--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -134,11 +134,12 @@ pub trait IdProvider {
         _machine_key: &tpm::MachineKey,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;
 
-    async fn unix_user_online_auth_step(
+    async fn unix_user_online_auth_step<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
         _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
+        _keystore: &mut D,
         _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError>;

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -200,11 +200,12 @@ impl IdProvider for KanidmProvider {
         Ok((AuthRequest::Password, AuthCredHandler::Password))
     }
 
-    async fn unix_user_online_auth_step(
+    async fn unix_user_online_auth_step<D: KeyStoreTxn + Send>(
         &self,
         account_id: &str,
         cred_handler: &mut AuthCredHandler,
         pam_next_req: PamAuthRequest,
+        _keystore: &mut D,
         _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError> {


### PR DESCRIPTION
Himmelblau requires access to the keystore at
auth time in order to store the id key modified
during a device join.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
