### PR TITLE
Update docs, closes SQLite Write-Ahead Logging might make page size immutable #2404

### DIFF
--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -121,7 +121,7 @@ pub struct ServerConfig {
     /// Trust the X-Forwarded-For header for client IP address. Defaults to false if unset.
     pub trust_x_forward_for: Option<bool>,
 
-    /// The filesystem type, either "zfs" or "generic". Defaults to "generic" if unset.
+    /// The filesystem type, either "zfs" or "generic". Defaults to "generic" if unset. I you change this, run a database vacuum.
     pub db_fs_type: Option<kanidm_proto::internal::FsType>,
     /// The path to the "admin" socket, used for local communication when performing cer ain server control tasks.
     pub adminbindpath: Option<String>,


### PR DESCRIPTION
Fixes #2404 - notes in the server config ref that a DB vacuum should be completed on changing the fs type. It's already in the database maintenance docs.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
