### PR TITLE
Build the kanidm cli tools deb as well

### DIFF
--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -47,6 +47,8 @@ jobs:
         run: cargo install wasm-pack
       - name: Build packages (kanidm-unixd)
         run: make -f platform/debian/Makefile debs/kanidm-unixd
+      - name: Build packages (kanidm cli)
+        run: make -f platform/debian/Makefile debs/kanidm
 
       - name: Upload debs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
First step towards fixing #2264, the PPA side also needs at least doc updates and a oneliner way to point to the Debian version of it.

Workflow functioning confirmed in fork: https://github.com/jinnatar/kanidm/actions/runs/7347218889

.. of course that doesn't prove the release or PPA mechanisms work for multi package, but one step at a time. (And reading the code, they _should_ work.)

Checklist

- [X] This pr contains no AI generated code
- [X] cargo fmt has been run
- [X] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
