### PR TITLE
Add Alpine Linux installation instructions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,6 +39,7 @@
 - Tobias Krischer (tobikris)
 - Daniil Egortsev (playhardgopro)
 - Anton Loukianov (antonl)
+- fossdd
 
 ## Acknowledgements
 

--- a/book/src/installing_client_tools.md
+++ b/book/src/installing_client_tools.md
@@ -19,6 +19,7 @@ Kanidm currently is packaged for the following systems:
 - Fedora 38
 - NixOS
 - Ubuntu
+- Alpine Linux
 
 The `kanidm` client has been built and tested from Windows, but is not (yet) packaged routinely.
 
@@ -91,6 +92,16 @@ dnf install kanidm-clients
 ### Ubuntu and Debian
 
 See <https://kanidm.github.io/kanidm_ppa/> for nightly-built packages of the current development builds, and how to install them.
+
+## Alpine Linux
+
+Kanidm is available in the [Alpine Linux testing repository](https://pkgs.alpinelinux.org/packages?name=kanidm%2A).
+
+To install the Kanidm client use:
+
+```bash
+apk add kanidm-clients
+```
 
 ## Tools Container
 

--- a/book/src/packaging/community_packages.md
+++ b/book/src/packaging/community_packages.md
@@ -6,3 +6,4 @@ not officially supported and may not function identically.
 - [Arch Linux](https://aur.archlinux.org/packages?O=0&K=kanidm)
 - [OpenSUSE](https://software.opensuse.org/search?baseproject=ALL&q=kanidm)
 - [NixOS](https://search.nixos.org/packages?sort=relevance&type=packages&query=kanidm)
+- [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=kanidm%2A)


### PR DESCRIPTION
Adds installation instructions for the Kanidm packages on Alpine Linux: https://pkgs.alpinelinux.org/packages?name=kanidm%2A

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
