### PR TITLE
reformat oauth2 URL list, highlight legacy bits

### DIFF
--- a/book/src/frequently_asked_questions.md
+++ b/book/src/frequently_asked_questions.md
@@ -101,7 +101,7 @@ scope of failure is reduced to that single client. This is not the case with TLS
 to configure, and in the case of compromise of an internal network between a load balancer and
 Kanidm, the attacker can access and steal all traffic and authentication data.
 
-### Why is RSA considered legacy
+### Why is RSA considered legacy?
 
 While RSA is cryptographically sound, to achieve the same level as security as ECDSA it requires
 signatures and keys that are significantly larger. This has costs for network transmission and CPU


### PR DESCRIPTION
# Change summary

- Highlight the three things Kanidm needs for OAuth2 to work, and reference attribute names. 
- Note less secure alternatives for services that don't meet those requirements
- Reformat the URL list into a definition list
- Put the OpenID Discovery and RFC 8414 URLs at the top, because they're the easiest thing to use

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
