### PR TITLE
ci: push docker image for git tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "csv",
  "futures",
  "kanidm_build_profiles",
+ "kanidm_proto",
  "serde",
  "serde_json",
  "serde_with",

--- a/proto/src/internal/error.rs
+++ b/proto/src/internal/error.rs
@@ -143,6 +143,11 @@ pub enum OperationError {
 
     // Specific internal errors.
 
+    // Kanidm Generic Errors
+    KG001TaskTimeout,
+    KG002TaskCommFailure,
+    KG003CacheClearFailed,
+
     // What about something like this for unique errors?
     // Credential Update Errors
     CU0001WebauthnAttestationNotTrusted,
@@ -230,6 +235,14 @@ pub enum OperationError {
     // Web UI
     UI0001ChallengeSerialisation,
     UI0002InvalidState,
+
+    // Unixd Things
+    KU001InitWhileSessionActive,
+    KU002ContinueWhileSessionInActive,
+    KU003PamAuthFailed,
+    KU004PamInitFailed,
+    KU005ErrorCheckingAccount,
+    KU006OnlyRootAllowed,
 }
 
 impl PartialEq for OperationError {
@@ -324,29 +337,16 @@ impl OperationError {
             Self::TransactionAlreadyCommitted => None,
             Self::ValueDenyName => None,
             Self::DatabaseLockAcquisitionTimeout => Some("Unable to acquire a database lock - the current server may be too busy. Try again later.".into()),
+            Self::CU0001WebauthnAttestationNotTrusted => None,
             Self::CU0002WebauthnRegistrationError => None,
             Self::CU0003WebauthnUserNotVerified => Some("User Verification bit not set while registering credential, you may need to configure a PIN on this device.".into()),
-            Self::CU0001WebauthnAttestationNotTrusted => None,
-            Self::VS0001IncomingReplSshPublicKey => None,
-            Self::VS0003CertificateDerDecode => Some("Decoding the stored certificate from DER failed.".into()),
-            Self::VS0002CertificatePublicKeyDigest |
-            Self::VS0004CertificatePublicKeyDigest |
-            Self::VS0005CertificatePublicKeyDigest => Some("The certificates public key is unabled to be digested.".into()),
-            Self::VL0001ValueSshPublicKeyString => None,
-            Self::LD0001AnonymousNotAllowed => Some("Anonymous is not allowed to access LDAP with this method.".into()),
-            Self::SC0001IncomingSshPublicKey => None,
-            Self::MG0001InvalidReMigrationLevel => None,
-            Self::MG0002RaiseDomainLevelExceedsMaximum => None,
-            Self::MG0003ServerPhaseInvalidForMigration => None,
             Self::DB0001MismatchedRestoreVersion => None,
             Self::DB0002MismatchedRestoreVersion => None,
             Self::DB0003FilterResolveCacheBuild => None,
             Self::DB0004DatabaseTooOld => Some("The database is too old to be migrated.".into()),
-            Self::MG0004DomainLevelInDevelopment => None,
-            Self::MG0005GidConstraintsNotMet => None,
-            Self::MG0006SKConstraintsNotMet => Some("Migration Constraints Not Met - Security Keys should not be present.".into()),
-            Self::MG0007Oauth2StrictConstraintsNotMet => Some("Migration Constraints Not Met - All OAuth2 clients must have strict-redirect-uri mode enabled.".into()),
-            Self::MG0008SkipUpgradeAttempted => Some("Skip Upgrade Attempted.".into()),
+            Self::KG001TaskTimeout => Some("Task timed out".into()),
+            Self::KG002TaskCommFailure => Some("Inter-Task communication failure".into()),
+            Self::KG003CacheClearFailed => Some("Failed to clear cache".into()),
             Self::KP0001KeyProviderNotLoaded => None,
             Self::KP0002KeyProviderInvalidClass => None,
             Self::KP0003KeyProviderInvalidType => None,
@@ -392,9 +392,31 @@ impl OperationError {
             Self::KP0042KeyObjectNoActiveEncryptionKeys => None,
             Self::KP0043KeyObjectJweA128GCMEncryption => None,
             Self::KP0044KeyObjectJwsPublicJwk => None,
+            Self::KU001InitWhileSessionActive => Some("The session was active when the init function was called.".into()),
+            Self::KU002ContinueWhileSessionInActive => Some("Attempted to continue auth session while current session is inactive".into()),
+            Self::KU003PamAuthFailed => Some("Failed PAM account authentication step".into()),
+            Self::KU004PamInitFailed => Some("Failed to initialise PAM authentication".into()),
+            Self::KU005ErrorCheckingAccount => Some("Error checking account".into()),
+            Self::KU006OnlyRootAllowed => Some("Only root is allowed to perform this operation".into()),
+            Self::LD0001AnonymousNotAllowed => Some("Anonymous is not allowed to access LDAP with this method.".into()),
+            Self::MG0001InvalidReMigrationLevel => None,
+            Self::MG0002RaiseDomainLevelExceedsMaximum => None,
+            Self::MG0003ServerPhaseInvalidForMigration => None,
+            Self::MG0004DomainLevelInDevelopment => None,
+            Self::MG0005GidConstraintsNotMet => None,
+            Self::MG0006SKConstraintsNotMet => Some("Migration Constraints Not Met - Security Keys should not be present.".into()),
+            Self::MG0007Oauth2StrictConstraintsNotMet => Some("Migration Constraints Not Met - All OAuth2 clients must have strict-redirect-uri mode enabled.".into()),
+            Self::MG0008SkipUpgradeAttempted => Some("Skip Upgrade Attempted.".into()),
             Self::PL0001GidOverlapsSystemRange => None,
+            Self::SC0001IncomingSshPublicKey => None,
             Self::UI0001ChallengeSerialisation => Some("The WebAuthn challenge was unable to be serialised.".into()),
             Self::UI0002InvalidState => Some("The credential update process returned an invalid state transition.".into()),
+            Self::VL0001ValueSshPublicKeyString => None,
+            Self::VS0001IncomingReplSshPublicKey => None,
+            Self::VS0002CertificatePublicKeyDigest |
+            Self::VS0003CertificateDerDecode => Some("Decoding the stored certificate from DER failed.".into()),
+            Self::VS0004CertificatePublicKeyDigest |
+            Self::VS0005CertificatePublicKeyDigest => Some("The certificates public key is unabled to be digested.".into()),
         }
     }
 }

--- a/unix_integration/common/Cargo.toml
+++ b/unix_integration/common/Cargo.toml
@@ -25,14 +25,15 @@ doctest = false
 bytes = { workspace = true }
 csv = { workspace = true }
 futures = { workspace = true }
+kanidm_proto = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-toml = { workspace = true }
-tokio = { workspace = true, features = ["time","net","macros"] }
-tokio-util = { workspace = true, features = ["codec"] }
-tracing = { workspace = true }
 sha-crypt = { workspace = true }
+tokio = { workspace = true, features = ["time", "net", "macros"] }
+tokio-util = { workspace = true, features = ["codec"] }
+toml = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 kanidm_build_profiles = { workspace = true }

--- a/unix_integration/common/src/unix_proto.rs
+++ b/unix_integration/common/src/unix_proto.rs
@@ -177,7 +177,7 @@ pub enum ClientResponse {
     ProviderStatus(Vec<ProviderStatus>),
 
     Ok,
-    Error,
+    Error(String),
 }
 
 impl From<PamAuthResponse> for ClientResponse {

--- a/unix_integration/common/src/unix_proto.rs
+++ b/unix_integration/common/src/unix_proto.rs
@@ -1,4 +1,5 @@
 use crate::unix_passwd::{EtcGroup, EtcUser};
+use kanidm_proto::internal::OperationError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -177,7 +178,7 @@ pub enum ClientResponse {
     ProviderStatus(Vec<ProviderStatus>),
 
     Ok,
-    Error(String),
+    Error(OperationError),
 }
 
 impl From<PamAuthResponse> for ClientResponse {

--- a/unix_integration/pam_kanidm/src/core.rs
+++ b/unix_integration/pam_kanidm/src/core.rs
@@ -299,7 +299,7 @@ pub fn sm_authenticate_connected<P: PamHandler>(
             }
 
             ClientResponse::Error(err) => {
-                error!("Error from kanidm-unixd: {:?}", err);
+                error!("Error from kanidm-unixd: {}", err);
                 return PamResultCode::PAM_AUTH_ERR;
             }
             ClientResponse::Ok

--- a/unix_integration/pam_kanidm/src/core.rs
+++ b/unix_integration/pam_kanidm/src/core.rs
@@ -298,8 +298,11 @@ pub fn sm_authenticate_connected<P: PamHandler>(
                 continue;
             }
 
+            ClientResponse::Error(err) => {
+                error!("Error from kanidm-unixd: {:?}", err);
+                return PamResultCode::PAM_AUTH_ERR;
+            }
             ClientResponse::Ok
-            | ClientResponse::Error
             | ClientResponse::SshKeys(_)
             | ClientResponse::NssAccounts(_)
             | ClientResponse::NssAccount(_)

--- a/unix_integration/resolver/src/bin/kanidm-unix.rs
+++ b/unix_integration/resolver/src/bin/kanidm-unix.rs
@@ -103,6 +103,10 @@ async fn main() -> ExitCode {
                             });
                             continue;
                         }
+                        ClientResponse::Error(err) => {
+                            error!("Error from kanidm-unixd: {}", err);
+                            break;
+                        }
                         ClientResponse::PamAuthenticateStepResponse(_)
                         | ClientResponse::SshKeys(_)
                         | ClientResponse::NssAccounts(_)
@@ -111,7 +115,6 @@ async fn main() -> ExitCode {
                         | ClientResponse::NssGroups(_)
                         | ClientResponse::ProviderStatus(_)
                         | ClientResponse::Ok
-                        | ClientResponse::Error
                         | ClientResponse::PamStatus(_) => {
                             // unexpected response.
                             error!("Error: unexpected response -> {:?}", r);


### PR DESCRIPTION
Fixes #2855

This PR modifies the github action condition for the various docker image push jobs in order to push built images for the master branch *and* for git tags.

No source code was modified in this PR, only github workflow configuration.

Ideally tags could be prefixed with `v` in order to specifically target git tags meant for releasing a new kanidm version (as opposed to git tags used for experimenting) but in the meantime docker images will be pushed for all git tags.

I did not go the extra mile, but the github job for pushing docker imags could probably be extracted and reused to avoid code duplication and to avoid modifying code three times (once per docker image) when modifications are needed

Note that merging this PR will not build and publish a docker image for the `1.2.3` release, so building and pushing one manually to the docker hub registry will ensure that anyone looking for a tagged docker image for this release will find one.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
