### PR TITLE
return consent map to service account

### DIFF
--- a/server/lib/src/constants/schema.rs
+++ b/server/lib/src/constants/schema.rs
@@ -806,6 +806,7 @@ pub static ref SCHEMA_CLASS_SERVICE_ACCOUNT_DL5: SchemaClass = SchemaClass {
         Attribute::SshPublicKey.into(),
         Attribute::UserAuthTokenSession.into(),
         Attribute::OAuth2Session.into(),
+        Attribute::OAuth2ConsentScopeMap.into(),
         Attribute::Description.into(),
 
         Attribute::Mail.into(),


### PR DESCRIPTION
Relates #2596 - this restores consent scope maps to service accounts in rc.16. Now, it is *key* to recognise here this will ONLY work for users who have not yet upgrade.

For users who have already upgraded they will need to re-run domain migration. OR they will need to wait for 1.2.0 where this will also be included as a separate migration. This then will cause everything to be "in sync" again. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
