### PR TITLE
Remove small ambiguity in docs

### DIFF
--- a/book/src/accounts/people_accounts.md
+++ b/book/src/accounts/people_accounts.md
@@ -114,5 +114,5 @@ Adding the user to the `idm_people_self_write_mail` group, as shown below, allow
 their own mail.
 
 ```bash
-kanidm group add-members idm_people_self_write_mail_priv demo_user --name idm_admin
+kanidm group add-members idm_people_self_write_mail demo_user --name idm_admin
 ```


### PR DESCRIPTION
Nonexistent `idm_people_self_write_mail_priv` is used instead of the correct `idm_people_self_write_mail` in the example in [Allowing people accounts to change their mail attribute](https://kanidm.github.io/kanidm/stable/accounts/people_accounts.html#allowing-people-accounts-to-change-their-mail-attribute).


- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)