### PR TITLE
Add instructions on how to enable PKCE in Nextcloud

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -378,10 +378,14 @@ OAUTH2_OIDC_DISCOVERY_ENDPOINT = "https://idm.example.com/oauth2/openid/<oauth2_
 Install the module [from the nextcloud market place](https://apps.nextcloud.com/apps/user_oidc) - it
 can also be found in the Apps section of your deployment as "OpenID Connect user backend".
 
-In Nextcloud's config.php you need to allow connection to remote servers:
+In Nextcloud's config.php you need to allow connection to remote servers and enable PKCE:
 
 ```php
 'allow_local_remote_servers' => true,
+
+'user_oidc' => [
+    'use_pkce' => true,
+],
 ```
 
 You may optionally choose to add:
@@ -395,13 +399,6 @@ If you forget this, you may see the following error in logs:
 
 ```bash
 Host 172.24.11.129 was not connected to because it violates local access rules
-```
-
-This module does not support PKCE or ES256. You will need to run:
-
-```bash
-kanidm system oauth2 warning-insecure-client-disable-pkce <resource server name>
-kanidm system oauth2 warning-enable-legacy-crypto <resource server name>
 ```
 
 In the settings menu, configure the discovery URL and client ID and secret.


### PR DESCRIPTION
Fixes #
`user_oidc` supports PKCE now, so let’s have the Kanidm book reflect that. I have verified that it works the way I described.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
