### PR TITLE
Fix the miniflux oauth2 example

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -369,7 +369,7 @@ match the `OAUTH2_PROVIDER` name.
 OAUTH2_PROVIDER = "oidc";
 OAUTH2_CLIENT_ID = "miniflux";
 OAUTH2_CLIENT_SECRET = "<oauth2_rs_basic_secret>";
-OAUTH2_REDIRECT_URL = "https://feeds.example.com/oauth2/kanidm/callback";
+OAUTH2_REDIRECT_URL = "https://feeds.example.com/oauth2/oidc/callback";
 OAUTH2_OIDC_DISCOVERY_ENDPOINT = "https://idm.example.com/oauth2/openid/<oauth2_rs_name>";
 ```
 


### PR DESCRIPTION
Fixes miniflux oauth2 example in documentation.

in the previous state, miniflux was reporting the following issue:

```
level=ERROR msg="Unable to initialize OAuth2 provider" provider=kanidm error="oauth2 provider not found"
```

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
