### PR TITLE
Re-enable HW tpm support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "prctl",
  "rpassword 7.3.1",
  "rusqlite",
+ "sd-notify",
  "selinux",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -477,6 +477,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.4.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease 0.2.16",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
@@ -515,9 +538,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitfield"
-version = "0.14.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -616,9 +639,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.2"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -671,9 +694,9 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -724,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -734,30 +757,30 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.4.10"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb745187d7f4d76267b37485a65e0149edd0e91a4cfcdd3f27524ad86cee9f3"
+checksum = "299353be8209bd133b049bf1c63582d184a8b39fd9c04f15fe65f50f88bdfe6c"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -767,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clru"
@@ -808,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "compact_jwt"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c88e50516e010f137593b9e80dab437bc82c7c7bb4c5bf5dd042e30b0807dd7"
+checksum = "46f626dea95ae258f9d05d2ac8e2fdb1ed98d183e0797ef304b88f205d423144"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -830,7 +853,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be4dc68bd9c37bcbd4670a644cc47494636d3e345d8d3b6db8bcd8ea65048c9"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
  "crossbeam-epoch",
  "crossbeam-queue",
  "crossbeam-utils",
@@ -930,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1136,7 +1159,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1150,7 +1173,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
@@ -1357,9 +1380,9 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encode_unicode"
@@ -1398,18 +1421,18 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
+checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
+checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1434,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
+checksum = "704ab670cffff92792405528eb8ec3d9f00be8939d56d947f6bc809f9ae249f8"
 dependencies = [
  "log",
  "once_cell",
@@ -2456,7 +2479,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -2485,7 +2508,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2494,7 +2517,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.8",
 ]
 
 [[package]]
@@ -2503,7 +2526,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.8",
  "allocator-api2",
  "serde",
 ]
@@ -2549,9 +2572,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -2773,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2819,12 +2842,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -2863,9 +2886,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
@@ -2891,7 +2914,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.8",
  "anyhow",
  "base64 0.21.7",
  "bytecount",
@@ -2917,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "kanidm-hsm-crypto"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0605892a3d0aca88b43a2d60a381ff7307c2c741d64ff87fb7c763556305791d"
+checksum = "e94124838cdc13bc8eeee3ef525e0bb4c2a86c0107f810216a8cb20c30f36557"
 dependencies = [
  "argon2",
  "hex",
@@ -2927,6 +2950,7 @@ dependencies = [
  "serde",
  "tracing",
  "tss-esapi",
+ "tss-esapi-sys",
  "zeroize",
 ]
 
@@ -3064,7 +3088,7 @@ dependencies = [
  "async-recursion",
  "clap",
  "clap_complete",
- "compact_jwt 0.3.3",
+ "compact_jwt 0.3.4",
  "dialoguer",
  "futures-concurrency",
  "kanidm_build_profiles",
@@ -3148,7 +3172,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "chrono",
- "compact_jwt 0.3.3",
+ "compact_jwt 0.3.4",
  "cron",
  "filetime",
  "futures",
@@ -3195,7 +3219,7 @@ version = "1.2.0-dev"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
- "compact_jwt 0.3.3",
+ "compact_jwt 0.3.4",
  "concread",
  "criterion",
  "dyn-clone",
@@ -3260,7 +3284,7 @@ name = "kanidmd_testkit"
 version = "1.2.0-dev"
 dependencies = [
  "assert_cmd",
- "compact_jwt 0.3.3",
+ "compact_jwt 0.3.4",
  "escargot",
  "fantoccini",
  "futures",
@@ -3583,6 +3607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloced"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfebb2f9e0b39509c62eead6ec7ae0c0ed45bb61d12bbcf4e976c566c5400ec"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,17 +3634,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a42bf938e4c9a6ad581cf528d5606eb50c5458ac759ca23719291e2f6499bec"
 dependencies = [
  "rand",
-]
-
-[[package]]
-name = "mbox"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f88d5c34d63aad11aa4321ef55ccb064af58b3ad8091079ae22bf83e5eb75d6"
-dependencies = [
- "libc",
- "rustc_version",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -3861,31 +3880,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3917,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -4321,6 +4328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "peg"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,24 +4367,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pest"
-version = "2.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_derive",
 ]
@@ -4981,15 +4983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5128,7 +5121,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6d6e616814290fe172d6514bebd9b723733ba7d68e1ab74d341a90b99a36bb4"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
  "cc",
  "dunce",
  "walkdir",
@@ -5136,21 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
@@ -5258,16 +5239,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -5275,9 +5257,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling 0.20.5",
  "proc-macro2",
@@ -5480,12 +5462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5496,6 +5472,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subtle"
@@ -5605,18 +5587,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5819,7 +5801,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
@@ -6037,21 +6019,24 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tss-esapi"
-version = "7.4.0"
+version = "8.0.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de234df360c349f78ecd33f0816ab3842db635732212b5cfad67f2638336864e"
+checksum = "3c1617a46161846de3a3d3e407cd30cb345599bc5e440c3907a59b34b75a2731"
 dependencies = [
  "bitfield",
+ "cfg-if",
  "enumflags2",
  "hostname-validator",
  "log",
- "mbox",
- "num-derive 0.4.2",
+ "malloced",
+ "num-derive",
  "num-traits",
  "oid",
+ "paste 1.0.14",
  "picky-asn1",
  "picky-asn1-x509",
  "regex",
+ "semver",
  "serde",
  "tss-esapi-sys",
  "zeroize",
@@ -6063,6 +6048,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535cd192581c2ec4d5f82e670b1d3fbba6a23ccce8c85de387642051d7cad5b5"
 dependencies = [
+ "bindgen 0.66.1",
  "pkg-config",
  "target-lexicon",
 ]
@@ -6072,12 +6058,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -6117,9 +6097,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -6163,7 +6143,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -6405,7 +6385,7 @@ dependencies = [
  "futures",
  "hex",
  "nom",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "openssl",
  "rpassword 5.0.1",
@@ -6754,9 +6734,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ kanidmd_lib_macros = { path = "./server/lib-macros", version = "=1.2.0-dev" }
 kanidmd_testkit = { path = "./server/testkit", version = "=1.2.0-dev" }
 kanidm_build_profiles = { path = "./libs/profiles", version = "=1.2.0-dev" }
 kanidm_client = { path = "./libs/client", version = "=1.2.0-dev" }
-kanidm-hsm-crypto = "^0.1.5"
+kanidm-hsm-crypto = "^0.1.6"
 kanidm_lib_crypto = { path = "./libs/crypto", version = "=1.2.0-dev" }
 kanidm_lib_file_permissions = { path = "./libs/file_permissions", version = "=1.2.0-dev" }
 kanidm_proto = { path = "./proto", version = "=1.2.0-dev" }
@@ -116,7 +116,7 @@ clap = { version = "^4.4.8", features = ["derive", "env"] }
 clap_complete = "^4.4.4"
 # Forced by saffron/cron
 chrono = "^0.4.31"
-compact_jwt = { version = "^0.3.3", default-features = false }
+compact_jwt = { version = "^0.3.4", default-features = false }
 concread = "^0.4.4"
 cron = "0.12.0"
 crossbeam = "0.8.1"

--- a/examples/unixd
+++ b/examples/unixd
@@ -15,8 +15,10 @@ pam_allowed_login_groups = ["posix_group"]
 #
 # * soft: A software hsm that encrypts all local key material
 # * tpm: Use a tpm for all key storage and binding
+# * tpm_if_possible: If a hardware tpm exists it is used, otherwise fall back to the software tpm.
+#                    If the hardware tpm has previously been used, software tpm will not be used.
 #
-# Default: soft
+# Default: tpm_if_possible
 
 # hsm_type = "tpm"
 

--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -7,7 +7,7 @@ After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
 
 [Service]
 User=root
-Type=simple
+Type=notify
 ExecStart=/usr/sbin/kanidm_unixd_tasks
 
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -18,7 +18,7 @@ CacheDirectory=kanidm-unixd
 RuntimeDirectory=kanidm-unixd
 StateDirectory=kanidm-unixd
 
-Type=simple
+Type=notify
 ExecStart=/usr/sbin/kanidm_unixd
 
 ## If you wish to setup an external HSM pin you should set:

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -229,7 +229,10 @@ fn main() -> ExitCode {
     // On linux when debug assertions are disabled, prevent ptrace
     // from attaching to us.
     #[cfg(all(target_os = "linux", not(debug_assertions)))]
-    prctl::set_dumpable(false);
+    if let Err(code) = prctl::set_dumpable(false) {
+        eprintln!(?code, "CRITICAL: Unable to set prctl flags");
+        return ExitCode::FAILURE;
+    }
 
     let maybe_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -90,6 +90,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 walkdir = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+sd-notify.workspace = true
+
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
 

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -92,12 +92,10 @@ walkdir = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-notify.workspace = true
+prctl.workspace = true
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-prctl.workspace = true
 
 [dev-dependencies]
 kanidmd_core = { workspace = true }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -480,7 +480,7 @@ fn open_tpm(tcti_name: &str) -> Option<BoxedDynTpm> {
 }
 
 #[cfg(not(feature = "tpm"))]
-fn open_tpm(tcti_name: &str) -> Option<BoxedDynTpm> {
+fn open_tpm(_tcti_name: &str) -> Option<BoxedDynTpm> {
     error!("Hardware TPM supported was not enabled in this build. Unable to proceed");
     None
 }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -510,7 +510,10 @@ async fn main() -> ExitCode {
     // On linux when debug assertions are disabled, prevent ptrace
     // from attaching to us.
     #[cfg(all(target_os = "linux", not(debug_assertions)))]
-    prctl::set_dumpable(false);
+    if let Err(code) = prctl::set_dumpable(false) {
+        eprintln!(?code, "CRITICAL: Unable to set prctl flags");
+        return ExitCode::FAILURE;
+    }
 
     let cuid = get_current_uid();
     let ceuid = get_effective_uid();

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -501,7 +501,7 @@ fn open_tpm_if_possible(tcti_name: &str) -> BoxedDynTpm {
 }
 
 #[cfg(not(feature = "tpm"))]
-fn open_tpm_if_possible(_tcti_name: &str) -> Option<BoxedDynTpm> {
+fn open_tpm_if_possible(_tcti_name: &str) -> BoxedDynTpm {
     BoxedDynTpm::new(SoftTpm::new())
 }
 

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -1068,6 +1068,10 @@ async fn main() -> ExitCode {
 
             info!("Server started ...");
 
+            // On linux, notify systemd.
+            #[cfg(target_os = "linux")]
+            let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
+
             loop {
                 tokio::select! {
                     Ok(()) = tokio::signal::ctrl_c() => {

--- a/unix_integration/src/db.rs
+++ b/unix_integration/src/db.rs
@@ -16,6 +16,8 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use kanidm_hsm_crypto::{HmacKey, LoadableHmacKey, LoadableMachineKey, Tpm};
 
+const DBV_MAIN: &str = "main";
+
 #[async_trait]
 pub trait Cache {
     type Txn<'db>
@@ -53,6 +55,8 @@ pub trait CacheTxn {
     fn invalidate(&mut self) -> Result<(), CacheError>;
 
     fn clear(&mut self) -> Result<(), CacheError>;
+
+    fn clear_hsm(&mut self) -> Result<(), CacheError>;
 
     fn get_hsm_machine_key(&mut self) -> Result<Option<LoadableMachineKey>, CacheError>;
 
@@ -208,6 +212,32 @@ impl<'a> DbTxn<'a> {
         CacheError::Sqlite
     }
 
+    fn get_db_version(&self, key: &str) -> i64 {
+        self.conn
+            .query_row(
+                "SELECT version FROM db_version_t WHERE id = :id",
+                &[(":id", key)],
+                |row| row.get(0),
+            )
+            .unwrap_or({
+                // The value is missing, default to 0.
+                0
+            })
+    }
+
+    fn set_db_version(&self, key: &str, v: i64) -> Result<(), CacheError> {
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO db_version_t (id, version) VALUES(:id, :dbv)",
+                named_params! {
+                    ":id": &key,
+                    ":dbv": v,
+                },
+            )
+            .map(|_| ())
+            .map_err(|e| self.sqlite_error("set db_version_t", &e))
+    }
+
     fn get_account_data_name(
         &mut self,
         account_id: &str,
@@ -358,82 +388,102 @@ impl<'a> CacheTxn for DbTxn<'a> {
             .and_then(|mut wal_stmt| wal_stmt.query([]).map(|_| ()))
             .map_err(|e| self.sqlite_error("account_t create", &e))?;
 
-        // Setup two tables - one for accounts, one for groups.
-        // correctly index the columns.
-        // Optional pw hash field
+        // This definition can never change.
         self.conn
             .execute(
-                "CREATE TABLE IF NOT EXISTS account_t (
-                uuid TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
-                spn TEXT NOT NULL UNIQUE,
-                gidnumber INTEGER NOT NULL UNIQUE,
-                password BLOB,
-                token BLOB NOT NULL,
-                expiry NUMERIC NOT NULL
-            )
-            ",
+                "CREATE TABLE IF NOT EXISTS db_version_t (
+                    id TEXT PRIMARY KEY,
+                    version INTEGER
+                )",
                 [],
             )
-            .map_err(|e| self.sqlite_error("account_t create", &e))?;
+            .map_err(|e| self.sqlite_error("db_version_t create", &e))?;
 
-        self.conn
-            .execute(
-                "CREATE TABLE IF NOT EXISTS group_t (
-                uuid TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
-                spn TEXT NOT NULL UNIQUE,
-                gidnumber INTEGER NOT NULL UNIQUE,
-                token BLOB NOT NULL,
-                expiry NUMERIC NOT NULL
-            )
-            ",
-                [],
-            )
-            .map_err(|e| self.sqlite_error("group_t create", &e))?;
+        let db_version = self.get_db_version(DBV_MAIN);
 
-        // We defer group foreign keys here because we now manually cascade delete these when
-        // required. This is because insert or replace into will always delete then add
-        // which triggers this. So instead we defer and manually cascade.
-        //
-        // However, on accounts, we CAN delete cascade because accounts will always redefine
-        // their memberships on updates so this is safe to cascade on this direction.
-        self.conn
-            .execute(
-                "CREATE TABLE IF NOT EXISTS memberof_t (
-                g_uuid TEXT,
-                a_uuid TEXT,
-                FOREIGN KEY(g_uuid) REFERENCES group_t(uuid) DEFERRABLE INITIALLY DEFERRED,
-                FOREIGN KEY(a_uuid) REFERENCES account_t(uuid) ON DELETE CASCADE
-            )
-            ",
-                [],
-            )
-            .map_err(|e| self.sqlite_error("memberof_t create error", &e))?;
-
-        // Create the hsm_data store. These are all generally encrypted private
-        // keys, and the hsm structures will decrypt these as required.
-        self.conn
-            .execute(
-                "CREATE TABLE IF NOT EXISTS hsm_int_t (
-                    key TEXT PRIMARY KEY,
-                    value BLOB NOT NULL
+        if db_version < 1 {
+            // Setup two tables - one for accounts, one for groups.
+            // correctly index the columns.
+            // Optional pw hash field
+            self.conn
+                .execute(
+                    "CREATE TABLE IF NOT EXISTS account_t (
+                    uuid TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    spn TEXT NOT NULL UNIQUE,
+                    gidnumber INTEGER NOT NULL UNIQUE,
+                    password BLOB,
+                    token BLOB NOT NULL,
+                    expiry NUMERIC NOT NULL
                 )
                 ",
-                [],
-            )
-            .map_err(|e| self.sqlite_error("hsm_int_t create error", &e))?;
+                    [],
+                )
+                .map_err(|e| self.sqlite_error("account_t create", &e))?;
 
-        self.conn
-            .execute(
-                "CREATE TABLE IF NOT EXISTS hsm_data_t (
-                    key TEXT PRIMARY KEY,
-                    value BLOB NOT NULL
+            self.conn
+                .execute(
+                    "CREATE TABLE IF NOT EXISTS group_t (
+                    uuid TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    spn TEXT NOT NULL UNIQUE,
+                    gidnumber INTEGER NOT NULL UNIQUE,
+                    token BLOB NOT NULL,
+                    expiry NUMERIC NOT NULL
                 )
                 ",
-                [],
-            )
-            .map_err(|e| self.sqlite_error("hsm_data_t create error", &e))?;
+                    [],
+                )
+                .map_err(|e| self.sqlite_error("group_t create", &e))?;
+
+            // We defer group foreign keys here because we now manually cascade delete these when
+            // required. This is because insert or replace into will always delete then add
+            // which triggers this. So instead we defer and manually cascade.
+            //
+            // However, on accounts, we CAN delete cascade because accounts will always redefine
+            // their memberships on updates so this is safe to cascade on this direction.
+            self.conn
+                .execute(
+                    "CREATE TABLE IF NOT EXISTS memberof_t (
+                    g_uuid TEXT,
+                    a_uuid TEXT,
+                    FOREIGN KEY(g_uuid) REFERENCES group_t(uuid) DEFERRABLE INITIALLY DEFERRED,
+                    FOREIGN KEY(a_uuid) REFERENCES account_t(uuid) ON DELETE CASCADE
+                )
+                ",
+                    [],
+                )
+                .map_err(|e| self.sqlite_error("memberof_t create error", &e))?;
+
+            // Create the hsm_data store. These are all generally encrypted private
+            // keys, and the hsm structures will decrypt these as required.
+            self.conn
+                .execute(
+                    "CREATE TABLE IF NOT EXISTS hsm_int_t (
+                        key TEXT PRIMARY KEY,
+                        value BLOB NOT NULL
+                    )
+                    ",
+                    [],
+                )
+                .map_err(|e| self.sqlite_error("hsm_int_t create error", &e))?;
+
+            self.conn
+                .execute(
+                    "CREATE TABLE IF NOT EXISTS hsm_data_t (
+                        key TEXT PRIMARY KEY,
+                        value BLOB NOT NULL
+                    )
+                    ",
+                    [],
+                )
+                .map_err(|e| self.sqlite_error("hsm_data_t create error", &e))?;
+
+            // Since this is the 0th migration, we have to reset the HSM here.
+            self.clear_hsm()?;
+        }
+
+        self.set_db_version(DBV_MAIN, 1)?;
 
         Ok(())
     }
@@ -476,6 +526,20 @@ impl<'a> CacheTxn for DbTxn<'a> {
         self.conn
             .execute("DELETE FROM account_t", [])
             .map_err(|e| self.sqlite_error("delete group_t", &e))?;
+
+        Ok(())
+    }
+
+    fn clear_hsm(&mut self) -> Result<(), CacheError> {
+        self.clear()?;
+
+        self.conn
+            .execute("DELETE FROM hsm_int_t", [])
+            .map_err(|e| self.sqlite_error("delete hsm_int_t", &e))?;
+
+        self.conn
+            .execute("DELETE FROM hsm_data_t", [])
+            .map_err(|e| self.sqlite_error("delete hsm_data_t", &e))?;
 
         Ok(())
     }

--- a/unix_integration/src/tasks_daemon.rs
+++ b/unix_integration/src/tasks_daemon.rs
@@ -363,6 +363,10 @@ async fn main() -> ExitCode {
 
             info!("Server started ...");
 
+            // On linux, notify systemd.
+            #[cfg(target_os = "linux")]
+            let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
+
             loop {
                 tokio::select! {
                     Ok(()) = tokio::signal::ctrl_c() => {

--- a/unix_integration/src/unix_config.rs
+++ b/unix_integration/src/unix_config.rs
@@ -81,6 +81,7 @@ pub enum HsmType {
     #[cfg_attr(not(feature = "tpm"), default)]
     Soft,
     #[cfg_attr(feature = "tpm", default)]
+    TpmIfPossible,
     Tpm,
 }
 
@@ -88,6 +89,7 @@ impl Display for HsmType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             HsmType::Soft => write!(f, "Soft"),
+            HsmType::TpmIfPossible => write!(f, "Tpm if possible"),
             HsmType::Tpm => write!(f, "Tpm"),
         }
     }
@@ -309,6 +311,7 @@ impl KanidmUnixdConfig {
                 .hsm_type
                 .and_then(|v| match v.as_str() {
                     "soft" => Some(HsmType::Soft),
+                    "tpm_if_possible" => Some(HsmType::TpmIfPossible),
                     "tpm" => Some(HsmType::Tpm),
                     _ => {
                         warn!("Invalid hsm_type configured, using default ...");


### PR DESCRIPTION
Fixes #2494 - re-enable HW tpm support based on the new hsm-crypto module. This was formerly blocked on lack of serde support upstream.

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
