### PR TITLE
Change some OperationError into HTTP Bad Request (400).

### DIFF
--- a/server/core/src/https/errors.rs
+++ b/server/core/src/https/errors.rs
@@ -55,8 +55,11 @@ impl IntoResponse for WebError {
                     OperationError::NoMatchingEntries => (StatusCode::NOT_FOUND, None),
                     OperationError::PasswordQuality(_)
                     | OperationError::EmptyRequest
+                    | OperationError::InvalidAttribute(_)
+                    | OperationError::InvalidAttributeName(_)
                     | OperationError::SchemaViolation(_)
-                    | OperationError::CU0003WebauthnUserNotVerified => {
+                    | OperationError::CU0003WebauthnUserNotVerified
+                    | OperationError::VL0001ValueSshPublicKeyString => {
                         (StatusCode::BAD_REQUEST, None)
                     }
                     _ => (StatusCode::INTERNAL_SERVER_ERROR, None),

--- a/server/testkit/tests/group.rs
+++ b/server/testkit/tests/group.rs
@@ -1,12 +1,12 @@
-use kanidm_client::KanidmClient;
+use kanidm_client::{ClientError, KanidmClient};
 use kanidm_proto::constants::ATTR_DESCRIPTION;
-use kanidmd_testkit::{create_user, ADMIN_TEST_PASSWORD};
+use kanidmd_testkit::{create_user, ADMIN_TEST_PASSWORD, ADMIN_TEST_USER};
 use serde_json::Value;
 
 #[kanidmd_testkit::test]
 async fn test_v1_group_id_patch(rsclient: KanidmClient) {
     let res = rsclient
-        .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
         .await;
     assert!(res.is_ok());
 
@@ -22,4 +22,32 @@ async fn test_v1_group_id_patch(rsclient: KanidmClient) {
         Err(err) => panic!("Failed to patch group: {:?}", err),
     };
     eprintln!("response: {:#?}", response);
+}
+
+#[kanidmd_testkit::test]
+async fn test_v1_group_id_attr_post(rsclient: KanidmClient) {
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
+    create_user(&rsclient, "foo", "foogroup").await;
+
+    let post_body = serde_json::json!(["foo"]);
+
+    let response: ClientError = match rsclient
+        .perform_post_request::<serde_json::Value, String>(
+            "/v1/group/foogroup/_attr/member2",
+            post_body,
+        )
+        .await
+    {
+        Ok(val) => panic!("Expected failure to post group attribute: {:?}", val),
+        Err(err) => err,
+    };
+    eprintln!("response: {:#?}", response);
+    assert!(matches!(
+        response,
+        ClientError::Http(reqwest::StatusCode::BAD_REQUEST, _, _)
+    ));
 }

--- a/server/testkit/tests/person.rs
+++ b/server/testkit/tests/person.rs
@@ -1,12 +1,12 @@
-use kanidm_client::KanidmClient;
+use kanidm_client::{ClientError, KanidmClient};
 use kanidm_proto::constants::ATTR_MAIL;
-use kanidmd_testkit::{create_user, ADMIN_TEST_PASSWORD};
+use kanidmd_testkit::{create_user, ADMIN_TEST_PASSWORD, ADMIN_TEST_USER};
 use serde_json::Value;
 
 #[kanidmd_testkit::test]
 async fn test_v1_person_id_patch(rsclient: KanidmClient) {
     let res = rsclient
-        .auth_simple_password("admin", ADMIN_TEST_PASSWORD)
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
         .await;
     assert!(res.is_ok());
 
@@ -22,4 +22,32 @@ async fn test_v1_person_id_patch(rsclient: KanidmClient) {
         Err(err) => panic!("Failed to patch person: {:?}", err),
     };
     eprintln!("response: {:#?}", response);
+}
+
+#[kanidmd_testkit::test]
+async fn test_v1_person_id_ssh_pubkeys_post(rsclient: KanidmClient) {
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
+    create_user(&rsclient, "foo", "foogroup").await;
+
+    let post_body = serde_json::json!([
+        "ssh-key-tag-goes-here",
+        "ed25519 im_a_real_ssh_public_key_just_trust_me comment"
+    ]);
+
+    let response: ClientError = match rsclient
+        .perform_post_request::<serde_json::Value, String>("/v1/person/foo/_ssh_pubkeys", post_body)
+        .await
+    {
+        Ok(val) => panic!("Expected failure to post person ssh pubkeys: {:?}", val),
+        Err(err) => err,
+    };
+    eprintln!("response: {:#?}", response);
+    assert!(matches!(
+        response,
+        ClientError::Http(reqwest::StatusCode::BAD_REQUEST, _, _)
+    ));
 }


### PR DESCRIPTION
# Change summary
This adds a few more `OperationError` errors to the list that should return a HTTP Bad Request (400) instead of HTTP Internal Server Error (500).

Fixes #2679

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
