### PR TITLE
Added flag to extend privileged authentication expiry

### DIFF
--- a/tools/orca/src/generate.rs
+++ b/tools/orca/src/generate.rs
@@ -53,8 +53,11 @@ pub async fn populate(_client: &KanidmOrcaClient, profile: Profile) -> Result<St
 
     let thread_count = profile.thread_count();
 
-    // PHASE 0 - For now, set require MFA off.
-    let preflight_flags = vec![Flag::DisableAllPersonsMFAPolicy];
+    // PHASE 0 - For now, set require MFA off and extend the privilege expiry.
+    let preflight_flags = vec![
+        Flag::DisableAllPersonsMFAPolicy,
+        Flag::ExtendPrivilegedAuthExpiry,
+    ];
 
     // PHASE 1 - generate a pool of persons that are not-yet created for future import.
 

--- a/tools/orca/src/kani.rs
+++ b/tools/orca/src/kani.rs
@@ -64,6 +64,24 @@ impl KanidmOrcaClient {
             })
     }
 
+    pub async fn extend_privilege_expiry(&self) -> Result<(), Error> {
+        self.idm_admin_client
+            .group_account_policy_privilege_expiry_set("idm_all_persons", 3600)
+            .await
+            .map_err(|err| {
+                error!(?err, "Unable to modify idm_all_persons policy");
+                Error::KanidmClient
+            })?;
+
+        self.idm_admin_client
+            .group_account_policy_privilege_expiry_set("idm_all_accounts", 3600)
+            .await
+            .map_err(|err| {
+                error!(?err, "Unable to modify idm_all_accounts policy");
+                Error::KanidmClient
+            })
+    }
+
     pub async fn person_exists(&self, username: &str) -> Result<bool, Error> {
         self.idm_admin_client
             .idm_person_account_get(username)

--- a/tools/orca/src/main.rs
+++ b/tools/orca/src/main.rs
@@ -77,6 +77,7 @@ fn main() -> ExitCode {
             profile_path,
             threads,
             model,
+            dump_raw_data,
         } => {
             // For now I hardcoded some dimensions, but we should prompt
             // the user for these later.
@@ -98,6 +99,7 @@ fn main() -> ExitCode {
                 idm_admin_password,
                 model,
                 threads,
+                dump_raw_data,
             )
             .seed(seed);
 

--- a/tools/orca/src/model.rs
+++ b/tools/orca/src/model.rs
@@ -32,6 +32,7 @@ impl Transition {
     }
 }
 
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
 pub enum TransitionResult {
     // Success
     Ok,

--- a/tools/orca/src/opt.rs
+++ b/tools/orca/src/opt.rs
@@ -70,6 +70,10 @@ pub enum OrcaOpt {
         #[clap(long, default_value_t, value_enum)]
         // Optional model to run the benchmark, defaults to the `Basic` model
         model: Model,
+
+        #[clap(long, default_value_t)]
+        /// Dump raw data to a separate csv file, defaults to false
+        dump_raw_data: bool,
     },
 
     #[clap(name = "conntest")]

--- a/tools/orca/src/populate.rs
+++ b/tools/orca/src/populate.rs
@@ -12,6 +12,7 @@ async fn apply_flags(client: Arc<kani::KanidmOrcaClient>, flags: &[Flag]) -> Res
     for flag in flags {
         match flag {
             Flag::DisableAllPersonsMFAPolicy => client.disable_mfa_requirement().await?,
+            Flag::ExtendPrivilegedAuthExpiry => client.extend_privilege_expiry().await?,
         }
     }
     Ok(())

--- a/tools/orca/src/profile.rs
+++ b/tools/orca/src/profile.rs
@@ -36,6 +36,8 @@ pub struct Profile {
     thread_count: Option<usize>,
     model: Model,
     group: BTreeMap<String, GroupProperties>,
+    #[serde(default)]
+    dump_raw_data: bool,
 }
 
 impl Profile {
@@ -91,6 +93,10 @@ impl Profile {
     pub fn test_time(&self) -> Option<Duration> {
         self.test_time.map(Duration::from_secs)
     }
+
+    pub fn dump_raw_data(&self) -> bool {
+        self.dump_raw_data
+    }
 }
 
 pub struct ProfileBuilder {
@@ -106,6 +112,7 @@ pub struct ProfileBuilder {
     pub person_count: Option<u64>,
     pub thread_count: Option<usize>,
     pub model: Model,
+    pub dump_raw_data: bool,
 }
 
 fn validate_u64_bound(value: Option<u64>, default: u64) -> Result<u64, Error> {
@@ -129,6 +136,7 @@ impl ProfileBuilder {
         idm_admin_password: String,
         model: Model,
         thread_count: Option<usize>,
+        dump_raw_data: bool,
     ) -> Self {
         ProfileBuilder {
             control_uri,
@@ -142,6 +150,7 @@ impl ProfileBuilder {
             person_count: None,
             thread_count,
             model,
+            dump_raw_data,
         }
     }
 
@@ -187,6 +196,7 @@ impl ProfileBuilder {
             person_count,
             thread_count,
             model,
+            dump_raw_data,
         } = self;
 
         let seed: u64 = seed.unwrap_or_else(|| {
@@ -224,6 +234,7 @@ impl ProfileBuilder {
             thread_count,
             group,
             model,
+            dump_raw_data,
         })
     }
 }

--- a/tools/orca/src/state.rs
+++ b/tools/orca/src/state.rs
@@ -58,6 +58,7 @@ impl TryFrom<&Path> for State {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Flag {
     DisableAllPersonsMFAPolicy,
+    ExtendPrivilegedAuthExpiry,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
If you're truly a masochis and you want to examine 500k event records one by one now you can. Also no more privileged sessions expiries getting in the way.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [x] cargo test has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
