### PR TITLE
Poking at the OpenAPI generator some more

### DIFF
--- a/server/core/src/https/apidocs/mod.rs
+++ b/server/core/src/https/apidocs/mod.rs
@@ -34,6 +34,16 @@ impl Modify for SecurityAddon {
 // docs for the derive macro are here: <https://docs.rs/utoipa-gen/3.5.0/utoipa_gen/derive.OpenApi.html#info-attribute-syntax>
 #[derive(OpenApi)]
 #[openapi(
+    servers(
+        (url="https://{host}:{port}",
+            variables(
+                ("host" = (default="localhost", description="Server's hostname")),
+                ("port" = (default="8443", description="Server HTTPS port")),
+            )
+        )
+    ),
+    external_docs(url = "https://kanidm.com/docs", description = "Kanidm documentation page"),
+
     paths(
         super::generic::status,
         super::generic::robots_txt,
@@ -267,9 +277,9 @@ impl Modify for SecurityAddon {
     ),
     info(
         title = "Kanidm",
-        description = "API for interacting with the Kanidm system. This is a work in progress",
+        description = "API for interacting with the Kanidm system. This is a work in progress.",
         contact( // <https://docs.rs/utoipa-gen/3.5.0/utoipa_gen/derive.OpenApi.html#info-attribute-syntax>
-            name="Kanidm",
+            name="Kanidm Github",
             url="https://github.com/kanidm/kanidm",
         )
     )

--- a/server/core/src/https/generic.rs
+++ b/server/core/src/https/generic.rs
@@ -38,6 +38,7 @@ pub async fn status(
         (status = 200, description = "Ok"),
     ),
     tag = "ui",
+    operation_id = "robots_txt",
 
 )]
 pub async fn robots_txt() -> impl IntoResponse {

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -82,6 +82,7 @@ pub(crate) fn oauth2_id(rs_name: &str) -> Filter<FilterInvalid> {
 #[utoipa::path(
     get,
     path = "/ui/images/oauth2/{rs_name}",
+    operation_id = "oauth2_image_get",
     responses(
         (status = 200, description = "Ok", body=&[u8]),
         (status = 403, description = "Authorization refused"),


### PR DESCRIPTION
This adds some operation IDs to allow OpenAPI clients to auto-generate things betterer.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
