### PR TITLE
Conflict nscd, start before sshd

### DIFF
--- a/platform/debian/systemd/kanidm-unixd.service
+++ b/platform/debian/systemd/kanidm-unixd.service
@@ -3,9 +3,12 @@
 
 [Unit]
 Description=Kanidm Local Client Resolver
-After=chronyd.service ntpd.service network-online.target
-Before=systemd-user-sessions.service nss-user-lookup.target
+After=chronyd.service nscd.service ntpd.service network-online.target
+Before=systemd-user-sessions.service sshd.service nss-user-lookup.target
 Wants=nss-user-lookup.target
+# While it seems confusing, we need to be after nscd.service so that the
+# Conflicts will triger and then automatically stop it.
+Conflicts=nscd.service
 
 [Service]
 DynamicUser=yes

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -3,9 +3,12 @@
 
 [Unit]
 Description=Kanidm Local Client Resolver
-After=chronyd.service ntpd.service network-online.target
-Before=systemd-user-sessions.service nss-user-lookup.target
+After=chronyd.service nscd.service ntpd.service network-online.target
+Before=systemd-user-sessions.service sshd.service nss-user-lookup.target
 Wants=nss-user-lookup.target
+# While it seems confusing, we need to be after nscd.service so that the
+# Conflicts will triger and then automatically stop it.
+Conflicts=nscd.service
 
 [Service]
 DynamicUser=yes


### PR DESCRIPTION
Conflict with nscd, start unixd before sshd starts.

Checklist

- [ x ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
