### PR TITLE
Allow /dev/tpmrm0 on older systemd versions

### DIFF
--- a/platform/debian/systemd/kanidm-unixd.service
+++ b/platform/debian/systemd/kanidm-unixd.service
@@ -35,6 +35,8 @@ NoNewPrivileges=true
 PrivateTmp=true
 # We have to disable this to allow tpmrm0 access for tpm binding.
 PrivateDevices=false
+# Older versions of systemd require this to be explicitly allowed.
+DeviceAllow=/dev/tpmrm0 rw
 ProtectHostname=true
 ProtectClock=true
 ProtectKernelTunables=true

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -35,6 +35,9 @@ NoNewPrivileges=true
 PrivateTmp=true
 # We have to disable this to allow tpmrm0 access for tpm binding.
 PrivateDevices=false
+# Older versions of systemd require this to be explicitly allowed.
+DeviceAllow=/dev/tpmrm0 rw
+
 ProtectHostname=true
 ProtectClock=true
 ProtectKernelTunables=true


### PR DESCRIPTION
Older systemd versions require a specific device allow for the tpm to be accessed.


Checklist

- [ x ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
