### PR TITLE
Add handler for empty str as all attrs

### DIFF
--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -227,6 +227,13 @@ impl LdapServer {
                         // map all vattrs.
                         all_attrs = true;
                         all_op_attrs = true;
+                    } else if sr.attrs.len() == 1 && a.is_empty() {
+                        // Some clients incorrectly send a vector with an
+                        // empty string for all attrs, rather than a *. This is to
+                        // catch that case, but without enabling a client that sent
+                        // a valid attr + empty str.
+                        info!("client LDAP bug - empty str is not all_attrs!");
+                        all_attrs = true;
                     }
                 })
             }


### PR DESCRIPTION
Fixes #2397 - adds a handler for an empty string to mean all attrs for broken clients. Waiting on spff to give feedback. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
