### PR TITLE
implements additional traits for filter types

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,6 +42,7 @@
 - fossdd
 - Wei Jian Gan (weijiangan)
 - adamcstephens
+- Chris Olstrom (colstrom)
 
 ## Acknowledgements
 

--- a/libs/scim_proto/src/filter.rs
+++ b/libs/scim_proto/src/filter.rs
@@ -63,6 +63,26 @@ pub enum ScimComplexFilter {
     LessOrEqual(String, Value),
 }
 
+impl ToString for ScimComplexFilter {
+    fn to_string(&self) -> String {
+        match self {
+            Self::And(this, that) => format!("({} and {})", this.to_string(), that.to_string()),
+            Self::Contains(attrname, value) => format!("({attrname} co {value})"),
+            Self::EndsWith(attrname, value) => format!("({attrname} ew {value})"),
+            Self::Equal(attrname, value) => format!("({attrname} eq {value})"),
+            Self::Greater(attrname, value) => format!("({attrname} gt {value})"),
+            Self::GreaterOrEqual(attrname, value) => format!("({attrname} ge {value})"),
+            Self::Less(attrname, value) => format!("({attrname} lt {value})"),
+            Self::LessOrEqual(attrname, value) => format!("({attrname} le {value})"),
+            Self::Not(expr) => format!("(not ({}))", expr.to_string()),
+            Self::NotEqual(attrname, value) => format!("({attrname} ne {value})"),
+            Self::Or(this, that) => format!("({} or {})", this.to_string(), that.to_string()),
+            Self::Present(attrname) => format!("({attrname} pr)"),
+            Self::StartsWith(attrname, value) => format!("({attrname} sw {value})"),
+        }
+    }
+}
+
 // separator()* "(" e:term() ")" separator()* { e }
 
 peg::parser! {

--- a/libs/scim_proto/src/filter.rs
+++ b/libs/scim_proto/src/filter.rs
@@ -271,6 +271,27 @@ peg::parser! {
     }
 }
 
+impl FromStr for AttrPath {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        scimfilter::attrpath(input)
+    }
+}
+
+impl FromStr for ScimFilter {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        scimfilter::parse(input)
+    }
+}
+
+impl FromStr for ScimComplexFilter {
+    type Err = peg::error::ParseError<peg::str::LineCol>;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        scimfilter::parse_complex(input)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/libs/scim_proto/src/filter.rs
+++ b/libs/scim_proto/src/filter.rs
@@ -45,6 +45,29 @@ pub enum ScimFilter {
     Complex(String, Box<ScimComplexFilter>),
 }
 
+impl ToString for ScimFilter {
+    fn to_string(&self) -> String {
+        match self {
+            Self::And(this, that) => format!("({} and {})", this.to_string(), that.to_string()),
+            Self::Contains(attrpath, value) => format!("({} co {value})", attrpath.to_string()),
+            Self::EndsWith(attrpath, value) => format!("({} ew {value})", attrpath.to_string()),
+            Self::Equal(attrpath, value) => format!("({} eq {value})", attrpath.to_string()),
+            Self::Greater(attrpath, value) => format!("({} gt {value})", attrpath.to_string()),
+            Self::GreaterOrEqual(attrpath, value) => {
+                format!("({} ge {value})", attrpath.to_string())
+            }
+            Self::Less(attrpath, value) => format!("({} lt {value})", attrpath.to_string()),
+            Self::LessOrEqual(attrpath, value) => format!("({} le {value})", attrpath.to_string()),
+            Self::Not(expr) => format!("(not ({}))", expr.to_string()),
+            Self::NotEqual(attrpath, value) => format!("({} ne {value})", attrpath.to_string()),
+            Self::Or(this, that) => format!("({} or {})", this.to_string(), that.to_string()),
+            Self::Present(attrpath) => format!("({} pr)", attrpath.to_string()),
+            Self::StartsWith(attrpath, value) => format!("({} sw {value})", attrpath.to_string()),
+            Self::Complex(attrname, expr) => format!("{attrname}[{}]", expr.to_string()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScimComplexFilter {
     Or(Box<ScimComplexFilter>, Box<ScimComplexFilter>),

--- a/libs/scim_proto/src/filter.rs
+++ b/libs/scim_proto/src/filter.rs
@@ -10,6 +10,21 @@ pub struct AttrPath {
     s: Option<String>,
 }
 
+impl ToString for AttrPath {
+    fn to_string(&self) -> String {
+        match self {
+            Self {
+                a: attrname,
+                s: Some(subattr),
+            } => format!("{attrname}.{subattr}"),
+            Self {
+                a: attrname,
+                s: None,
+            } => attrname.to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScimFilter {
     Or(Box<ScimFilter>, Box<ScimFilter>),

--- a/libs/scim_proto/src/filter.rs
+++ b/libs/scim_proto/src/filter.rs
@@ -1,9 +1,10 @@
 #![allow(warnings)]
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttrPath {
     // Uri: Option<String>,
     a: String,
@@ -25,7 +26,7 @@ impl ToString for AttrPath {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ScimFilter {
     Or(Box<ScimFilter>, Box<ScimFilter>),
     And(Box<ScimFilter>, Box<ScimFilter>),
@@ -68,7 +69,7 @@ impl ToString for ScimFilter {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ScimComplexFilter {
     Or(Box<ScimComplexFilter>, Box<ScimComplexFilter>),
     And(Box<ScimComplexFilter>, Box<ScimComplexFilter>),


### PR DESCRIPTION
# Change summary

This is mostly resolving my own feature request in https://github.com/kanidm/kanidm/issues/3035, with the addition of a `ToString` implementation.

- for each of `filter::AttrPath`, `filter::ScimFilter`, and `filter::ScimComplexFilter`:
  - implements `serde::Serialize` and `serde::Deserialize` using the typical `derive` macros.
  - implements `FromStr` by calling the parsing function for the corresponding type in the crate-private `scimfilter` module.
  - implements `ToString` by hand, so if I botched something, it's probably here. `match` can only ensure completeness, not correctness. 😅
    - Typically I would test something like this by round-tripping through the conversion, but the implementation here parenthesizes all expressions to preserve precedence, so the resulting string may differ from the original input.

Fixes #3035, for the most part. While `parse()` is public, the containing module is not, and changing the module visibility there exposes a lot more just `parse()`, which may or may not be desirable (thoughts?). The `FromStr` implementation seems like a reasonable compromise there.

This is essentially an updated version of [my previous pull request](https://github.com/kanidm/scim/pull/5) to the now-archived [kanidim/scim](https://github.com/kanidm/scim) repo. Quoting the relevant bits from that PR message, since it applies here as well:

> I checked the [Developer Guide](https://kanidm.github.io/kanidm/master/developers/index.html) for any rules or guidance around formatting and pull request structure, and made what I hope to be reasonable assumptions:
>
> - Since this repository does not contain a `rustfmt.toml`, it's formatted using the default formatting rules.
> - The changes are one commit per feature, in case any happen to be undesirable or incorrect.
> - I didn't see any [DCO](https://developercertificate.org/) requirements mentioned, but all commits are signed and include sign-off, just in case.

Notable differences from the original PR are omitting the version bump (per [this comment](https://github.com/kanidm/scim/pull/5#issuecomment-2342688678)), and including implementations for `filter::ScimComplexFilter`.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)

Please let me know if I've missed anything.

Thanks!
