### PR TITLE
20241017 unixd home

### DIFF
--- a/examples/unixd
+++ b/examples/unixd
@@ -54,8 +54,9 @@ version = '2'
 
 # home_attr = "uuid"
 
-# Controls the prefix that will be prepended to the home alias when mounting home directories. Must
-# end with a trailing `/`. If unset, defaults to the value of the `home_prefix`.
+# Controls the prefix that will be prepended to the home name when using mounted home directories from
+# a location that is outside of them `home_prefix`. Must end with a trailing `/`. If unset then home
+# directories will be created in `home_prefix`.
 #
 # This is option is useful when implementing a networked home directory layout. A common implementation
 # is to configure a networked filesystem that contains user directories mounted at `/u/` (eg /u/$user_uuid)
@@ -66,6 +67,13 @@ version = '2'
 # > home_alias = "name"
 # > home_prefix = "/home/"
 # > home_mount_prefix = "/u/"
+#
+# ⚠️  If you expect directories to be created by kanidm unixd tasks in an alternate mount prefix, then
+# you need to run `systemctl edit kanidm-unixd-tasks` to allow the daemon to write to these locations.
+#
+# > [Service]
+# > ReadWritePaths=/home /var/run/kanidm-unixd /u
+#
 #
 # Default: unset
 #

--- a/examples/unixd
+++ b/examples/unixd
@@ -54,7 +54,7 @@ version = '2'
 
 # home_attr = "uuid"
 
-# Controls the prefix that will be appended to the home alias when mounting home directories. Must
+# Controls the prefix that will be prepended to the home alias when mounting home directories. Must
 # end with a trailing `/`. If unset, defaults to the value of the `home_prefix`.
 #
 # This is option is useful when implementing a networked home directory layout. A common implementation
@@ -64,12 +64,12 @@ version = '2'
 #
 # > home_attr = "uuid"
 # > home_alias = "name"
-# > home_prefix = "/u/"
-# > home_mount_prefix = "/home/"
+# > home_prefix = "/home/"
+# > home_mount_prefix = "/u/"
 #
 # Default: unset
 #
-# home_mount_prefix = "/home/"
+# home_mount_prefix = "/u/"
 #
 
 # The default token attribute used for generating symlinks pointing to the user's home

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -97,13 +97,13 @@ fn create_home_directory(
     // be possible, but we assert this to be sure.
     let name = info.name.trim_start_matches('.').replace(['/', '\\'], "");
 
-    // This is where the storage is *mounted*
-    let home_mount_prefix_path_is_set = home_mount_prefix_path.is_some();
-
+    // This is where the users home dir "is" and aliases from here go to the true storage
+    // mounts
     let home_prefix_path = home_prefix_path
         .canonicalize()
         .map_err(|e| format!("{:?}", e))?;
 
+    // This is where the storage is *mounted*. If not set, falls back to the home_prefix.
     let home_mount_prefix_path = home_mount_prefix_path
         .unwrap_or(&home_prefix_path)
         .canonicalize()
@@ -261,7 +261,7 @@ fn create_home_directory(
             // Does not exist. Create.
             debug!("creating symlink {:?} -> {:?}", alias_path, hd_mount_path);
             // This is (original, link)
-            if let Err(e) = symlink(&hd_mount_path, alias_path) {
+            if let Err(e) = symlink(&hd_mount_path, &alias_path) {
                 error!(err = ?e, ?alias_path, "Unable to create alias path");
                 return Err(format!("{:?}", e));
             }

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -97,6 +97,8 @@ fn create_home_directory(
     // be possible, but we assert this to be sure.
     let name = info.name.trim_start_matches('.').replace(['/', '\\'], "");
 
+    debug!(?home_prefix_path, ?home_mount_prefix_path, ?info);
+
     // This is where the users home dir "is" and aliases from here go to the true storage
     // mounts
     let home_prefix_path = home_prefix_path

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -246,7 +246,7 @@ fn create_home_directory(
                 }
 
                 debug!("updating symlink {:?} -> {:?}", alias_path, hd_mount_path);
-                if let Err(e) = symlink(&hd_mount_path, &alias_path) {
+                if let Err(e) = symlink(&alias_path, &hd_mount_path) {
                     error!(err = ?e, ?alias_path, "Unable to update alias path");
                     return Err(format!("{:?}", e));
                 }
@@ -260,8 +260,7 @@ fn create_home_directory(
         } else {
             // Does not exist. Create.
             debug!("creating symlink {:?} -> {:?}", alias_path, hd_mount_path);
-            // This is (original, link)
-            if let Err(e) = symlink(&hd_mount_path, &alias_path) {
+            if let Err(e) = symlink(&alias_path, &hd_mount_path) {
                 error!(err = ?e, ?alias_path, "Unable to create alias path");
                 return Err(format!("{:?}", e));
             }

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -132,10 +132,7 @@ fn create_home_directory(
 
     if let Some(pp) = hd_mount_path.parent() {
         if pp != home_mount_prefix_path {
-            return Err(
-                "Invalid home directory name - not within home_mount_prefix"
-                    .to_string(),
-            );
+            return Err("Invalid home directory name - not within home_mount_prefix".to_string());
         }
     } else {
         return Err("Invalid/Corrupt home directory path - no prefix found".to_string());

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -232,6 +232,7 @@ fn create_home_directory(
         }
 
         if alias_path.exists() {
+            debug!("checking symlink {:?} -> {:?}", alias_path, hd_mount_path);
             let attr = match fs::symlink_metadata(&alias_path) {
                 Ok(a) => a,
                 Err(e) => {
@@ -248,7 +249,7 @@ fn create_home_directory(
                 }
 
                 debug!("updating symlink {:?} -> {:?}", alias_path, hd_mount_path);
-                if let Err(e) = symlink(&alias_path, &hd_mount_path) {
+                if let Err(e) = symlink(&hd_mount_path, &alias_path) {
                     error!(err = ?e, ?alias_path, "Unable to update alias path");
                     return Err(format!("{:?}", e));
                 }
@@ -262,7 +263,7 @@ fn create_home_directory(
         } else {
             // Does not exist. Create.
             debug!("creating symlink {:?} -> {:?}", alias_path, hd_mount_path);
-            if let Err(e) = symlink(&alias_path, &hd_mount_path) {
+            if let Err(e) = symlink(&hd_mount_path, &alias_path) {
                 error!(err = ?e, ?alias_path, "Unable to create alias path");
                 return Err(format!("{:?}", e));
             }


### PR DESCRIPTION
# Change summary

- Fix documentation to correctly list home_prefix and home_mount_prefix in the correct roles
- Note that systemd may need editing to allow writing to mount_prefix path
- Smooth some code that may not be needed in the tasks daemon
- Add more debug logging and error information

Fixes #3105 

Checklist

- [ x ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
