### PR TITLE
scim_proto: fix incorrect language tag (de-DE)

### DIFF
--- a/libs/scim_proto/src/user.rs
+++ b/libs/scim_proto/src/user.rs
@@ -41,7 +41,7 @@ pub enum Locale {
     #[serde(rename = "en-US")]
     en_US,
     de,
-    #[serde(rename = "en-DE")]
+    #[serde(rename = "de-DE")]
     de_DE,
 }
 


### PR DESCRIPTION
# Change summary

Map `de-DE` to `Locale::de_DE`, rather than `en-DE`.

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
