### PR TITLE
20231222 piv authentication

### DIFF
--- a/examples/insecure_server.toml
+++ b/examples/insecure_server.toml
@@ -5,6 +5,7 @@ db_fs_type = "zfs"
 db_path = "/tmp/kanidm/kanidm.db"
 tls_chain = "/tmp/kanidm/chain.pem"
 tls_key = "/tmp/kanidm/key.pem"
+tls_client_ca = "/tmp/kanidm/client_ca"
 
 #   The log level of the server. May be one of info, debug, trace
 #

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -235,15 +235,14 @@ impl QueryServerReadV1 {
         }
 
         // pattern to find automatically generated backup files
-        let re = Regex::new(r"^backup-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z\.json$").map_err(
-            |error| {
+        let re = Regex::new(r"^backup-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z\.json$")
+            .map_err(|error| {
                 error!(
                     "Failed to parse regexp for online backup files: {:?}",
                     error
                 );
                 OperationError::InvalidState
-            },
-        )?;
+            })?;
 
         // cleanup of maximum backup versions to keep
         let mut backup_file_list: Vec<PathBuf> = Vec::new();

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -83,7 +83,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(?e, "Invalid identity");
                 e
@@ -167,7 +167,7 @@ impl QueryServerReadV1 {
         security_info!("Begin reauth event");
 
         let ident = idm_auth
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(?e, "Invalid identity");
                 e
@@ -341,7 +341,7 @@ impl QueryServerReadV1 {
         // then move this to core.rs, and don't allow Option<UAT> to get
         // this far.
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(?e, "Invalid identity");
                 e
@@ -404,7 +404,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
 
         let ident = idms_prox_read
-                .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+                .validate_client_auth_info_to_ident(uat.as_deref(), ct)
                 .map_err(|e| {
                     admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_get_image {:?}", uat);
                     e
@@ -447,7 +447,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -491,7 +491,7 @@ impl QueryServerReadV1 {
         let mut idms_prox_read = self.idms.proxy_read().await;
 
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -533,7 +533,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -594,7 +594,7 @@ impl QueryServerReadV1 {
         let mut idms_prox_read = self.idms.proxy_read().await;
 
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -641,7 +641,7 @@ impl QueryServerReadV1 {
         let mut idms_prox_read = self.idms.proxy_read().await;
 
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -693,7 +693,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -739,7 +739,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -802,7 +802,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -866,7 +866,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -898,7 +898,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -932,7 +932,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -973,7 +973,7 @@ impl QueryServerReadV1 {
         let mut idm_auth = self.idms.auth().await;
         // resolve the id
         let ident = idm_auth
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1022,7 +1022,7 @@ impl QueryServerReadV1 {
         let mut idms_prox_read = self.idms.proxy_read().await;
 
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1068,7 +1068,7 @@ impl QueryServerReadV1 {
         let mut idms_prox_read = self.idms.proxy_read().await;
 
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -1300,7 +1300,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -1470,7 +1470,7 @@ impl QueryServerReadV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -1524,11 +1524,12 @@ impl QueryServerReadV1 {
         eventid: Uuid,
         protomsg: LdapMsg,
         uat: Option<LdapBoundToken>,
+        ip_addr: IpAddr,
     ) -> Option<LdapResponseState> {
         let res = match ServerOps::try_from(protomsg) {
             Ok(server_op) => self
                 .ldap
-                .do_op(&self.idms, server_op, uat, eventid)
+                .do_op(&self.idms, server_op, uat, ip_addr, eventid)
                 .await
                 .unwrap_or_else(|e| {
                     admin_error!("do_op failed -> {:?}", e);

--- a/server/core/src/actors/v1_scim.rs
+++ b/server/core/src/actors/v1_scim.rs
@@ -24,7 +24,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -63,7 +63,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -96,7 +96,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -131,7 +131,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -167,7 +167,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident =
-            idms_prox_write.validate_and_parse_sync_token_to_ident(bearer.as_deref(), ct)?;
+            idms_prox_write.validate_sync_client_auth_info_to_ident(bearer.as_deref(), ct)?;
 
         let sse = ScimSyncUpdateEvent { ident };
 

--- a/server/core/src/actors/v1_scim.rs
+++ b/server/core/src/actors/v1_scim.rs
@@ -16,7 +16,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_sync_account_token_generate(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         label: String,
         eventid: Uuid,
@@ -24,7 +24,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -56,14 +56,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_sync_account_token_destroy(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -89,14 +89,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_sync_account_finalise(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -124,14 +124,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_sync_account_terminate(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -159,7 +159,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_scim_sync_apply(
         &self,
-        bearer: Option<String>,
+        client_auth_info: ClientAuthInfo,
         changes: ScimSyncRequest,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
@@ -167,7 +167,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident =
-            idms_prox_write.validate_sync_client_auth_info_to_ident(bearer.as_deref(), ct)?;
+            idms_prox_write.validate_sync_client_auth_info_to_ident(client_auth_info, ct)?;
 
         let sse = ScimSyncUpdateEvent { ident };
 
@@ -185,13 +185,13 @@ impl QueryServerReadV1 {
     )]
     pub async fn handle_scim_sync_status(
         &self,
-        bearer: Option<String>,
+        client_auth_info: ClientAuthInfo,
         eventid: Uuid,
     ) -> Result<ScimSyncState, OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await;
 
-        let ident = idms_prox_read.validate_and_parse_sync_token_to_ident(bearer.as_deref(), ct)?;
+        let ident = idms_prox_read.validate_sync_client_auth_info_to_ident(client_auth_info, ct)?;
 
         idms_prox_read.scim_sync_get_state(&ident)
     }

--- a/server/core/src/actors/v1_write.rs
+++ b/server/core/src/actors/v1_write.rs
@@ -1191,11 +1191,11 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
 
         let ident = idms_prox_write
-                .validate_client_auth_info_to_ident(client_auth_info, ct)
-                .map_err(|e| {
-                    admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_delete");
-                    e
-                })?;
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
+            .map_err(|e| {
+                admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_delete");
+                e
+            })?;
         let ml = ModifyList::new_purge(Attribute::Image);
         let mdf = match ModifyEvent::from_internal_parts(ident, &ml, &rs, &idms_prox_write.qs_write)
         {

--- a/server/core/src/actors/v1_write.rs
+++ b/server/core/src/actors/v1_write.rs
@@ -55,7 +55,7 @@ impl QueryServerWriteV1 {
     #[instrument(level = "debug", skip_all)]
     async fn modify_from_parts(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: &str,
         proto_ml: &ProtoModifyList,
         filter: Filter<FilterInvalid>,
@@ -64,7 +64,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -103,7 +103,7 @@ impl QueryServerWriteV1 {
     #[instrument(level = "debug", skip_all)]
     async fn modify_from_internal_parts(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: &str,
         ml: &ModifyList<ModifyInvalid>,
         filter: Filter<FilterInvalid>,
@@ -112,7 +112,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -158,7 +158,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_create(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         req: CreateRequest,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
@@ -166,7 +166,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -195,14 +195,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_modify(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         req: ModifyRequest,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -231,14 +231,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_delete(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         req: DeleteRequest,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -266,7 +266,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_internalpatch(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         filter: Filter<FilterInvalid>,
         update: ProtoEntry,
         eventid: Uuid,
@@ -275,7 +275,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -310,14 +310,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_internaldelete(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         filter: Filter<FilterInvalid>,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -345,14 +345,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_reviverecycled(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         filter: Filter<FilterInvalid>,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -380,14 +380,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_service_account_credential_generate(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<String, OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -425,7 +425,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_service_account_api_token_generate(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         label: String,
         expiry: Option<OffsetDateTime>,
@@ -435,7 +435,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -469,7 +469,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_service_account_api_token_destroy(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         token_id: Uuid,
         eventid: Uuid,
@@ -477,7 +477,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -509,7 +509,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_account_user_auth_token_destroy(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         token_id: Uuid,
         eventid: Uuid,
@@ -517,7 +517,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -549,23 +549,22 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_logout(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         // We specifically need a uat here to assess the auth type!
-        let (ident, uat) = idms_prox_write
-            .validate_and_parse_uat(uat.as_deref(), ct)
-            .and_then(|uat| {
-                idms_prox_write
-                    .process_uat_to_identity(&uat, ct)
-                    .map(|ident| (ident, uat))
+        let ident = idms_prox_write
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
+            .map_err(|e| {
+                admin_error!(err = ?e, "Invalid identity");
+                e
             })?;
 
-        if uat.uuid == UUID_ANONYMOUS {
-            info!("Ignoring request to logout anonymous session - these sessions are not recorded");
+        if ident.can_logout() {
+            info!("Ignoring request to logout session - these sessions are not recorded");
             return Ok(());
         }
 
@@ -594,14 +593,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_idmcredentialupdate(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<(CUSessionToken, CUStatus), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -642,7 +641,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_idmcredentialupdateintent(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         ttl: Option<Duration>,
         eventid: Uuid,
@@ -650,7 +649,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -781,14 +780,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_service_account_into_person(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<(), OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -813,14 +812,14 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_regenerateradius(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         eventid: Uuid,
     ) -> Result<String, OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -859,7 +858,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_purgeattribute(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         attr: String,
         filter: Filter<FilterInvalid>,
@@ -868,7 +867,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -911,7 +910,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_removeattributevalues(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         attr: String,
         values: Vec<String>,
@@ -921,7 +920,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -966,12 +965,12 @@ impl QueryServerWriteV1 {
     #[instrument(
         level = "info",
         name = "append_attribute",
-        skip(self, uat, uuid_or_name, attr, values, filter, eventid)
+        skip_all,
         fields(uuid = ?eventid)
     )]
     pub async fn handle_appendattribute(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         attr: String,
         values: Vec<String>,
@@ -986,19 +985,19 @@ impl QueryServerWriteV1 {
                 .map(|v| ProtoModify::Present(attr.clone(), v))
                 .collect(),
         );
-        self.modify_from_parts(uat, &uuid_or_name, &proto_ml, filter)
+        self.modify_from_parts(client_auth_info, &uuid_or_name, &proto_ml, filter)
             .await
     }
 
     #[instrument(
         level = "info",
         name = "set_attribute",
-        skip(self, uat, uuid_or_name, attr, values, filter, eventid)
+        skip_all,
         fields(uuid = ?eventid)
     )]
     pub async fn handle_setattribute(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         attr: String,
         values: Vec<String>,
@@ -1016,7 +1015,7 @@ impl QueryServerWriteV1 {
                 )
                 .collect(),
         );
-        self.modify_from_parts(uat, &uuid_or_name, &proto_ml, filter)
+        self.modify_from_parts(client_auth_info, &uuid_or_name, &proto_ml, filter)
             .await
     }
 
@@ -1028,7 +1027,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_sshkeycreate(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         tag: &str,
         key: &str,
@@ -1041,7 +1040,7 @@ impl QueryServerWriteV1 {
         // than relying on the proto ones.
         let ml = ModifyList::new_append(Attribute::SshPublicKey, v_sk);
 
-        self.modify_from_internal_parts(uat, &uuid_or_name, &ml, filter)
+        self.modify_from_internal_parts(client_auth_info, &uuid_or_name, &ml, filter)
             .await
     }
 
@@ -1053,7 +1052,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_idmaccountunixextend(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         ux: AccountUnixExtend,
         eventid: Uuid,
@@ -1088,19 +1087,19 @@ impl QueryServerWriteV1 {
 
         let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
 
-        self.modify_from_internal_parts(uat, &uuid_or_name, &ml, filter)
+        self.modify_from_internal_parts(client_auth_info, &uuid_or_name, &ml, filter)
             .await
     }
 
     #[instrument(
         level = "info",
         name = "idm_group_unix_extend",
-        skip(self, uat, uuid_or_name, gx, eventid)
+        skip_all,
         fields(uuid = ?eventid)
     )]
     pub async fn handle_idmgroupunixextend(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         gx: GroupUnixExtend,
         eventid: Uuid,
@@ -1131,7 +1130,7 @@ impl QueryServerWriteV1 {
 
         let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
 
-        self.modify_from_internal_parts(uat, &uuid_or_name, &ml, filter)
+        self.modify_from_internal_parts(client_auth_info, &uuid_or_name, &ml, filter)
             .await
     }
 
@@ -1142,7 +1141,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_idmaccountunixsetcred(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         uuid_or_name: String,
         cred: String,
         eventid: Uuid,
@@ -1150,7 +1149,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1185,16 +1184,16 @@ impl QueryServerWriteV1 {
     #[instrument(level = "debug", skip_all)]
     pub async fn handle_oauth2_rs_image_delete(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         rs: Filter<FilterInvalid>,
     ) -> Result<(), OperationError> {
         let mut idms_prox_write = self.idms.proxy_write(duration_from_epoch_now()).await;
         let ct = duration_from_epoch_now();
 
         let ident = idms_prox_write
-                .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+                .validate_client_auth_info_to_ident(client_auth_info, ct)
                 .map_err(|e| {
-                    admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_delete {:?}", uat);
+                    admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_delete");
                     e
                 })?;
         let ml = ModifyList::new_purge(Attribute::Image);
@@ -1215,7 +1214,7 @@ impl QueryServerWriteV1 {
     #[instrument(level = "debug", skip_all)]
     pub async fn handle_oauth2_rs_image_update(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         rs: Filter<FilterInvalid>,
         image: ImageValue,
     ) -> Result<(), OperationError> {
@@ -1223,9 +1222,9 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
-                admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_update {:?}", uat);
+                admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_update");
                 e
             })?;
 
@@ -1255,7 +1254,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_oauth2_scopemap_update(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         group: String,
         scopes: Vec<String>,
         filter: Filter<FilterInvalid>,
@@ -1267,7 +1266,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1316,7 +1315,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_oauth2_scopemap_delete(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         group: String,
         filter: Filter<FilterInvalid>,
         eventid: Uuid,
@@ -1325,7 +1324,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1370,7 +1369,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_oauth2_sup_scopemap_update(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         group: String,
         scopes: Vec<String>,
         filter: Filter<FilterInvalid>,
@@ -1382,7 +1381,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1431,7 +1430,7 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_oauth2_sup_scopemap_delete(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         group: String,
         filter: Filter<FilterInvalid>,
         eventid: Uuid,
@@ -1440,7 +1439,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1487,33 +1486,22 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_oauth2_authorise_permit(
         &self,
-        uat: Option<String>,
+        client_auth_info: ClientAuthInfo,
         consent_req: String,
         eventid: Uuid,
     ) -> Result<AuthorisePermitSuccess, OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
-        let (ident, uat) = idms_prox_write
-            .validate_and_parse_uat(uat.as_deref(), ct)
-            .and_then(|uat| {
-                idms_prox_write
-                    .process_uat_to_identity(&uat, ct)
-                    .map(|ident| (ident, uat))
-            })
-            .map_err(|e| {
-                admin_error!("Invalid identity: {:?}", e);
-                e
-            })?;
 
         let ident = idms_prox_write
-            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
             })?;
 
         idms_prox_write
-            .check_oauth2_authorise_permit(&ident, &uat, &consent_req, ct)
+            .check_oauth2_authorise_permit(&ident, &consent_req, ct)
             .and_then(|r| idms_prox_write.commit().map(|()| r))
     }
 

--- a/server/core/src/actors/v1_write.rs
+++ b/server/core/src/actors/v1_write.rs
@@ -563,7 +563,7 @@ impl QueryServerWriteV1 {
                 e
             })?;
 
-        if ident.can_logout() {
+        if !ident.can_logout() {
             info!("Ignoring request to logout session - these sessions are not recorded");
             return Ok(());
         }

--- a/server/core/src/actors/v1_write.rs
+++ b/server/core/src/actors/v1_write.rs
@@ -64,7 +64,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -112,7 +112,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -166,7 +166,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -202,7 +202,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -238,7 +238,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -275,7 +275,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -317,7 +317,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -352,7 +352,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -387,7 +387,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -435,7 +435,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -477,7 +477,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -517,7 +517,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -601,7 +601,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -650,7 +650,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -788,7 +788,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -820,7 +820,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -868,7 +868,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -921,7 +921,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1150,7 +1150,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1192,7 +1192,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
 
         let ident = idms_prox_write
-                .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+                .validate_client_auth_info_to_ident(uat.as_deref(), ct)
                 .map_err(|e| {
                     admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_delete {:?}", uat);
                     e
@@ -1223,7 +1223,7 @@ impl QueryServerWriteV1 {
         let ct = duration_from_epoch_now();
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity in handle_oauth2_rs_image_update {:?}", uat);
                 e
@@ -1267,7 +1267,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1325,7 +1325,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1382,7 +1382,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1440,7 +1440,7 @@ impl QueryServerWriteV1 {
         let mut idms_prox_write = self.idms.proxy_write(ct).await;
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(uat.as_deref(), ct)
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
             .map_err(|e| {
                 admin_error!(err = ?e, "Invalid identity");
                 e
@@ -1502,6 +1502,13 @@ impl QueryServerWriteV1 {
             })
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
+                e
+            })?;
+
+        let ident = idms_prox_write
+            .validate_client_auth_info_to_ident(uat.as_deref(), ct)
+            .map_err(|e| {
+                admin_error!(err = ?e, "Invalid identity");
                 e
             })?;
 

--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -77,6 +77,7 @@ fn default_online_backup_versions() -> usize {
 pub struct TlsConfiguration {
     pub chain: String,
     pub key: String,
+    pub client_ca: Option<String>,
 }
 
 /// This is the Server Configuration as read from `server.toml`.
@@ -99,6 +100,9 @@ pub struct ServerConfig {
     pub tls_chain: Option<String>,
     /// The file path to the TLS Private Key
     pub tls_key: Option<String>,
+
+    /// The directory path of the client ca and crl dir.
+    pub tls_client_ca: Option<String>,
 
     /// The listener address for the HTTPS server.
     ///
@@ -212,6 +216,9 @@ impl ServerConfig {
                 }
                 "TLS_KEY" => {
                     self.tls_key = Some(value.to_string());
+                }
+                "TLS_CLIENT_CA" => {
+                    self.tls_client_ca = Some(value.to_string());
                 }
                 "BINDADDRESS" => {
                     self.bindaddress = Some(value.to_string());
@@ -571,7 +578,7 @@ impl Configuration {
     pub fn update_config_for_server_mode(&mut self, sconfig: &ServerConfig) {
         #[cfg(any(test, debug_assertions))]
         debug!("update_config_for_server_mode {:?}", sconfig);
-        self.update_tls(&sconfig.tls_chain, &sconfig.tls_key);
+        self.update_tls(&sconfig.tls_chain, &sconfig.tls_key, &sconfig.tls_client_ca);
         self.update_bind(&sconfig.bindaddress);
         self.update_ldapbind(&sconfig.ldapbindaddress);
         self.update_online_backup(&sconfig.online_backup);
@@ -632,13 +639,23 @@ impl Configuration {
         self.repl_config = repl_config;
     }
 
-    pub fn update_tls(&mut self, chain: &Option<String>, key: &Option<String>) {
+    pub fn update_tls(
+        &mut self,
+        chain: &Option<String>,
+        key: &Option<String>,
+        client_ca: &Option<String>,
+    ) {
         match (chain, key) {
             (None, None) => {}
             (Some(chainp), Some(keyp)) => {
                 let chain = chainp.to_string();
                 let key = keyp.to_string();
-                self.tls_config = Some(TlsConfiguration { chain, key })
+                let client_ca = client_ca.clone();
+                self.tls_config = Some(TlsConfiguration {
+                    chain,
+                    key,
+                    client_ca,
+                })
             }
             _ => {
                 eprintln!("ERROR: Invalid TLS configuration - must provide chain and key!");

--- a/server/core/src/https/extractors/mod.rs
+++ b/server/core/src/https/extractors/mod.rs
@@ -17,7 +17,6 @@ use crate::https::ServerState;
 const X_FORWARDED_FOR_HEADER: HeaderName = HeaderName::from_static(X_FORWARDED_FOR);
 
 pub struct VerifiedClientInformation (
-    pub IpAddr,
     pub ClientAuthInfo,
 );
 
@@ -46,7 +45,7 @@ impl FromRequestParts<ServerState> for VerifiedClientInformation {
                 })?;
 
 
-        let xff_addr = if state.trust_x_forward_for {
+        let ip_addr = if state.trust_x_forward_for {
             if let Some(x_forward_for) = parts.headers.get(X_FORWARDED_FOR_HEADER) {
                 // X forward for may be comma separated.
                 let first = x_forward_for
@@ -76,8 +75,8 @@ impl FromRequestParts<ServerState> for VerifiedClientInformation {
         };
 
         Ok(VerifiedClientInformation(
-            xff_addr,
             ClientAuthInfo {
+                ip_addr,
                 bearer_token: None,
                 client_cert,
             }

--- a/server/core/src/https/extractors/mod.rs
+++ b/server/core/src/https/extractors/mod.rs
@@ -132,7 +132,7 @@ impl FromRequestParts<ServerState> for VerifiedClientInformation {
                     warn!(?err, "Invalid bearer token, ignoring");
                 })
                 .ok()
-                .and_then(|s| s.split_once(" "))
+                .and_then(|s| s.split_once(' '))
                 .map(|(_, s)| s.to_string())
                 .or_else(|| {
                     warn!("bearer token format invalid, ignoring");

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -1,9 +1,7 @@
 use axum::{
-    headers::{authorization::Bearer, Authorization},
     http::{HeaderValue, Request},
     middleware::Next,
     response::Response,
-    TypedHeader,
 };
 use kanidm_proto::constants::{KOPID, KVERSION};
 use uuid::Uuid;
@@ -51,25 +49,19 @@ pub async fn are_we_json_yet<B>(request: Request<B>, next: Next<B>) -> Response 
 pub struct KOpId {
     /// The event correlation ID
     pub eventid: Uuid,
-    /// The User Access Token, if present
-    pub uat: Option<String>,
 }
 
 /// This runs at the start of the request, adding an extension with `KOpId` which has useful things inside it.
 #[instrument(level = "debug", name = "kopid_middleware", skip_all)]
 pub async fn kopid_middleware<B>(
-    auth: Option<TypedHeader<Authorization<Bearer>>>,
     mut request: Request<B>,
     next: Next<B>,
 ) -> Response {
     // generate the event ID
     let eventid = sketching::tracing_forest::id();
 
-    // get the bearer token from the headers if present.
-    let uat = auth.map(|bearer| bearer.token().to_string());
-
     // insert the extension so we can pull it out later
-    request.extensions_mut().insert(KOpId { eventid, uat });
+    request.extensions_mut().insert(KOpId { eventid });
     let mut response = next.run(request).await;
 
     // This conversion *should never* fail. If it does, rather than panic, we warn and

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -24,15 +24,6 @@ pub async fn version_middleware<B>(request: Request<B>, next: Next<B>) -> Respon
     response
 }
 
-#[derive(Clone, Debug)]
-/// For holding onto the event ID and other handy request-based things
-pub struct KOpId {
-    /// The event correlation ID
-    pub eventid: Uuid,
-    /// The User Access Token, if present
-    pub uat: Option<String>,
-}
-
 #[cfg(any(test, debug_assertions))]
 /// This is a debug middleware to ensure that /v1/ endpoints only return JSON
 #[instrument(level = "debug", name = "are_we_json_yet", skip_all)]
@@ -53,6 +44,15 @@ pub async fn are_we_json_yet<B>(request: Request<B>, next: Next<B>) -> Response 
     }
 
     response
+}
+
+#[derive(Clone, Debug)]
+/// For holding onto the event ID and other handy request-based things
+pub struct KOpId {
+    /// The event correlation ID
+    pub eventid: Uuid,
+    /// The User Access Token, if present
+    pub uat: Option<String>,
 }
 
 /// This runs at the start of the request, adding an extension with `KOpId` which has useful things inside it.

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -35,7 +35,7 @@ pub struct KOpId {
 
 #[cfg(any(test, debug_assertions))]
 /// This is a debug middleware to ensure that /v1/ endpoints only return JSON
-#[instrument(name = "are_we_json_yet", skip_all)]
+#[instrument(level = "debug", name = "are_we_json_yet", skip_all)]
 pub async fn are_we_json_yet<B>(request: Request<B>, next: Next<B>) -> Response {
     let uri = request.uri().path().to_string();
 
@@ -56,7 +56,7 @@ pub async fn are_we_json_yet<B>(request: Request<B>, next: Next<B>) -> Response 
 }
 
 /// This runs at the start of the request, adding an extension with `KOpId` which has useful things inside it.
-#[instrument(name = "kopid_middleware", skip_all, level = "DEBUG")]
+#[instrument(level = "debug", name = "kopid_middleware", skip_all)]
 pub async fn kopid_middleware<B>(
     auth: Option<TypedHeader<Authorization<Bearer>>>,
     mut request: Request<B>,

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -53,10 +53,7 @@ pub struct KOpId {
 
 /// This runs at the start of the request, adding an extension with `KOpId` which has useful things inside it.
 #[instrument(level = "debug", name = "kopid_middleware", skip_all)]
-pub async fn kopid_middleware<B>(
-    mut request: Request<B>,
-    next: Next<B>,
-) -> Response {
+pub async fn kopid_middleware<B>(mut request: Request<B>, next: Next<B>) -> Response {
     // generate the event ID
     let eventid = sketching::tracing_forest::id();
 

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -14,8 +14,8 @@ mod v1;
 mod v1_oauth2;
 mod v1_scim;
 
-use self::javascript::*;
 use self::extractors::ClientConnInfo;
+use self::javascript::*;
 use crate::actors::v1_read::QueryServerReadV1;
 use crate::actors::v1_write::QueryServerWriteV1;
 use crate::config::{Configuration, ServerRole, TlsConfiguration};
@@ -32,8 +32,8 @@ use hashbrown::HashMap;
 use hyper::server::accept::Accept;
 use hyper::server::conn::{AddrStream, Http};
 use kanidm_proto::constants::KSESSIONID;
-use kanidmd_lib::status::StatusActor;
 use kanidmd_lib::idm::ClientCertInfo;
+use kanidmd_lib::status::StatusActor;
 use openssl::nid;
 use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod, SslVerifyMode};
 use openssl::x509::X509;
@@ -458,9 +458,7 @@ async fn server_loop(
         // Allow dumping client cert chains for dev debugging
         // In the case this is status=false, should we be dumping these anyway?
         if enabled!(tracing::Level::TRACE) {
-            tls_builder.set_verify_callback(verify, |
-                status, x509store
-            | {
+            tls_builder.set_verify_callback(verify, |status, x509store| {
                 if let Some(current_cert) = x509store.current_cert() {
                     let cert_text_bytes = current_cert.to_text().unwrap_or_default();
                     let cert_text = String::from_utf8_lossy(cert_text_bytes.as_slice());
@@ -536,7 +534,11 @@ pub(crate) async fn handle_conn(
                     None
                 };
 
-                let cn = if let Some(cn) = peer_cert.subject_name().entries_by_nid(nid::Nid::COMMONNAME).next() {
+                let cn = if let Some(cn) = peer_cert
+                    .subject_name()
+                    .entries_by_nid(nid::Nid::COMMONNAME)
+                    .next()
+                {
                     String::from_utf8(cn.data().as_slice().to_vec())
                         .map_err(|err| {
                             warn!(?err, "client certificate CN contains invalid utf-8 - the CN will be ignored!");
@@ -546,18 +548,12 @@ pub(crate) async fn handle_conn(
                     None
                 };
 
-                Some(ClientCertInfo {
-                    subject_key_id,
-                    cn
-                })
+                Some(ClientCertInfo { subject_key_id, cn })
             } else {
                 None
             };
 
-            let client_conn_info = ClientConnInfo {
-                addr,
-                client_cert
-            };
+            let client_conn_info = ClientConnInfo { addr, client_cert };
 
             debug!(?client_conn_info);
 

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -528,11 +528,9 @@ pub(crate) async fn handle_conn(
             let client_cert = if let Some(peer_cert) = tls_stream.ssl().peer_certificate() {
                 // TODO: This is where we should be checking the CRL!!!
 
-                let subject_key_id = if let Some(ski) = peer_cert.subject_key_id() {
-                    Some(ski.as_slice().to_vec())
-                } else {
-                    None
-                };
+                let subject_key_id = peer_cert
+                    .subject_key_id()
+                    .map(|ski| ski.as_slice().to_vec());
 
                 let cn = if let Some(cn) = peer_cert
                     .subject_name()

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -15,10 +15,11 @@ mod v1_oauth2;
 mod v1_scim;
 
 use self::javascript::*;
+use self::extractors::ClientConnInfo;
 use crate::actors::v1_read::QueryServerReadV1;
 use crate::actors::v1_write::QueryServerWriteV1;
 use crate::config::{Configuration, ServerRole, TlsConfiguration};
-use axum::extract::connect_info::{IntoMakeServiceWithConnectInfo, ResponseFuture};
+use axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use axum::http::{HeaderMap, HeaderValue};
 use axum::middleware::{from_fn, from_fn_with_state};
 use axum::response::Redirect;
@@ -32,14 +33,18 @@ use hyper::server::accept::Accept;
 use hyper::server::conn::{AddrStream, Http};
 use kanidm_proto::constants::KSESSIONID;
 use kanidmd_lib::status::StatusActor;
-use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod};
+use kanidmd_lib::idm::ClientCertInfo;
+use openssl::nid;
+use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod, SslVerifyMode};
+use openssl::x509::X509;
 use sketching::*;
 use tokio_openssl::SslStream;
 
 use futures_util::future::poll_fn;
 use tokio::net::TcpListener;
 
-use std::io::ErrorKind;
+use std::fs;
+use std::io::{ErrorKind, Read};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -311,7 +316,7 @@ pub async fn create_https_server(
         .layer(trace_layer)
         .with_state(state)
         // the connect_info bit here lets us pick up the remote address of the client
-        .into_make_service_with_connect_info::<SocketAddr>();
+        .into_make_service_with_connect_info::<ClientConnInfo>();
 
     let addr = SocketAddr::from_str(&config.address).map_err(|err| {
         error!(
@@ -361,10 +366,10 @@ pub async fn create_https_server(
 async fn server_loop(
     tls_param: TlsConfiguration,
     listener: TcpListener,
-    app: IntoMakeServiceWithConnectInfo<Router, SocketAddr>,
+    app: IntoMakeServiceWithConnectInfo<Router, ClientConnInfo>,
 ) -> Result<(), std::io::Error> {
     let mut tls_builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())?;
-    let mut app = app;
+
     tls_builder
         .set_certificate_chain_file(tls_param.chain.clone())
         .map_err(|err| {
@@ -373,6 +378,7 @@ async fn server_loop(
                 format!("Failed to create TLS listener: {:?}", err),
             )
         })?;
+
     tls_builder
         .set_private_key_file(tls_param.key.clone(), SslFiletype::PEM)
         .map_err(|err| {
@@ -381,13 +387,102 @@ async fn server_loop(
                 format!("Failed to create TLS listener: {:?}", err),
             )
         })?;
+
     tls_builder.check_private_key().map_err(|err| {
         std::io::Error::new(
             ErrorKind::Other,
             format!("Failed to create TLS listener: {:?}", err),
         )
     })?;
-    let acceptor = tls_builder.build();
+
+    // If configured, setup TLS client authentication.
+    if let Some(client_ca) = tls_param.client_ca.as_ref() {
+        debug!("Configuring client certificates from {}", client_ca);
+
+        let verify = SslVerifyMode::PEER;
+        // In future we may add a "require mTLS option" which would necesitate this.
+        // verify.insert(SslVerifyMode::FAIL_IF_NO_PEER_CERT);
+        tls_builder.set_verify(verify);
+
+        let read_dir = fs::read_dir(client_ca).map_err(|err| {
+            std::io::Error::new(
+                ErrorKind::Other,
+                format!("Failed to create TLS listener: {:?}", err),
+            )
+        })?;
+
+        for cert_dir_ent in read_dir.filter_map(|item| item.ok()).filter(|item| {
+            item.file_name()
+                .to_str()
+                // Hashed certs end in .0
+                // Hsahed crls are .r0
+                .map(|fname| fname.ends_with(".0"))
+                .unwrap_or_default()
+        }) {
+            let mut cert_pem = String::new();
+            fs::File::open(cert_dir_ent.path())
+                .and_then(|mut file| file.read_to_string(&mut cert_pem))
+                .map_err(|err| {
+                    std::io::Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to create TLS listener: {:?}", err),
+                    )
+                })?;
+
+            let cert = X509::from_pem(cert_pem.as_bytes()).map_err(|err| {
+                std::io::Error::new(
+                    ErrorKind::Other,
+                    format!("Failed to create TLS listener: {:?}", err),
+                )
+            })?;
+
+            let cert_store = tls_builder.cert_store_mut();
+            cert_store.add_cert(cert.clone()).map_err(|err| {
+                std::io::Error::new(
+                    ErrorKind::Other,
+                    format!("Failed to create TLS listener: {:?}", err),
+                )
+            })?;
+            // This tells the client what CA's they should use. It DOES NOT
+            // verify them. That's the job of the cert store above!
+            tls_builder.add_client_ca(&cert).map_err(|err| {
+                std::io::Error::new(
+                    ErrorKind::Other,
+                    format!("Failed to create TLS listener: {:?}", err),
+                )
+            })?;
+        }
+
+        // TODO: Build our own CRL map HERE!
+
+        // Allow dumping client cert chains for dev debugging
+        // In the case this is status=false, should we be dumping these anyway?
+        if enabled!(tracing::Level::TRACE) {
+            tls_builder.set_verify_callback(verify, |
+                status, x509store
+            | {
+                if let Some(current_cert) = x509store.current_cert() {
+                    let cert_text_bytes = current_cert.to_text().unwrap_or_default();
+                    let cert_text = String::from_utf8_lossy(cert_text_bytes.as_slice());
+                    tracing::warn!(client_cert = %cert_text);
+                };
+
+                if let Some(chain) = x509store.chain() {
+                    for cert in chain.iter() {
+                        let cert_text_bytes = cert.to_text().unwrap_or_default();
+                        let cert_text = String::from_utf8_lossy(cert_text_bytes.as_slice());
+                        tracing::warn!(chain_cert = %cert_text);
+                    }
+                }
+
+                status
+            });
+        }
+
+        // End tls_client setup
+    }
+
+    let tls_acceptor = tls_builder.build();
 
     let protocol = Arc::new(Http::new());
     let mut listener =
@@ -399,9 +494,12 @@ async fn server_loop(
         })?;
     loop {
         if let Some(Ok(stream)) = poll_fn(|cx| Pin::new(&mut listener).poll_accept(cx)).await {
-            let acceptor = acceptor.clone();
-            let svc = tower::MakeService::make_service(&mut app, &stream);
-            tokio::spawn(handle_conn(acceptor, stream, svc, protocol.clone()));
+            let tls_acceptor = tls_acceptor.clone();
+            let app = app.clone();
+
+            // let svc = tower::MakeService::make_service(&mut app, &stream);
+            // tokio::spawn(handle_conn(tls_acceptor, stream, svc, protocol.clone()));
+            tokio::spawn(handle_conn(tls_acceptor, stream, app, protocol.clone()));
         }
     }
 }
@@ -410,13 +508,16 @@ async fn server_loop(
 pub(crate) async fn handle_conn(
     acceptor: SslAcceptor,
     stream: AddrStream,
-    svc: ResponseFuture<Router, SocketAddr>,
+    // svc: ResponseFuture<Router, ClientConnInfo>,
+    mut app: IntoMakeServiceWithConnectInfo<Router, ClientConnInfo>,
     protocol: Arc<Http>,
 ) -> Result<(), std::io::Error> {
     let ssl = Ssl::new(acceptor.context()).map_err(|e| {
         error!("Failed to create TLS context: {:?}", e);
         std::io::Error::from(ErrorKind::ConnectionAborted)
     })?;
+
+    let addr = stream.remote_addr();
 
     let mut tls_stream = SslStream::new(ssl, stream).map_err(|e| {
         error!("Failed to create TLS stream: {:?}", e);
@@ -425,6 +526,43 @@ pub(crate) async fn handle_conn(
 
     match SslStream::accept(Pin::new(&mut tls_stream)).await {
         Ok(_) => {
+            // Process the client cert (if any)
+            let client_cert = if let Some(peer_cert) = tls_stream.ssl().peer_certificate() {
+                // TODO: This is where we should be checking the CRL!!!
+
+                let subject_key_id = if let Some(ski) = peer_cert.subject_key_id() {
+                    Some(ski.as_slice().to_vec())
+                } else {
+                    None
+                };
+
+                let cn = if let Some(cn) = peer_cert.subject_name().entries_by_nid(nid::Nid::COMMONNAME).next() {
+                    String::from_utf8(cn.data().as_slice().to_vec())
+                        .map_err(|err| {
+                            warn!(?err, "client certificate CN contains invalid utf-8 - the CN will be ignored!");
+                        })
+                        .ok()
+                } else {
+                    None
+                };
+
+                Some(ClientCertInfo {
+                    subject_key_id,
+                    cn
+                })
+            } else {
+                None
+            };
+
+            let client_conn_info = ClientConnInfo {
+                addr,
+                client_cert
+            };
+
+            debug!(?client_conn_info);
+
+            let svc = tower::MakeService::make_service(&mut app, client_conn_info);
+
             let svc = svc.await.map_err(|e| {
                 error!("Failed to build HTTP response: {:?}", e);
                 std::io::Error::from(ErrorKind::Other)

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -1,6 +1,7 @@
 use super::errors::WebError;
 use super::middleware::KOpId;
 use super::ServerState;
+use crate::https::extractors::VerifiedClientInformation;
 use axum::extract::{Path, Query, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, CONTENT_TYPE,
@@ -27,7 +28,6 @@ use kanidmd_lib::prelude::f_eq;
 use kanidmd_lib::prelude::*;
 use kanidmd_lib::value::PartialValue;
 use serde::{Deserialize, Serialize};
-use crate::https::extractors::VerifiedClientInformation;
 
 // TODO: merge this into a value in WebError later
 pub struct HTTPOauth2Error(Oauth2Error);
@@ -215,7 +215,7 @@ async fn oauth2_authorise(
     state: ServerState,
     auth_req: AuthorisationRequest,
     kopid: KOpId,
-    client_auth_info: ClientAuthInfo
+    client_auth_info: ClientAuthInfo,
 ) -> impl IntoResponse {
     let res: Result<AuthoriseResponse, Oauth2Error> = state
         .qe_r_ref
@@ -357,7 +357,7 @@ async fn oauth2_authorise_permit(
     state: ServerState,
     consent_req: String,
     kopid: KOpId,
-    client_auth_info: ClientAuthInfo
+    client_auth_info: ClientAuthInfo,
 ) -> impl IntoResponse {
     let res = state
         .qe_w_ref

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -2303,7 +2303,15 @@ pub async fn domain_attr_get(
     Path(attr): Path<String>,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::DomainInfo.into()));
-    json_rest_event_get_attr(state, STR_UUID_DOMAIN_INFO, attr, filter, kopid, client_auth_info).await
+    json_rest_event_get_attr(
+        state,
+        STR_UUID_DOMAIN_INFO,
+        attr,
+        filter,
+        kopid,
+        client_auth_info,
+    )
+    .await
 }
 
 #[utoipa::path(
@@ -2405,7 +2413,15 @@ pub async fn system_attr_get(
     VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::SystemConfig.into()));
-    json_rest_event_get_attr(state, STR_UUID_SYSTEM_CONFIG, attr, filter, kopid, client_auth_info).await
+    json_rest_event_get_attr(
+        state,
+        STR_UUID_SYSTEM_CONFIG,
+        attr,
+        filter,
+        kopid,
+        client_auth_info,
+    )
+    .await
 }
 
 #[utoipa::path(

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -2505,7 +2505,7 @@ pub async fn applinks_get(
 )] // TODO: post body stuff
 pub async fn reauth(
     State(state): State<ServerState>,
-    VerifiedClientInformation(ip_addr, client_auth_info): VerifiedClientInformation,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Extension(kopid): Extension<KOpId>,
     Json(obj): Json<AuthIssueSession>,
 ) -> Result<Response, WebError> {
@@ -2531,7 +2531,7 @@ pub async fn reauth(
 )]
 pub async fn auth(
     State(state): State<ServerState>,
-    VerifiedClientInformation(ip_addr, client_auth_info): VerifiedClientInformation,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     headers: HeaderMap,
     Extension(kopid): Extension<KOpId>,
     Json(obj): Json<AuthRequest>,
@@ -2675,9 +2675,9 @@ pub async fn auth_valid(
 )]
 pub async fn debug_ipinfo(
     State(_state): State<ServerState>,
-    VerifiedClientInformation(ip_addr, client_auth_info): VerifiedClientInformation,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<IpAddr>>, ()> {
-    Ok(Json::from(vec![ip_addr]))
+    Ok(Json::from(vec![client_auth_info.ip_addr]))
 }
 
 fn cacheable_routes(state: ServerState) -> Router<ServerState> {

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -52,11 +52,12 @@ pub(crate) struct SessionId {
 pub async fn raw_create(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(msg): Json<CreateRequest>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_create(kopid.uat, msg, kopid.eventid)
+        .handle_create(client_auth_info, msg, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -76,11 +77,12 @@ pub async fn raw_create(
 pub async fn raw_modify(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(msg): Json<ModifyRequest>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_modify(kopid.uat, msg, kopid.eventid)
+        .handle_modify(client_auth_info, msg, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -100,11 +102,12 @@ pub async fn raw_modify(
 pub async fn raw_delete(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(msg): Json<DeleteRequest>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_delete(kopid.uat, msg, kopid.eventid)
+        .handle_delete(client_auth_info, msg, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -125,11 +128,12 @@ pub async fn raw_delete(
 pub async fn raw_search(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(msg): Json<SearchRequest>,
 ) -> Result<Json<SearchResponse>, WebError> {
     state
         .qe_r_ref
-        .handle_search(kopid.uat, msg, kopid.eventid)
+        .handle_search(client_auth_info, msg, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -149,11 +153,12 @@ pub async fn raw_search(
 pub async fn whoami(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<WhoamiResponse>, WebError> {
     // New event, feed current auth data from the token to it.
     state
         .qe_r_ref
-        .handle_whoami(kopid.uat, kopid.eventid)
+        .handle_whoami(client_auth_info, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -172,10 +177,11 @@ pub async fn whoami(
 pub async fn whoami_uat(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<UserAuthToken>, WebError> {
     state
         .qe_r_ref
-        .handle_whoami_uat(kopid.uat, kopid.eventid)
+        .handle_whoami_uat(client_auth_info, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -193,10 +199,11 @@ pub async fn whoami_uat(
 pub async fn logout(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_logout(kopid.uat, kopid.eventid)
+        .handle_logout(client_auth_info, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -210,10 +217,11 @@ pub async fn json_rest_event_get(
     attrs: Option<Vec<String>>,
     filter: Filter<FilterInvalid>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsearch(kopid.uat, filter, attrs, kopid.eventid)
+        .handle_internalsearch(client_auth_info, filter, attrs, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -225,12 +233,13 @@ pub async fn json_rest_event_get_id(
     filter: Filter<FilterInvalid>,
     attrs: Option<Vec<String>>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(id.as_str())));
 
     state
         .qe_r_ref
-        .handle_internalsearch(kopid.uat, filter, attrs, kopid.eventid)
+        .handle_internalsearch(client_auth_info, filter, attrs, kopid.eventid)
         .await
         .map(|mut r| r.pop())
         .map(Json::from)
@@ -242,11 +251,12 @@ pub async fn json_rest_event_delete_id(
     id: String,
     filter: Filter<FilterInvalid>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(id.as_str())));
     state
         .qe_w_ref
-        .handle_internaldelete(kopid.uat, filter, kopid.eventid)
+        .handle_internaldelete(client_auth_info, filter, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -258,12 +268,13 @@ pub async fn json_rest_event_get_attr(
     attr: String,
     filter: Filter<FilterInvalid>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(id)));
     let attrs = Some(vec![attr.clone()]);
     state
         .qe_r_ref
-        .handle_internalsearch(kopid.uat, filter, attrs, kopid.eventid)
+        .handle_internalsearch(client_auth_info, filter, attrs, kopid.eventid)
         .await
         .map(|mut event_result| event_result.pop().and_then(|mut e| e.attrs.remove(&attr)))
         .map(Json::from)
@@ -276,8 +287,9 @@ pub async fn json_rest_event_get_id_attr(
     attr: String,
     filter: Filter<FilterInvalid>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
-    json_rest_event_get_attr(state, id.as_str(), attr, filter, kopid).await
+    json_rest_event_get_attr(state, id.as_str(), attr, filter, kopid, client_auth_info).await
 }
 
 pub async fn json_rest_event_post(
@@ -285,6 +297,7 @@ pub async fn json_rest_event_post(
     classes: Vec<String>,
     obj: ProtoEntry,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
     debug_assert!(!classes.is_empty());
 
@@ -296,7 +309,7 @@ pub async fn json_rest_event_post(
 
     state
         .qe_w_ref
-        .handle_create(kopid.uat, msg, kopid.eventid)
+        .handle_create(client_auth_info, msg, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -309,10 +322,11 @@ pub async fn json_rest_event_post_id_attr(
     filter: Filter<FilterInvalid>,
     values: Vec<String>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_appendattribute(kopid.uat, id, attr, values, filter, kopid.eventid)
+        .handle_appendattribute(client_auth_info, id, attr, values, filter, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -325,10 +339,11 @@ pub async fn json_rest_event_put_attr(
     filter: Filter<FilterInvalid>,
     values: Vec<String>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_setattribute(kopid.uat, id, attr, values, filter, kopid.eventid)
+        .handle_setattribute(client_auth_info, id, attr, values, filter, kopid.eventid)
         .await
         .map_err(WebError::from)
         .map(Json::from)
@@ -341,10 +356,11 @@ pub async fn json_rest_event_post_attr(
     filter: Filter<FilterInvalid>,
     values: Vec<String>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_appendattribute(kopid.uat, id, attr, values, filter, kopid.eventid)
+        .handle_appendattribute(client_auth_info, id, attr, values, filter, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -366,8 +382,9 @@ pub async fn json_rest_event_put_id_attr(
     filter: Filter<FilterInvalid>,
     values: Vec<String>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
-    json_rest_event_put_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_put_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 pub async fn json_rest_event_delete_id_attr(
@@ -377,8 +394,9 @@ pub async fn json_rest_event_delete_id_attr(
     filter: Filter<FilterInvalid>,
     values: Option<Vec<String>>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
-    json_rest_event_delete_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_delete_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 pub async fn json_rest_event_delete_attr(
@@ -388,6 +406,7 @@ pub async fn json_rest_event_delete_attr(
     filter: Filter<FilterInvalid>,
     values: Option<Vec<String>>,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<()>, WebError> {
     let values = match values {
         Some(val) => val,
@@ -397,13 +416,13 @@ pub async fn json_rest_event_delete_attr(
     if values.is_empty() {
         state
             .qe_w_ref
-            .handle_purgeattribute(kopid.uat, uuid_or_name, attr, filter, kopid.eventid)
+            .handle_purgeattribute(client_auth_info, uuid_or_name, attr, filter, kopid.eventid)
             .await
     } else {
         state
             .qe_w_ref
             .handle_removeattributevalues(
-                kopid.uat,
+                client_auth_info,
                 uuid_or_name,
                 attr,
                 values,
@@ -430,6 +449,7 @@ pub async fn json_rest_event_delete_attr(
 pub async fn schema_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     // NOTE: This is filter_all, because from_internal_message will still do the alterations
     // needed to make it safe. This is needed because there may be aci's that block access
@@ -439,7 +459,7 @@ pub async fn schema_get(
         f_eq(Attribute::Class, EntryClass::AttributeType.into()),
         f_eq(Attribute::Class, EntryClass::ClassType.into())
     ]));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -455,9 +475,10 @@ pub async fn schema_get(
 pub async fn schema_attributetype_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::AttributeType.into()));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -474,6 +495,7 @@ pub async fn schema_attributetype_get_id(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     // These can't use get_id because the attribute name and class name aren't ... well name.
     let filter = filter_all!(f_and!([
@@ -486,7 +508,7 @@ pub async fn schema_attributetype_get_id(
 
     state
         .qe_r_ref
-        .handle_internalsearch(kopid.uat, filter, None, kopid.eventid)
+        .handle_internalsearch(client_auth_info, filter, None, kopid.eventid)
         .await
         .map(|mut r| r.pop())
         .map(Json::from)
@@ -506,9 +528,10 @@ pub async fn schema_attributetype_get_id(
 pub async fn schema_classtype_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::ClassType.into()));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -524,6 +547,7 @@ pub async fn schema_classtype_get(
 pub async fn schema_classtype_get_id(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     // These can't use get_id because they attribute name and class name aren't ... well name.
@@ -533,7 +557,7 @@ pub async fn schema_classtype_get_id(
     ]));
     state
         .qe_r_ref
-        .handle_internalsearch(kopid.uat, filter, None, kopid.eventid)
+        .handle_internalsearch(client_auth_info, filter, None, kopid.eventid)
         .await
         .map(|mut r| r.pop())
         .map(Json::from)
@@ -553,9 +577,10 @@ pub async fn schema_classtype_get_id(
 pub async fn person_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Person.into()));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -572,6 +597,7 @@ pub async fn person_get(
 pub async fn person_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<ProtoEntry>,
 ) -> Result<Json<()>, WebError> {
     let classes: Vec<String> = vec![
@@ -579,7 +605,7 @@ pub async fn person_post(
         EntryClass::Account.into(),
         EntryClass::Object.into(),
     ];
-    json_rest_event_post(state, classes, obj, kopid).await
+    json_rest_event_post(state, classes, obj, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -596,9 +622,10 @@ pub async fn person_id_get(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Person.into()));
-    json_rest_event_get_id(state, id, filter, None, kopid).await
+    json_rest_event_get_id(state, id, filter, None, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -614,9 +641,10 @@ pub async fn person_id_delete(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Person.into()));
-    json_rest_event_delete_id(state, id, filter, kopid).await
+    json_rest_event_delete_id(state, id, filter, kopid, client_auth_info).await
 }
 
 // // == account ==
@@ -634,9 +662,10 @@ pub async fn person_id_delete(
 pub async fn service_account_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::ServiceAccount.into()));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -652,6 +681,7 @@ pub async fn service_account_get(
 pub async fn service_account_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<ProtoEntry>,
 ) -> Result<Json<()>, WebError> {
     let classes: Vec<String> = vec![
@@ -659,7 +689,7 @@ pub async fn service_account_post(
         EntryClass::Account.into(),
         EntryClass::Object.into(),
     ];
-    json_rest_event_post(state, classes, obj, kopid).await
+    json_rest_event_post(state, classes, obj, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -675,6 +705,7 @@ pub async fn service_account_post(
 pub async fn service_account_id_patch(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json(obj): Json<ProtoEntry>,
 ) -> Result<Json<()>, WebError> {
@@ -683,7 +714,7 @@ pub async fn service_account_id_patch(
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(id.as_str())));
     state
         .qe_w_ref
-        .handle_internalpatch(kopid.uat, filter, obj, kopid.eventid)
+        .handle_internalpatch(client_auth_info, filter, obj, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -703,9 +734,10 @@ pub async fn service_account_id_get(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::ServiceAccount.into()));
-    json_rest_event_get_id(state, id, filter, None, kopid).await
+    json_rest_event_get_id(state, id, filter, None, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -721,9 +753,10 @@ pub async fn service_account_id_delete(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::ServiceAccount.into()));
-    json_rest_event_delete_id(state, id, filter, kopid).await
+    json_rest_event_delete_id(state, id, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -740,10 +773,11 @@ pub async fn service_account_credential_generate(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<String>, WebError> {
     state
         .qe_w_ref
-        .handle_service_account_credential_generate(kopid.uat, id, kopid.eventid)
+        .handle_service_account_credential_generate(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -767,11 +801,12 @@ pub async fn service_account_credential_generate(
 pub async fn service_account_into_person(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_service_account_into_person(kopid.uat, id, kopid.eventid)
+        .handle_service_account_into_person(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -790,11 +825,12 @@ pub async fn service_account_into_person(
 pub async fn service_account_api_token_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<ApiToken>>, WebError> {
     state
         .qe_r_ref
-        .handle_service_account_api_token_get(kopid.uat, id, kopid.eventid)
+        .handle_service_account_api_token_get(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -814,13 +850,14 @@ pub async fn service_account_api_token_get(
 pub async fn service_account_api_token_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json(obj): Json<ApiTokenGenerate>,
 ) -> Result<Json<String>, WebError> {
     state
         .qe_w_ref
         .handle_service_account_api_token_generate(
-            kopid.uat,
+            client_auth_info,
             id,
             obj.label,
             obj.expiry,
@@ -845,10 +882,11 @@ pub async fn service_account_api_token_delete(
     State(state): State<ServerState>,
     Path((id, token_id)): Path<(String, Uuid)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_service_account_api_token_destroy(kopid.uat, id, token_id, kopid.eventid)
+        .handle_service_account_api_token_destroy(client_auth_info, id, token_id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -869,9 +907,10 @@ pub async fn person_id_get_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_get_attr(state, id.as_str(), attr, filter, kopid).await
+    json_rest_event_get_attr(state, id.as_str(), attr, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -888,9 +927,10 @@ pub async fn service_account_id_get_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_get_attr(state, id.as_str(), attr, filter, kopid).await
+    json_rest_event_get_attr(state, id.as_str(), attr, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -907,10 +947,11 @@ pub async fn person_id_post_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_post_id_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_post_id_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -927,10 +968,11 @@ pub async fn service_account_id_post_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_post_id_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_post_id_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -946,9 +988,10 @@ pub async fn person_id_delete_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_delete_id_attr(state, id, attr, filter, None, kopid).await
+    json_rest_event_delete_id_attr(state, id, attr, filter, None, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -964,9 +1007,10 @@ pub async fn service_account_id_delete_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_delete_id_attr(state, id, attr, filter, None, kopid).await
+    json_rest_event_delete_id_attr(state, id, attr, filter, None, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -982,10 +1026,11 @@ pub async fn person_id_put_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_put_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_put_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -1002,10 +1047,11 @@ pub async fn service_account_id_put_attr(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_put_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_put_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -1021,6 +1067,7 @@ pub async fn service_account_id_put_attr(
 pub async fn person_id_patch(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json(obj): Json<ProtoEntry>,
 ) -> Result<Json<()>, WebError> {
@@ -1029,7 +1076,7 @@ pub async fn person_id_patch(
     let filter = Filter::join_parts_and(filter, filter_all!(f_id(id.as_str())));
     state
         .qe_w_ref
-        .handle_internalpatch(kopid.uat, filter, obj, kopid.eventid)
+        .handle_internalpatch(client_auth_info, filter, obj, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1048,11 +1095,12 @@ pub async fn person_id_patch(
 pub async fn person_id_credential_update_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<(CUSessionToken, CUStatus)>, WebError> {
     state
         .qe_w_ref
-        .handle_idmcredentialupdate(kopid.uat, id, kopid.eventid)
+        .handle_idmcredentialupdate(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1076,13 +1124,14 @@ pub async fn person_id_credential_update_get(
 pub async fn person_id_credential_update_intent_ttl_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Query(ttl): Query<u64>,
 ) -> Result<Json<CUIntentToken>, WebError> {
     state
         .qe_w_ref
         .handle_idmcredentialupdateintent(
-            kopid.uat,
+            client_auth_info,
             id,
             Some(Duration::from_secs(ttl)),
             kopid.eventid,
@@ -1106,11 +1155,12 @@ pub async fn person_id_credential_update_intent_ttl_get(
 pub async fn person_id_credential_update_intent_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<CUIntentToken>, WebError> {
     state
         .qe_w_ref
-        .handle_idmcredentialupdateintent(kopid.uat, id, None, kopid.eventid)
+        .handle_idmcredentialupdateintent(client_auth_info, id, None, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1130,10 +1180,11 @@ pub async fn account_id_user_auth_token_get(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<UatStatus>>, WebError> {
     state
         .qe_r_ref
-        .handle_account_user_auth_token_get(kopid.uat, id, kopid.eventid)
+        .handle_account_user_auth_token_get(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1152,10 +1203,11 @@ pub async fn account_user_auth_token_delete(
     State(state): State<ServerState>,
     Path((id, token_id)): Path<(String, Uuid)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_account_user_auth_token_destroy(kopid.uat, id, token_id, kopid.eventid)
+        .handle_account_user_auth_token_destroy(client_auth_info, id, token_id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1309,11 +1361,12 @@ pub async fn credential_update_cancel(
 pub async fn service_account_id_credential_status_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<CredentialStatus>, WebError> {
     match state
         .qe_r_ref
-        .handle_idmcredentialstatus(kopid.uat, id.clone(), kopid.eventid)
+        .handle_idmcredentialstatus(client_auth_info, id.clone(), kopid.eventid)
         .await
         .map(Json::from)
     {
@@ -1342,11 +1395,12 @@ pub async fn service_account_id_credential_status_get(
 pub async fn person_get_id_credential_status(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<CredentialStatus>, WebError> {
     match state
         .qe_r_ref
-        .handle_idmcredentialstatus(kopid.uat, id.clone(), kopid.eventid)
+        .handle_idmcredentialstatus(client_auth_info, id.clone(), kopid.eventid)
         .await
         .map(Json::from)
     {
@@ -1375,11 +1429,12 @@ pub async fn person_get_id_credential_status(
 pub async fn person_id_ssh_pubkeys_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<String>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsshkeyread(kopid.uat, id, kopid.eventid)
+        .handle_internalsshkeyread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1399,11 +1454,12 @@ pub async fn person_id_ssh_pubkeys_get(
 pub async fn account_id_ssh_pubkeys_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<String>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsshkeyread(kopid.uat, id, kopid.eventid)
+        .handle_internalsshkeyread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1422,11 +1478,12 @@ pub async fn account_id_ssh_pubkeys_get(
 pub async fn service_account_id_ssh_pubkeys_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Vec<String>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsshkeyread(kopid.uat, id, kopid.eventid)
+        .handle_internalsshkeyread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1444,6 +1501,7 @@ pub async fn service_account_id_ssh_pubkeys_get(
 pub async fn person_id_ssh_pubkeys_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json((tag, key)): Json<(String, String)>,
 ) -> Result<Json<()>, WebError> {
@@ -1451,7 +1509,7 @@ pub async fn person_id_ssh_pubkeys_post(
     // Add a msg here
     state
         .qe_w_ref
-        .handle_sshkeycreate(kopid.uat, id, &tag, &key, filter, kopid.eventid)
+        .handle_sshkeycreate(client_auth_info, id, &tag, &key, filter, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1470,6 +1528,7 @@ pub async fn person_id_ssh_pubkeys_post(
 pub async fn service_account_id_ssh_pubkeys_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json((tag, key)): Json<(String, String)>,
 ) -> Result<Json<()>, WebError> {
@@ -1477,7 +1536,7 @@ pub async fn service_account_id_ssh_pubkeys_post(
     // Add a msg here
     state
         .qe_w_ref
-        .handle_sshkeycreate(kopid.uat, id, &tag, &key, filter, kopid.eventid)
+        .handle_sshkeycreate(client_auth_info, id, &tag, &key, filter, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1496,11 +1555,12 @@ pub async fn service_account_id_ssh_pubkeys_post(
 pub async fn person_id_ssh_pubkeys_tag_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<Option<String>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsshkeytagread(kopid.uat, id, tag, kopid.eventid)
+        .handle_internalsshkeytagread(client_auth_info, id, tag, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1518,11 +1578,12 @@ pub async fn person_id_ssh_pubkeys_tag_get(
 pub async fn account_id_ssh_pubkeys_tag_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<Option<String>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsshkeytagread(kopid.uat, id, tag, kopid.eventid)
+        .handle_internalsshkeytagread(client_auth_info, id, tag, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1541,11 +1602,12 @@ pub async fn account_id_ssh_pubkeys_tag_get(
 pub async fn service_account_id_ssh_pubkeys_tag_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<Option<String>>, WebError> {
     state
         .qe_r_ref
-        .handle_internalsshkeytagread(kopid.uat, id, tag, kopid.eventid)
+        .handle_internalsshkeytagread(client_auth_info, id, tag, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1566,6 +1628,7 @@ pub async fn service_account_id_ssh_pubkeys_tag_get(
 pub async fn person_id_ssh_pubkeys_tag_delete(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<()>, WebError> {
     let values = vec![tag];
@@ -1573,7 +1636,7 @@ pub async fn person_id_ssh_pubkeys_tag_delete(
     state
         .qe_w_ref
         .handle_removeattributevalues(
-            kopid.uat,
+            client_auth_info,
             id,
             Attribute::SshPublicKey.to_string(),
             values,
@@ -1600,6 +1663,7 @@ pub async fn person_id_ssh_pubkeys_tag_delete(
 pub async fn service_account_id_ssh_pubkeys_tag_delete(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<()>, WebError> {
     let values = vec![tag];
@@ -1607,7 +1671,7 @@ pub async fn service_account_id_ssh_pubkeys_tag_delete(
     state
         .qe_w_ref
         .handle_removeattributevalues(
-            kopid.uat,
+            client_auth_info,
             id,
             Attribute::SshPublicKey.to_string(),
             values,
@@ -1633,12 +1697,13 @@ pub async fn service_account_id_ssh_pubkeys_tag_delete(
 pub async fn person_id_radius_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Option<String>>, WebError> {
     // TODO: string
     state
         .qe_r_ref
-        .handle_internalradiusread(kopid.uat, id, kopid.eventid)
+        .handle_internalradiusread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1658,12 +1723,13 @@ pub async fn person_id_radius_get(
 pub async fn person_id_radius_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<String>, WebError> {
     // Need to to send the regen msg
     state
         .qe_w_ref
-        .handle_regenerateradius(kopid.uat, id, kopid.eventid)
+        .handle_regenerateradius(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1682,10 +1748,11 @@ pub async fn person_id_radius_delete(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     let attr = "radius_secret".to_string();
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Account.into()));
-    json_rest_event_delete_id_attr(state, id, attr, filter, None, kopid).await
+    json_rest_event_delete_id_attr(state, id, attr, filter, None, kopid, client_auth_info).await
 }
 
 // /v1/person/:id/_radius/_token
@@ -1703,8 +1770,9 @@ pub async fn person_id_radius_token_get(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<RadiusAuthToken>, WebError> {
-    person_id_radius_handler(state, id, kopid).await
+    person_id_radius_handler(state, id, kopid, client_auth_info).await
 }
 
 // /v1/account/:id/_radius/_token
@@ -1722,8 +1790,9 @@ pub async fn account_id_radius_token_get(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<RadiusAuthToken>, WebError> {
-    person_id_radius_handler(state, id, kopid).await
+    person_id_radius_handler(state, id, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -1740,18 +1809,20 @@ pub async fn account_id_radius_token_post(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<RadiusAuthToken>, WebError> {
-    person_id_radius_handler(state, id, kopid).await
+    person_id_radius_handler(state, id, kopid, client_auth_info).await
 }
 
 async fn person_id_radius_handler(
     state: ServerState,
     id: String,
     kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
 ) -> Result<Json<RadiusAuthToken>, WebError> {
     state
         .qe_r_ref
-        .handle_internalradiustokenread(kopid.uat, id, kopid.eventid)
+        .handle_internalradiustokenread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1772,11 +1843,12 @@ pub async fn person_id_unix_post(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<AccountUnixExtend>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_idmaccountunixextend(kopid.uat, id, obj, kopid.eventid)
+        .handle_idmaccountunixextend(client_auth_info, id, obj, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1798,11 +1870,12 @@ pub async fn service_account_id_unix_post(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<AccountUnixExtend>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_idmaccountunixextend(kopid.uat, id, obj, kopid.eventid)
+        .handle_idmaccountunixextend(client_auth_info, id, obj, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1823,11 +1896,12 @@ pub async fn account_id_unix_post(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<AccountUnixExtend>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_idmaccountunixextend(kopid.uat, id, obj, kopid.eventid)
+        .handle_idmaccountunixextend(client_auth_info, id, obj, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1847,6 +1921,7 @@ pub async fn account_id_unix_post(
 pub async fn account_id_unix_token(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<UnixUserToken>, WebError> {
     // no point asking for an empty id
@@ -1856,7 +1931,7 @@ pub async fn account_id_unix_token(
 
     let res = state
         .qe_r_ref
-        .handle_internalunixusertokenread(kopid.uat, id, kopid.eventid)
+        .handle_internalunixusertokenread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from);
 
@@ -1886,12 +1961,13 @@ pub async fn account_id_unix_token(
 pub async fn account_id_unix_auth_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json(obj): Json<SingleStringRequest>,
 ) -> Result<Json<Option<UnixUserToken>>, WebError> {
     state
         .qe_r_ref
-        .handle_idmaccountunixauth(kopid.uat, id, obj.value, kopid.eventid)
+        .handle_idmaccountunixauth(client_auth_info, id, obj.value, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1910,12 +1986,13 @@ pub async fn account_id_unix_auth_post(
 pub async fn person_id_unix_credential_put(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json(obj): Json<SingleStringRequest>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_idmaccountunixsetcred(kopid.uat, id, obj.value, kopid.eventid)
+        .handle_idmaccountunixsetcred(client_auth_info, id, obj.value, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1933,13 +2010,14 @@ pub async fn person_id_unix_credential_put(
 pub async fn person_id_unix_credential_delete(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::PosixAccount.into()));
     state
         .qe_w_ref
         .handle_purgeattribute(
-            kopid.uat,
+            client_auth_info,
             id,
             "unix_password".to_string(),
             filter,
@@ -1963,12 +2041,13 @@ pub async fn person_id_unix_credential_delete(
 pub async fn person_identify_user_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
     Json(user_request): Json<IdentifyUserRequest>,
 ) -> Result<Json<IdentifyUserResponse>, WebError> {
     state
         .qe_r_ref
-        .handle_user_identity_verification(kopid.uat, kopid.eventid, user_request, id)
+        .handle_user_identity_verification(client_auth_info, kopid.eventid, user_request, id)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -1988,9 +2067,10 @@ pub async fn person_identify_user_post(
 pub async fn group_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2008,10 +2088,11 @@ pub async fn group_get(
 pub async fn group_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<ProtoEntry>,
 ) -> Result<Json<()>, WebError> {
     let classes = vec!["group".to_string(), "object".to_string()];
-    json_rest_event_post(state, classes, obj, kopid).await
+    json_rest_event_post(state, classes, obj, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2027,10 +2108,11 @@ pub async fn group_post(
 pub async fn group_id_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
-    json_rest_event_get_id(state, id, filter, None, kopid).await
+    json_rest_event_get_id(state, id, filter, None, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2045,10 +2127,11 @@ pub async fn group_id_get(
 pub async fn group_id_delete(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
-    json_rest_event_delete_id(state, id, filter, kopid).await
+    json_rest_event_delete_id(state, id, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2065,9 +2148,10 @@ pub async fn group_id_attr_get(
     State(state): State<ServerState>,
     Path((id, attr)): Path<(String, String)>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
-    json_rest_event_get_id_attr(state, id, attr, filter, kopid).await
+    json_rest_event_get_id_attr(state, id, attr, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2084,10 +2168,11 @@ pub async fn group_id_attr_post(
     Path((id, attr)): Path<(String, String)>,
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
-    json_rest_event_post_id_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_post_id_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2104,11 +2189,12 @@ pub async fn group_id_attr_delete(
     Path((id, attr)): Path<(String, String)>,
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     values: Option<Json<Vec<String>>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
     let values = values.map(|v| v.0);
-    json_rest_event_delete_id_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_delete_id_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2125,10 +2211,11 @@ pub async fn group_id_attr_put(
     Path((id, attr)): Path<(String, String)>,
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::Group.into()));
-    json_rest_event_put_id_attr(state, id, attr, filter, values, kopid).await
+    json_rest_event_put_id_attr(state, id, attr, filter, values, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2145,11 +2232,12 @@ pub async fn group_id_unix_post(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(obj): Json<GroupUnixExtend>,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_w_ref
-        .handle_idmgroupunixextend(kopid.uat, id, obj, kopid.eventid)
+        .handle_idmgroupunixextend(client_auth_info, id, obj, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -2168,11 +2256,12 @@ pub async fn group_id_unix_post(
 pub async fn group_id_unix_token_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(id): Path<String>,
 ) -> Result<Json<UnixGroupToken>, WebError> {
     state
         .qe_r_ref
-        .handle_internalunixgrouptokenread(kopid.uat, id, kopid.eventid)
+        .handle_internalunixgrouptokenread(client_auth_info, id, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -2191,9 +2280,10 @@ pub async fn group_id_unix_token_get(
 pub async fn domain_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Uuid, PartialValue::Uuid(UUID_DOMAIN_INFO)));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2209,10 +2299,11 @@ pub async fn domain_get(
 pub async fn domain_attr_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(attr): Path<String>,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::DomainInfo.into()));
-    json_rest_event_get_attr(state, STR_UUID_DOMAIN_INFO, attr, filter, kopid).await
+    json_rest_event_get_attr(state, STR_UUID_DOMAIN_INFO, attr, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2228,6 +2319,7 @@ pub async fn domain_attr_get(
 pub async fn domain_attr_put(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Path(attr): Path<String>,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
@@ -2239,6 +2331,7 @@ pub async fn domain_attr_put(
         filter,
         values,
         kopid,
+        client_auth_info,
     )
     .await
 }
@@ -2257,6 +2350,7 @@ pub async fn domain_attr_delete(
     State(state): State<ServerState>,
     Path(attr): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Option<Vec<String>>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::DomainInfo.into()));
@@ -2267,6 +2361,7 @@ pub async fn domain_attr_delete(
         filter,
         values,
         kopid,
+        client_auth_info,
     )
     .await
 }
@@ -2284,12 +2379,13 @@ pub async fn domain_attr_delete(
 pub async fn system_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_eq(
         Attribute::Uuid,
         PartialValue::Uuid(UUID_SYSTEM_CONFIG)
     ));
-    json_rest_event_get(state, None, filter, kopid).await
+    json_rest_event_get(state, None, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2306,9 +2402,10 @@ pub async fn system_attr_get(
     State(state): State<ServerState>,
     Path(attr): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<Vec<String>>>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::SystemConfig.into()));
-    json_rest_event_get_attr(state, STR_UUID_SYSTEM_CONFIG, attr, filter, kopid).await
+    json_rest_event_get_attr(state, STR_UUID_SYSTEM_CONFIG, attr, filter, kopid, client_auth_info).await
 }
 
 #[utoipa::path(
@@ -2325,6 +2422,7 @@ pub async fn system_attr_post(
     State(state): State<ServerState>,
     Path(attr): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::SystemConfig.into()));
@@ -2335,6 +2433,7 @@ pub async fn system_attr_post(
         filter,
         values,
         kopid,
+        client_auth_info,
     )
     .await
 }
@@ -2353,6 +2452,7 @@ pub async fn system_attr_delete(
     State(state): State<ServerState>,
     Path(attr): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Option<Vec<String>>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::SystemConfig.into()));
@@ -2363,6 +2463,7 @@ pub async fn system_attr_delete(
         filter,
         values,
         kopid,
+        client_auth_info,
     )
     .await
 }
@@ -2381,6 +2482,7 @@ pub async fn system_attr_put(
     State(state): State<ServerState>,
     Path(attr): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
     Json(values): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_eq(Attribute::Class, EntryClass::SystemConfig.into()));
@@ -2391,6 +2493,7 @@ pub async fn system_attr_put(
         filter,
         values,
         kopid,
+        client_auth_info,
     )
     .await
 }
@@ -2408,12 +2511,13 @@ pub async fn system_attr_put(
 pub async fn recycle_bin_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_pres(Attribute::Class));
     let attrs = None;
     state
         .qe_r_ref
-        .handle_internalsearchrecycled(kopid.uat, filter, attrs, kopid.eventid)
+        .handle_internalsearchrecycled(client_auth_info, filter, attrs, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -2433,13 +2537,14 @@ pub async fn recycle_bin_id_get(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Option<ProtoEntry>>, WebError> {
     let filter = filter_all!(f_id(id.as_str()));
     let attrs = None;
 
     state
         .qe_r_ref
-        .handle_internalsearchrecycled(kopid.uat, filter, attrs, kopid.eventid)
+        .handle_internalsearchrecycled(client_auth_info, filter, attrs, kopid.eventid)
         .await
         .map(|mut r| r.pop())
         .map(Json::from)
@@ -2459,11 +2564,12 @@ pub async fn recycle_bin_revive_id_post(
     State(state): State<ServerState>,
     Path(id): Path<String>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     let filter = filter_all!(f_id(id.as_str()));
     state
         .qe_w_ref
-        .handle_reviverecycled(kopid.uat, filter, kopid.eventid)
+        .handle_reviverecycled(client_auth_info, filter, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -2483,10 +2589,11 @@ pub async fn recycle_bin_revive_id_post(
 pub async fn applinks_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<AppLink>>, WebError> {
     state
         .qe_r_ref
-        .handle_list_applinks(kopid.uat, kopid.eventid)
+        .handle_list_applinks(client_auth_info, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)
@@ -2512,7 +2619,7 @@ pub async fn reauth(
     // This may change in the future ...
     let inter = state
         .qe_r_ref
-        .handle_reauth(kopid.uat, obj, kopid.eventid, client_auth_info)
+        .handle_reauth(client_auth_info, obj, kopid.eventid)
         .await;
     debug!("ReAuth result: {:?}", inter);
     auth_session_state_management(state, inter)
@@ -2655,10 +2762,11 @@ fn auth_session_state_management(
 pub async fn auth_valid(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
+    VerifiedClientInformation(client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<()>, WebError> {
     state
         .qe_r_ref
-        .handle_auth_valid(kopid.uat, kopid.eventid)
+        .handle_auth_valid(client_auth_info, kopid.eventid)
         .await
         .map(Json::from)
         .map_err(WebError::from)

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -31,7 +31,7 @@ use super::middleware::caching::{cache_me, dont_cache_me};
 use super::middleware::KOpId;
 use super::ServerState;
 use crate::https::apidocs::response_schema::{ApiResponseWithout200, DefaultApiResponse};
-use crate::https::extractors::TrustedClientIp;
+use crate::https::extractors::VerifiedClientInformation;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct SessionId {
@@ -2505,7 +2505,7 @@ pub async fn applinks_get(
 )] // TODO: post body stuff
 pub async fn reauth(
     State(state): State<ServerState>,
-    TrustedClientIp(ip_addr): TrustedClientIp,
+    VerifiedClientInformation(ip_addr, client_auth_info): VerifiedClientInformation,
     Extension(kopid): Extension<KOpId>,
     Json(obj): Json<AuthIssueSession>,
 ) -> Result<Response, WebError> {
@@ -2531,7 +2531,7 @@ pub async fn reauth(
 )]
 pub async fn auth(
     State(state): State<ServerState>,
-    TrustedClientIp(ip_addr): TrustedClientIp,
+    VerifiedClientInformation(ip_addr, client_auth_info): VerifiedClientInformation,
     headers: HeaderMap,
     Extension(kopid): Extension<KOpId>,
     Json(obj): Json<AuthRequest>,
@@ -2675,7 +2675,7 @@ pub async fn auth_valid(
 )]
 pub async fn debug_ipinfo(
     State(_state): State<ServerState>,
-    TrustedClientIp(ip_addr): TrustedClientIp,
+    VerifiedClientInformation(ip_addr, client_auth_info): VerifiedClientInformation,
 ) -> Result<Json<Vec<IpAddr>>, ()> {
     Ok(Json::from(vec![ip_addr]))
 }

--- a/server/core/src/https/v1_oauth2.rs
+++ b/server/core/src/https/v1_oauth2.rs
@@ -5,6 +5,7 @@ use super::oauth2::oauth2_id;
 use super::v1::{json_rest_event_get, json_rest_event_post};
 use super::ServerState;
 
+use crate::https::extractors::VerifiedClientInformation;
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
 use kanidm_proto::internal::{ImageType, ImageValue};
@@ -12,7 +13,6 @@ use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidmd_lib::prelude::*;
 use kanidmd_lib::valueset::image::ImageValueThings;
 use sketching::admin_error;
-use crate::https::extractors::VerifiedClientInformation;
 
 #[utoipa::path(
     get,

--- a/server/core/src/https/v1_scim.rs
+++ b/server/core/src/https/v1_scim.rs
@@ -6,6 +6,7 @@ use super::v1::{
     json_rest_event_put_id_attr,
 };
 use super::ServerState;
+use crate::https::extractors::VerifiedClientInformation;
 use axum::extract::{Path, State};
 use axum::response::Html;
 use axum::routing::{get, post};
@@ -14,7 +15,6 @@ use axum_auth::AuthBearer;
 use kanidm_proto::scim_v1::{ScimSyncRequest, ScimSyncState};
 use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidmd_lib::prelude::*;
-use crate::https::extractors::VerifiedClientInformation;
 
 #[utoipa::path(
     get,

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -43,7 +43,7 @@ async fn client_process_msg(
         client_port = %client_address.port(),
         "LDAP client"
     );
-    qe_r_ref.handle_ldaprequest(eventid, protomsg, uat).await
+    qe_r_ref.handle_ldaprequest(eventid, protomsg, uat, client_address.ip()).await
 }
 
 async fn client_process(

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -43,7 +43,9 @@ async fn client_process_msg(
         client_port = %client_address.port(),
         "LDAP client"
     );
-    qe_r_ref.handle_ldaprequest(eventid, protomsg, uat, client_address.ip()).await
+    qe_r_ref
+        .handle_ldaprequest(eventid, protomsg, uat, client_address.ip())
+        .await
 }
 
 async fn client_process(

--- a/server/daemon/run_insecure_dev_server.sh
+++ b/server/daemon/run_insecure_dev_server.sh
@@ -18,6 +18,8 @@ if [ ! -d "${KANI_TMP}" ]; then
     mkdir -p "${KANI_TMP}"
 fi
 
+mkdir -p "${KANI_TMP}"/client_ca
+
 CONFIG_FILE=${CONFIG_FILE:="../../examples/insecure_server.toml"}
 
 if [ ! -f "${CONFIG_FILE}" ]; then

--- a/server/lib/src/idm/audit.rs
+++ b/server/lib/src/idm/audit.rs
@@ -7,6 +7,7 @@ use time::OffsetDateTime;
 pub enum AuditSource {
     Internal,
     Https(IpAddr),
+    Ldaps(IpAddr),
 }
 
 impl From<Source> for AuditSource {
@@ -14,6 +15,7 @@ impl From<Source> for AuditSource {
         match value {
             Source::Internal => AuditSource::Internal,
             Source::Https(ip) => AuditSource::Https(ip),
+            Source::Ldaps(ip) => AuditSource::Ldaps(ip),
         }
     }
 }

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -889,7 +889,7 @@ pub(crate) struct AuthSessionData<'a> {
     pub(crate) issue: AuthIssueSession,
     pub(crate) webauthn: &'a Webauthn,
     pub(crate) ct: Duration,
-    pub(crate) source: Source,
+    pub(crate) client_auth_info: ClientAuthInfo,
 }
 
 #[derive(Clone)]
@@ -1008,7 +1008,7 @@ impl AuthSession {
                 state,
                 issue: asd.issue,
                 intent: AuthIntent::InitialAuth { privileged },
-                source: asd.source,
+                source: asd.client_auth_info.source,
             };
             // Get the set of mechanisms that can proceed. This is tied
             // to the session so that it can mutate state and have progression
@@ -1149,7 +1149,7 @@ impl AuthSession {
                         session_id,
                         session_expiry,
                     },
-                    source: asd.source,
+                    source: asd.client_auth_info.source,
                 };
 
                 let as_state = AuthState::Continue(allow);
@@ -1548,7 +1548,7 @@ mod tests {
             issue: AuthIssueSession::Token,
             webauthn: &webauthn,
             ct: duration_from_epoch_now(),
-            source: Source::Internal,
+            client_auth_info: Source::Internal.into(),
         };
         let (session, state) = AuthSession::new(asd, false);
         if let AuthState::Choose(auth_mechs) = state {
@@ -1584,7 +1584,7 @@ mod tests {
                 issue: AuthIssueSession::Token,
                 webauthn: $webauthn,
                 ct: duration_from_epoch_now(),
-                source: Source::Internal,
+                client_auth_info: Source::Internal.into(),
             };
             let (session, state) = AuthSession::new(asd, $privileged);
             let mut session = session.unwrap();
@@ -1771,7 +1771,7 @@ mod tests {
                 issue: AuthIssueSession::Token,
                 webauthn: $webauthn,
                 ct: duration_from_epoch_now(),
-                source: Source::Internal,
+                client_auth_info: Source::Internal.into(),
             };
             let (session, state) = AuthSession::new(asd, false);
             let mut session = session.expect("Session was unable to be created.");
@@ -2099,7 +2099,7 @@ mod tests {
                 issue: AuthIssueSession::Token,
                 webauthn: $webauthn,
                 ct: duration_from_epoch_now(),
-                source: Source::Internal,
+                client_auth_info: Source::Internal.into(),
             };
             let (session, state) = AuthSession::new(asd, false);
             let mut session = session.unwrap();

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -2534,7 +2534,9 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
+        let r1 = idms_auth
+            .auth(&auth_init, ct, Source::Internal.into())
+            .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2545,7 +2547,9 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Password);
 
-        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&auth_begin, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2554,7 +2558,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r2 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
+        let r2 = idms_auth.auth(&pw_step, ct, Source::Internal.into()).await;
         debug!("r2 ==> {:?}", r2);
         idms_auth.commit().expect("Must not fail");
 
@@ -2584,7 +2588,9 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
+        let r1 = idms_auth
+            .auth(&auth_init, ct, Source::Internal.into())
+            .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2595,7 +2601,9 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::PasswordMfa);
 
-        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&auth_begin, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2606,7 +2614,9 @@ mod tests {
             .expect("Failed to perform totp step");
 
         let totp_step = AuthEvent::cred_step_totp(sessionid, totp);
-        let r2 = idms_auth.auth(&totp_step, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&totp_step, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2615,7 +2625,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal.into()).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -2644,7 +2654,9 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
+        let r1 = idms_auth
+            .auth(&auth_init, ct, Source::Internal.into())
+            .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2655,14 +2667,18 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::PasswordMfa);
 
-        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&auth_begin, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
         assert!(matches!(state, AuthState::Continue(_)));
 
         let code_step = AuthEvent::cred_step_backup_code(sessionid, code);
-        let r2 = idms_auth.auth(&code_step, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&code_step, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2671,7 +2687,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal.into()).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -2706,7 +2722,9 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
+        let r1 = idms_auth
+            .auth(&auth_init, ct, Source::Internal.into())
+            .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2717,7 +2735,9 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Passkey);
 
-        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&auth_begin, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -2739,7 +2759,9 @@ mod tests {
 
         let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
 
-        let r3 = idms_auth.auth(&passkey_step, ct, Source::Internal).await;
+        let r3 = idms_auth
+            .auth(&passkey_step, ct, Source::Internal.into())
+            .await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 

--- a/server/lib/src/idm/mod.rs
+++ b/server/lib/src/idm/mod.rs
@@ -23,8 +23,8 @@ pub mod serviceaccount;
 pub(crate) mod unix;
 
 use std::fmt;
-
 use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech};
+use crate::server::identity::Source;
 
 pub enum AuthState {
     Choose(Vec<AuthMech>),
@@ -46,7 +46,7 @@ impl fmt::Debug for AuthState {
 
 #[derive(Debug, Clone)]
 pub struct ClientAuthInfo {
-    pub ip_addr: IpAddr,
+    pub source: Source,
     pub client_cert: Option<ClientCertInfo>,
     pub bearer_token: Option<String>,
 }

--- a/server/lib/src/idm/mod.rs
+++ b/server/lib/src/idm/mod.rs
@@ -22,9 +22,9 @@ pub mod server;
 pub mod serviceaccount;
 pub(crate) mod unix;
 
-use std::fmt;
-use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech};
 use crate::server::identity::Source;
+use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech};
+use std::fmt;
 
 pub enum AuthState {
     Choose(Vec<AuthMech>),
@@ -55,4 +55,26 @@ pub struct ClientAuthInfo {
 pub struct ClientCertInfo {
     pub subject_key_id: Option<Vec<u8>>,
     pub cn: Option<String>,
+}
+
+#[cfg(test)]
+impl From<&str> for ClientAuthInfo {
+    fn from(value: &str) -> ClientAuthInfo {
+        ClientAuthInfo {
+            source: Source::Internal,
+            client_cert: None,
+            bearer_token: Some(value.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<ClientCertInfo> for ClientAuthInfo {
+    fn from(value: ClientCertInfo) -> ClientAuthInfo {
+        ClientAuthInfo {
+            source: Source::Internal,
+            client_cert: Some(value),
+            bearer_token: None,
+        }
+    }
 }

--- a/server/lib/src/idm/mod.rs
+++ b/server/lib/src/idm/mod.rs
@@ -58,6 +58,17 @@ pub struct ClientCertInfo {
 }
 
 #[cfg(test)]
+impl From<Source> for ClientAuthInfo {
+    fn from(value: Source) -> ClientAuthInfo {
+        ClientAuthInfo {
+            source: value,
+            client_cert: None,
+            bearer_token: None,
+        }
+    }
+}
+
+#[cfg(test)]
 impl From<&str> for ClientAuthInfo {
     fn from(value: &str) -> ClientAuthInfo {
         ClientAuthInfo {

--- a/server/lib/src/idm/mod.rs
+++ b/server/lib/src/idm/mod.rs
@@ -43,3 +43,15 @@ impl fmt::Debug for AuthState {
         }
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct ClientAuthInfo {
+    pub client_cert: Option<ClientCertInfo>,
+    pub bearer_token: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClientCertInfo {
+    pub subject_key_id: Option<Vec<u8>>,
+    pub cn: Option<String>,
+}

--- a/server/lib/src/idm/mod.rs
+++ b/server/lib/src/idm/mod.rs
@@ -46,6 +46,7 @@ impl fmt::Debug for AuthState {
 
 #[derive(Debug, Clone)]
 pub struct ClientAuthInfo {
+    pub ip_addr: IpAddr,
     pub client_cert: Option<ClientCertInfo>,
     pub bearer_token: Option<String>,
 }

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -23,7 +23,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
         ident: Identity,
         issue: AuthIssueSession,
         ct: Duration,
-        source: Source,
+        client_auth_info: ClientAuthInfo,
     ) -> Result<AuthResult, OperationError> {
         // re-auth only works on users, so lets get the user account.
         // hint - it's in the ident!
@@ -135,7 +135,7 @@ impl<'a> IdmServerAuthTransaction<'a> {
             issue,
             webauthn: self.webauthn,
             ct,
-            source,
+            client_auth_info,
         };
         let (auth_session, state) =
             AuthSession::new_reauth(asd, ident.session_id, session, session_cred_id);
@@ -330,7 +330,9 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
+        let r1 = idms_auth
+            .auth(&auth_init, ct, Source::Internal.into())
+            .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -341,7 +343,9 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::Passkey);
 
-        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&auth_begin, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -363,7 +367,9 @@ mod tests {
 
         let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
 
-        let r3 = idms_auth.auth(&passkey_step, ct, Source::Internal).await;
+        let r3 = idms_auth
+            .auth(&passkey_step, ct, Source::Internal.into())
+            .await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -403,7 +409,9 @@ mod tests {
 
         let auth_init = AuthEvent::named_init("testperson");
 
-        let r1 = idms_auth.auth(&auth_init, ct, Source::Internal).await;
+        let r1 = idms_auth
+            .auth(&auth_init, ct, Source::Internal.into())
+            .await;
         let ar = r1.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -414,7 +422,9 @@ mod tests {
 
         let auth_begin = AuthEvent::begin_mech(sessionid, AuthMech::PasswordMfa);
 
-        let r2 = idms_auth.auth(&auth_begin, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&auth_begin, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -425,7 +435,9 @@ mod tests {
             .expect("Failed to perform totp step");
 
         let totp_step = AuthEvent::cred_step_totp(sessionid, totp);
-        let r2 = idms_auth.auth(&totp_step, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&totp_step, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -434,7 +446,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal.into()).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -480,7 +492,12 @@ mod tests {
         let origin = idms_auth.get_origin().clone();
 
         let auth_allowed = idms_auth
-            .reauth_init(ident.clone(), AuthIssueSession::Token, ct, Source::Internal)
+            .reauth_init(
+                ident.clone(),
+                AuthIssueSession::Token,
+                ct,
+                Source::Internal.into(),
+            )
             .await
             .expect("Failed to start reauth.");
 
@@ -504,7 +521,9 @@ mod tests {
 
         let passkey_step = AuthEvent::cred_step_passkey(sessionid, resp);
 
-        let r3 = idms_auth.auth(&passkey_step, ct, Source::Internal).await;
+        let r3 = idms_auth
+            .auth(&passkey_step, ct, Source::Internal.into())
+            .await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 
@@ -539,7 +558,12 @@ mod tests {
         let mut idms_auth = idms.auth().await;
 
         let auth_allowed = idms_auth
-            .reauth_init(ident.clone(), AuthIssueSession::Token, ct, Source::Internal)
+            .reauth_init(
+                ident.clone(),
+                AuthIssueSession::Token,
+                ct,
+                Source::Internal.into(),
+            )
             .await
             .expect("Failed to start reauth.");
 
@@ -564,7 +588,9 @@ mod tests {
             .expect("Failed to perform totp step");
 
         let totp_step = AuthEvent::cred_step_totp(sessionid, totp);
-        let r2 = idms_auth.auth(&totp_step, ct, Source::Internal).await;
+        let r2 = idms_auth
+            .auth(&totp_step, ct, Source::Internal.into())
+            .await;
         let ar = r2.unwrap();
         let AuthResult { sessionid, state } = ar;
 
@@ -573,7 +599,7 @@ mod tests {
         let pw_step = AuthEvent::cred_step_password(sessionid, pw);
 
         // Expect success
-        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal).await;
+        let r3 = idms_auth.auth(&pw_step, ct, Source::Internal.into()).await;
         debug!("r3 ==> {:?}", r3);
         idms_auth.commit().expect("Must not fail");
 

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -457,11 +457,15 @@ mod tests {
         }
     }
 
-    async fn token_to_ident(idms: &IdmServer, ct: Duration, token: Option<&str>) -> Identity {
+    async fn token_to_ident(
+        idms: &IdmServer,
+        ct: Duration,
+        client_auth_info: ClientAuthInfo,
+    ) -> Identity {
         let mut idms_prox_read = idms.proxy_read().await;
 
         idms_prox_read
-            .validate_and_parse_token_to_ident(token, ct)
+            .validate_client_auth_info_to_ident(client_auth_info, ct)
             .expect("Invalid UAT")
     }
 
@@ -601,7 +605,7 @@ mod tests {
             .expect("failed to authenticate with passkey");
 
         // Token_str to uat
-        let ident = token_to_ident(idms, ct, Some(token.as_str())).await;
+        let ident = token_to_ident(idms, ct, token.as_str().into()).await;
 
         // Check that the rw entitlement is not present
         debug!(?ident);
@@ -620,7 +624,7 @@ mod tests {
             .expect("Failed to get new session token");
 
         // Token_str to uat
-        let ident = token_to_ident(idms, ct, Some(token.as_str())).await;
+        let ident = token_to_ident(idms, ct, token.as_str().into()).await;
 
         // They now have the entitlement.
         debug!(?ident);
@@ -647,7 +651,7 @@ mod tests {
             .expect("failed to authenticate with passkey");
 
         // Token_str to uat
-        let ident = token_to_ident(idms, ct, Some(token.as_str())).await;
+        let ident = token_to_ident(idms, ct, token.as_str().into()).await;
 
         // Check that the rw entitlement is not present
         debug!(?ident);

--- a/server/lib/src/idm/scim.rs
+++ b/server/lib/src/idm/scim.rs
@@ -1594,7 +1594,7 @@ mod tests {
         let mut idms_prox_read = idms.proxy_read().await;
 
         let ident = idms_prox_read
-            .validate_and_parse_sync_token_to_ident(Some(sync_token.as_str()), ct)
+            .validate_sync_client_auth_info_to_ident(sync_token.as_str().into(), ct)
             .expect("Failed to validate sync token");
 
         assert!(Some(sync_uuid) == ident.get_uuid());
@@ -1650,7 +1650,7 @@ mod tests {
         // -- Check the happy path.
         let mut idms_prox_read = idms.proxy_read().await;
         let ident = idms_prox_read
-            .validate_and_parse_sync_token_to_ident(Some(sync_token.as_str()), ct)
+            .validate_sync_client_auth_info_to_ident(sync_token.as_str().into(), ct)
             .expect("Failed to validate sync token");
         assert!(Some(sync_uuid) == ident.get_uuid());
         drop(idms_prox_read);
@@ -1671,7 +1671,7 @@ mod tests {
         // Must fail
         let mut idms_prox_read = idms.proxy_read().await;
         let fail =
-            idms_prox_read.validate_and_parse_sync_token_to_ident(Some(sync_token.as_str()), ct);
+            idms_prox_read.validate_sync_client_auth_info_to_ident(sync_token.as_str().into(), ct);
         assert!(matches!(fail, Err(OperationError::NotAuthenticated)));
         drop(idms_prox_read);
 
@@ -1695,7 +1695,7 @@ mod tests {
 
         let mut idms_prox_read = idms.proxy_read().await;
         let fail =
-            idms_prox_read.validate_and_parse_sync_token_to_ident(Some(sync_token.as_str()), ct);
+            idms_prox_read.validate_sync_client_auth_info_to_ident(sync_token.as_str().into(), ct);
         assert!(matches!(fail, Err(OperationError::NotAuthenticated)));
 
         // -- Forge a session, use wrong types
@@ -1737,8 +1737,8 @@ mod tests {
             .map(|jws_signed| jws_signed.to_string())
             .expect("Unable to sign forged token");
 
-        let fail =
-            idms_prox_read.validate_and_parse_sync_token_to_ident(Some(forged_token.as_str()), ct);
+        let fail = idms_prox_read
+            .validate_sync_client_auth_info_to_ident(forged_token.as_str().into(), ct);
         assert!(matches!(fail, Err(OperationError::NotAuthenticated)));
     }
 
@@ -1770,7 +1770,7 @@ mod tests {
             .expect("failed to generate new scim sync token");
 
         let ident = idms_prox_write
-            .validate_and_parse_sync_token_to_ident(Some(sync_token.as_str()), ct)
+            .validate_sync_client_auth_info_to_ident(sync_token.as_str().into(), ct)
             .expect("Failed to process sync token to ident");
 
         (sync_uuid, ident)

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -420,7 +420,7 @@ pub trait IdmServerTransaction<'a> {
 
         match (client_cert, bearer_token) {
             (Some(_client_cert_info), _) => {
-                // Cert validation here.
+                // TODO: Cert validation here.
                 warn!("Unable to process client certificate identity");
                 Err(OperationError::NotAuthenticated)
             }
@@ -451,7 +451,7 @@ pub trait IdmServerTransaction<'a> {
 
         match (client_cert, bearer_token) {
             (Some(_client_cert_info), _) => {
-                // Cert validation here.
+                // TODO: Cert validation here.
                 warn!("Unable to process client certificate identity");
                 Err(OperationError::NotAuthenticated)
             }

--- a/server/lib/src/idm/serviceaccount.rs
+++ b/server/lib/src/idm/serviceaccount.rs
@@ -490,7 +490,7 @@ mod tests {
             .unwrap();
 
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(Some(&api_token), ct)
+            .validate_client_auth_info_to_ident(api_token.as_str().into(), ct)
             .expect("Unable to verify api token.");
 
         assert!(ident.get_uuid() == Some(testaccount_uuid));
@@ -500,7 +500,7 @@ mod tests {
         // Check the expiry
         assert!(
             idms_prox_write
-                .validate_and_parse_token_to_ident(Some(&api_token), post_exp)
+                .validate_client_auth_info_to_ident(api_token.as_str().into(), post_exp)
                 .expect_err("Should not succeed")
                 == OperationError::SessionExpired
         );
@@ -515,14 +515,14 @@ mod tests {
         // Within gracewindow?
         // This is okay, because we are within the gracewindow.
         let ident = idms_prox_write
-            .validate_and_parse_token_to_ident(Some(&api_token), ct)
+            .validate_client_auth_info_to_ident(api_token.as_str().into(), ct)
             .expect("Unable to verify api token.");
         assert!(ident.get_uuid() == Some(testaccount_uuid));
 
         // Past gracewindow?
         assert!(
             idms_prox_write
-                .validate_and_parse_token_to_ident(Some(&api_token), past_grc)
+                .validate_client_auth_info_to_ident(api_token.as_str().into(), past_grc)
                 .expect_err("Should not succeed")
                 == OperationError::SessionExpired
         );

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -88,8 +88,8 @@ pub mod prelude {
         f_and, f_andnot, f_eq, f_id, f_inc, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub, Filter,
         FilterInvalid, FilterValid, FC,
     };
-    pub use crate::idm::{ClientCertInfo, ClientAuthInfo};
     pub use crate::idm::server::{IdmServer, IdmServerAudit, IdmServerDelayed};
+    pub use crate::idm::{ClientAuthInfo, ClientCertInfo};
     pub use crate::modify::{
         m_assert, m_pres, m_purge, m_remove, Modify, ModifyInvalid, ModifyList, ModifyValid,
     };

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -88,6 +88,7 @@ pub mod prelude {
         f_and, f_andnot, f_eq, f_id, f_inc, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub, Filter,
         FilterInvalid, FilterValid, FC,
     };
+    pub use crate::idm::{ClientCertInfo, ClientAuthInfo};
     pub use crate::idm::server::{IdmServer, IdmServerAudit, IdmServerDelayed};
     pub use crate::modify::{
         m_assert, m_pres, m_purge, m_remove, Modify, ModifyInvalid, ModifyList, ModifyValid,

--- a/server/lib/src/server/identity.rs
+++ b/server/lib/src/server/identity.rs
@@ -220,6 +220,17 @@ impl Identity {
         }
     }
 
+    /// Indicate if the session associated with this identity has a session
+    /// that can logout. Examples of sessions that *can not* logout are anonymous,
+    /// tokens, or PIV sessions.
+    pub fn can_logout(&self) -> bool {
+        match &self.origin {
+            IdentType::Internal => false,
+            IdentType::User(u) => u.entry.get_uuid() != UUID_ANONYMOUS,
+            IdentType::Synch(_) => false,
+        }
+    }
+
     pub fn get_event_origin_id(&self) -> IdentityId {
         IdentityId::from(&self.origin)
     }

--- a/server/lib/src/server/identity.rs
+++ b/server/lib/src/server/identity.rs
@@ -21,7 +21,7 @@ use crate::value::Session;
 pub enum Source {
     Internal,
     Https(IpAddr),
-    // Ldaps,
+    Ldaps(IpAddr),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,7 +102,7 @@ impl From<&IdentType> for IdentityId {
 /// and other info that can assist with server decision making.
 pub struct Identity {
     pub origin: IdentType,
-    // pub(crate) source:
+    pub(crate) source: Source,
     // pub(crate) impersonate: bool,
     // In a way I guess these are session claims?
     pub(crate) session_id: Uuid,
@@ -131,9 +131,14 @@ impl std::fmt::Display for Identity {
 }
 
 impl Identity {
+    pub fn source(&self) -> &Source {
+        &self.source
+    }
+
     pub fn from_internal() -> Self {
         Identity {
             origin: IdentType::Internal,
+            source: Source::Internal,
             session_id: uuid!("00000000-0000-0000-0000-000000000000"),
             scope: AccessScope::ReadWrite,
             limits: Limits::unlimited(),
@@ -144,6 +149,7 @@ impl Identity {
     pub fn from_impersonate_entry_readonly(entry: Arc<Entry<EntrySealed, EntryCommitted>>) -> Self {
         Identity {
             origin: IdentType::User(IdentUser { entry }),
+            source: Source::Internal,
             session_id: uuid!("00000000-0000-0000-0000-000000000000"),
             scope: AccessScope::ReadOnly,
             limits: Limits::unlimited(),
@@ -156,6 +162,7 @@ impl Identity {
     ) -> Self {
         Identity {
             origin: IdentType::User(IdentUser { entry }),
+            source: Source::Internal,
             session_id: uuid!("00000000-0000-0000-0000-000000000000"),
             scope: AccessScope::ReadWrite,
             limits: Limits::unlimited(),


### PR DESCRIPTION
This is the first stage of adding PIV authentication. It changes all requests to take a "client auth info" structure that has collected data about the clients request such as IP, client cert, and the bearer token. This is not only the foundations of PIV, but now also means that the clients IP is now on every request so we can do IP range based access controls, and we can do anonymous auth limits to ip ranges. 

Finally, while this adds the abitily to mTLS in Kanidm, it is MISSING revocation checks (which I need to add in PR 2), as well as tests for the certificate auth and such. As a result, currently use of mTLS does NOT implicitly bind to an identity, meaning it "does nothing". 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x  ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
