### PR TITLE
Fix incorrect documentation elements

### DIFF
--- a/book/src/accounts/policy.md
+++ b/book/src/accounts/policy.md
@@ -12,14 +12,24 @@ assigned to `idm_admin` by default.
 
 ## Default Account Policy
 
-A default Account Policy is applied to `idm_all_accounts`. This provides the defaults that influence
-all accounts in Kanidm. This policy can be modified the same as any other group's policy.
+A default Account Policy is applied to `idm_all_persons`. This provides the defaults that influence
+all people in Kanidm. This policy can be modified the same as any other group's policy.
 
 ## Enforced Attributes
 
 ### Auth Expiry
 
 The maximum length in seconds that an authentication session may exist for.
+
+### Credential Type Minimum
+
+The minimum security strength of credentials that may be assigned to this account. In order from
+weakest to strongest:
+
+* `any`
+* `mfa`
+* `passkey`
+* `attested_passkey`
 
 ### Password Minimum Length
 
@@ -46,6 +56,7 @@ parts.
 | value                        | ordering                     |
 | ---------------------------- | ---------------------------- |
 | auth-expiry                  | smallest value               |
+| credential-type-minimum      | largest value                |
 | password-minimum-length      | largest value                |
 | privilege-expiry             | smallest value               |
 | webauthn-attestation-ca-list | intersection of equal values |

--- a/server/core/src/repl/config.rs
+++ b/server/core/src/repl/config.rs
@@ -19,12 +19,14 @@ pub enum RepNodeConfig {
     Pull {
         #[serde(with = "x509b64")]
         supplier_cert: X509,
+        #[serde(default)]
         automatic_refresh: bool,
     },
     #[serde(rename = "mutual-pull")]
     MutualPull {
         #[serde(with = "x509b64")]
         partner_cert: X509,
+        #[serde(default)]
         automatic_refresh: bool,
     },
     /*


### PR DESCRIPTION
This adds the account-policy section for credential-type-minimums and fixes the replication config defaults to match the documented behaviour.

Intend to backport to rc.16

Fixes #2532

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ x ] book chapter included (if relevant)
- [ ] design document included (if relevant)
