### PR TITLE
Adding max_ber_size option in config for ldap sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,9 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "ldap3_client"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec3fe7dd2cd58ea17bf49e794dd89b7773bff180300fc8667a8ca8f38e4aed0"
+version = "0.4.3"
 dependencies = [
  "base64 0.21.5",
  "base64urlsafedata",
@@ -3543,9 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "ldap3_proto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4598dd32dbd16d4fd06a1eb423bf569563d7c65e808ceae5ef3c12179134bc36"
+version = "0.4.3"
 dependencies = [
  "base64 0.21.5",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,8 @@ dependencies = [
 [[package]]
 name = "ldap3_client"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f294d8b0c3a0906caca55d2004f1192e174b895afa3f0f177ead05f314544d2"
 dependencies = [
  "base64 0.21.5",
  "base64urlsafedata",
@@ -3542,6 +3544,8 @@ dependencies = [
 [[package]]
 name = "ldap3_proto"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29eca0a9fef365d6d376a1b262e269a17b1c8c6de2cee76618642cd3c923506"
 dependencies = [
  "base64 0.21.5",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ repository = "https://github.com/kanidm/kanidm/"
 
 # idlset = { path = "../idlset" }
 
-# ldap3_client = { path = "../ldap3/client" }
-# ldap3_proto = { path = "../ldap3/proto" }
+ldap3_client = { path = "../ldap3/client" }
+ldap3_proto = { path = "../ldap3/proto" }
 # ldap3_client = { git = "https://github.com/kanidm/ldap3.git" }
 # ldap3_proto = { git = "https://github.com/kanidm/ldap3.git" }
 
@@ -148,8 +148,8 @@ js-sys = "^0.3.65"
 kanidmd_web_ui_shared = { path = "./server/web_ui/shared" }
 # REMOVE this
 lazy_static = "^1.4.0"
-ldap3_client = "^0.4.2"
-ldap3_proto = { version = "^0.4.2", features = ["serde"] }
+ldap3_client = "^0.4.3"
+ldap3_proto = { version = "^0.4.3", features = ["serde"] }
 
 libc = "^0.2.150"
 libnss = "^0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ repository = "https://github.com/kanidm/kanidm/"
 
 # idlset = { path = "../idlset" }
 
-ldap3_client = { path = "../ldap3/client" }
-ldap3_proto = { path = "../ldap3/proto" }
+# ldap3_client = { path = "../ldap3/client" }
+# ldap3_proto = { path = "../ldap3/proto" }
 # ldap3_client = { git = "https://github.com/kanidm/ldap3.git" }
 # ldap3_proto = { git = "https://github.com/kanidm/ldap3.git" }
 

--- a/tools/iam_migrations/ldap/src/config.rs
+++ b/tools/iam_migrations/ldap/src/config.rs
@@ -105,6 +105,9 @@ pub struct Config {
 
     #[serde(flatten)]
     pub entry_map: BTreeMap<Uuid, EntryConfig>,
+
+    /// Maximum LDAP message size (in kilobytes)
+    pub max_ber_size: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]

--- a/tools/iam_migrations/ldap/src/main.rs
+++ b/tools/iam_migrations/ldap/src/main.rs
@@ -268,6 +268,7 @@ async fn run_sync(
     // Preflight check.
     //  * can we connect to ldap?
     let mut ldap_client = match LdapClientBuilder::new(&sync_config.ldap_uri)
+        .max_ber_size(sync_config.max_ber_size)
         .add_tls_ca(&sync_config.ldap_ca)
         .build()
         .await


### PR DESCRIPTION
Fixes #2414 - adds max_ber_size option in config

Depends on kanidm/ldap3#49

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
