### PR TITLE
illumos support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dhat",
- "fs2",
+ "fs4",
  "futures",
  "kanidm_build_profiles",
  "kanidm_lib_file_permissions",
@@ -1715,13 +1715,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ dhat = "0.3.3"
 dyn-clone = "^1.0.17"
 fernet = "^0.2.1"
 filetime = "^0.2.23"
-fs2 = "^0.4.3"
+fs4 = "^0.8.3"
 futures = "^0.3.30"
 futures-concurrency = "^3.1.0"
 futures-util = { version = "^0.3.30", features = ["sink"] }

--- a/libs/file_permissions/src/unix.rs
+++ b/libs/file_permissions/src/unix.rs
@@ -6,6 +6,9 @@ use std::os::linux::fs::MetadataExt;
 #[cfg(target_os = "macos")]
 use std::os::macos::fs::MetadataExt;
 
+#[cfg(target_os = "illumos")]
+use std::os::illumos::fs::MetadataExt;
+
 use kanidm_utils_users::{get_current_gid, get_current_uid};
 
 use std::fmt;

--- a/server/daemon/Cargo.toml
+++ b/server/daemon/Cargo.toml
@@ -28,12 +28,11 @@ kanidm_proto = { workspace = true }
 kanidmd_core = { workspace = true }
 kanidm_lib_file_permissions = { workspace = true }
 sketching = { workspace = true }
-fs2 = { workspace = true }
+fs4 = { workspace = true }
 futures = { workspace = true }
 
 dhat = { workspace = true, optional = true }
 clap = { workspace = true, features = ["env"] }
-mimalloc = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
@@ -55,6 +54,9 @@ whoami = { workspace = true }
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
+
+[target.'cfg(not(target_os = "illumos"))'.dependencies]
+mimalloc = { workspace = true }
 
 [build-dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -10,7 +10,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-#[cfg(not(feature = "dhat-heap"))]
+#[cfg(not(any(feature = "dhat-heap", target_os = "illumos")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
@@ -20,7 +20,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use std::fs::{metadata, File};
 // This works on both unix and windows.
-use fs2::FileExt;
+use fs4::FileExt;
 use kanidm_proto::messages::ConsoleOutputMode;
 use sketching::otel::TracingPipelineGuard;
 use sketching::LogLevel;

--- a/server/lib/Cargo.toml
+++ b/server/lib/Cargo.toml
@@ -109,8 +109,10 @@ compact_jwt = { workspace = true, features = ["openssl", "hsm-crypto", "unsafe_r
 criterion = { workspace = true, features = ["html_reports"] }
 futures = { workspace = true }
 kanidmd_lib_macros = { workspace = true }
-mimalloc = { workspace = true }
 webauthn-authenticator-rs = { workspace = true }
+
+[target.'cfg(not(target_os = "illumos"))'.dev-dependencies]
+mimalloc = { workspace = true }
 
 [build-dependencies]
 hashbrown = { workspace = true }

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(clippy::manual_let_else)]
 #![allow(clippy::unreachable)]
 
-#[cfg(all(test, not(feature = "dhat-heap")))]
+#[cfg(all(test, not(any(feature = "dhat-heap", target_os = "illumos"))))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/tools/orca/Cargo.toml
+++ b/tools/orca/Cargo.toml
@@ -28,7 +28,6 @@ hashbrown = { workspace = true }
 kanidm_client = { workspace = true }
 kanidm_proto = { workspace = true }
 mathru = { workspace = true }
-mimalloc = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -38,6 +37,9 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4" ] }
+
+[target.'cfg(not(any(target_family = "windows", target_os = "illumos")))'.dependencies]
+mimalloc = { workspace = true }
 
 [build-dependencies]
 kanidm_build_profiles = { workspace = true }

--- a/tools/orca/src/main.rs
+++ b/tools/orca/src/main.rs
@@ -6,7 +6,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-#[cfg(not(target_family = "windows"))]
+#[cfg(not(any(target_family = "windows", target_os = "illumos")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/unix_integration/Cargo.toml
+++ b/unix_integration/Cargo.toml
@@ -67,7 +67,6 @@ kanidm_proto = { workspace = true }
 kanidm-hsm-crypto = { workspace = true }
 kanidm_lib_crypto = { workspace = true }
 kanidm_lib_file_permissions = { workspace = true }
-mimalloc = { workspace = true }
 notify-debouncer-full = { workspace = true }
 rpassword = { workspace = true }
 rusqlite = { workspace = true }
@@ -97,6 +96,9 @@ prctl.workspace = true
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
+
+[target.'cfg(not(target_os = "illumos"))'.dependencies]
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 kanidmd_core = { workspace = true }

--- a/unix_integration/src/daemon.rs
+++ b/unix_integration/src/daemon.rs
@@ -53,6 +53,7 @@ use kanidm_hsm_crypto::{soft::SoftTpm, AuthValue, BoxedDynTpm, Tpm};
 
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, notify::Watcher};
 
+#[cfg(not(target_os = "illumos"))]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
A few minor changes to get the software to at least build on [illumos](https://illumos.org) systems.

* disable mimalloc on illumos, in part because it immediately segfaults, but also because we prefer [libumem](https://illumos.org/man/3LIB/libumem) and link it into all Rust binaries
  ```
  $ pstack core | demangle
  core 'core' of 12571:   ./target/release/kanidmd --help
   00000000032c07d0 mi_segments_page_find_and_allocate.cold ()
   00000000032c164f mi_segments_page_alloc.constprop.1 () + 6f
   00000000032c1921 mi_page_fresh_alloc () + 31
   00000000032c1ff3 mi_page_queue_find_free_ex () + 3d3
   00000000032c3049 _mi_malloc_generic () + 49
   00000000032c46f0 mi_heap_malloc_zero_aligned_at_generic () + 150
   000000000303cc30 std::sys::pal::unix::stack_overflow::imp::signal_handler::h9f2a03a6a3736889 () + b0
   fffffc7fef272976 __sighndlr () + 6
   fffffc7fef265491 call_user_handler (b, fffffc7fef132ef0, fffffc7fef132b90) + 1d1
   fffffc7fef2657a6 sigacthandler (b, fffffc7fef132ef0, fffffc7fef132b80) + f6
   --- called from signal handler with signal 11 (SIGSEGV) ---
   ffffffffffffffff ???????? ()
   00000000032c164f mi_segments_page_alloc.constprop.1 () + 6f
   00000000032c1921 mi_page_fresh_alloc () + 31
   00000000032c1ff3 mi_page_queue_find_free_ex () + 3d3
   00000000032c3049 _mi_malloc_generic () + 49
   00000000032c46f0 mi_heap_malloc_zero_aligned_at_generic () + 150
   000000000302c5b1 std::rt::lang_start_internal::h8fc06c5d656f3808 () + 281
   0000000001851fc3 main () + 33
   000000000125d637 _start_crt () + 87
   000000000125d598 _start () + 18
  ```

* switch from fs2 (unmaintained crate) to fs4 which provides the same interface and has wider platform support

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run _(it has, but all of the noise that pops out seems unrelated...)_
- [x] cargo test has been run and passes