### PR TITLE
feat: add support for ldap compare request

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@
 - illode
 - Jinna Kiisuo (jinnatar)
 - Merlijn Verstraete (ToxicMushroom)
+- Tobias Krischer (tobikris)
 
 ## Acknowledgements
 

--- a/book/src/supported_features.md
+++ b/book/src/supported_features.md
@@ -34,6 +34,7 @@ This is a list of supported features and standards within Kanidm.
   - search
   - filter
   - whoami
+  - compare
 - LDAPS (LDAP over TLS)
 
 # OAuth2 / OpenID Connect


### PR DESCRIPTION
This adds support for the LDAP CompareRequest. The implementation is ~~using~~ based on the existing `Search` operation.

I tried to follow this description of the request: https://ldap.com/the-ldap-compare-operation/.
~~As the `Search` operation is not exposing the reason for errors, I could not return `invalidDNSyntax`.~~
I decided on using the same authentication decision as for the `Search`.

Edit:
After the review, I changed the implementation to be standalone with copy-pasted code from `do_search` instead of calling the method.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
