### PR TITLE
fix(oauth2): typo in basic path

### DIFF
--- a/server/core/src/https/v1_oauth2.rs
+++ b/server/core/src/https/v1_oauth2.rs
@@ -39,7 +39,7 @@ pub(crate) async fn oauth2_get(
 
 #[utoipa::path(
     post,
-    path = "/v1/oauth2/basic",
+    path = "/v1/oauth2/_basic",
     request_body=ProtoEntry,
     responses(
         DefaultApiResponse,


### PR DESCRIPTION
Fixes # openapi.json

Hello! I have found the problem generating http client from `openapi.json`. I used `oauth2_basic_post` but received `405 Method Not Implemented`.

Some while later I found [this code in py module](https://github.com/kanidm/kanidm/blob/5794cc5217975dcf46b80d7c1a3685895a3150a8/pykanidm/kanidm/__init__.py#L581).

So, looks like the correct route is `/_basic`.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
