### PR TITLE
Update docs, improve locking

### DIFF
--- a/book/src/integrations/pam_and_nsswitch/suse.md
+++ b/book/src/integrations/pam_and_nsswitch/suse.md
@@ -38,14 +38,12 @@ The content should look like:
 # /etc/pam.d/common-account
 # Controls authorisation to this system (who may login)
 account    sufficient    pam_kanidm.so ignore_unknown_user
-account    sufficient    pam_unix.so
 account    required      pam_deny.so
 
 # /etc/pam.d/common-auth
 # Controls authentication to this system (verification of credentials)
 auth        required      pam_env.so
 auth        sufficient    pam_kanidm.so ignore_unknown_user
-auth        sufficient    pam_unix.so try_first_pass
 auth        required      pam_deny.so
 
 # /etc/pam.d/common-password
@@ -60,7 +58,6 @@ session optional    pam_systemd.so
 session required    pam_limits.so
 session optional    pam_umask.so
 session optional    pam_kanidm.so
-session optional    pam_unix.so try_first_pass
 session optional    pam_env.so
 ```
 

--- a/unix_integration/resolver/src/resolver.rs
+++ b/unix_integration/resolver/src/resolver.rs
@@ -165,17 +165,17 @@ impl Resolver {
 
     #[instrument(level = "debug", skip_all)]
     pub async fn clear_cache(&self) -> Result<(), ()> {
+        let mut dbtxn = self.db.write().await;
         let mut nxcache_txn = self.nxcache.lock().await;
         nxcache_txn.clear();
-        let mut dbtxn = self.db.write().await;
         dbtxn.clear().and_then(|_| dbtxn.commit()).map_err(|_| ())
     }
 
     #[instrument(level = "debug", skip_all)]
     pub async fn invalidate(&self) -> Result<(), ()> {
+        let mut dbtxn = self.db.write().await;
         let mut nxcache_txn = self.nxcache.lock().await;
         nxcache_txn.clear();
-        let mut dbtxn = self.db.write().await;
         dbtxn
             .invalidate()
             .and_then(|_| dbtxn.commit())


### PR DESCRIPTION
# Change summary

- Ensure nxcache lock is always taken after dbtxn
- Change book to represent new feature support in pam unix

Fixes #2632

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
