### PR TITLE
Don't need to check versions when there's an intermediary reporting connectivity issues

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -633,6 +633,13 @@ impl KanidmClient {
             return;
         }
 
+        if response.status() == StatusCode::BAD_GATEWAY {
+            // don't need to check versions when there's an intermediary reporting connectivity
+            debug!("Bad Gateway error in response - version check skipped.");
+            *guard = false;
+            return;
+        }
+
         let ver = response
             .headers()
             .get(KVERSION)

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -640,7 +640,7 @@ impl KanidmClient {
             return;
         }
 
-        let ver = response
+        let ver: &str = response
             .headers()
             .get(KVERSION)
             .and_then(|hv| hv.to_str().ok())
@@ -2034,4 +2034,20 @@ impl KanidmClient {
         self.perform_post_request(&format!("/v1/recycle_bin/{}/_revive", id), ())
             .await
     }
+}
+
+#[tokio::test]
+async fn test_no_client_version_check_on_502() {
+    let res = reqwest::Response::from(
+        hyper::Response::builder()
+            .status(502)
+            .body(hyper::Body::empty())
+            .unwrap(),
+    );
+    let client = KanidmClientBuilder::new()
+        .address("http://localhost:8080".to_string())
+        .build()
+        .expect("Failed to build client");
+    eprintln!("This should pass because we are returning 502 and shouldn't check version...");
+    client.expect_version(&res).await;
 }


### PR DESCRIPTION
On a 502 returned from the client, we shouldn't be checking for version headers because that's just confusing.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
