### PR TITLE
Remove white background from square logo

### DIFF
--- a/artwork/logo-square.svg
+++ b/artwork/logo-square.svg
@@ -88,15 +88,6 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <rect
-     style="fill:#ffffff;stroke-width:0.243721"
-     id="rect443"
-     width="135.46666"
-     height="135.46666"
-     x="0"
-     y="0"
-     inkscape:label="background"
-     sodipodi:insensitive="true" />
   <g
      id="layer1"
      transform="matrix(0.91407203,0,0,0.91407203,-34.121105,-24.362694)"


### PR DESCRIPTION
# Change summary

All the logos in `artwork/` have transparent backgrounds - except `logo-square.svg`, which has a white background. When using browser extensions such as Dark Reader, this becomes very noticeable on the login page (see screenshot). The change removes the white `rect` object from the SVG.

![Dark Kanidm login page with white background behind logo](https://github.com/user-attachments/assets/d24f709a-94eb-4f14-8eb2-1708abbd094b)

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
