### PR TITLE
README: Update gitter link, add keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ When we develop features we follow our projects guidelines on [rights and ethics
 
 ## Getting in Contact / Questions
 
-We have a [gitter community channel] where project members are always happy to answer questions.
+We have a Matrix-powered [gitter community channel] where project members are always happy to chat and answer questions.
 Alternately you can open a new [github discussion].
 
-[gitter community channel]: https://gitter.im/kanidm/community
+[gitter community channel]: https://app.gitter.im/#/room/#kanidm_community:gitter.im
 [github discussion]: https://github.com/kanidm/kanidm/discussions
 
 ## What does Kanidm mean?


### PR DESCRIPTION
This updates the gitter link to point directly to the app.gitter.im matrix server (the current link forwards to this one), and adds keywords ("Matrix", "chat") so idiots that can't read are slightly more likely to find the link to the channel. (I spent an embarrassing amount of time looking for it.)