### PR TITLE
making the internals of kanidmclientconfig public for other users

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -109,11 +109,13 @@ pub struct KanidmClientConfigInstance {
 /// 3. All of these may be overridden by setting environment variables.
 ///
 pub struct KanidmClientConfig {
+    // future editors, please leave this public so others can parse the config!
     #[serde(flatten)]
-    default: KanidmClientConfigInstance,
+    pub default: KanidmClientConfigInstance,
 
     #[serde(flatten)]
-    instances: BTreeMap<String, KanidmClientConfigInstance>,
+    // future editors, please leave this public so others can parse the config!
+    pub instances: BTreeMap<String, KanidmClientConfigInstance>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/server/lib/src/idm/authsession.rs
+++ b/server/lib/src/idm/authsession.rs
@@ -1481,7 +1481,7 @@ impl AuthSession {
                 ) {
                     CredState::Success { auth_type, cred_id } => {
                         // Issue the uat based on a set of factors.
-                        let uat = self.issue_uat(&auth_type, time, async_tx, cred_id)?;
+                        let uat = self.issue_uat(auth_type, time, async_tx, cred_id)?;
 
                         let jwt = Jws::into_json(&uat).map_err(|e| {
                             admin_error!(?e, "Failed to serialise into Jws");
@@ -1546,7 +1546,7 @@ impl AuthSession {
 
     fn issue_uat(
         &mut self,
-        auth_type: &AuthType,
+        auth_type: AuthType,
         time: Duration,
         async_tx: &Sender<DelayedAction>,
         cred_id: Uuid,
@@ -1614,7 +1614,7 @@ impl AuthSession {
                             issued_at: uat.issued_at,
                             issued_by: IdentityId::User(self.account.uuid),
                             scope,
-                            type_: *auth_type,
+                            type_: auth_type,
                         }))
                         .map_err(|e| {
                             debug!(?e, "queue failure");

--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -112,7 +112,7 @@ impl ValueSetSession {
                         type_,
                     } => {
                         // Convert things.
-                        let issued_at = OffsetDateTime::parse(&issued_at, &Rfc3339)
+                        let issued_at = OffsetDateTime::parse(issued_at, &Rfc3339)
                             .map(|odt| odt.to_offset(time::UtcOffset::UTC))
                             .map_err(|e| {
                                 admin_error!(
@@ -125,7 +125,7 @@ impl ValueSetSession {
 
                         let state = match state {
                             DbValueSessionStateV1::ExpiresAt(e_inner) => {
-                                OffsetDateTime::parse(&e_inner, &Rfc3339)
+                                OffsetDateTime::parse(e_inner, &Rfc3339)
                                     .map(|odt| odt.to_offset(time::UtcOffset::UTC))
                                     .map(SessionState::ExpiresAt)
                                     .map_err(|e| {

--- a/unix_integration/resolver/src/idprovider/interface.rs
+++ b/unix_integration/resolver/src/idprovider/interface.rs
@@ -139,6 +139,7 @@ pub enum AuthCacheAction {
 }
 
 #[async_trait]
+#[allow(clippy::too_many_arguments)]
 pub trait IdProvider {
     async fn configure_hsm_keys(
         &self,


### PR DESCRIPTION
Fixes the fact I can't use `kanidm_client` to parse configs 😄 

Also... made clippy happy in a few places.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
