### PR TITLE
fix: typos in OpenApi

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@
 - Jinna Kiisuo (jinnatar)
 - Merlijn Verstraete (ToxicMushroom)
 - Tobias Krischer (tobikris)
+- Daniil Egortsev (playhardgopro)
 
 ## Acknowledgements
 

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -1238,7 +1238,7 @@ pub async fn account_user_auth_token_delete(
 }
 
 #[utoipa::path(
-    get,
+    post,
     path = "/v1/credential/_exchange_intent",
     params(
     ),
@@ -1263,7 +1263,7 @@ pub async fn credential_update_exchange_intent(
 }
 
 #[utoipa::path(
-    get,
+    post,
     path = "/v1/credential/_status",
     responses(
         (status=200), // TODO: define response

--- a/server/web_ui/user/src/components/create_reset_code.rs
+++ b/server/web_ui/user/src/components/create_reset_code.rs
@@ -236,7 +236,7 @@ impl Component for CreateResetCode {
 
 impl CreateResetCode {
     async fn credential_get_update_intent_token(id: String) -> Result<Msg, FetchError> {
-        let uri = format!("/v1/person/{}/_credential/_update_intent?ttl=0", id);
+        let uri = format!("/v1/person/{}/_credential/_update_intent/0", id);
 
         let (kopid, status, value, _) =
             do_request(&uri, RequestMethod::GET, None::<JsValue>).await?;


### PR DESCRIPTION
Hi! I have found a few typos

`/v1/credential/_exchange_intent` [uses POST method instead of GET](https://github.com/kanidm/kanidm/blob/073ed403edd6360bb1406611965b81fb6c25710e/server/core/src/https/v1.rs#L3224C9-L3227C10)
`/v1/credential/_status` [uses POST method instead of GET](https://github.com/kanidm/kanidm/blob/073ed403edd6360bb1406611965b81fb6c25710e/server/core/src/https/v1.rs#L3228C7-L3228C73)
`/v1/person/{}/_credential/_update_intent` [uses route params instead of query params](https://github.com/kanidm/kanidm/blob/073ed403edd6360bb1406611965b81fb6c25710e/server/core/src/https/v1.rs#L3102C8-L3105C10)

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
