### PR TITLE
Update suse.md to avoid Authentication token manipulation error

### DIFF
--- a/book/src/integrations/pam_and_nsswitch/suse.md
+++ b/book/src/integrations/pam_and_nsswitch/suse.md
@@ -53,7 +53,7 @@ auth        required      pam_deny.so
 # Controls flow of what happens when a user invokes the passwd command. Currently does NOT
 # push password changes back to kanidm
 password    [default=1 ignore=ignore success=ok] pam_localuser.so
-password    required    pam_unix.so use_authtok nullok shadow try_first_pass
+password    required    pam_unix.so nullok shadow try_first_pass
 password    [default=1 ignore=ignore success=ok]  pam_succeed_if.so uid >= 1000 quiet_success quiet_fail
 password    required    pam_kanidm.so
 


### PR DESCRIPTION
The option use_authok for pam_unix requires a password on the stack, for example from a previous module such as pam_cracklib. If that is not the case, pam_unix fails, leading to this error:

    ~ # passwd
    passwd: Authentication token manipulation error
    passwd: password unchanged

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] `cargo fmt` has been run
- [ ] `cargo clippy` has been run
- [ ] `cargo test` has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
