### PR TITLE
Fix incorrect logic in cred update flow

### DIFF
--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -1470,10 +1470,11 @@ async fn credential_update_exec(
                     Ok(status) => {
                         if !status.can_commit {
                             display_warnings(&status.warnings);
+                            // Reset the loop
+                            println!("Changes have NOT been saved.");
+                            continue;
                         }
-                        // Reset the loop
-                        println!("Changes have NOT been saved.");
-                        continue;
+                        // Can proceed
                     }
                     Err(e) => {
                         eprintln!("An error occurred -> {:?}", e);


### PR DESCRIPTION
I did a silly whoopsie daisy, and made it so that any time we got a status back we'd can the commit flow. Silly me. Skill issue.

Checklist

- [ x ] This PR contains no AI generated code
- [ x ] `cargo fmt` has been run
- [ ] `cargo clippy` has been run
- [ x ] `cargo test` has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
