### PR TITLE
Require kanidm-unixd before kanidm-unixd-tasks

### DIFF
--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -4,6 +4,7 @@
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
+Requires=kanidm-unixd.service
 
 [Service]
 User=root


### PR DESCRIPTION
The kanidm-unixd-tasks service refuses to start before kanidm-unixd:

```
systemd[1]: Started Kanidm Local Tasks.
(xd_tasks)[29469]: kanidm-unixd-tasks.service: Failed to set up mount namespacing: /run/systemd/unit-root/run/kanidm-unixd: No such file or directory
(xd_tasks)[29469]: kanidm-unixd-tasks.service: Failed at step NAMESPACE spawning /usr/sbin/kanidm_unixd_tasks: No such file or directory
systemd[1]: kanidm-unixd-tasks.service: Main process exited, code=exited, status=226/NAMESPACE
systemd[1]: kanidm-unixd-tasks.service: Failed with result 'exit-code'.
```

Resolve this by ensuring kanidm-unixd gets activated as a dependency. The ordering ("After") is already in place.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
