### PR TITLE
db: Fix insert_tagged_hsm_key doesn't cache the hsm key

### DIFF
--- a/unix_integration/src/db.rs
+++ b/unix_integration/src/db.rs
@@ -324,7 +324,7 @@ impl<'a> KeyStoreTxn for DbTxn<'a> {
 
         let mut stmt = self
             .conn
-            .prepare("INSERT OR REPLACE INTO hsm_int_t (key, value) VALUES (:key, :value)")
+            .prepare("INSERT OR REPLACE INTO hsm_data_t (key, value) VALUES (:key, :value)")
             .map_err(|e| self.sqlite_error("prepare", &e))?;
 
         stmt.execute(named_params! {


### PR DESCRIPTION
Fixes #2387 `insert_tagged_hsm_key` doesn't cache the hsm key. Looks like a copy/paste error when copying similar code from `insert_hsm_machine_key`.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
