### PR TITLE
Add code_challenge_methods_supported to OIDC discovery

### DIFF
--- a/proto/src/oauth2.rs
+++ b/proto/src/oauth2.rs
@@ -350,6 +350,8 @@ pub struct OidcDiscoveryResponse {
     pub request_uri_parameter_supported: bool,
     #[serde(default = "require_request_uri_parameter_supported_default")]
     pub require_request_uri_registration: bool,
+
+    pub code_challenge_methods_supported: Vec<PkceAlg>,
 }
 
 #[skip_serializing_none]

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2305,6 +2305,17 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
         let claims_supported = None;
         let service_documentation = Some(URL_SERVICE_DOCUMENTATION.clone());
 
+        let require_pkce = match &o2rs.type_ {
+            OauthRSType::Basic { enable_pkce, .. } => *enable_pkce,
+            OauthRSType::Public { .. } => true,
+        };
+
+        let code_challenge_methods_supported = if require_pkce {
+            vec![PkceAlg::S256]
+        } else {
+            Vec::with_capacity(0)
+        };
+
         Ok(OidcDiscoveryResponse {
             issuer,
             authorization_endpoint,
@@ -2344,6 +2355,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
             require_request_uri_registration: false,
             op_policy_uri: None,
             op_tos_uri: None,
+            code_challenge_methods_supported,
         })
     }
 
@@ -4148,6 +4160,10 @@ mod tests {
         assert!(!discovery.request_uri_parameter_supported);
         assert!(!discovery.require_request_uri_registration);
         assert!(!discovery.request_parameter_supported);
+        assert_eq!(
+            discovery.code_challenge_methods_supported,
+            vec![PkceAlg::S256]
+        )
     }
 
     #[idm_test]


### PR DESCRIPTION
Fixes #2506 add code challenge methods to oidc discovery. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
