### PR TITLE
Windows Hello Authentication requirements

### DIFF
--- a/unix_integration/pam_kanidm/src/pam/mod.rs
+++ b/unix_integration/pam_kanidm/src/pam/mod.rs
@@ -397,6 +397,72 @@ impl PamHooks for PamKanidm {
                         );
 
                     }
+                },
+                ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::SetupPin {
+                    msg,
+                }) => {
+                    match conv.send(PAM_TEXT_INFO, &msg) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            if opts.debug {
+                                println!("Message prompt failed");
+                            }
+                            return err;
+                        }
+                    }
+
+                    let mut pin;
+                    let mut confirm;
+                    loop {
+                        pin = match conv.send(PAM_PROMPT_ECHO_OFF, "New PIN") {
+                            Ok(password) => match password {
+                                Some(cred) => cred,
+                                None => {
+                                    debug!("no pin");
+                                    return PamResultCode::PAM_CRED_INSUFFICIENT;
+                                }
+                            },
+                            Err(err) => {
+                                debug!("unable to get pin");
+                                return err;
+                            }
+                        };
+
+                        confirm = match conv.send(PAM_PROMPT_ECHO_OFF, "Confirm PIN") {
+                            Ok(password) => match password {
+                                Some(cred) => cred,
+                                None => {
+                                    debug!("no confirmation pin");
+                                    return PamResultCode::PAM_CRED_INSUFFICIENT;
+                                }
+                            },
+                            Err(err) => {
+                                debug!("unable to get confirmation pin");
+                                return err;
+                            }
+                        };
+
+                        if pin == confirm {
+                            break;
+                        } else {
+                            match conv.send(PAM_TEXT_INFO, "Inputs did not match. Try again.") {
+                                Ok(_) => {}
+                                Err(err) => {
+                                    if opts.debug {
+                                        println!("Message prompt failed");
+                                    }
+                                    return err;
+                                }
+                            }
+                        }
+                    }
+
+                    // Now setup the request for the next loop.
+                    timeout = cfg.unix_sock_timeout;
+                    req = ClientRequest::PamAuthenticateStep(PamAuthRequest::SetupPin {
+                        pin,
+                    });
+                    continue;
                 }
             );
         } // while true, continue calling PamAuthenticateStep until we get a decision.

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -161,10 +161,11 @@ pub trait IdProvider {
         _machine_key: &tpm::MachineKey,
     ) -> Result<UserToken, IdpError>;
 
-    async fn unix_user_online_auth_init(
+    async fn unix_user_online_auth_init<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
         _token: Option<&UserToken>,
+        _keystore: &mut D,
         _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
         _shutdown_rx: &broadcast::Receiver<()>,

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -76,6 +76,7 @@ pub enum AuthCredHandler {
     MFA {
         data: Vec<String>,
     },
+    SetupPin,
 }
 
 pub enum AuthRequest {
@@ -93,6 +94,10 @@ pub enum AuthRequest {
         polling_interval: u32,
     },
     MFAPollWait,
+    SetupPin {
+        /// Message to display to the user.
+        msg: String,
+    },
 }
 
 #[allow(clippy::from_over_into)]
@@ -112,6 +117,7 @@ impl Into<PamAuthResponse> for AuthRequest {
                 polling_interval,
             },
             AuthRequest::MFAPollWait => PamAuthResponse::MFAPollWait,
+            AuthRequest::SetupPin { msg } => PamAuthResponse::SetupPin { msg },
         }
     }
 }

--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -77,6 +77,7 @@ pub enum AuthCredHandler {
         data: Vec<String>,
     },
     SetupPin,
+    Pin,
 }
 
 pub enum AuthRequest {
@@ -98,6 +99,7 @@ pub enum AuthRequest {
         /// Message to display to the user.
         msg: String,
     },
+    Pin,
 }
 
 #[allow(clippy::from_over_into)]
@@ -118,6 +120,7 @@ impl Into<PamAuthResponse> for AuthRequest {
             },
             AuthRequest::MFAPollWait => PamAuthResponse::MFAPollWait,
             AuthRequest::SetupPin { msg } => PamAuthResponse::SetupPin { msg },
+            AuthRequest::Pin => PamAuthResponse::Pin,
         }
     }
 }
@@ -188,13 +191,13 @@ pub trait IdProvider {
         _shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError>;
 
-    async fn unix_user_offline_auth_init(
+    async fn unix_user_offline_auth_init<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
         _token: Option<&UserToken>,
+        _keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;
 
-    /*
     // I thought about this part of the interface a lot. we could have the
     // provider actually need to check the password or credentials, but then
     // we need to rework the tpm/crypto engine to be an argument to pass here
@@ -209,14 +212,22 @@ pub trait IdProvider {
     // involved if there is some "custom logic" or similar that is needed but
     // for now I think making it generic is a good first step and we can change
     // it later.
-    async fn unix_user_offline_auth_step(
+    //
+    // EDIT 04042024: When we're performing an offline PIN auth, the PIN can
+    // unlock the associated TPM key. While we can't perform a full request
+    // for an auth token, we can verify that the PIN successfully unlocks the
+    // TPM key.
+    async fn unix_user_offline_auth_step<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
+        _token: &UserToken,
         _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
+        _keystore: &mut D,
+        _tpm: &mut tpm::BoxedDynTpm,
+        _machine_key: &tpm::MachineKey,
         _online_at_init: bool,
     ) -> Result<AuthResult, IdpError>;
-    */
 
     async fn unix_group_get(
         &self,

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -191,10 +191,11 @@ impl IdProvider for KanidmProvider {
         }
     }
 
-    async fn unix_user_online_auth_init(
+    async fn unix_user_online_auth_init<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
         _token: Option<&UserToken>,
+        _keystore: &mut D,
         _tpm: &mut tpm::BoxedDynTpm,
         _machine_key: &tpm::MachineKey,
         _shutdown_rx: &broadcast::Receiver<()>,

--- a/unix_integration/src/idprovider/kanidm.rs
+++ b/unix_integration/src/idprovider/kanidm.rs
@@ -293,27 +293,30 @@ impl IdProvider for KanidmProvider {
         }
     }
 
-    async fn unix_user_offline_auth_init(
+    async fn unix_user_offline_auth_init<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
         _token: Option<&UserToken>,
+        _keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
         // Not sure that I need to do much here?
         Ok((AuthRequest::Password, AuthCredHandler::Password))
     }
 
-    /*
-    async fn unix_user_offline_auth_step(
+    async fn unix_user_offline_auth_step<D: KeyStoreTxn + Send>(
         &self,
         _account_id: &str,
+        _token: &UserToken,
         _cred_handler: &mut AuthCredHandler,
         _pam_next_req: PamAuthRequest,
+        _keystore: &mut D,
+        _tpm: &mut tpm::BoxedDynTpm,
+        _machine_key: &tpm::MachineKey,
         _online_at_init: bool,
     ) -> Result<AuthResult, IdpError> {
         // We need any cached credentials here.
-        todo!();
+        Err(IdpError::BadRequest)
     }
-    */
 
     async fn unix_group_get(
         &self,

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -1057,6 +1057,10 @@ where
                         // AuthCredHandler::MFA is invalid for offline auth
                         return Err(());
                     }
+                    (AuthCredHandler::SetupPin, _) => {
+                        // AuthCredHandler::SetupPin is invalid for offline auth
+                        return Err(());
+                    }
                 }
 
                 /*
@@ -1144,6 +1148,10 @@ where
                 auth_session
             }
             (auth_session, PamAuthResponse::MFAPollWait) => {
+                // Can continue!
+                auth_session
+            }
+            (auth_session, PamAuthResponse::SetupPin { .. }) => {
                 // Can continue!
                 auth_session
             }

--- a/unix_integration/src/resolver.rs
+++ b/unix_integration/src/resolver.rs
@@ -893,10 +893,13 @@ where
 
         let maybe_err = if online_at_init {
             let mut hsm_lock = self.hsm.lock().await;
+            let mut dbtxn = self.db.write().await;
+
             self.client
                 .unix_user_online_auth_init(
                     account_id,
                     token.as_ref(),
+                    &mut dbtxn,
                     hsm_lock.deref_mut(),
                     &self.machine_key,
                     &shutdown_rx,

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -55,6 +55,7 @@ pub enum PamAuthResponse {
     SetupPin {
         msg: String,
     },
+    Pin,
     // CTAP2
 }
 
@@ -65,6 +66,7 @@ pub enum PamAuthRequest {
     MFACode { cred: String },
     MFAPoll,
     SetupPin { pin: String },
+    Pin { cred: String },
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -51,6 +51,10 @@ pub enum PamAuthResponse {
         polling_interval: u32,
     },
     MFAPollWait,
+    /// PAM must prompt for a new PIN and confirm that PIN input
+    SetupPin {
+        msg: String,
+    },
     // CTAP2
 }
 
@@ -60,6 +64,7 @@ pub enum PamAuthRequest {
     DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
     MFACode { cred: String },
     MFAPoll,
+    SetupPin { pin: String },
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This adds the ability in the client to set, then authenticate using a Pin code. This will be used in Himmelblau as the auth value when creating a TPM key. That TPM key is then assigned in Azure as a Windows Hello Key. Afterward, users will be able to authenticate with the Pin, which will load the Windows Hello Key from the TPM, which can be used to sign an authentication request as an Azure Entra ID user.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
