### PR TITLE
Book SUMMARY.md: Fix part titles according to mdbook

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -56,13 +56,13 @@
 
 - [Access Control](access_control/intro.md)
 
-## Support
+# Support
 
 - [Troubleshooting](troubleshooting.md)
 - [Frequently Asked Questions](frequently_asked_questions.md)
 - [Glossary of Technical Terms](glossary.md)
 
-## For Developers
+# For Developers
 
 - [Developer Guide](DEVELOPER_README.md)
 - [FAQ](developers/faq.md)


### PR DESCRIPTION
mdBook requires part titles to be H1, not any other heading level.

Format documentation on `SUMMARY.md` shows using H1 (one `#`):
https://github.com/rust-lang/mdBook/blob/220cb4f0c8e9eed968c44d989211e237ebc54124/guide/src/format/summary.md

Parser code specifically looks for H1:
https://github.com/rust-lang/mdBook/blob/220cb4f0c8e9eed968c44d989211e237ebc54124/src/book/summary.rs#L268