### PR TITLE
Fix for incorrect domain migration rollbacks

### DIFF
--- a/examples/insecure_server.toml
+++ b/examples/insecure_server.toml
@@ -12,8 +12,8 @@ tls_client_ca = "/tmp/kanidm/client_ca"
 #   NOTE: this is overridden by environment variables at runtime
 #   Defaults to "info"
 #
-# log_level = "info"
-log_level = "debug"
+log_level = "info"
+# log_level = "debug"
 # log_level = "trace"
 
 # otel_grpc_url = "http://localhost:4317"

--- a/proto/src/v1.rs
+++ b/proto/src/v1.rs
@@ -301,6 +301,7 @@ pub enum OperationError {
     // Migration
     MG0001InvalidReMigrationLevel,
     MG0002RaiseDomainLevelExceedsMaximum,
+    MG0003ServerPhaseInvalidForMigration,
 }
 
 impl PartialEq for OperationError {

--- a/server/lib/src/constants/entries.rs
+++ b/server/lib/src/constants/entries.rs
@@ -750,7 +750,7 @@ lazy_static! {
 Attribute::Description,
             Value::new_utf8s("System (local) info and metadata object.")
         ),
-        (Attribute::Version, Value::Uint32(18))
+        (Attribute::Version, Value::Uint32(19))
     );
 
     pub static ref E_DOMAIN_INFO_V1: EntryInitNew = entry_init!(

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -19,7 +19,7 @@ pub use crate::constants::values::*;
 use std::time::Duration;
 
 // Increment this as we add new schema types and values!!!
-pub const SYSTEM_INDEX_VERSION: i64 = 30;
+pub const SYSTEM_INDEX_VERSION: i64 = 31;
 
 /*
  * domain functional levels

--- a/server/lib/src/plugins/dyngroup.rs
+++ b/server/lib/src/plugins/dyngroup.rs
@@ -5,6 +5,7 @@ use kanidm_proto::v1::Filter as ProtoFilter;
 
 use crate::filter::FilterInvalid;
 use crate::prelude::*;
+use crate::server::ServerPhase;
 
 #[derive(Clone, Default)]
 pub struct DynGroupCache {
@@ -34,6 +35,11 @@ impl DynGroup {
             return Err(OperationError::SystemProtectedObject);
         }
         */
+
+        if qs.get_phase() < ServerPhase::SchemaReady {
+            trace!("Server is not ready to load dyngroups");
+            return Ok(());
+        }
 
         // Search all the new groups first.
         let filt = filter!(FC::Or(

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -99,6 +99,10 @@ impl QueryServer {
             }
 
             if system_info_version < 17 {
+                write_txn.initialise_schema_idm()?;
+
+                write_txn.reload()?;
+
                 write_txn.migrate_16_to_17()?;
             }
 
@@ -132,9 +136,7 @@ impl QueryServer {
         // No domain info was present, so neither was the rest of the IDM. We need to bootstrap
         // the base-schema here.
         if db_domain_version == 0 {
-            write_txn
-                .initialise_schema_idm()
-                .and_then(|_| write_txn.reload())?;
+            write_txn.initialise_schema_idm()?;
 
             write_txn.reload()?;
         }

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -53,8 +53,8 @@ const RESOLVE_FILTER_CACHE_LOCAL: usize = 0;
 pub type ResolveFilterCacheReadTxn<'a> =
     ARCacheReadTxn<'a, (IdentityId, Filter<FilterValid>), Filter<FilterValidResolved>, ()>;
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
-enum ServerPhase {
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq)]
+pub(crate) enum ServerPhase {
     Bootstrap,
     SchemaReady,
     DomainInfoReady,
@@ -1823,6 +1823,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
     fn set_phase(&mut self, phase: ServerPhase) {
         *self.phase = phase
+    }
+
+    pub(crate) fn get_phase(&mut self) -> ServerPhase {
+        *self.phase
     }
 
     pub(crate) fn reload(&mut self) -> Result<(), OperationError> {


### PR DESCRIPTION
Fixes #2470 - due to incorrect logic ordering, the older migration framework would "rollback" changes from the new domain migrations. Due to the limited number of migrations in place, there were very few symptoms that were hard to detect, but thanks to @jinnatar and @dvv who both reported this (in different ways) this gave enough clues to find the cause. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
