### PR TITLE
Fix typo in oauth2 error message

### DIFF
--- a/server/web_ui/login_flows/src/oauth2.rs
+++ b/server/web_ui/login_flows/src/oauth2.rs
@@ -507,7 +507,7 @@ impl Component for Oauth2App {
             }
             State::ErrInvalidRequest => do_alert_error(
                 "Invalid request",
-                Some("Please close this window and try again again from the beginning."),
+                Some("Please close this window and try again from the beginning."),
                 false,
             ),
         };


### PR DESCRIPTION
Removes a duplicate 'again' in the error message _"Please close this window and try again again from the beginning."_ 

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
