### PR TITLE
fix(docs): capitalization fixes

### DIFF
--- a/book/src/choosing_a_domain_name.md
+++ b/book/src/choosing_a_domain_name.md
@@ -35,9 +35,9 @@ Due to how web browsers and webauthn work, any matching domain name or subdomain
 domain may have access to cookies within a browser session. An example is that `host.a.example.com`
 has access to cookies from `a.example.com` and `example.com`.
 
-For this reason your kanidm host (or hosts) should be on a unique subdomain, with no other services
+For this reason your Kanidm host (or hosts) should be on a unique subdomain, with no other services
 registered under that subdomain. For example, consider `idm.example.com` as a subdomain for
-exclusive use of kanidm. This is _inverse_ to Active Directory which often has it's domain name
+exclusive use of Kanidm. This is _inverse_ to Active Directory which often has it's domain name
 selected to be the parent (toplevel) domain (`example.com`).
 
 Failure to use a unique subdomain may allow cookies to leak to other entities within your domain,

--- a/book/src/developers/faq.md
+++ b/book/src/developers/faq.md
@@ -4,7 +4,7 @@ This is a list of common questions that are generally raised by developers or te
 
 ## Why don't you use library/project X?
 
-A critical aspect of kanidm is the ability to test it. Generally requests to add libraries or
+A critical aspect of Kanidm is the ability to test it. Generally requests to add libraries or
 projects can come in different forms so I'll answer to a few of them:
 
 ## Is the library in Rust?
@@ -25,7 +25,7 @@ parts. This creates production fragility and issues such as:
 - Design choices of the project not being compatible with Kanidm's model
 - Extra requirements for testing/production configuration
 
-This last point is key. It is a critical part of kanidm that the following must work on all
+This last point is key. It is a critical part of Kanidm that the following must work on all
 machines, and run every single test in the suite.
 
 ```shell


### PR DESCRIPTION
There were two files in documentation where the first letter of Kanidm should have been capitalized.
