### PR TITLE
Mail substr index

### DIFF
--- a/server/lib/src/be/idl_sqlite.rs
+++ b/server/lib/src/be/idl_sqlite.rs
@@ -1204,6 +1204,7 @@ impl IdlSqliteWriteTransaction {
         })
     }
 
+    #[instrument(level = "debug", skip(self))]
     pub fn create_idx(&self, attr: Attribute, itype: IndexType) -> Result<(), OperationError> {
         // Is there a better way than formatting this? I can't seem
         // to template into the str.
@@ -1215,7 +1216,6 @@ impl IdlSqliteWriteTransaction {
             itype.as_idx_str(),
             attr
         );
-        trace!(idx = %idx_stmt, "creating index");
 
         self.get_conn()?
             .execute(idx_stmt.as_str(), [])

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -23,7 +23,9 @@ use std::time::Duration;
 // This value no longer requires incrementing during releases. It only
 // serves as a "once off" marker so that we know when the initial db
 // index is performed on first-run.
-pub const SYSTEM_INDEX_VERSION: i64 = 31;
+//
+// It's also useful if we need to force a reindex due to a bug though :)
+pub const SYSTEM_INDEX_VERSION: i64 = 32;
 
 /*
  * domain functional levels

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -140,7 +140,7 @@ impl QueryServer {
             // which in turn can trigger schema reloads etc.
             write_txn.reload()?;
             // Force a reindex here since schema probably changed and we aren't at the
-            // runtime phase where it will trigger on it's own yet.
+            // runtime phase where it will trigger on its own yet.
             write_txn.reindex()?;
         } else if domain_development_taint {
             // This forces pre-release versions to re-migrate each start up. This solves
@@ -156,7 +156,7 @@ impl QueryServer {
             write_txn.domain_remigrate(DOMAIN_PREVIOUS_TGT_LEVEL)?;
             write_txn.reload()?;
             // Force a reindex here since schema probably changed and we aren't at the
-            // runtime phase where it will trigger on it's own yet.
+            // runtime phase where it will trigger on its own yet.
             write_txn.reindex()?;
         }
 

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -139,6 +139,9 @@ impl QueryServer {
             // Reload if anything in migrations requires it - this triggers the domain migrations
             // which in turn can trigger schema reloads etc.
             write_txn.reload()?;
+            // Force a reindex here since schema probably changed and we aren't at the
+            // runtime phase where it will trigger on it's own yet.
+            write_txn.reindex()?;
         } else if domain_development_taint {
             // This forces pre-release versions to re-migrate each start up. This solves
             // the domain-version-sprawl issue so that during a development cycle we can
@@ -152,6 +155,9 @@ impl QueryServer {
             // We did not already need a version migration as above
             write_txn.domain_remigrate(DOMAIN_PREVIOUS_TGT_LEVEL)?;
             write_txn.reload()?;
+            // Force a reindex here since schema probably changed and we aren't at the
+            // runtime phase where it will trigger on it's own yet.
+            write_txn.reindex()?;
         }
 
         if domain_target_level >= DOMAIN_LEVEL_7 && domain_patch_level < DOMAIN_TGT_PATCH_LEVEL {

--- a/server/lib/src/valueset/address.rs
+++ b/server/lib/src/valueset/address.rs
@@ -357,16 +357,52 @@ impl ValueSetT for ValueSetEmailAddress {
         }
     }
 
-    fn substring(&self, _pv: &PartialValue) -> bool {
-        false
+    fn substring(&self, pv: &PartialValue) -> bool {
+        match pv {
+            PartialValue::EmailAddress(s2) => {
+                // We lowercase as LDAP and similar expect case insensitive searches here.
+                let s2_lower = s2.to_lowercase();
+                self.set
+                    .iter()
+                    .any(|s1| s1.to_lowercase().contains(&s2_lower))
+            }
+            _ => {
+                debug_assert!(false);
+                false
+            }
+        }
     }
 
-    fn startswith(&self, _pv: &PartialValue) -> bool {
-        false
+    fn startswith(&self, pv: &PartialValue) -> bool {
+        match pv {
+            PartialValue::EmailAddress(s2) => {
+                // We lowercase as LDAP and similar expect case insensitive searches here.
+                let s2_lower = s2.to_lowercase();
+                self.set
+                    .iter()
+                    .any(|s1| s1.to_lowercase().starts_with(&s2_lower))
+            }
+            _ => {
+                debug_assert!(false);
+                false
+            }
+        }
     }
 
-    fn endswith(&self, _pv: &PartialValue) -> bool {
-        false
+    fn endswith(&self, pv: &PartialValue) -> bool {
+        match pv {
+            PartialValue::EmailAddress(s2) => {
+                // We lowercase as LDAP and similar expect case insensitive searches here.
+                let s2_lower = s2.to_lowercase();
+                self.set
+                    .iter()
+                    .any(|s1| s1.to_lowercase().ends_with(&s2_lower))
+            }
+            _ => {
+                debug_assert!(false);
+                false
+            }
+        }
     }
 
     fn lessthan(&self, _pv: &PartialValue) -> bool {


### PR DESCRIPTION
Fixes #2978 - needs backport to 1.3 IMO. 

We incorrectly were not applying re-indexing during migrations, and we were not properly handling the new substr entry-no-match-index process on email. 

Checklist

- [ x ] This PR contains no AI generated code
- [ x ] `cargo fmt` has been run
- [ ] `cargo clippy` has been run
- [ x ] `cargo test` has been run and passes
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
