### PR TITLE
Sometimes an MFA Code prompt requires polling

### DIFF
--- a/unix_integration/src/idprovider/interface.rs
+++ b/unix_integration/src/idprovider/interface.rs
@@ -86,7 +86,10 @@ pub enum AuthRequest {
         data: DeviceAuthorizationResponse,
     },
     MFACode {
+        /// Message to display to the user.
         msg: String,
+        /// Interval in seconds between poll attemts.
+        polling_interval: u32,
     },
     MFAPoll {
         /// Message to display to the user.
@@ -110,7 +113,13 @@ impl Into<PamAuthResponse> for AuthRequest {
             AuthRequest::DeviceAuthorizationGrant { data } => {
                 PamAuthResponse::DeviceAuthorizationGrant { data }
             }
-            AuthRequest::MFACode { msg } => PamAuthResponse::MFACode { msg },
+            AuthRequest::MFACode {
+                msg,
+                polling_interval,
+            } => PamAuthResponse::MFACode {
+                msg,
+                polling_interval,
+            },
             AuthRequest::MFAPoll {
                 msg,
                 polling_interval,

--- a/unix_integration/src/unix_proto.rs
+++ b/unix_integration/src/unix_proto.rs
@@ -41,7 +41,10 @@ pub enum PamAuthResponse {
     },
     /// PAM must prompt for an authentication code
     MFACode {
+        /// Initial message to display as the polling begins.
         msg: String,
+        /// Seconds between polling attempts.
+        polling_interval: u32,
     },
     /// PAM will poll for an external response
     MFAPoll {


### PR DESCRIPTION
The MS Authenticator app requires both a code
entered from the app, and input on the app for a
entropy code (sent in the same PAM message). This
requires the idprovider to poll and wait for the
user to enter the entropy code on the app.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
