### PR TITLE
examples: add ExecReload for server

### DIFF
--- a/examples/systemd/kanidmd.service
+++ b/examples/systemd/kanidmd.service
@@ -10,6 +10,7 @@ Wants=network-online.target
 Type=notify
 
 ExecStart=/usr/local/sbin/kanidmd server --config=/etc/kanidm/server.toml
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=15s
 WorkingDirectory=/var/lib/kanidm


### PR DESCRIPTION
With cert reloading available to the server, add an `ExecReload=` directive to the example systemd unit providing this functionality.

# Change summary
- Add an `ExecReload=` directive to the server example systemd unit

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
