### PR TITLE
Add rfc7009 and rfc7662 metadata to oidc discovery

### DIFF
--- a/proto/src/oauth2.rs
+++ b/proto/src/oauth2.rs
@@ -433,6 +433,21 @@ pub struct OidcDiscoveryResponse {
     pub require_request_uri_registration: bool,
 
     pub code_challenge_methods_supported: Vec<PkceAlg>,
+
+    // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse
+    // "content type that contains a set of Claims as its members that are a subset of the Metadata
+    //  values defined in Section 3. Other Claims MAY also be returned. "
+    //
+    // In addition, we also return the following claims in kanidm
+
+    // rfc7009
+    pub revocation_endpoint: Option<Url>,
+    pub revocation_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+
+    // rfc7662
+    pub introspection_endpoint: Option<Url>,
+    pub introspection_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub introspection_endpoint_auth_signing_alg_values_supported: Option<Vec<IdTokenSignAlg>>,
 }
 
 /// The response to an OAuth2 rfc8414 metadata request

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2473,6 +2473,20 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
             Vec::with_capacity(0)
         };
 
+        // The following are extensions allowed by the oidc specification.
+
+        let revocation_endpoint = Some(o2rs.revocation_endpoint.clone());
+        let revocation_endpoint_auth_methods_supported = vec![
+            TokenEndpointAuthMethod::ClientSecretBasic,
+            TokenEndpointAuthMethod::ClientSecretPost,
+        ];
+
+        let introspection_endpoint = Some(o2rs.introspection_endpoint.clone());
+        let introspection_endpoint_auth_methods_supported = vec![
+            TokenEndpointAuthMethod::ClientSecretBasic,
+            TokenEndpointAuthMethod::ClientSecretPost,
+        ];
+
         Ok(OidcDiscoveryResponse {
             issuer,
             authorization_endpoint,
@@ -2513,6 +2527,12 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
             op_policy_uri: None,
             op_tos_uri: None,
             code_challenge_methods_supported,
+            // Extensions
+            revocation_endpoint,
+            revocation_endpoint_auth_methods_supported,
+            introspection_endpoint,
+            introspection_endpoint_auth_methods_supported,
+            introspection_endpoint_auth_signing_alg_values_supported: None,
         })
     }
 
@@ -4481,7 +4501,35 @@ mod tests {
         assert_eq!(
             discovery.code_challenge_methods_supported,
             vec![PkceAlg::S256]
-        )
+        );
+
+        // Extensions
+        assert!(
+            discovery.revocation_endpoint
+                == Some(Url::parse("https://idm.example.com/oauth2/token/revoke").unwrap())
+        );
+        assert!(
+            discovery.revocation_endpoint_auth_methods_supported
+                == vec![
+                    TokenEndpointAuthMethod::ClientSecretBasic,
+                    TokenEndpointAuthMethod::ClientSecretPost
+                ]
+        );
+
+        assert!(
+            discovery.introspection_endpoint
+                == Some(Url::parse("https://idm.example.com/oauth2/token/introspect").unwrap())
+        );
+        assert!(
+            discovery.introspection_endpoint_auth_methods_supported
+                == vec![
+                    TokenEndpointAuthMethod::ClientSecretBasic,
+                    TokenEndpointAuthMethod::ClientSecretPost
+                ]
+        );
+        assert!(discovery
+            .introspection_endpoint_auth_signing_alg_values_supported
+            .is_none());
     }
 
     #[idm_test]


### PR DESCRIPTION
# Change summary

- Add RFC7009 and RFC7662 metadata to OIDC Discovery Response

Fixes #3042

Checklist

- [ x ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
