### PR TITLE
Fix string comparison in Debian build script

### DIFF
--- a/platform/debian/build_kanidm.sh
+++ b/platform/debian/build_kanidm.sh
@@ -8,7 +8,7 @@ if [ -z "${ARCH}" ]; then
     ARCH="$(dpkg --print-architecture)"
 fi
 
-if [ "${ARCH}" != "$(dpkg --print-architecture)" ]; then
+if [[ "${ARCH}" != "$(dpkg --print-architecture)" ]]; then
     echo "${ARCH} != $(dpkg --print-architecture), cross-compiling!"
     export PKG_CONFIG_ALLOW_CROSS=1
 else


### PR DESCRIPTION
Fixes `bash: [: : integer expression expected` error

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
