### PR TITLE
Add support for initgroups hooks in libnss_kanidm

### DIFF
--- a/unix_integration/nss_kanidm/src/implementation.rs
+++ b/unix_integration/nss_kanidm/src/implementation.rs
@@ -5,6 +5,7 @@ use kanidm_unix_common::unix_proto::{ClientRequest, ClientResponse, NssGroup, Ns
 use libnss::group::{Group, GroupHooks};
 use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
+use libnss::initgroups::{InitgroupsHooks};
 
 struct KanidmPasswd;
 libnss_passwd_hooks!(kanidm, KanidmPasswd);
@@ -179,6 +180,22 @@ impl GroupHooks for KanidmGroup {
                 _ => Response::NotFound,
             })
             .unwrap_or_else(|_| Response::NotFound)
+    }
+}
+
+struct KanidmInitgroups;
+libnss_initgroups_hooks!(kanidm, KanidmInitgroups);
+
+impl InitgroupsHooks for KanidmInitgroups {
+    fn get_entries_by_user(user: String) -> Response<Vec<Group>> {
+        return match KanidmGroup::get_all_entries() {
+            Response::Success(g) => Response::Success(
+                g.into_iter()
+                    .filter(|g| g.members.contains(&user))
+                    .collect(),
+            ),
+            res => res,
+        };
     }
 }
 


### PR DESCRIPTION
# Change summary

This adds support for the `initgroups` NSS feature to Kanidm.

The reasoning behind this change is that [musl-nscd](https://github.com/pikhq/musl-nscd/blob/master/src/main.c#L181) can't use `getgrent` / `setgrent` / `endgrent` hooks to instead populate auxiliary groups. glibc's NSS has a solution for this: `libnss_compat`, but musl has no such feature.

This results in the current [experimental Alpine package](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/kanidm) to not resolve any auxiliary groups, leaving users with only their primary group. This is of course suboptimal.

This introduces an implementation of the `initgroups` hooks therefor, which makes musl happy and populates all groups on Alpine.

I understand if this PR is not wanted, but since it is so little code I figured I'd submit it anyway :)

# Checklist

- [x] This PR contains no AI generated code
- ~[ ] book chapter included (if relevant)~
- ~[ ] design document included (if relevant)~