### PR TITLE
More openapi tweaks

### DIFF
--- a/proto/src/attribute.rs
+++ b/proto/src/attribute.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::constants::*;
 use crate::internal::OperationError;
@@ -6,7 +7,9 @@ use std::fmt;
 
 pub use smartstring::alias::String as AttrString;
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Serialize, Deserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Default, ToSchema,
+)]
 #[cfg_attr(test, derive(enum_iterator::Sequence))]
 #[serde(rename_all = "lowercase", try_from = "&str", into = "AttrString")]
 pub enum Attribute {

--- a/server/core/src/https/apidocs/mod.rs
+++ b/server/core/src/https/apidocs/mod.rs
@@ -1,8 +1,5 @@
 use axum::{middleware::from_fn, response::Redirect, routing::get, Router};
-use kanidm_proto::{
-    internal, scim_v1,
-    v1::{self, Entry as ProtoEntry},
-};
+use kanidm_proto::{internal, scim_v1, v1};
 use utoipa::{
     openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
     Modify, OpenApi,
@@ -297,7 +294,6 @@ impl Modify for SecurityAddon {
             //  workaround for the fact that BTreeSet can't be represented in JSON
             response_schema::ProtoEntry,
             // terrible workaround for other things
-            Jwk,
             response_schema::Jwk,
             response_schema::ScimComplexAttr,
             WebError,

--- a/server/core/src/https/apidocs/mod.rs
+++ b/server/core/src/https/apidocs/mod.rs
@@ -212,7 +212,7 @@ impl Modify for SecurityAddon {
     components(
         schemas(
             kanidm_proto::attribute::Attribute,
-            ProtoEntry,
+
 
             scim_v1::ScimSyncState,
             scim_v1::ScimSyncRequest,
@@ -294,7 +294,10 @@ impl Modify for SecurityAddon {
             response_schema::Result,
             // terrible workaround for other things
             response_schema::ScimEntry,
+            //  workaround for the fact that BTreeSet can't be represented in JSON
+            response_schema::ProtoEntry,
             // terrible workaround for other things
+            Jwk,
             response_schema::Jwk,
             response_schema::ScimComplexAttr,
             WebError,

--- a/server/core/src/https/apidocs/mod.rs
+++ b/server/core/src/https/apidocs/mod.rs
@@ -208,7 +208,7 @@ impl Modify for SecurityAddon {
     ),
     components(
         schemas(
-            kanidm_proto::attribute::Attribute,
+            // kanidm_proto::attribute::Attribute,
 
 
             scim_v1::ScimSyncState,

--- a/server/core/src/https/apidocs/mod.rs
+++ b/server/core/src/https/apidocs/mod.rs
@@ -1,5 +1,8 @@
 use axum::{middleware::from_fn, response::Redirect, routing::get, Router};
-use kanidm_proto::{internal, scim_v1, v1};
+use kanidm_proto::{
+    internal, scim_v1,
+    v1::{self, Entry as ProtoEntry},
+};
 use utoipa::{
     openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
     Modify, OpenApi,
@@ -208,6 +211,9 @@ impl Modify for SecurityAddon {
     ),
     components(
         schemas(
+            kanidm_proto::attribute::Attribute,
+            ProtoEntry,
+
             scim_v1::ScimSyncState,
             scim_v1::ScimSyncRequest,
             scim_v1::ScimSyncRetentionMode,
@@ -215,8 +221,7 @@ impl Modify for SecurityAddon {
             scim_v1::ScimValue,
             scim_v1::ScimMeta,
             scim_v1::ScimAttr,
-            // TODO: can't add Entry/ProtoEntry to schema as this was only recently supported utoipa v3.5.0 doesn't support it - ref <https://github.com/juhaku/utoipa/pull/756/files>
-            // v1::Entry,
+
             internal::ApiToken,
             internal::ApiTokenPurpose,
             internal::BackupCodesView,
@@ -276,8 +281,7 @@ impl Modify for SecurityAddon {
             internal::IdentifyUserRequest,
             // terrible workaround for other things
             response_schema::CreationChallengeResponse,
-            // terrible workaround for other things
-            response_schema::ProtoEntry,
+
             // terrible workaround for other things
             response_schema::PublicKeyCredential,
             // terrible workaround for other things

--- a/server/core/src/https/apidocs/response_schema.rs
+++ b/server/core/src/https/apidocs/response_schema.rs
@@ -91,6 +91,7 @@ pub(crate) struct ScimEntry {}
 #[derive(Debug, Clone, ToSchema)]
 ///  workaround for the fact that BTreeSet can't be represented in JSON
 pub(crate) struct ProtoEntry {
+    #[allow(dead_code)] // because it's a schema definition
     attrs: std::collections::HashMap<String, Vec<String>>,
 }
 

--- a/server/core/src/https/apidocs/response_schema.rs
+++ b/server/core/src/https/apidocs/response_schema.rs
@@ -60,10 +60,6 @@ impl IntoResponses for ApiResponseWithout200 {
     }
 }
 
-/// Placeholder until we can handle a BTree in utipa
-#[derive(Debug, Clone, ToSchema)]
-pub(crate) struct ProtoEntry {}
-
 #[derive(Debug, Clone, ToSchema)]
 // TODO: this should be `webauthn_rs_proto::auth::PublicKeyCredential``, but ... I don't know how to make it possible in utoipa
 pub(crate) struct PublicKeyCredential {}

--- a/server/core/src/https/apidocs/response_schema.rs
+++ b/server/core/src/https/apidocs/response_schema.rs
@@ -92,7 +92,7 @@ pub(crate) struct ScimEntry {}
 ///  workaround for the fact that BTreeSet can't be represented in JSON
 pub(crate) struct ProtoEntry {
     #[allow(dead_code, clippy::disallowed_types)] // because it's a schema definition
-    attrs: std::collections::HashMap<String, Vec<String>>,
+    attrs: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone, ToSchema)]

--- a/server/core/src/https/apidocs/response_schema.rs
+++ b/server/core/src/https/apidocs/response_schema.rs
@@ -89,6 +89,12 @@ pub(crate) struct Result {}
 pub(crate) struct ScimEntry {}
 
 #[derive(Debug, Clone, ToSchema)]
+///  workaround for the fact that BTreeSet can't be represented in JSON
+pub(crate) struct ProtoEntry {
+    attrs: std::collections::HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, ToSchema)]
 pub(crate) struct Jwk {}
 
 #[derive(Debug, Clone, ToSchema)]

--- a/server/core/src/https/apidocs/response_schema.rs
+++ b/server/core/src/https/apidocs/response_schema.rs
@@ -91,7 +91,7 @@ pub(crate) struct ScimEntry {}
 #[derive(Debug, Clone, ToSchema)]
 ///  workaround for the fact that BTreeSet can't be represented in JSON
 pub(crate) struct ProtoEntry {
-    #[allow(dead_code)] // because it's a schema definition
+    #[allow(dead_code, clippy::disallowed_types)] // because it's a schema definition
     attrs: std::collections::HashMap<String, Vec<String>>,
 }
 

--- a/server/core/src/https/generic.rs
+++ b/server/core/src/https/generic.rs
@@ -1,8 +1,7 @@
 use axum::extract::State;
 use axum::http::header::CONTENT_TYPE;
 use axum::response::IntoResponse;
-use axum::routing::get;
-use axum::{Extension, Router};
+use axum::Extension;
 use kanidmd_lib::status::StatusRequestEvent;
 
 use super::middleware::KOpId;
@@ -50,10 +49,4 @@ pub async fn robots_txt() -> impl IntoResponse {
 "#,
         ),
     )
-}
-
-pub(crate) fn route_setup() -> Router<ServerState> {
-    Router::new()
-        .route("/robots.txt", get(robots_txt))
-        .route("/status", get(status))
 }

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -301,10 +301,10 @@ pub async fn create_https_server(
         ServerRole::WriteReplicaNoUI => Router::new(),
     };
     let app = Router::new()
-        .merge(generic::route_setup())
         .merge(oauth2::route_setup(state.clone()))
         .merge(v1_scim::route_setup())
-        .merge(v1::route_setup(state.clone()));
+        .merge(v1::route_setup(state.clone()))
+        .route("/robots.txt", get(generic::robots_txt));
 
     let app = match config.role {
         ServerRole::WriteReplicaNoUI => app,
@@ -362,6 +362,7 @@ pub async fn create_https_server(
     let app = app.layer(from_fn(middleware::are_we_json_yet));
 
     let app = app
+        .route("/status", get(generic::status))
         // This must be the LAST middleware.
         // This is because the last middleware here is the first to be entered and the last
         // to be exited, and this middleware sets up ids' and other bits for for logging

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -114,14 +114,10 @@ pub(crate) async fn oauth2_image_get(
         )
             .into_response(),
         Ok(None) => {
-            warn!(?rs_name, "No image set for oauth2 client");
+            warn!(?rs_name, "No image set for OAuth2 client");
             (StatusCode::NOT_FOUND, "").into_response()
         }
-        Err(err) => {
-            error!(?err, "Unable to get image for oauth2 client");
-            // TODO: a 404 probably isn't perfect but it's not the worst
-            (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
-        }
+        Err(err) => WebError::from(err).into_response(),
     }
 }
 
@@ -292,12 +288,12 @@ async fn oauth2_authorise(
         }
         Err(Oauth2Error::AccessDenied) => {
             // If scopes are not available for this account.
-            #[allow(clippy::unwrap_used)]
+            #[allow(clippy::expect_used)]
             Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .body(Body::empty())
-                .unwrap()
+                .expect("Failed to generate a forbidden response")
         }
         /*
         RFC - If the request fails due to a missing, invalid, or mismatching
@@ -315,12 +311,12 @@ async fn oauth2_authorise(
                 kopid.eventid,
                 &e.to_string()
             );
-            #[allow(clippy::unwrap_used)]
+            #[allow(clippy::expect_used)]
             Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .body(Body::empty())
-                .unwrap()
+                .expect("Failed to generate a bad request response")
         }
     }
 }
@@ -380,7 +376,7 @@ async fn oauth2_authorise_permit(
                 .clear()
                 .append_pair("state", &state)
                 .append_pair("code", &code);
-            #[allow(clippy::unwrap_used)]
+            #[allow(clippy::expect_used)]
             Response::builder()
                 .status(StatusCode::FOUND)
                 .header(LOCATION, redirect_uri.as_str())
@@ -389,23 +385,30 @@ async fn oauth2_authorise_permit(
                     redirect_uri.origin().ascii_serialization(),
                 )
                 .body(Body::empty())
-                .unwrap()
+                .expect("Failed to generate response")
         }
-        Err(_e) => {
-            // If an error happens in our consent flow, I think
-            // that we should NOT redirect to the calling application
-            // and we need to handle that locally somehow.
-            // This needs to be better!
-            //
-            // Turns out this instinct was correct:
-            //  https://www.proofpoint.com/us/blog/cloud-security/microsoft-and-github-oauth-implementation-vulnerabilities-lead-redirection
-            // Possible to use this with a malicious client configuration to phish / spam.
-            #[allow(clippy::unwrap_used)]
-            Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-                .body(Body::empty())
-                .unwrap()
+        Err(err) => {
+            match err {
+                OperationError::NotAuthenticated => {
+                    WebError::from(err).response_with_access_control_origin_header()
+                }
+                _ => {
+                    // If an error happens in our consent flow, I think
+                    // that we should NOT redirect to the calling application
+                    // and we need to handle that locally somehow.
+                    // This needs to be better!
+                    //
+                    // Turns out this instinct was correct:
+                    //  https://www.proofpoint.com/us/blog/cloud-security/microsoft-and-github-oauth-implementation-vulnerabilities-lead-redirection
+                    // Possible to use this with a malicious client configuration to phish / spam.
+                    #[allow(clippy::expect_used)]
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                        .body(Body::empty())
+                        .expect("Failed to generate error response")
+                }
+            }
         }
     }
 }
@@ -464,17 +467,24 @@ async fn oauth2_authorise_reject(
                 .unwrap()
             // I think the client server needs this
         }
-        Err(_e) => {
-            // If an error happens in our reject flow, I think
-            // that we should NOT redirect to the calling application
-            // and we need to handle that locally somehow.
-            // This needs to be better!
-            #[allow(clippy::unwrap_used)]
-            Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-                .body(Body::empty())
-                .unwrap()
+        Err(err) => {
+            match err {
+                OperationError::NotAuthenticated => {
+                    WebError::from(err).response_with_access_control_origin_header()
+                }
+                _ => {
+                    // If an error happens in our reject flow, I think
+                    // that we should NOT redirect to the calling application
+                    // and we need to handle that locally somehow.
+                    // This needs to be better!
+                    #[allow(clippy::expect_used)]
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                        .body(Body::empty())
+                        .expect("Failed to generate an error response")
+                }
+            }
         }
     }
 }
@@ -629,12 +639,12 @@ pub async fn oauth2_token_introspect_post(
         }
         Err(Oauth2Error::AuthenticationRequired) => {
             // This will trigger our ui to auth and retry.
-            #[allow(clippy::unwrap_used)]
+            #[allow(clippy::expect_used)]
             Response::builder()
                 .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .status(StatusCode::UNAUTHORIZED)
                 .body(Body::empty())
-                .unwrap()
+                .expect("Failed to generate an unauthorized response")
         }
         Err(e) => {
             // https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
@@ -649,12 +659,12 @@ pub async fn oauth2_token_introspect_post(
                     format!("{:?}", e)
                 }
             };
-            #[allow(clippy::unwrap_used)]
+            #[allow(clippy::expect_used)]
             Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .body(Body::from(body))
-                .unwrap()
+                .expect("Failed to generate an error response")
         }
     }
 }


### PR DESCRIPTION
# Change summary

- Some unauthenticated requests were throwing 500 errors
- Made Attribute and ProtoEntry ToSchema objects
- moved robots.txt and the status endpoints around a little, because status doesn't need CSP headers or *especially* caching headers and all that nonsense, which left robots.txt in its own router, which was dumb.

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
