### PR TITLE
Run rust_build CI between multiple Rust versions

### DIFF
--- a/.github/workflows/debian_package_kanidm.yml
+++ b/.github/workflows/debian_package_kanidm.yml
@@ -59,7 +59,7 @@ jobs:
   upload-to-releases:
     permissions:
       # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-      contents: write # allows the action to create a release
+      contents: write  # allows the action to create a release
 
     name: Upload to releases
     needs: build-deb-package

--- a/.github/workflows/docker_build_kanidm.yml
+++ b/.github/workflows/docker_build_kanidm.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     name: set lower case owner name
     steps:
-    - id: step1
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_OUTPUT}"
-      env:
-        OWNER: '${{ github.repository_owner }}'
+      - id: step1
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_OUTPUT}"
+        env:
+          OWNER: '${{ github.repository_owner }}'
     outputs:
       owner_lc: ${{ steps.step1.outputs.OWNER_LC }}
 
@@ -69,5 +69,7 @@ jobs:
 
       - name: Push image to GHCR
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ghcr.io
-          oras copy --from-oci-layout "/tmp/kanidm-docker.tar:devel" "ghcr.io/${{ github.repository_owner }}/kanidm:devel"
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            oras login -u "${{ github.actor }}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/kanidm-docker.tar:devel" \
+            "ghcr.io/${{ github.repository_owner }}/kanidm:devel"

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     name: set lower case owner name
     steps:
-    - id: step1
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_OUTPUT}"
-      env:
-        OWNER: '${{ github.repository_owner }}'
+      - id: step1
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_OUTPUT}"
+        env:
+          OWNER: '${{ github.repository_owner }}'
     outputs:
       owner_lc: ${{ steps.step1.outputs.OWNER_LC }}
 
@@ -85,5 +85,7 @@ jobs:
 
       - name: Push image to GHCR
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ghcr.io
-          oras copy --from-oci-layout "/tmp/kanidmd-docker.tar:devel" "ghcr.io/${{ github.repository_owner }}/kanidmd:devel"
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            oras login -u "${{ github.actor }}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/kanidmd-docker.tar:devel" \
+            "ghcr.io/${{ github.repository_owner }}/kanidmd:devel"

--- a/.github/workflows/docker_build_radiusd.yml
+++ b/.github/workflows/docker_build_radiusd.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     name: set lower case owner name
     steps:
-    - id: step1
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_OUTPUT}"
-      env:
-        OWNER: '${{ github.repository_owner }}'
+      - id: step1
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_OUTPUT}"
+        env:
+          OWNER: '${{ github.repository_owner }}'
     outputs:
       owner_lc: ${{ steps.step1.outputs.OWNER_LC }}
 
@@ -69,5 +69,7 @@ jobs:
       # features, but ORAS will: https://oras.land/docs/commands/oras_copy
       - name: Push image to GHCR
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login -u "${{ github.actor }}" --password-stdin ghcr.io
-          oras copy --from-oci-layout "/tmp/radius-docker.tar:devel" "ghcr.io/${{ github.repository_owner }}/radius:devel"
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            oras login -u "${{ github.actor }}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/radius-docker.tar:devel" \
+            "ghcr.io/${{ github.repository_owner }}/radius:devel"

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "{{ matrix.rust_version }}"
+          toolchain: ${{ matrix.rust_version }}
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
         with:

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -55,6 +55,51 @@ jobs:
       - name: "Check disk space at the end"
         run:
           du -shc *
+
+  rust_build_next:
+    runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
+      CARGO_INCREMENTAL: 0
+      CARGO_TERM_COLOR: always
+    strategy:
+      matrix:
+        rust_version: ['beta', 'nightly']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@{{ matrix.rust_version }}
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.5
+        with:
+          version: "v0.4.2"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y \
+            libpam0g-dev \
+            libudev-dev \
+            libssl-dev
+
+      - name: "Build the workspace"
+        run: cargo build --workspace
+      - name: "Check disk space and size of target, then clean it"
+        run: |
+          df -h
+          echo "Checking base dir"
+          du -shc *
+          echo "Checking target dir"
+          du -shc target/*
+          rm -rf target/*
+
+      - name: "Run cargo test"
+        run: cargo test
+      - name: "Check disk space at the end"
+        run:
+          du -shc *
+
   run_release:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -69,7 +69,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@{{ matrix.rust_version }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "{{ matrix.rust_version }}"
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
         with:

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -55,9 +55,10 @@ jobs:
       - name: "Check disk space at the end"
         run:
           du -shc *
-
   rust_build_next:
+    # build future versions to find possible next-version bugs
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       SCCACHE_GHA_ENABLED: true
       RUSTC_WRAPPER: sccache


### PR DESCRIPTION
This way, build failures on a upcoming Rust version can be found earlier, and doesn't hold new Kandim releases.

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [x] `cargo fmt` has been run
- [x] `cargo clippy` has been run
- [x] `cargo test` has been run and passes
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
