### PR TITLE
Fix migration of last mod cid

### DIFF
--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2352,6 +2352,21 @@ where
             vs.trim(trim_cid);
         }
 
+        // During migration to the new modified/created cid system, we need to account
+        // for entries that don't have this yet. Normally we would apply this in seal()
+        // to the current CID. At this point we enter in the expected value from the
+        // entry. Note, we don't set last mod to cid yet, we leave that to seal() so that
+        // if this entry is excluded later in the change, we haven't tainted anything, or
+        // so that if the change only applies to non-replicated attrs we haven't mucked
+        // up the value.
+        let last_mod_cid = self.valid.ecstate.get_max_cid();
+        let cv = vs_cid![last_mod_cid.clone()];
+        let _ = self.attrs.insert(Attribute::LastModifiedCid, cv);
+
+        let create_at_cid = self.valid.ecstate.at();
+        let cv = vs_cid![create_at_cid.clone()];
+        let _ = self.attrs.insert(Attribute::CreatedAtCid, cv);
+
         Entry {
             valid: EntryInvalid {
                 cid,

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -221,21 +221,6 @@ impl<'a> QueryServerWriteTransaction<'a> {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub fn internal_migrate_or_create_str(&mut self, e_str: &str) -> Result<(), OperationError> {
-        let res = Entry::from_proto_entry_str(e_str, self)
-            /*
-            .and_then(|e: Entry<EntryInvalid, EntryNew>| {
-                let schema = self.get_schema();
-                e.validate(schema).map_err(OperationError::SchemaViolation)
-            })
-            */
-            .and_then(|e: Entry<EntryInit, EntryNew>| self.internal_migrate_or_create(e));
-        trace!(?res);
-        debug_assert!(res.is_ok());
-        res
-    }
-
-    #[instrument(level = "debug", skip_all)]
     /// - If the thing exists:
     ///   - Ensure the set of attributes match and are present
     ///     (but don't delete multivalue, or extended attributes in the situation.


### PR DESCRIPTION
# Change summary

- Fix addition of lastmodcid and createdatcid during invalidation during migration.

Fixes #3063

Checklist

- [ x ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
