### PR TITLE
Use fully qualified container URLS

### DIFF
--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -13,7 +13,7 @@ considerations you should be aware of for production deployments.
 ### Get the software
 
 ```bash
-docker pull kanidm/server:latest
+docker pull docker.io/kanidm/server:latest
 ```
 
 ### Configure the container
@@ -24,7 +24,7 @@ docker create --name kanidmd \
   -p 443:8443 \
   -p 636:3636 \
   -v kanidmd:/data \
-  kanidm/server:latest
+  docker.io/kanidm/kanidm/server:latest
 ```
 
 ### Configure the server
@@ -45,7 +45,7 @@ docker cp server.toml kanidmd:/data/server.toml
 
 ```bash
 docker run --rm -i -t -v kanidmd:/data \
-  kanidm/server:latest \
+  docker.io/kanidm/server:latest \
   kanidmd cert-generate
 ```
 


### PR DESCRIPTION
Use fully qualified container URLS instead of abbrevations to make the quickstart guide better approachable for non-docker container engines, which might not default to using docker.io.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run - not applicable
- [ ] cargo clippy has been run - not applicable
- [ ] cargo test has been run and passes - not applicable
- [ ] book chapter included (if relevant) - not applicable
- [ ] design document included (if relevant) - not applicable
