### PR TITLE
Fix landing and redirect URLs for GitLab, add some useful links

### DIFF
--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -78,7 +78,7 @@ To set up a self-managed GitLab instance to authenticate with Kanidm:
     and scope access to the `gitlab_users` group:
 
     ```sh
-    kanidm system oauth2 create gitlab GitLab https://gitlab.example.com
+    kanidm system oauth2 create gitlab GitLab https://gitlab.example.com/users/sign_in
     kanidm system oauth2 update-scope-map gitlab gitlab_users email openid profile groups
     ```
 

--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -155,6 +155,16 @@ To set up a self-managed GitLab instance to authenticate with Kanidm:
 Once GitLab is up and running, you should now see a "Kanidm" option on your
 GitLab sign-in page below the normal login form.
 
+Once you've got everything working, you may wish configure GitLab to:
+
+*   [Automatically redirect to the `openid_connect` provider at the login form](https://docs.gitlab.com/ee/integration/omniauth.html#sign-in-with-a-provider-automatically)
+
+*   [Disable password authentication in GitLab](https://docs.gitlab.com/ee/administration/settings/sign_in_restrictions.html#password-authentication-enabled)
+
+*   [Disable new sign-ups in GitLab](https://docs.gitlab.com/ee/administration/settings/sign_up_restrictions.html)
+
+More information about these features is available in GitLab's documentation.
+
 ## JetBrains Hub and YouTrack
 
 > These instructions were tested with the on-prem version of JetBrains YouTrack

--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -74,12 +74,11 @@ To set up a self-managed GitLab instance to authenticate with Kanidm:
     kanidm group add-members gitlab_users your_username
     ```
 
-3.  Create a new OAuth2 application configuration in Kanidm (`gitlab`),
-    configure the redirect URL, and scope access to the `gitlab_users` group:
+3.  Create a new OAuth2 application configuration in Kanidm (`gitlab`)
+    and scope access to the `gitlab_users` group:
 
     ```sh
     kanidm system oauth2 create gitlab GitLab https://gitlab.example.com
-    kanidm system oauth2 add-redirect-url gitlab https://gitlab.example.com/users/auth/oauth2_generic/callback
     kanidm system oauth2 update-scope-map gitlab gitlab_users email openid profile groups
     ```
 

--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -74,11 +74,12 @@ To set up a self-managed GitLab instance to authenticate with Kanidm:
     kanidm group add-members gitlab_users your_username
     ```
 
-3.  Create a new OAuth2 application configuration in Kanidm (`gitlab`)
-    and scope access to the `gitlab_users` group:
+3.  Create a new OAuth2 application configuration in Kanidm (`gitlab`),
+    configure the redirect URL, and scope access to the `gitlab_users` group:
 
     ```sh
     kanidm system oauth2 create gitlab GitLab https://gitlab.example.com/users/sign_in
+    kanidm system oauth2 add-redirect-url gitlab https://gitlab.example.com/users/auth/openid_connect/callback
     kanidm system oauth2 update-scope-map gitlab gitlab_users email openid profile groups
     ```
 


### PR DESCRIPTION
# Change summary

The redirect URL added in #3050 was for an `oauth2_generic` provider rather than `openid_generic`, so wasn't actually used. I've fixed this to use the correct redirect URL.

This changes the landing URL to `/users/sign_in` which makes things a bit nicer when public access is allowed.

This adds some links to some useful sections in GitLab's documentation for disabling local password auth and making the sign-in process more streamlined.

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
