### PR TITLE
fix: `Dockerfile` - `VOLUME` directive is an anti-pattern

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -77,7 +77,6 @@ COPY --from=builder /usr/src/kanidm/server/core/static /hpkg
 RUN chmod +x /sbin/kanidmd
 
 EXPOSE 8443 3636
-VOLUME /data
 
 ENV RUST_BACKTRACE 1
 

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -2000,7 +2000,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 mut_d_info.d_name,
             );
             admin_warn!(
-                    "If you think this is an error, see https://kanidm.github.io/kanidm/stable/administrivia.html#rename-the-domain"
+                    "If you think this is an error, see https://kanidm.github.io/kanidm/server_configuration.html"
                 );
             mut_d_info.d_name = domain_name;
         }


### PR DESCRIPTION
The `VOLUME` directive provides **no value** to an image. It **only causes problems.**

For detailed justification, please see below context or my past writeup on this subject: https://github.com/ory/hydra/issues/3683

## Checklist

- [x] This PR contains no AI generated code
- [x] `cargo fmt` has been run
- [x] `cargo clippy` has been run
- [x] `cargo test` has been run and passes
- [ ] ~~book chapter included (if relevant)~~
- [ ] ~~design document included (if relevant)~~

---

## Context

### Reproduction Example

```yaml
services:
  kanidm:
    image: docker.io/kanidm/server:latest
    ports:
      - 443:8443
    # This feature is like `volumes`,
    # except you can define the file content inline with the `compose.yaml` file.
    # I use this for simple copy/paste examples I share online.
    configs:
      - source: kanidm-config
        target: /data/server.toml
      # I've provisioned certs via Smallstep CA (content excluded due to added verbosity):
      - source: tls-leaf-cert-ecdsa-localhost
        target: /data/chain.pem
      - source: tls-leaf-key-ecdsa-localhost
        target: /data/key.pem

# `VOLUME /data` paired with `db_path = "/data/kanidm.db"` was problematic
# when I changed the `domain` + `origin` and certs.
configs:
  kanidm-config:
    content: |
      #domain = "auth.example.test"
      #origin = "https://auth.example.test:8443"
      domain = "auth.localhost"
      origin = "https://auth.localhost:8443"
      tls_chain = "/data/chain.pem"
      tls_key = "/data/key.pem"
      db_path = "/data/kanidm.db"
      bindaddress = "[::]:8443"
```

After running the above `compose.yaml` with the config update to `domain` + `origin`, the container fails unexpectedly:

```console
$ docker compose up --force-recreate

[+] Running 1/1
 ✔ Container kanidm-1  Recreated
Attaching to kanidm-1
📜 Using config file: "/data/server.toml"
Log filter: Info
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: This is running as uid == 0 (root) which may be a security risk.
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: permissions on /data/server.toml may not be secure. Should be readonly to running uid. This could be a security risk ...
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: WARNING: /data/server.toml has 'everyone' permission bits in the mode. This could be a security risk ...
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: WARNING: /data/server.toml owned by the current uid, which may allow file permission changes. This could be a security risk ...
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: WARNING: DB folder /data has 'everyone' permission bits in the mode. This could be a security risk ...
00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Running in server mode ...
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: permissions on /data/chain.pem may not be secure. Should be readonly to running uid. This could be a security risk ...
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: permissions on /data/key.pem may not be secure. Should be readonly to running uid. This could be a security risk ...
00000000-0000-0000-0000-000000000000 WARN     🚧 [warn]: WARNING: /data/key.pem has 'everyone' permission bits in the mode. This could be a security risk ...
00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Starting kanidm with configuration: address: [::]:8443, domain: auth.localhost, ldap address: disabled, origin: https://auth.localhost:8443 admin bind path: /data/kanidmd.sock, thread count: 16, dbpath: /data/kanidm.db, arcsize: AUTO, max request size: 262144b, trust X-Forwarded-For: false, with TLS: true, online_backup: disabled, integration mode: false, console output format: Text log_level: inforole: write replica, replication: disabled, otel_grpc_url: None
3773f806-c462-49d6-912f-fd5b6eae3710 INFO     system_initialisation [ 34.7ms | 28.69% / 100.00% ]
3773f806-c462-49d6-912f-fd5b6eae3710 INFO     ┝━ initialise_schema_core [ 18.4ms | 53.01% ]
3773f806-c462-49d6-912f-fd5b6eae3710 INFO     ┝━ initialise_domain_info [ 2.17ms | 6.27% ]
3773f806-c462-49d6-912f-fd5b6eae3710 WARN     ┝━ 🚧 [warn]: Using domain name from the database auth.example.com - was auth.localhost in memory | event_tag_id: 2
3773f806-c462-49d6-912f-fd5b6eae3710 WARN     ┝━ 🚧 [warn]: If you think this is an error, see https://kanidm.github.io/kanidm/stable/administrivia.html#rename-the-domain | event_tag_id: 2
3773f806-c462-49d6-912f-fd5b6eae3710 INFO     ┕━ qswt_commit [ 4.17ms | 12.03% ]
00000000-0000-0000-0000-000000000000 ERROR    🚨 [error]: Effective domain is not a descendent of server domain name (rp_id). | event_tag_id: 1
00000000-0000-0000-0000-000000000000 ERROR    🚨 [error]: You must change origin or domain name to be consistent. ed: "https://auth.localhost:8443" - rp_id: "auth.example.com" | event_tag_id: 1
00000000-0000-0000-0000-000000000000 ERROR    🚨 [error]: To change the origin or domain name see: https://kanidm.github.io/kanidm/server_configuration.html | event_tag_id: 1
00000000-0000-0000-0000-000000000000 ERROR    🚨 [error]: Unable to setup query server or idm server -> InvalidState
00000000-0000-0000-0000-000000000000 ERROR    🚨 [error]: Failed to start server core!
Logging pipeline completed shutdown
exited with code 1
```

Specifically the problem is identified at this log line:

```
🚧 [warn]: Using domain name from the database auth.example.com - was auth.localhost in memory | event_tag_id: 2
```

### Problem triggered in relation to `VOLUME` directive

I am aware of the requirements for changing the configuration, but this failure was not expected as I was using `docker compose up --force-recreate`.

Typically that should be equivalent to `docker run --rm ...`, ensuring a fresh container instance is created, discarding any internal state. Nor did `docker compose down` help.

- I provided no volume mount for `/data` since I was only in an evaluation stage and wanting to quickly get the bare minimum up and running.
- Any additional runtime data that `kanidm` may write to `/data` in the container was expected to have been discarded for a clean slate.
- Anonymous volumes are created when an image has a `VOLUME` directive. They will initialize by copying any of the existing content at the mount point, unlike a bind mount volume which replaces.
  - With `docker run --rm ...`, each container instance started will create a new anonymous volume. Without the `--rm`, these will accumulate pointlessly, the user may not be aware of it.
  - Docker Compose behaves differently, with additional logic to preserve the same anonymous volume across instances of the container for a given compose project.

Thus I had to remove the actual anonymous volume manually to get a fresh container like the first time I started `kanidm`, which would then not attempt to re-use the unwanted prior database in `/data`.

### Conclusion

There is no reason to use `VOLUME` in `Dockerfile`. It only causes issues.

Your database in `/data` will persist with the internal container state for the lifecycle of that container. If a user wants to persist it externally, then they can do so with an explicit volume (_be that anonymous/named/bind/etc_).

**Please avoid this anti-pattern, thanks!**