### PR TITLE
Add missing group for application admin

### DIFF
--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -613,6 +613,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
         // Update access controls.
         let idm_data = [
+            BUILTIN_GROUP_APPLICATION_ADMINS.clone().try_into()?,
             IDM_ACP_SELF_READ_DL8.clone().into(),
             IDM_ACP_SELF_WRITE_DL8.clone().into(),
             IDM_ACP_APPLICATION_MANAGE_DL8.clone().into(),


### PR DESCRIPTION
The application admin group was created as a builtin which works in tests, but for existing installs it needs manual migration. 

Checklist

- [ x ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
