### PR TITLE
Add missing groups scope to Grafana example scope-map

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -485,7 +485,7 @@ Prepare the environment:
 
 ```bash
 $ kanidm system oauth2 create grafana "grafana.domain.name" https://grafana.domain.name
-$ kanidm system oauth2 update-scope-map grafana grafana_users email openid profile
+$ kanidm system oauth2 update-scope-map grafana grafana_users email openid profile groups
 $ kanidm system oauth2 enable-pkce grafana
 $ kanidm system oauth2 get grafana
 $ kanidm system oauth2 show-basic-secret grafana


### PR DESCRIPTION
Fixes the scope map for the Grafana example, where Grafana requests the group scope, which is not configured.

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
