### PR TITLE
Shutting down the logging pipeline twice is a bit overkill 😄 

### DIFF
--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -389,8 +389,6 @@ pub async fn create_https_server(
 
         };
 
-        opentelemetry::global::shutdown_tracer_provider();
-
         info!("Stopped {}", super::TaskName::HttpsServer);
     }))
 }


### PR DESCRIPTION
Fixes the fact that the HTTPS server wouldn't shut down while OTLP export was enabled.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
