### PR TITLE
docs: Fix typo for oauth2 grafana claim-map example

### DIFF
--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -169,7 +169,7 @@ kanidm group create 'grafana_users'
 Setup the claim-map that will set what role each group will map to in Grafana:
 
 ```bash
-kanidmm oauth2 update-claim-map-join 'grafana' 'grafana_role' array
+kanidm system oauth2 update-claim-map-join 'grafana' 'grafana_role' array
 kanidm system oauth2 update-claim-map 'grafana' 'grafana_role' 'grafana_superadmins' 'GrafanaAdmin'
 kanidm system oauth2 update-claim-map 'grafana' 'grafana_role' 'grafana_admins' 'Admin'
 kanidm system oauth2 update-claim-map 'grafana' 'grafana_role' 'grafana_editors' 'Editor'


### PR DESCRIPTION
The docs are a bit out of date in some places.

This fixes a typo, although I'm not sure if it was intentional to omit a line for the `grafana_users` group either?

---

FWIW it's been a little frustrating to try get a basic setup going (_I'm not integrating with Grafana in this case_). The enforced requirement for TLS (_with no opt-out support?_) doesn't help as I'm attempting to do this on Windows 11 (host with web browser) and a completely offline self-hosted setup in WSL2 with Docker.

I've got certs provisioned but may need to add in custom DNS since the containers can't leverage host networking mode, and localhost/loopback is not equivalent to the host.

---

**Known issues in docs:**
- I recall one of the OIDC/OAuth2 URLs documented was incorrect, I think it was the auth URI missing `/ui` path prefix (before `/oauth`), which I found by querying the OIDC client well-known endpoint to get the correct URI.
- Another was with the redirect uri command, this was renamed to landing uri.
- The tools example with docker mounted config to `/home` dir but the container has no such user in `/etc/passwd` thus you can't run the container with that user for that to be relevant.

Might have been others.

I'm open to contributing doc updates for those provided I can get `kanidm` to work the way I would like to (_`compose.yaml` with `docker-mailserver` + `roundcube`, with minimal commands to pair with an IDP outside of the config file itself_). I'll open a discussion with config for reproduction and advice if I get stuck.

## Checklist

- [x] This PR contains no AI generated code
- [x] `cargo fmt` has been run
- [x] `cargo clippy` has been run
- [x] `cargo test` has been run and passes
- [ ] ~~book chapter included (if relevant)~~
- [ ] ~~design document included (if relevant)~~
