### PR TITLE
Constrain scopes on refresh token usage

### DIFF
--- a/book/src/database_maintenance.md
+++ b/book/src/database_maintenance.md
@@ -25,7 +25,7 @@ definitions.
 ```bash
 docker stop <container name>
 docker run --rm -i -t -v kanidmd:/data \
-    kanidm/server:latest /sbin/kanidmd reindex -c /data/server.toml
+    kanidm/server:latest /sbin/kanidmd database reindex -c /data/server.toml
 docker start <container name>
 ```
 
@@ -41,7 +41,7 @@ affects pagesize) in server.toml, you must run a vacuum for this to take effect:
 ```bash
 docker stop <container name>
 docker run --rm -i -t -v kanidmd:/data \
-    kanidm/server:latest /sbin/kanidmd vacuum -c /data/server.toml
+    kanidm/server:latest /sbin/kanidmd database vacuum -c /data/server.toml
 docker start <container name>
 ```
 
@@ -59,7 +59,7 @@ You can run a verification with:
 ```bash
 docker stop <container name>
 docker run --rm -i -t -v kanidmd:/data \
-    kanidm/server:latest /sbin/kanidmd verify -c /data/server.toml
+    kanidm/server:latest /sbin/kanidmd database verify -c /data/server.toml
 docker start <container name>
 ```
 

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -2409,4 +2409,20 @@ mod tests {
         assert!(KeyStatus::Valid < KeyStatus::Retained);
         assert!(KeyStatus::Retained < KeyStatus::Revoked);
     }
+
+    #[test]
+    fn test_value_session_state_order() {
+        assert!(
+            SessionState::RevokedAt(Cid::new_zero()) > SessionState::RevokedAt(Cid::new_count(1))
+        );
+        assert!(
+            SessionState::RevokedAt(Cid::new_zero())
+                > SessionState::ExpiresAt(OffsetDateTime::UNIX_EPOCH)
+        );
+        assert!(
+            SessionState::ExpiresAt(OffsetDateTime::UNIX_EPOCH + Duration::from_secs(1))
+                > SessionState::ExpiresAt(OffsetDateTime::UNIX_EPOCH)
+        );
+        assert!(SessionState::ExpiresAt(OffsetDateTime::UNIX_EPOCH) > SessionState::NeverExpires);
+    }
 }

--- a/server/lib/src/valueset/session.rs
+++ b/server/lib/src/valueset/session.rs
@@ -391,7 +391,7 @@ impl ValueSetT for ValueSetSession {
             // session.state value and what it currently is set to.
             for (k_other, v_other) in b.iter() {
                 if let Some(v_self) = self.map.get_mut(k_other) {
-                    // We only update if lower. This is where RevokedAt
+                    // We only update if greater. This is where RevokedAt
                     // always proceeds other states, and lower revoked
                     // cids will always take effect.
                     if v_other.state > v_self.state {
@@ -1030,7 +1030,7 @@ impl ValueSetT for ValueSetOauth2Session {
             let mut rs_filter = self.rs_filter;
             for (k_other, v_other) in b.iter() {
                 if let Some(v_self) = map.get_mut(k_other) {
-                    // We only update if lower. This is where RevokedAt
+                    // We only update if greater. This is where RevokedAt
                     // always proceeds other states, and lower revoked
                     // cids will always take effect.
                     if v_other.state > v_self.state {


### PR DESCRIPTION
When a refresh token is used, allow constraint of the scopes.

Extend tests for session handling

Use the correct invalidGrant response when a refresh token is expired.

Fix docs command.

-

Fixes #2527 

Checklist

- [ x ] This PR contains no AI generated code
- [ x ] book chapter included (if relevant)
- [ ] design document included (if relevant)
