### PR TITLE
cookies

### DIFF
--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 [dependencies]
 tracing = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = [
+    "cookies",
     "multipart",
 ] }
 kanidm_proto = { workspace = true }

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -447,6 +447,9 @@ impl KanidmClientBuilder {
 
         let client_builder = reqwest::Client::builder()
             .user_agent(KanidmClientBuilder::user_agent())
+            // We don't directly use cookies, but it may be required for load balancers that
+            // implement sticky sessions with cookies.
+            .cookie_store(true)
             .danger_accept_invalid_hostnames(!self.verify_hostnames)
             .danger_accept_invalid_certs(!self.verify_ca);
 


### PR DESCRIPTION
Re-enable cookies on the cli client for load balancer sticky sessions. cc @jinnatar 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
