### PR TITLE
Himmelblau requires the machine key for unix_user_get

### DIFF
--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -124,6 +124,7 @@ pub trait IdProvider {
         _id: &Id,
         _token: Option<&UserToken>,
         _tpm: &mut tpm::BoxedDynTpm,
+        _machine_key: &tpm::MachineKey,
     ) -> Result<UserToken, IdpError>;
 
     async fn unix_user_online_auth_init(

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -131,6 +131,7 @@ impl IdProvider for KanidmProvider {
         id: &Id,
         _token: Option<&UserToken>,
         _tpm: &mut tpm::BoxedDynTpm,
+        _machine_key: &tpm::MachineKey,
     ) -> Result<UserToken, IdpError> {
         match self
             .client

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -477,7 +477,12 @@ where
 
         let user_get_result = self
             .client
-            .unix_user_get(account_id, token.as_ref(), hsm_lock.deref_mut())
+            .unix_user_get(
+                account_id,
+                token.as_ref(),
+                hsm_lock.deref_mut(),
+                &self.machine_key,
+            )
             .await;
 
         drop(hsm_lock);


### PR DESCRIPTION
I need access to the machine key here in order to
send a new request to Azure for user details.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
