### PR TITLE
fix DB_PATH variable propagation

### DIFF
--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -274,7 +274,7 @@ impl ServerConfig {
                     self.origin = Some(value.to_string());
                 }
                 "DB_PATH" => {
-                    self.origin = Some(value.to_string());
+                    self.db_path = Some(value.to_string());
                 }
                 "TLS_CHAIN" => {
                     self.tls_chain = Some(value.to_string());


### PR DESCRIPTION
The `DB_PATH` environment variable was set to the `origin` value of the server config (I guess that was just a copy-paste bug). This PR fixes that :)

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
