### PR TITLE
Return consent scope to service account

### DIFF
--- a/server/lib/src/constants/schema.rs
+++ b/server/lib/src/constants/schema.rs
@@ -854,6 +854,28 @@ pub static ref SCHEMA_CLASS_SERVICE_ACCOUNT_DL5: SchemaClass = SchemaClass {
     ..Default::default()
 };
 
+pub static ref SCHEMA_CLASS_SERVICE_ACCOUNT_DL6: SchemaClass = SchemaClass {
+    uuid: UUID_SCHEMA_CLASS_SERVICE_ACCOUNT,
+    name: EntryClass::ServiceAccount.into(),
+    description: "Object representation of service account".to_string(),
+
+    sync_allowed: true,
+    systemmay: vec![
+        Attribute::SshPublicKey.into(),
+        Attribute::UserAuthTokenSession.into(),
+        Attribute::OAuth2Session.into(),
+        Attribute::OAuth2ConsentScopeMap.into(),
+        Attribute::Description.into(),
+
+        Attribute::Mail.into(),
+        Attribute::PrimaryCredential.into(),
+        Attribute::JwsEs256PrivateKey.into(),
+        Attribute::ApiTokenSession.into(),
+    ],
+    systemexcludes: vec![EntryClass::Person.into()],
+    ..Default::default()
+};
+
 pub static ref SCHEMA_CLASS_SYNC_ACCOUNT: SchemaClass = SchemaClass {
     uuid: UUID_SCHEMA_CLASS_SYNC_ACCOUNT,
     name: EntryClass::SyncAccount.into(),

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -867,6 +867,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
             SCHEMA_ATTR_LIMIT_SEARCH_MAX_RESULTS_DL6.clone().into(),
             SCHEMA_ATTR_LIMIT_SEARCH_MAX_FILTER_TEST_DL6.clone().into(),
             SCHEMA_CLASS_ACCOUNT_POLICY_DL6.clone().into(),
+            SCHEMA_CLASS_SERVICE_ACCOUNT_DL6.clone().into(),
         ];
 
         idm_schema_classes


### PR DESCRIPTION
Fixes ##2596 - This returns the oauth2 consent scope map to service accounts until we complete oauth2 shared key domains. Relates to #2604. 

Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ x ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
