### PR TITLE
Improve OAuth2 authorisation ux

### DIFF
--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1422,13 +1422,13 @@ impl QueryServerReadV1 {
             .map_err(Oauth2Error::ServerError)?;
         let ident = idms_prox_read
             .validate_client_auth_info_to_ident(client_auth_info, ct)
-            .map_err(|e| {
+            .inspect_err(|e| {
                 error!("Invalid identity: {:?}", e);
-                Oauth2Error::AuthenticationRequired
-            })?;
+            })
+            .ok();
 
         // Now we can send to the idm server for authorisation checking.
-        idms_prox_read.check_oauth2_authorisation(&ident, &auth_req, ct)
+        idms_prox_read.check_oauth2_authorisation(ident.as_ref(), &auth_req, ct)
     }
 
     #[instrument(

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -289,7 +289,8 @@ async fn oauth2_authorise(
                 .body(body)
                 .unwrap()
         }
-        Err(Oauth2Error::AuthenticationRequired) => {
+        Ok(AuthoriseResponse::AuthenticationRequired { .. })
+        | Err(Oauth2Error::AuthenticationRequired) => {
             // This will trigger our ui to auth and retry.
             #[allow(clippy::unwrap_used)]
             Response::builder()

--- a/server/core/src/https/views/constants.rs
+++ b/server/core/src/https/views/constants.rs
@@ -28,6 +28,7 @@ pub(crate) enum Urls {
     UpdateCredentials,
     Oauth2Resume,
     Login,
+    Ui,
 }
 
 impl AsRef<str> for Urls {
@@ -39,6 +40,7 @@ impl AsRef<str> for Urls {
             Self::UpdateCredentials => "/ui/update_credentials",
             Self::Oauth2Resume => "/ui/oauth2/resume",
             Self::Login => "/ui/login",
+            Self::Ui => "/ui",
         }
     }
 }

--- a/server/core/src/https/views/profile.rs
+++ b/server/core/src/https/views/profile.rs
@@ -73,6 +73,7 @@ pub(crate) async fn view_profile_unlock_get(
 
     let display_ctx = LoginDisplayCtx {
         domain_info,
+        oauth2: None,
         reauth: Some(Reauth {
             username: uat.spn,
             purpose: ReauthPurpose::ProfileSettings,

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -653,6 +653,7 @@ pub(crate) async fn view_self_reset_get(
     } else {
         let display_ctx = LoginDisplayCtx {
             domain_info,
+            oauth2: None,
             reauth: Some(Reauth {
                 username: uat.spn,
                 purpose: ReauthPurpose::ProfileSettings,

--- a/server/core/templates/login_base.html
+++ b/server/core/templates/login_base.html
@@ -20,6 +20,10 @@
 	<div class="alert alert-info" role="alert">
 		Reauthenticating as (( reauth.username )) to access (( reauth.purpose ))
 	</div>
+	(% else if let Some(oauth2) = display_ctx.oauth2 %)
+	<div class="alert alert-info" role="alert">
+		Authenticate to access (( oauth2.client_name ))
+	</div>
 	(% endif %)
 	<div>
 		(% block logincontainer %)

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -208,6 +208,12 @@ impl fmt::Display for Oauth2TokenType {
 
 #[derive(Debug)]
 pub enum AuthoriseResponse {
+    AuthenticationRequired {
+        // A pretty-name of the client
+        client_name: String,
+        // A username hint, if any
+        login_hint: Option<String>,
+    },
     ConsentRequested {
         // A pretty-name of the client
         client_name: String,
@@ -1775,7 +1781,7 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
     #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_authorisation(
         &self,
-        ident: &Identity,
+        maybe_ident: Option<&Identity>,
         auth_req: &AuthorisationRequest,
         ct: Duration,
     ) -> Result<AuthoriseResponse, Oauth2Error> {
@@ -1889,6 +1895,11 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
             None
         };
 
+        // =============================================================================
+        // By this point, we have validated the majority of the security related
+        // parameters of the request. We can now inspect the identity and decide
+        // if we should ask the user to re-authenticate and proceed.
+
         // TODO: https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters
         // Are we going to provide the functions for these? Most of these can be "later".
         // IF CHANGED: Update OidcDiscoveryResponse!!!
@@ -1908,7 +1919,13 @@ impl<'a> IdmServerProxyReadTransaction<'a> {
 
         // TODO: id_token_hint - a past token which can be used as a hint.
 
-        // NOTE: login_hint is handled in the UI code, not here.
+        let Some(ident) = maybe_ident else {
+            debug!("No identity available, assume authentication required");
+            return Ok(AuthoriseResponse::AuthenticationRequired {
+                client_name: o2rs.displayname.clone(),
+                login_hint: auth_req.oidc_ext.login_hint.clone(),
+            });
+        };
 
         let Some(account_uuid) = ident.get_uuid() else {
             error!("consent request ident does not have a valid uuid, unable to proceed");
@@ -2939,7 +2956,7 @@ mod tests {
             };
 
             $idms_prox_read
-                .check_oauth2_authorisation($ident, &auth_req, $ct)
+                .check_oauth2_authorisation(Some($ident), &auth_req, $ct)
                 .expect("OAuth2 authorisation failed")
         }};
     }
@@ -3431,7 +3448,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::UnsupportedResponseType
         );
@@ -3451,7 +3468,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidRequest
         );
@@ -3471,7 +3488,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidClientId
         );
@@ -3491,7 +3508,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -3511,10 +3528,32 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
+
+        // Not Authenticated
+        let auth_req = AuthorisationRequest {
+            response_type: "code".to_string(),
+            client_id: "test_resource_server".to_string(),
+            state: "123".to_string(),
+            pkce_request: pkce_request.clone(),
+            redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),
+            scope: OAUTH2_SCOPE_OPENID.to_string(),
+            nonce: None,
+            oidc_ext: Default::default(),
+            unknown_keys: Default::default(),
+        };
+
+        let req = idms_prox_read
+            .check_oauth2_authorisation(None, &auth_req, ct)
+            .unwrap();
+
+        assert!(matches!(
+            req,
+            AuthoriseResponse::AuthenticationRequired { .. }
+        ));
 
         // Requested scope is not available
         let auth_req = AuthorisationRequest {
@@ -3531,7 +3570,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::AccessDenied
         );
@@ -3551,7 +3590,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&idm_admin_ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&idm_admin_ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::AccessDenied
         );
@@ -3571,7 +3610,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&anon_ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&anon_ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::AccessDenied
         );
@@ -3863,7 +3902,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("OAuth2 authorisation failed");
 
         trace!(?consent_request);
@@ -3932,7 +3971,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("OAuth2 authorisation failed");
 
         trace!(?consent_request);
@@ -5134,7 +5173,7 @@ mod tests {
         };
 
         idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("Oauth2 authorisation failed");
     }
 
@@ -5347,7 +5386,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("Oauth2 authorisation failed");
 
         // Should be in the consent phase;
@@ -5405,7 +5444,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("Oauth2 authorisation failed");
 
         // Should be present in the consent phase however!
@@ -5542,7 +5581,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("Failed to perform OAuth2 authorisation request.");
 
         // Should be in the consent phase;
@@ -5620,7 +5659,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(&ident, &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -6575,7 +6614,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(&ident, &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("OAuth2 authorisation failed");
 
         // Should be in the consent phase;


### PR DESCRIPTION
- Resolve an issue where oauth2 could trigger the login page to incorrectly redirect to an oauth2 application instead of apps
- Add indication of what client application we are accessing if the session is not yet authenticated

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
