### PR TITLE
Fix developer ethics link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ When we develop features, we follow our project's guidelines on [rights and ethi
 
 [code of conduct]: https://github.com/kanidm/kanidm/blob/master/CODE_OF_CONDUCT.md
 
-[rights and ethics]: https://github.com/kanidm/kanidm/blob/master/book/src/developers/ethics.md
+[rights and ethics]: https://github.com/kanidm/kanidm/blob/master/book/src/developers/developer_ethics.md
 
 ## Getting in Contact / Questions
 


### PR DESCRIPTION
Fixes
The link to the developer ethics is broken in the README, this fixes it.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
