### PR TITLE
Fix deb release flow to find the matrix split artifacts

### DIFF
--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -73,6 +73,8 @@ jobs:
       - name: List packages
         run: |
           find $(pwd) -name '*.deb'
+      # TODO: This action is old and falling apart and will soon stop working.
+      # Context: https://github.com/marvinpinto/action-automatic-releases/pull/2
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -67,6 +67,10 @@ jobs:
     steps:
       - name: Download previously built debs
         uses: actions/download-artifact@v4
+        with:
+          path: debs
+          pattern: "*.deb"
+          merge-multiple: true
       - name: List packages
         run: |
           find $(pwd) -name '*.deb'
@@ -76,5 +80,5 @@ jobs:
           automatic_release_tag: "debs"
           prerelease: true
           title: ".deb Packages"
-          files: "*.deb"
+          files: "debs/*.deb"
         if: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}

--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -81,4 +81,4 @@ jobs:
           prerelease: true
           title: ".deb Packages"
           files: "debs/*.deb"
-        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}
+        #if: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}

--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -82,4 +82,4 @@ jobs:
           prerelease: true
           title: ".deb Packages"
           files: "debs/*.deb"
-        #if: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}
+        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'kanidm/kanidm' }}

--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -69,7 +69,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: debs
-          pattern: "*.deb"
           merge-multiple: true
       - name: List packages
         run: |


### PR DESCRIPTION
References #2264. This fixes the `debs` auto release again after the recent changes. More updates are needed on the PPA side, which is coming next.

Tested to generate valid artefacts at https://github.com/jinnatar/kanidm/actions/runs/7363766967 which produced the following valid debs release: https://github.com/jinnatar/kanidm/releases/tag/debs

I did leave in a TODO for a step in the workflow that is about to break, but still works, will create a separate issue to address that.

Checklist

- [X] This pr contains no AI generated code
- [X] cargo fmt has been run
- [X] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
