### PR TITLE
daemon: Fix inverted logic on cache dir check

### DIFF
--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -696,7 +696,7 @@ async fn main() -> ExitCode {
                         );
                         return ExitCode::FAILURE
                     }
-                    if !kanidm_lib_file_permissions::readonly(&i_meta) {
+                    if kanidm_lib_file_permissions::readonly(&i_meta) {
                         warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
                         );


### PR DESCRIPTION
This logic is backwards in the daemon. We should print the "may not be RW" warning when the directory is read-only, not when the directory is *NOT* read-only.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
