### PR TITLE
When the HTTPS server fails, handle that gracefully, and check client_ca on startup 😄 

### DIFF
--- a/scripts/test_run_release_server.sh
+++ b/scripts/test_run_release_server.sh
@@ -9,6 +9,7 @@ set -e
 
 WAIT_TIMER=5
 
+
 echo "Building release binaries..."
 cargo build --release --bin kanidm --bin kanidmd
 
@@ -17,6 +18,7 @@ if [ -d '.git' ]; then
     CURRENT_DIR="$(pwd)"
     cd server/daemon/ || exit 1
 fi
+
 
 if [ ! -f "run_insecure_dev_server.sh" ]; then
     echo "I'm not sure where you are, please run this from the root of the repository or the server/daemon directory"
@@ -29,12 +31,13 @@ echo "Generating certificates..."
 cargo run --bin kanidmd --release cert-generate --config ../../examples/insecure_server.toml
 
 echo "Making sure it runs with the DB..."
-cargo run --bin kanidmd --release recover-account idm_admin -o json
+cargo run --bin kanidmd --release recover-account idm_admin -o json --config ../../examples/insecure_server.toml
 
 echo "Running the server..."
 cargo run --bin kanidmd --release server --config ../../examples/insecure_server.toml &
 KANIDMD_PID=$!
-echo "${KANIDMD_PID}"
+echo "Kanidm PID: ${KANIDMD_PID}"
+
 
 if [ "$(jobs -p | wc -l)" -eq 0 ]; then
     echo "Kanidmd failed to start!"
@@ -48,8 +51,8 @@ KANIDM_URL="$(rg origin "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')
 KANIDM_CA_PATH="/tmp/kanidm/ca.pem"
 
 while true; do
-    echo "Waiting the server to start... testing ${KANIDM_URL}"
-    curl --cacert "${KANIDM_CA_PATH}" -fs "${KANIDM_URL}" >/dev/null && break
+    echo "Waiting for the server to start... testing ${KANIDM_URL}"
+    curl --cacert "${KANIDM_CA_PATH}" -fs "${KANIDM_URL}/status" >/dev/null && break
     sleep 2
     ATTEMPT="$((ATTEMPT + 1))"
     if [ "${ATTEMPT}" -gt 3 ]; then

--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -748,7 +748,7 @@ impl Display for TaskName {
 
 pub struct CoreHandle {
     clean_shutdown: bool,
-    tx: broadcast::Sender<CoreAction>,
+    pub tx: broadcast::Sender<CoreAction>,
     /// This stores a name for the handle, and the handle itself so we can tell which failed/succeeded at the end.
     handles: Vec<(TaskName, tokio::task::JoinHandle<()>)>,
 }
@@ -1068,6 +1068,7 @@ pub async fn create_server_core(
             server_write_ref,
             server_read_ref,
             broadcast_tx.subscribe(),
+            broadcast_tx.clone(),
         )
         .await
         {

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -530,6 +530,43 @@ async fn kanidm_main() -> ExitCode {
                 }
             }
 
+            if let Some(ca_dir) = &(sconfig.tls_client_ca) {
+                // check that the TLS client CA config option is what we expect
+                let ca_dir_path = PathBuf::from(&ca_dir);
+                if !ca_dir_path.exists() {
+                    error!(
+                        "TLS CA folder {} does not exist, server startup will FAIL!",
+                        ca_dir
+                    );
+                    let diag = kanidm_lib_file_permissions::diagnose_path(&ca_dir_path);
+                    info!(%diag);
+                }
+
+                let i_meta = match metadata(&ca_dir_path) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        error!("Unable to read metadata for '{}' - {:?}", ca_dir, e);
+                        let diag = kanidm_lib_file_permissions::diagnose_path(&ca_dir_path);
+                        info!(%diag);
+                        return ExitCode::FAILURE;
+                    }
+                };
+                if !i_meta.is_dir() {
+                    error!(
+                        "ERROR: Refusing to run - TLS Client CA folder {} may not be a directory",
+                        ca_dir
+                    );
+                    return ExitCode::FAILURE;
+                }
+                if kanidm_lib_file_permissions::readonly(&i_meta) {
+                    warn!("WARNING: TLS Client CA folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", ca_dir);
+                }
+                #[cfg(not(target_os = "windows"))]
+                if i_meta.mode() & 0o007 != 0 {
+                    warn!("WARNING: TLS Client CA folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", ca_dir);
+                }
+            }
+
             let sctx = create_server_core(config, config_test).await;
             if !config_test {
                 // On linux, notify systemd.
@@ -541,46 +578,54 @@ async fn kanidm_main() -> ExitCode {
                         loop {
                             #[cfg(target_family = "unix")]
                             {
+                                let mut listener = sctx.tx.subscribe();
                                 tokio::select! {
-                                                                Ok(()) = tokio::signal::ctrl_c() => {
-                                                                    break
-                                                                }
-                                                                Some(()) = async move {
-                                                                    let sigterm = tokio::signal::unix::SignalKind::terminate();
-                                #[allow(clippy::unwrap_used)]
-                                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                                } => {
-                                                                    break
-                                                                }
-                                                                Some(()) = async move {
-                                                                    let sigterm = tokio::signal::unix::SignalKind::alarm();
-                                #[allow(clippy::unwrap_used)]
-                                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                                } => {
-                                                                    // Ignore
-                                                                }
-                                                                Some(()) = async move {
-                                                                    let sigterm = tokio::signal::unix::SignalKind::hangup();
-                                #[allow(clippy::unwrap_used)]
-                                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                                } => {
-                                                                    // Ignore
-                                                                }
-                                                                Some(()) = async move {
-                                                                    let sigterm = tokio::signal::unix::SignalKind::user_defined1();
-                                #[allow(clippy::unwrap_used)]
-                                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                                } => {
-                                                                    // Ignore
-                                                                }
-                                                                Some(()) = async move {
-                                                                    let sigterm = tokio::signal::unix::SignalKind::user_defined2();
-                                #[allow(clippy::unwrap_used)]
-                                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                                } => {
-                                                                    // Ignore
-                                                                }
-                                                            }
+                                    Ok(()) = tokio::signal::ctrl_c() => {
+                                        break
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::terminate();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        break
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::alarm();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::hangup();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::user_defined1();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::user_defined2();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    // we got a message on thr broadcast from somewhere else
+                                    Ok(msg) = async move {
+                                        listener.recv().await
+                                    } => {
+                                        debug!("Main loop received message: {:?}", msg);
+                                        break
+                                    }
+                                }
                             }
                             #[cfg(target_family = "windows")]
                             {


### PR DESCRIPTION
Previously if the client_ca path was set, but it didn't work the HTTPS server would stop silently. This handles it before startup, and also handles internal failures at runtime of the HTTPS server by sending a shutdown signal.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
