### PR TITLE
increase severity for "{:?} !⊆ allowed: {:?}"

### DIFF
--- a/server/lib/src/server/access/create.rs
+++ b/server/lib/src/server/access/create.rs
@@ -140,8 +140,8 @@ fn create_filter_entry<'a>(
         let allowed_classes: BTreeSet<&str> = accr.acp.classes.iter().map(|s| s.as_str()).collect();
 
         if !create_attrs.is_subset(&allowed_attrs) {
-            security_access!("create_attrs is not a subset of allowed");
-            security_access!("create: {:?} !⊆ allowed: {:?}", create_attrs, allowed_attrs);
+            security_error!("create_attrs is not a subset of allowed");
+            security_error!("create: {:?} !⊆ allowed: {:?}", create_attrs, allowed_attrs);
             false
         } else if !create_classes.is_subset(&allowed_classes) {
             security_error!("create_classes is not a subset of allowed");

--- a/server/lib/src/server/access/mod.rs
+++ b/server/lib/src/server/access/mod.rs
@@ -484,24 +484,24 @@ pub trait AccessControlsTransaction<'a> {
                 ModifyResult::Grant => true,
                 ModifyResult::Allow { pres, rem, cls } => {
                     if !requested_pres.is_subset(&pres) {
-                        security_access!("requested_pres is not a subset of allowed");
-                        security_access!(
+                        security_error!("requested_pres is not a subset of allowed");
+                        security_error!(
                             "requested_pres: {:?} !⊆ allowed: {:?}",
                             requested_pres,
                             pres
                         );
                         false
                     } else if !requested_rem.is_subset(&rem) {
-                        security_access!("requested_rem is not a subset of allowed");
-                        security_access!(
+                        security_error!("requested_rem is not a subset of allowed");
+                        security_error!(
                             "requested_rem: {:?} !⊆ allowed: {:?}",
                             requested_rem,
                             rem
                         );
                         false
                     } else if !requested_classes.is_subset(&cls) {
-                        security_access!("requested_classes is not a subset of allowed");
-                        security_access!(
+                        security_error!("requested_classes is not a subset of allowed");
+                        security_error!(
                             "requested_classes: {:?} !⊆ allowed: {:?}",
                             requested_classes,
                             cls
@@ -617,24 +617,24 @@ pub trait AccessControlsTransaction<'a> {
                 ModifyResult::Grant => true,
                 ModifyResult::Allow { pres, rem, cls } => {
                     if !requested_pres.is_subset(&pres) {
-                        security_access!("requested_pres is not a subset of allowed");
-                        security_access!(
+                        security_error!("requested_pres is not a subset of allowed");
+                        security_error!(
                             "requested_pres: {:?} !⊆ allowed: {:?}",
                             requested_pres,
                             pres
                         );
                         false
                     } else if !requested_rem.is_subset(&rem) {
-                        security_access!("requested_rem is not a subset of allowed");
-                        security_access!(
+                        security_error!("requested_rem is not a subset of allowed");
+                        security_error!(
                             "requested_rem: {:?} !⊆ allowed: {:?}",
                             requested_rem,
                             rem
                         );
                         false
                     } else if !requested_classes.is_subset(&cls) {
-                        security_access!("requested_classes is not a subset of allowed");
-                        security_access!(
+                        security_error!("requested_classes is not a subset of allowed");
+                        security_error!(
                             "requested_classes: {:?} !⊆ allowed: {:?}",
                             requested_classes,
                             cls


### PR DESCRIPTION
Help to see access errors when loglevel > INFO. Please consider applying.

Checklist

- [X] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
