### PR TITLE
Docs: TLS between load balancer and kanidm

### DIFF
--- a/book/src/frequently_asked_questions.md
+++ b/book/src/frequently_asked_questions.md
@@ -37,6 +37,19 @@ practice. This can allow account hijacking, privilege escalation, credential dis
 information leaks and more. The entire path between a client and the server must be protected at all
 times.
 
+There are a variety of ways that you can configure TLS between your load balancer and Kanidm.
+Ultimately, any option that maintains the confidentiality and integrity of the communication will
+suffice. Some options include, but are not limited to:
+
+- Generating a self-signed certificate
+  - Utilize certificate pinning to ensure that the load balancer only trusts connections made with
+  that particular certificate
+- Not terminating TLS / TLS passthrough / TCP proxy
+- Running your own certificate authority (CA)
+
+The "best" option for you will depend on a number of factors, including your threat model and the
+specifc load balancer you are using.
+
 ## OAuth2
 
 [RFC6819 - OAuth2 Threat Model and Security Considerations](https://www.rfc-editor.org/rfc/rfc6819)


### PR DESCRIPTION
## tl;dr

Give users some options to consider for how they could implement TLS between a load balancer (LB) and kanidm.

## Motivation

While the docs make it clear that kanidm  must be accessed over HTTPS, they do not provide much information regarding how to accomplish this between a LB and kanidm; this is left as an exercise to the reader. 

For users who have their LB and kanidm on the same host and simply wish to have their reverse proxy communicate with kanidm using HTTP over localhost, this requirement can be quite the pain point.

In lieu of providing a more seamless solution for users, I think it would be ideal to at least somewhat enumerate the options available to accomplish this.

## Why is this in draft?

Because I'm not super confident with what I have written so far and would like some input from others so I can iterate.

## Related
https://github.com/kanidm/kanidm/issues/1726#issuecomment-1588191790
https://github.com/kanidm/kanidm/discussions/2403
[Various](https://matrix.to/#/!fzbFDgtoaOQXSSxOZc:gitter.im/$MBJpjNudcRBRMvo5UbedeApwH8x7AYv3XMtSX4NCR3A) [discussions](https://matrix.to/#/!fzbFDgtoaOQXSSxOZc:gitter.im/$oRqho3K0RxHirwIydkYwQJOWTinub8QwhEFdXWiWEFM) [in the](https://matrix.to/#/!fzbFDgtoaOQXSSxOZc:gitter.im/$pEv94uFkxtE0zTPmS6jn0C8UT-zuXgNhS5Wl4azHmKc) kanidm Gitter community.

:heart: 

