### PR TITLE
Add tools for remigration and domain level raising

### DIFF
--- a/proto/src/internal.rs
+++ b/proto/src/internal.rs
@@ -173,6 +173,14 @@ pub enum Oauth2ClaimMapJoin {
     Array,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DomainInfo {
+    pub name: String,
+    pub displayname: String,
+    pub uuid: Uuid,
+    pub level: u32,
+}
+
 #[test]
 fn test_fstype_deser() {
     assert_eq!(FsType::try_from("zfs"), Ok(FsType::Zfs));

--- a/proto/src/v1.rs
+++ b/proto/src/v1.rs
@@ -296,7 +296,11 @@ pub enum OperationError {
     VS0001IncomingReplSshPublicKey,
     // Value Errors
     VL0001ValueSshPublicKeyString,
+    // SCIM
     SC0001IncomingSshPublicKey,
+    // Migration
+    MG0001InvalidReMigrationLevel,
+    MG0002RaiseDomainLevelExceedsMaximum,
 }
 
 impl PartialEq for OperationError {

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
+# ARG BASE_IMAGE=opensuse/leap:15.5
+
 # FROM ${BASE_IMAGE} as repos
 FROM ${BASE_IMAGE}
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,6 @@
 # Build the main Kanidmd server
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
+# ARG BASE_IMAGE=opensuse/leap:15.5
 
 FROM ${BASE_IMAGE} AS repos
 ADD scripts/zypper_fixing.sh /zypper_fixing.sh

--- a/server/daemon/src/opt.rs
+++ b/server/daemon/src/opt.rs
@@ -28,9 +28,32 @@ struct RestoreOpt {
 
 #[derive(Debug, Subcommand)]
 enum DomainSettingsCmds {
+    #[clap(name = "show")]
+    /// Show the current domain
+    Show {
+        #[clap(flatten)]
+        commonopts: CommonOpt,
+    },
     #[clap(name = "rename")]
-    /// Change the IDM domain name
-    DomainChange(CommonOpt),
+    /// Change the IDM domain name based on the values in the configuration
+    Change {
+        #[clap(flatten)]
+        commonopts: CommonOpt,
+    },
+    #[clap(name = "raise")]
+    /// Raise the functional level of this domain to the maximum available.
+    Raise {
+        #[clap(flatten)]
+        commonopts: CommonOpt,
+    },
+    #[clap(name = "remigrate")]
+    /// Rerun migrations of this domains database, optionally nominating the level
+    /// to start from.
+    Remigrate {
+        #[clap(flatten)]
+        commonopts: CommonOpt,
+        level: Option<u32>,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -49,6 +49,8 @@ pub const DOMAIN_LEVEL_2: DomainVersion = 2;
 pub const DOMAIN_LEVEL_3: DomainVersion = 3;
 pub const DOMAIN_LEVEL_4: DomainVersion = 4;
 pub const DOMAIN_LEVEL_5: DomainVersion = 5;
+// The minimum level that we can re-migrate from
+pub const DOMAIN_MIN_REMIGRATION_LEVEL: DomainVersion = DOMAIN_LEVEL_2;
 // The minimum supported domain functional level
 pub const DOMAIN_MIN_LEVEL: DomainVersion = DOMAIN_LEVEL_5;
 // The target supported domain functional level

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -781,10 +781,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
         self.internal_modify(&filter, &modlist)?;
 
         // Now move all oauth2 rs name.
-        let filter = filter!(f_eq(
-            Attribute::Class,
-            EntryClass::OAuth2ResourceServer.into()
-        ));
+        let filter = filter!(f_and!([
+            f_eq(Attribute::Class, EntryClass::OAuth2ResourceServer.into()),
+            f_pres(Attribute::OAuth2RsName),
+        ]));
 
         let pre_candidates = self.internal_search(filter).map_err(|err| {
             admin_error!(?err, "migrate_domain_4_to_5 internal search failure");

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,5 +1,7 @@
 # This builds the kanidm CLI tools
 ARG BASE_IMAGE=opensuse/tumbleweed:latest
+# ARG BASE_IMAGE=opensuse/leap:15.5
+
 FROM ${BASE_IMAGE} AS repos
 ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
 RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh


### PR DESCRIPTION
@jinnatar - This adds the tools needed to re-run migrations, and force domain levels to be raised. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
