### PR TITLE
Return sshkey label to cli fields

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -1871,6 +1871,8 @@ impl KanidmClient {
     }
 
     // == generic ssh key handlers
+    // These return the ssh keys in their "authorized keys" form rather than a format that
+    // shows labels and can be easily updated.
     pub async fn idm_account_get_ssh_pubkey(
         &self,
         id: &str,

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -781,13 +781,11 @@ pub trait QueryServerTransaction<'a> {
                 })
                 .collect();
             v
-        /*
-        // We previously special cased sshkeys here, but proto string now yields
-        // these as the proper string keys that ldap expects.
-        } else if let Some(k_set) = value.as_sshkey_map() {
-            let v: Vec<_> = k_set.values().cloned().map(|s| s.into_bytes()).collect();
+        // We have to special case ssh keys here as the proto form isn't valid for
+        // sss_ssh_authorized_keys to consume.
+        } else if let Some(key_iter) = value.as_sshpubkey_string_iter() {
+            let v: Vec<_> = key_iter.map(|s| s.into_bytes()).collect();
             Ok(v)
-        */
         } else {
             let v: Vec<_> = value
                 .to_proto_string_clone_iter()

--- a/server/lib/src/valueset/ssh.rs
+++ b/server/lib/src/valueset/ssh.rs
@@ -138,7 +138,11 @@ impl ValueSetT for ValueSetSshKey {
     }
 
     fn to_proto_string_clone_iter(&self) -> Box<dyn Iterator<Item = String> + '_> {
-        Box::new(self.map.values().map(|pk| pk.to_string()))
+        Box::new(
+            self.map
+                .iter()
+                .map(|(tag, pk)| format!("{}: {}", tag, pk.to_string())),
+        )
     }
 
     fn to_db_valueset_v2(&self) -> DbValueSetV2 {

--- a/server/lib/src/valueset/ssh.rs
+++ b/server/lib/src/valueset/ssh.rs
@@ -138,11 +138,7 @@ impl ValueSetT for ValueSetSshKey {
     }
 
     fn to_proto_string_clone_iter(&self) -> Box<dyn Iterator<Item = String> + '_> {
-        Box::new(
-            self.map
-                .iter()
-                .map(|(tag, pk)| format!("{}: {}", tag, pk.to_string())),
-        )
+        Box::new(self.map.iter().map(|(tag, pk)| format!("{}: {}", tag, pk)))
     }
 
     fn to_db_valueset_v2(&self) -> DbValueSetV2 {

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -6,7 +6,7 @@ use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input, Password, Select};
 use kanidm_client::ClientError::Http as ClientErrorHttp;
 use kanidm_client::KanidmClient;
-use kanidm_proto::constants::{ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM};
+use kanidm_proto::constants::{ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM, ATTR_SSH_PUBLICKEY};
 use kanidm_proto::messages::{AccountChangeMessage, ConsoleOutputMode, MessageStatus};
 use kanidm_proto::v1::OperationError::PasswordQuality;
 use kanidm_proto::v1::{
@@ -215,10 +215,13 @@ impl PersonOpt {
                     let client = aopt.copt.to_client(OpType::Read).await;
 
                     match client
-                        .idm_account_get_ssh_pubkeys(aopt.aopts.account_id.as_str())
+                        .idm_person_account_get_attr(
+                            aopt.aopts.account_id.as_str(),
+                            ATTR_SSH_PUBLICKEY,
+                        )
                         .await
                     {
-                        Ok(pkeys) => pkeys.iter().for_each(|pkey| println!("{}", pkey)),
+                        Ok(pkeys) => pkeys.iter().flatten().for_each(|pkey| println!("{}", pkey)),
                         Err(e) => handle_client_error(e, aopt.copt.output_mode),
                     }
                 }

--- a/tools/cli/src/cli/serviceaccount.rs
+++ b/tools/cli/src/cli/serviceaccount.rs
@@ -1,5 +1,5 @@
 use crate::common::{try_expire_at_from_string, OpType};
-use kanidm_proto::constants::{ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM};
+use kanidm_proto::constants::{ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM, ATTR_SSH_PUBLICKEY};
 use kanidm_proto::messages::{AccountChangeMessage, ConsoleOutputMode, MessageStatus};
 use time::OffsetDateTime;
 
@@ -254,10 +254,13 @@ impl ServiceAccountOpt {
                     let client = aopt.copt.to_client(OpType::Read).await;
 
                     match client
-                        .idm_account_get_ssh_pubkeys(aopt.aopts.account_id.as_str())
+                        .idm_service_account_get_attr(
+                            aopt.aopts.account_id.as_str(),
+                            ATTR_SSH_PUBLICKEY,
+                        )
                         .await
                     {
-                        Ok(pkeys) => pkeys.iter().for_each(|pkey| println!("{}", pkey)),
+                        Ok(pkeys) => pkeys.iter().flatten().for_each(|pkey| println!("{}", pkey)),
                         Err(e) => handle_client_error(e, aopt.copt.output_mode),
                     }
                 }


### PR DESCRIPTION
Fixes #2318 - A previous change modified sshkey display in ldap to use the proto form rather than special casing. For sssd compat this proto form was modified to remove the label. However, the proto form is also how we display the keys on the cli.

Since kanidm_ssh_authorized_keys uses a special api handler, we can revert the proto form to include the label, and return ldap ssh key resolving to a special case that uses the same internals as the authorized keys handler.

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
