### PR TITLE
Prevent bug in pam

### DIFF
--- a/unix_integration/pam_kanidm/src/pam/module.rs
+++ b/unix_integration/pam_kanidm/src/pam/module.rs
@@ -51,7 +51,7 @@ extern "C" {
 
     fn pam_get_user(
         pamh: *const PamHandle,
-        user: &*mut c_char,
+        user: &mut *const c_char,
         prompt: *const c_char,
     ) -> PamResultCode;
 }
@@ -176,21 +176,20 @@ impl PamHandle {
     /// See `pam_get_user` in
     /// <http://www.linux-pam.org/Linux-PAM-html/mwg-expected-by-module-item.html>
     pub fn get_user(&self, prompt: Option<&str>) -> PamResult<String> {
-        let ptr: *mut c_char = ptr::null_mut();
+        let mut ptr: *const c_char = ptr::null_mut();
         let res = match prompt {
             Some(p) => {
                 let c_prompt = CString::new(p).unwrap();
-                unsafe { pam_get_user(self, &ptr, c_prompt.as_ptr()) }
+                unsafe { pam_get_user(self, &mut ptr, c_prompt.as_ptr()) }
             }
-            None => unsafe { pam_get_user(self, &ptr, ptr::null()) },
+            None => unsafe { pam_get_user(self, &mut ptr, ptr::null()) },
         };
 
         if PamResultCode::PAM_SUCCESS == res {
             if ptr.is_null() {
                 Err(PamResultCode::PAM_AUTHINFO_UNAVAIL)
             } else {
-                let const_ptr = ptr as *const c_char;
-                let bytes = unsafe { CStr::from_ptr(const_ptr).to_bytes() };
+                let bytes = unsafe { CStr::from_ptr(ptr).to_bytes() };
                 String::from_utf8(bytes.to_vec()).map_err(|_| PamResultCode::PAM_CONV_ERR)
             }
         } else {

--- a/unix_integration/pam_kanidm/src/pam/module.rs
+++ b/unix_integration/pam_kanidm/src/pam/module.rs
@@ -185,10 +185,14 @@ impl PamHandle {
             None => unsafe { pam_get_user(self, &ptr, ptr::null()) },
         };
 
-        if PamResultCode::PAM_SUCCESS == res && !ptr.is_null() {
-            let const_ptr = ptr as *const c_char;
-            let bytes = unsafe { CStr::from_ptr(const_ptr).to_bytes() };
-            String::from_utf8(bytes.to_vec()).map_err(|_| PamResultCode::PAM_CONV_ERR)
+        if PamResultCode::PAM_SUCCESS == res {
+            if ptr.is_null() {
+                Err(PamResultCode::PAM_AUTHINFO_UNAVAIL)
+            } else {
+                let const_ptr = ptr as *const c_char;
+                let bytes = unsafe { CStr::from_ptr(const_ptr).to_bytes() };
+                String::from_utf8(bytes.to_vec()).map_err(|_| PamResultCode::PAM_CONV_ERR)
+            }
         } else {
             Err(res)
         }


### PR DESCRIPTION
Fixes #2915 - seems that a pam or sudo updated triggered this behaviour for me - appears to be an external bug but we need to defend it. 

Checklist

- [ x ] This PR contains no AI generated code
- [ x ] `cargo fmt` has been run
- [ ] `cargo clippy` has been run
- [ x ] `cargo test` has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
