### PR TITLE
Feat: Adding JSON/Authorized_keys api for SSH Publickeys

### DIFF
--- a/libs/client/src/person.rs
+++ b/libs/client/src/person.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use http::header::ACCEPT;
+use http::HeaderMap;
 use kanidm_proto::constants::*;
 use kanidm_proto::internal::{CredentialStatus, IdentifyUserRequest, IdentifyUserResponse};
 use kanidm_proto::v1::{AccountUnixExtend, Entry, SingleStringRequest, UatStatus};
@@ -154,6 +156,37 @@ impl KanidmClient {
 
         self.idm_account_credential_update_commit(&session_tok)
             .await
+    }
+
+    pub async fn idm_person_account_get_ssh_pubkey(
+        &self,
+        id: &str,
+        tag: &str,
+    ) -> Result<Option<String>, ClientError> {
+        let mut headers = HeaderMap::new();
+
+        headers.insert(ACCEPT, CONTENT_TYPE_KANIDM_PUBKEY_JSON.parse().unwrap());
+
+        self.perform_get_request_with_header(
+            format!("/v1/person/{}/_ssh_pubkeys/{}", id, tag).as_str(),
+            headers,
+        )
+        .await
+    }
+
+    pub async fn idm_person_account_get_ssh_pubkeys(
+        &self,
+        id: &str,
+    ) -> Result<BTreeMap<String, String>, ClientError> {
+        let mut headers = HeaderMap::new();
+
+        headers.insert(ACCEPT, CONTENT_TYPE_KANIDM_PUBKEY_JSON.parse().unwrap());
+
+        self.perform_get_request_with_header(
+            format!("/v1/person/{}/_ssh_pubkeys", id).as_str(),
+            headers,
+        )
+        .await
     }
 
     pub async fn idm_person_account_post_ssh_pubkey(

--- a/libs/client/src/service_account.rs
+++ b/libs/client/src/service_account.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
-use kanidm_proto::constants::{ATTR_DISPLAYNAME, ATTR_ENTRY_MANAGED_BY, ATTR_MAIL, ATTR_NAME};
+use http::header::ACCEPT;
+use http::HeaderMap;
+use kanidm_proto::constants::{ATTR_DISPLAYNAME, ATTR_ENTRY_MANAGED_BY, ATTR_MAIL, ATTR_NAME, CONTENT_TYPE_KANIDM_PUBKEY_JSON};
 use kanidm_proto::internal::{ApiToken, CredentialStatus};
 use kanidm_proto::v1::{AccountUnixExtend, ApiTokenGenerate, Entry};
 use time::OffsetDateTime;
@@ -134,6 +136,21 @@ impl KanidmClient {
     ) -> Result<(), ClientError> {
         self.perform_delete_request(format!("/v1/service_account/{}/_attr/{}", id, attr).as_str())
             .await
+    }
+
+    pub async fn idm_service_account_get_ssh_pubkey(
+        &self,
+        id: &str,
+    ) -> Result<BTreeMap<String, String>, ClientError> {
+        let mut headers = HeaderMap::new();
+
+        headers.insert(ACCEPT, CONTENT_TYPE_KANIDM_PUBKEY_JSON.parse().unwrap());
+
+        self.perform_get_request_with_header(
+            format!("/v1/service_account/{}/_ssh_pubkeys", id).as_str(),
+            headers,
+        )
+        .await
     }
 
     pub async fn idm_service_account_post_ssh_pubkey(

--- a/proto/src/constants.rs
+++ b/proto/src/constants.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 /// The default location for the `kanidm` CLI tool's token cache.
 pub const CLIENT_TOKEN_CACHE: &str = "~/.cache/kanidm_tokens";
 
+/// Content type string for json
+pub const CONTENT_TYPE_JSON: &str = "application/json";
 /// Content type string for jpeg
 pub const CONTENT_TYPE_JPG: &str = "image/jpeg";
 /// Content type string for png
@@ -18,6 +20,11 @@ pub const CONTENT_TYPE_SVG: &str = "image/svg+xml";
 /// Content type string for webp
 pub const CONTENT_TYPE_WEBP: &str = "image/webp";
 
+/// Kanidm specific json content type
+pub const CONTENT_TYPE_KANIDM_PUBKEY_JSON: &str = "application/vnd.kanidm.pubkeys+json";
+/// Kanidm specific authorized_keys content type
+pub const CONTENT_TYPE_KANIDM_PUBKEY_AUTHORIZED_KEYS: &str = "application/vnd.kanidm.pubkeys+authorized_keys";
+
 // For when the user uploads things to the various image endpoints, these are the valid content-types.
 pub const VALID_IMAGE_UPLOAD_CONTENT_TYPES: [&str; 5] = [
     CONTENT_TYPE_JPG,
@@ -26,8 +33,6 @@ pub const VALID_IMAGE_UPLOAD_CONTENT_TYPES: [&str; 5] = [
     CONTENT_TYPE_SVG,
     CONTENT_TYPE_WEBP,
 ];
-
-pub const APPLICATION_JSON: &str = "application/json";
 
 /// The "system" path for Kanidm client config
 pub const DEFAULT_CLIENT_CONFIG_PATH: &str = "/etc/kanidm/config";

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -763,6 +763,7 @@ impl QueryServerReadV1 {
         idms_prox_read.get_unixgrouptoken(&rate)
     }
 
+    //TODO: Do we really want to turn this into only a string?
     #[instrument(
         level = "info",
         skip_all,
@@ -812,7 +813,7 @@ impl QueryServerReadV1 {
                     .and_then(|e| {
                         // From the entry, turn it into the value
                         e.get_ava_iter_sshpubkeys(Attribute::SshPublicKey)
-                            .map(|i| i.collect())
+                            .map(|i| i.map(|(_, key)| key.to_string()).collect())
                     })
                     .unwrap_or_else(|| {
                         // No matching entry? Return none.

--- a/server/core/src/https/apidocs/response_schema.rs
+++ b/server/core/src/https/apidocs/response_schema.rs
@@ -2,7 +2,7 @@
 //!
 //! These are used to generate the OpenAPI schema definitions.
 //!
-use kanidm_proto::constants::APPLICATION_JSON;
+use kanidm_proto::constants::CONTENT_TYPE_JSON;
 use std::collections::BTreeMap;
 use utoipa::{
     openapi::{Content, RefOr, Response, ResponseBuilder, ResponsesBuilder},
@@ -24,7 +24,7 @@ impl IntoResponses for DefaultApiResponse {
             .response(
                 "200",
                 ResponseBuilder::new()
-                    .content(APPLICATION_JSON, Content::default())
+                    .content(CONTENT_TYPE_JSON, Content::default())
                     .description("Ok"),
             )
             .response("400", ResponseBuilder::new().description("Invalid Request"))

--- a/server/core/src/https/errors.rs
+++ b/server/core/src/https/errors.rs
@@ -14,6 +14,7 @@ pub enum WebError {
     /// Something went wrong when doing things.
     OperationError(OperationError),
     InternalServerError(String),
+    BadRequest(String),
 }
 
 impl From<OperationError> for WebError {
@@ -67,7 +68,8 @@ impl IntoResponse for WebError {
                     Some(headers) => (code, headers, body).into_response(),
                     None => (code, body).into_response(),
                 }
-            }
+            },
+            WebError::BadRequest(inner) => (StatusCode::BAD_REQUEST, inner).into_response(),
         }
     }
 }

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -38,7 +38,7 @@ pub async fn are_we_json_yet(request: Request<Body>, next: Next) -> Response {
         assert!(
             headers.get(axum::http::header::CONTENT_TYPE)
                 == Some(&HeaderValue::from_static(
-                    kanidm_proto::constants::APPLICATION_JSON
+                    kanidm_proto::constants::CONTENT_TYPE_JSON
                 ))
         );
     }

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -20,7 +20,7 @@ use compact_jwt::{JwkKeySet, OidcToken};
 use kanidm_proto::constants::uri::{
     OAUTH2_AUTHORISE, OAUTH2_AUTHORISE_PERMIT, OAUTH2_AUTHORISE_REJECT,
 };
-use kanidm_proto::constants::APPLICATION_JSON;
+use kanidm_proto::constants::CONTENT_TYPE_JSON;
 use kanidm_proto::oauth2::AuthorisationResponse;
 use kanidmd_lib::idm::oauth2::{
     AccessTokenIntrospectRequest, AccessTokenRequest, AuthorisationRequest, AuthorisePermitSuccess,
@@ -633,7 +633,7 @@ pub async fn oauth2_token_introspect_post(
             #[allow(clippy::unwrap_used)]
             Response::builder()
                 .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-                .header(CONTENT_TYPE, APPLICATION_JSON)
+                .header(CONTENT_TYPE, CONTENT_TYPE_JSON)
                 .body(Body::from(body))
                 .unwrap()
         }

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2551,7 +2551,7 @@ impl<VALID, STATE> Entry<VALID, STATE> {
         attr: A,
     ) -> Option<impl Iterator<Item = (&String, &PublicKey)> + '_> {
         self.get_ava_set(attr)
-            .and_then(|vs| vs.as_sshkey_map().map(|v| v.into_iter()))
+            .and_then(|vs| vs.as_sshkey_map().map(|v| v.iter()))
     }
 
     // These are special types to allow returning typed values from

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -39,6 +39,7 @@ use kanidm_proto::v1::Entry as ProtoEntry;
 use ldap3_proto::simple::{LdapPartialAttribute, LdapSearchResultEntry};
 use openssl::ec::EcKey;
 use openssl::pkey::{Private, Public};
+use sshkey_attest::proto::PublicKey;
 use time::OffsetDateTime;
 use tracing::trace;
 use uuid::Uuid;
@@ -2548,9 +2549,9 @@ impl<VALID, STATE> Entry<VALID, STATE> {
     pub fn get_ava_iter_sshpubkeys<A: AsRef<Attribute>>(
         &self,
         attr: A,
-    ) -> Option<impl Iterator<Item = String> + '_> {
+    ) -> Option<impl Iterator<Item = (&String, &PublicKey)> + '_> {
         self.get_ava_set(attr)
-            .and_then(|vs| vs.as_sshpubkey_string_iter())
+            .and_then(|vs| vs.as_sshkey_map().map(|v| v.into_iter()))
     }
 
     // These are special types to allow returning typed values from

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2554,6 +2554,14 @@ impl<VALID, STATE> Entry<VALID, STATE> {
             .and_then(|vs| vs.as_sshkey_map().map(|v| v.iter()))
     }
 
+    pub fn get_ava_sshpubkey_map<A: AsRef<Attribute>>(
+        &self,
+        attr: A,
+    ) -> Option<BTreeMap<String, PublicKey>> {
+        self.get_ava_set(attr)
+            .and_then(|vs| vs.as_sshkey_map().cloned())
+    }
+
     // These are special types to allow returning typed values from
     // an entry, if we "know" what we expect to receive.
 

--- a/server/lib/src/idm/scim.rs
+++ b/server/lib/src/idm/scim.rs
@@ -1507,6 +1507,7 @@ mod tests {
     use compact_jwt::{Jws, JwsCompact, JwsEs256Signer, JwsSigner};
     use kanidm_proto::internal::ApiTokenPurpose;
     use kanidm_proto::scim_v1::*;
+    use sshkey_attest::proto::PublicKey;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -2647,7 +2648,7 @@ mod tests {
             .get_ava_iter_sshpubkeys(Attribute::SshPublicKey)
             .expect("Failed to access ssh pubkeys");
 
-        assert_eq!(ssh_keyiter.next(), Some("sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBENubZikrb8hu+HeVRdZ0pp/VAk2qv4JDbuJhvD0yNdWDL2e3cBbERiDeNPkWx58Q4rVnxkbV1fa8E2waRtT91wAAAAEc3NoOg== testuser@fidokey".to_string()));
+        assert_eq!(ssh_keyiter.next(), Some((&"Key McKeyface".to_string(), &PublicKey::from_string("sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBENubZikrb8hu+HeVRdZ0pp/VAk2qv4JDbuJhvD0yNdWDL2e3cBbERiDeNPkWx58Q4rVnxkbV1fa8E2waRtT91wAAAAEc3NoOg== testuser@fidokey").expect("PublicKey failed to parse"))));
         assert_eq!(ssh_keyiter.next(), None);
 
         // Check memberof works.

--- a/server/testkit/tests/oauth2_test.rs
+++ b/server/testkit/tests/oauth2_test.rs
@@ -343,7 +343,7 @@ async fn test_oauth2_openid_basic_flow(rsclient: KanidmClient) {
     assert!(cors_header.eq("*"));
 
     assert!(
-        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(CONTENT_TYPE_JSON))
     );
     assert_no_cache!(response);
 
@@ -371,7 +371,7 @@ async fn test_oauth2_openid_basic_flow(rsclient: KanidmClient) {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     tracing::trace!("{:?}", response.headers());
     assert!(
-        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(CONTENT_TYPE_JSON))
     );
     assert_no_cache!(response);
 
@@ -422,7 +422,7 @@ async fn test_oauth2_openid_basic_flow(rsclient: KanidmClient) {
 
     tracing::trace!("{:?}", response.headers());
     assert!(
-        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(CONTENT_TYPE_JSON))
     );
     let userinfo = response
         .json::<OidcToken>()

--- a/server/web_ui/login_flows/src/oauth2.rs
+++ b/server/web_ui/login_flows/src/oauth2.rs
@@ -1,6 +1,6 @@
 use gloo::console;
 use kanidm_proto::constants::uri::{OAUTH2_AUTHORISE, OAUTH2_AUTHORISE_PERMIT};
-use kanidm_proto::constants::{APPLICATION_JSON, KOPID};
+use kanidm_proto::constants::{CONTENT_TYPE_JSON, KOPID};
 pub use kanidm_proto::oauth2::{AuthorisationRequest, AuthorisationResponse};
 use kanidmd_web_ui_shared::constants::{CONTENT_TYPE, CSS_ALERT_DANGER, URL_OAUTH2};
 use kanidmd_web_ui_shared::utils::{do_alert_error, do_footer, window};
@@ -164,7 +164,7 @@ impl Oauth2App {
 
         request
             .headers()
-            .set(CONTENT_TYPE, APPLICATION_JSON)
+            .set(CONTENT_TYPE, CONTENT_TYPE_JSON)
             .expect_throw("failed to set header");
 
         /*

--- a/server/web_ui/shared/src/lib.rs
+++ b/server/web_ui/shared/src/lib.rs
@@ -5,7 +5,7 @@ use error::FetchError;
 use gloo::console;
 
 use kanidm_proto::constants::uri::V1_AUTH_VALID;
-use kanidm_proto::constants::APPLICATION_JSON;
+use kanidm_proto::constants::CONTENT_TYPE_JSON;
 use kanidm_proto::constants::KOPID;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -49,7 +49,7 @@ pub async fn do_request<JV: AsRef<JsValue>>(
     let request = Request::new_with_str_and_init(uri, &opts)?;
     request
         .headers()
-        .set(CONTENT_TYPE, APPLICATION_JSON)
+        .set(CONTENT_TYPE, CONTENT_TYPE_JSON)
         .expect_throw("failed to set content-type header");
 
     let window = utils::window();


### PR DESCRIPTION
# Change summary

Adds a new http endpoint (or modifies an existing one in a backwards compatible way) to retrieve the ssh keys in either a JSON kv mapping
```json
{
  "name1": "...",
  "name2": "..."
}
```
or in the `authorized_keys` format.

Fixes #2983

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
