### PR TITLE
LDAP: Fix building Identity from LdapSession

### DIFF
--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -686,22 +686,10 @@ pub trait IdmServerTransaction<'a> {
     ) -> Result<Identity, OperationError> {
         match session {
             LdapSession::UnixBind(uuid) => {
-                let anon_entry = self
-                    .get_qs_txn()
-                    .internal_search_uuid(UUID_ANONYMOUS)
-                    .map_err(|e| {
-                        admin_error!("Failed to validate ldap session -> {:?}", e);
-                        e
-                    })?;
-
-                let entry = if *uuid == UUID_ANONYMOUS {
-                    anon_entry.clone()
-                } else {
-                    self.get_qs_txn().internal_search_uuid(*uuid).map_err(|e| {
-                        admin_error!("Failed to start auth ldap -> {:?}", e);
-                        e
-                    })?
-                };
+                let entry = self.get_qs_txn().internal_search_uuid(*uuid).map_err(|e| {
+                    admin_error!("Failed to start auth ldap -> {:?}", e);
+                    e
+                })?;
 
                 if Account::check_within_valid_time(
                     ct,
@@ -717,7 +705,7 @@ pub trait IdmServerTransaction<'a> {
                     let session_id = Uuid::new_v4();
 
                     Ok(Identity {
-                        origin: IdentType::User(IdentUser { entry: anon_entry }),
+                        origin: IdentType::User(IdentUser { entry }),
                         source,
                         session_id,
                         scope: AccessScope::ReadOnly,


### PR DESCRIPTION
The assigned IdentUser was always UUID_ANONYMOUS

Checklist

- [X] This pr contains no AI generated code
- [X] cargo fmt has been run
- [ ] cargo clippy has been run
- [X] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
