### PR TITLE
Force apply idm migrations to apply access controls

### DIFF
--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -239,15 +239,14 @@ impl QueryServerReadV1 {
         }
 
         // pattern to find automatically generated backup files
-        let re = Regex::new(r"^backup-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z\.json$").map_err(
-            |error| {
+        let re = Regex::new(r"^backup-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z\.json$")
+            .map_err(|error| {
                 error!(
                     "Failed to parse regexp for online backup files: {:?}",
                     error
                 );
                 OperationError::InvalidState
-            },
-        )?;
+            })?;
 
         // cleanup of maximum backup versions to keep
         let mut backup_file_list: Vec<PathBuf> = Vec::new();

--- a/server/lib/src/constants/acp.rs
+++ b/server/lib/src/constants/acp.rs
@@ -654,6 +654,7 @@ lazy_static! {
             Attribute::FernetPrivateKeyStr,
             Attribute::CookiePrivateKey,
             Attribute::LdapAllowUnixPwBind,
+            Attribute::Version,
         ],
         modify_removed_attrs: vec![
             Attribute::DomainDisplayName,
@@ -1043,6 +1044,7 @@ lazy_static! {
             Attribute::DeniedName,
             Attribute::AuthSessionExpiry,
             Attribute::PrivilegeExpiry,
+            Attribute::Version,
         ],
         modify_removed_attrs: vec![
             Attribute::BadlistPassword,

--- a/server/lib/src/constants/entries.rs
+++ b/server/lib/src/constants/entries.rs
@@ -741,7 +741,7 @@ lazy_static! {
 Attribute::Description,
             Value::new_utf8s("System (local) info and metadata object.")
         ),
-        (Attribute::Version, Value::Uint32(17))
+        (Attribute::Version, Value::Uint32(18))
     );
 
     pub static ref E_DOMAIN_INFO_V1: EntryInitNew = entry_init!(


### PR DESCRIPTION
Fixes #2391 - In testing the access control rework was applied through the older system info migrations tooling. This applied the idm base entries every startup.

However, as part of the #1435 change, the domain migration framework was added - this moved init idm to a section where it would only apply if your domain version was 0 (ie empty db).

That meant if you had of updated between these two PR's everything would work properly. But if you jumped from a version before access control rework, to after enforce mfa, then the needed migration to setup the new access controls was not applied, leaving your DB in a very, very sad state. 

This PR adds a once-off re-run of init_idm in the old framework, that then resolves the issue and allows everything to be happy again. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
