### PR TITLE
Add MFA capabilites

### DIFF
--- a/unix_integration/pam_kanidm/src/pam/mod.rs
+++ b/unix_integration/pam_kanidm/src/pam/mod.rs
@@ -53,6 +53,9 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 
+use std::thread;
+use std::time::Duration;
+
 pub fn get_cfg() -> Result<KanidmUnixdConfig, PamResultCode> {
     KanidmUnixdConfig::new()
         .read_options_from_optional_config(DEFAULT_CONFIG_PATH)
@@ -105,6 +108,38 @@ impl TryFrom<&Vec<&CStr>> for Options {
 pub struct PamKanidm;
 
 pam_hooks!(PamKanidm);
+
+macro_rules! match_sm_auth_client_response {
+    ($expr:expr, $opts:ident, $($pat:pat => $result:expr),*) => {
+        match $expr {
+            Ok(r) => match r {
+                $($pat => $result),*
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Success) => {
+                    return PamResultCode::PAM_SUCCESS;
+                }
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Denied) => {
+                    return PamResultCode::PAM_AUTH_ERR;
+                }
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Unknown) => {
+                    if $opts.ignore_unknown_user {
+                        return PamResultCode::PAM_IGNORE;
+                    } else {
+                        return PamResultCode::PAM_USER_UNKNOWN;
+                    }
+                }
+                _ => {
+                    // unexpected response.
+                    error!(err = ?r, "PAM_IGNORE, unexpected resolver response");
+                    return PamResultCode::PAM_IGNORE;
+                }
+            },
+            Err(err) => {
+                error!(?err, "PAM_IGNORE");
+                return PamResultCode::PAM_IGNORE;
+            }
+        }
+    }
+}
 
 impl PamHooks for PamKanidm {
     fn acct_mgmt(pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
@@ -241,85 +276,130 @@ impl PamHooks for PamKanidm {
         let mut req = ClientRequest::PamAuthenticateInit(account_id);
 
         loop {
-            match daemon_client.call_and_wait(&req, timeout) {
-                Ok(r) => match r {
-                    ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Success) => {
-                        return PamResultCode::PAM_SUCCESS;
-                    }
-                    ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Denied) => {
-                        return PamResultCode::PAM_AUTH_ERR;
-                    }
-                    ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Unknown) => {
-                        if opts.ignore_unknown_user {
-                            return PamResultCode::PAM_IGNORE;
-                        } else {
-                            return PamResultCode::PAM_USER_UNKNOWN;
-                        }
-                    }
-                    ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Password) => {
-                        let mut consume_authtok = None;
-                        // Swap the authtok out with a None, so it can only be consumed once.
-                        // If it's already been swapped, we are just swapping two null pointers
-                        // here effectively.
-                        std::mem::swap(&mut authtok, &mut consume_authtok);
-                        let cred = if let Some(cred) = consume_authtok {
-                            cred
-                        } else {
-                            match conv.send(PAM_PROMPT_ECHO_OFF, "Password: ") {
-                                Ok(password) => match password {
-                                    Some(cred) => cred,
-                                    None => {
-                                        debug!("no password");
-                                        return PamResultCode::PAM_CRED_INSUFFICIENT;
-                                    }
-                                },
-                                Err(err) => {
-                                    debug!("unable to get password");
-                                    return err;
+            match_sm_auth_client_response!(daemon_client.call_and_wait(&req, timeout), opts,
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Password) => {
+                    let mut consume_authtok = None;
+                    // Swap the authtok out with a None, so it can only be consumed once.
+                    // If it's already been swapped, we are just swapping two null pointers
+                    // here effectively.
+                    std::mem::swap(&mut authtok, &mut consume_authtok);
+                    let cred = if let Some(cred) = consume_authtok {
+                        cred
+                    } else {
+                        match conv.send(PAM_PROMPT_ECHO_OFF, "Password: ") {
+                            Ok(password) => match password {
+                                Some(cred) => cred,
+                                None => {
+                                    debug!("no password");
+                                    return PamResultCode::PAM_CRED_INSUFFICIENT;
                                 }
-                            }
-                        };
-
-                        // Now setup the request for the next loop.
-                        timeout = cfg.unix_sock_timeout;
-                        req = ClientRequest::PamAuthenticateStep(PamAuthRequest::Password { cred });
-                        continue;
-                    }
-                    ClientResponse::PamAuthenticateStepResponse(
-                        PamAuthResponse::DeviceAuthorizationGrant { data },
-                    ) => {
-                        let msg = match &data.message {
-                            Some(msg) => msg.clone(),
-                            None => format!("Using a browser on another device, visit:\n{}\nAnd enter the code:\n{}",
-                                            data.verification_uri, data.user_code)
-                        };
-                        match conv.send(PAM_TEXT_INFO, &msg) {
-                            Ok(_) => {}
+                            },
                             Err(err) => {
-                                if opts.debug {
-                                    println!("Message prompt failed");
-                                }
+                                debug!("unable to get password");
                                 return err;
                             }
                         }
+                    };
 
-                        timeout = u64::from(data.expires_in);
-                        req = ClientRequest::PamAuthenticateStep(
-                            PamAuthRequest::DeviceAuthorizationGrant { data },
-                        );
-                        continue;
-                    }
-                    _ => {
-                        // unexpected response.
-                        error!(err = ?r, "PAM_IGNORE, unexpected resolver response");
-                        return PamResultCode::PAM_IGNORE;
-                    }
+                    // Now setup the request for the next loop.
+                    timeout = cfg.unix_sock_timeout;
+                    req = ClientRequest::PamAuthenticateStep(PamAuthRequest::Password { cred });
+                    continue;
                 },
-                Err(err) => {
-                    error!(?err, "PAM_IGNORE");
-                    return PamResultCode::PAM_IGNORE;
+                ClientResponse::PamAuthenticateStepResponse(
+                    PamAuthResponse::DeviceAuthorizationGrant { data },
+                ) => {
+                    let msg = match &data.message {
+                        Some(msg) => msg.clone(),
+                        None => format!("Using a browser on another device, visit:\n{}\nAnd enter the code:\n{}",
+                                        data.verification_uri, data.user_code)
+                    };
+                    match conv.send(PAM_TEXT_INFO, &msg) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            if opts.debug {
+                                println!("Message prompt failed");
+                            }
+                            return err;
+                        }
+                    }
+
+                    timeout = u64::from(data.expires_in);
+                    req = ClientRequest::PamAuthenticateStep(
+                        PamAuthRequest::DeviceAuthorizationGrant { data },
+                    );
+                    continue;
+                },
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::MFACode {
+                    msg,
+                    data,
+                }) => {
+                    match conv.send(PAM_TEXT_INFO, &msg) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            if opts.debug {
+                                println!("Message prompt failed");
+                            }
+                            return err;
+                        }
+                    }
+                    let cred = match conv.send(PAM_PROMPT_ECHO_OFF, "Code") {
+                        Ok(password) => match password {
+                            Some(cred) => cred,
+                            None => {
+                                debug!("no mfa code");
+                                return PamResultCode::PAM_CRED_INSUFFICIENT;
+                            }
+                        },
+                        Err(err) => {
+                            debug!("unable to get mfa code");
+                            return err;
+                        }
+                    };
+
+                    // Now setup the request for the next loop.
+                    timeout = cfg.unix_sock_timeout;
+                    req = ClientRequest::PamAuthenticateStep(PamAuthRequest::MFACode {
+                        cred,
+                        data,
+                    });
+                    continue;
+                },
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::MFAPoll {
+                    msg,
+                    max_poll_attempts,
+                    polling_interval,
+                    data,
+                }) => {
+                    match conv.send(PAM_TEXT_INFO, &msg) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            if opts.debug {
+                                println!("Message prompt failed");
+                            }
+                            return err;
+                        }
+                    }
+
+                    for poll_attempt in 1..max_poll_attempts {
+                        thread::sleep(Duration::from_secs(polling_interval.into()));
+                        timeout = cfg.unix_sock_timeout;
+                        req = ClientRequest::PamAuthenticateStep(PamAuthRequest::MFAPoll {
+                            poll_attempt,
+                            data: data.clone(),
+                        });
+                        match_sm_auth_client_response!(
+                            daemon_client.call_and_wait(&req, timeout), opts,
+                            ClientResponse::PamAuthenticateStepResponse(
+                                    PamAuthResponse::MFAPollWait,
+                            ) => {
+                                    // Continue polling if the daemon says to wait
+                                    continue;
+                            }
+                        );
+                    }
                 }
-            }
+            );
         } // while true, continue calling PamAuthenticateStep until we get a decision.
     }
 

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -63,11 +63,31 @@ pub struct UserToken {
 pub enum AuthCredHandler {
     Password,
     DeviceAuthorizationGrant,
+    MFA,
 }
 
 pub enum AuthRequest {
     Password,
-    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
+    DeviceAuthorizationGrant {
+        data: DeviceAuthorizationResponse,
+    },
+    MFACode {
+        msg: String,
+        /// Additional data required by the provider to complete the
+        /// authentication, but not required by PAM
+        data: Vec<String>,
+    },
+    MFAPoll {
+        msg: String,
+        /// Maximum number of permitted polling attempts
+        max_poll_attempts: u32,
+        /// Interval in seconds between poll attemts
+        polling_interval: u32,
+        /// Additional data required by the provider to complete the
+        /// authentication, but not required by PAM
+        data: Vec<String>,
+    },
+    MFAPollWait,
 }
 
 #[allow(clippy::from_over_into)]
@@ -78,6 +98,19 @@ impl Into<PamAuthResponse> for AuthRequest {
             AuthRequest::DeviceAuthorizationGrant { data } => {
                 PamAuthResponse::DeviceAuthorizationGrant { data }
             }
+            AuthRequest::MFACode { msg, data } => PamAuthResponse::MFACode { msg, data },
+            AuthRequest::MFAPoll {
+                msg,
+                max_poll_attempts,
+                polling_interval,
+                data,
+            } => PamAuthResponse::MFAPoll {
+                msg,
+                max_poll_attempts,
+                polling_interval,
+                data,
+            },
+            AuthRequest::MFAPollWait => PamAuthResponse::MFAPollWait,
         }
     }
 }

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -1038,6 +1038,10 @@ where
                         // AuthCredHandler::DeviceAuthorizationGrant is invalid for offline auth
                         return Err(());
                     }
+                    (AuthCredHandler::MFA, _) => {
+                        // AuthCredHandler::MFA is invalid for offline auth
+                        return Err(());
+                    }
                 }
 
                 /*
@@ -1108,6 +1112,18 @@ where
                 auth_session
             }
             (auth_session, PamAuthResponse::DeviceAuthorizationGrant { .. }) => {
+                // Can continue!
+                auth_session
+            }
+            (auth_session, PamAuthResponse::MFACode { .. }) => {
+                // Can continue!
+                auth_session
+            }
+            (auth_session, PamAuthResponse::MFAPoll { .. }) => {
+                // Can continue!
+                auth_session
+            }
+            (auth_session, PamAuthResponse::MFAPollWait) => {
                 // Can continue!
                 auth_session
             }

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -36,22 +36,41 @@ pub enum PamAuthResponse {
     Success,
     Denied,
     Password,
-    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
-    /*
-    MFACode {
+    DeviceAuthorizationGrant {
+        data: DeviceAuthorizationResponse,
     },
-    */
+    /// PAM must prompt for an authentication code
+    MFACode {
+        msg: String,
+        data: Vec<String>,
+    },
+    /// PAM will poll for an external response
+    MFAPoll {
+        msg: String,
+        max_poll_attempts: u32,
+        polling_interval: u32,
+        data: Vec<String>,
+    },
+    MFAPollWait,
     // CTAP2
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthRequest {
-    Password { cred: String },
-    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse }, /*
-                                                                    MFACode {
-                                                                        cred: Option<PamCred>
-                                                                    }
-                                                                    */
+    Password {
+        cred: String,
+    },
+    DeviceAuthorizationGrant {
+        data: DeviceAuthorizationResponse,
+    },
+    MFACode {
+        cred: String,
+        data: Vec<String>,
+    },
+    MFAPoll {
+        poll_attempt: u32,
+        data: Vec<String>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Adds the ability to send a generic MFA request. Himmelblau requires that we keep track of a bunch of urls, cookies, tokens, etc in order to continue the MFA auth after talking to PAM, so that is the reason for the `data` blob (which is a json string). Perhaps there is a way we can standardize this into something reasonable that Kanidm can also use for MFA.
This specifically is what that json (converted from a struct) looks like:
```rust
#[derive(Deserialize, Serialize)]
pub struct MFAAuthContinue {
    pub mfa_method: String,
    pub msg: String,
    max_poll_attempts: Option<u32>,
    polling_interval: Option<u32>,
    session_id: String,
    flow_token: String,
    ctx: String,
    canary: String,
    url_end_auth: String,
    url_begin_auth: String,
    url_post: String,
}
```

MS supplies literally hundreds of random bits, and I'm only storing the bare minimum. It's possible the required data could change. MS has not written up any specification or standard for this.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
