### PR TITLE
Fix typo in TotpDigits::try_from

### DIFF
--- a/server/lib/src/credential/totp.rs
+++ b/server/lib/src/credential/totp.rs
@@ -34,7 +34,7 @@ impl TryFrom<u8> for TotpDigits {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             6 => Ok(TotpDigits::Six),
-            8 => Ok(TotpDigits::Six),
+            8 => Ok(TotpDigits::Eight),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
It looks like a typo, but I am not sure -  I am not the codebase owner :)
Ref #1328 

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
