### PR TITLE
Adding freebsd target_os for filesystem metadata ops

### DIFF
--- a/libs/file_permissions/src/unix.rs
+++ b/libs/file_permissions/src/unix.rs
@@ -1,5 +1,8 @@
 use std::fs::Metadata;
 
+#[cfg(target_os = "freebsd")]
+use std::os::freebsd::fs::MetadataExt;
+
 #[cfg(target_os = "linux")]
 use std::os::linux::fs::MetadataExt;
 


### PR DESCRIPTION
Fixes #2857

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
