### PR TITLE
docs(monitoring): Fix syntax for OpenTelemetry config

### DIFF
--- a/book/src/monitoring.md
+++ b/book/src/monitoring.md
@@ -18,8 +18,13 @@ either "true" or "false". `true` indicates that the platform is responding to re
 
 ## OpenTelemetry Tracing
 
-Configure OTLP trace exports by setting a `otel_grpc_endpoint` in the server configuration. This'll
+Configure OTLP trace exports by setting a `otel_grpc_url` in the server configuration. This'll
 enable [OpenTelemetry traces](https://opentelemetry.io) to be sent for observability use cases.
+
+Example:
+```toml
+otel_grpc_url = "http://my-otel-host:4317"
+```
 
 ### Troubleshooting
 
@@ -33,7 +38,7 @@ Grafana Tempo
 
 ```yaml
 distributor:
-  receivers: 
+  receivers:
     otlp:
       protocols:
         grpc:


### PR DESCRIPTION
Fixes to the correct config key and provides an example of what a valid endpoint could look like.


Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
