### PR TITLE
chore: Made scopes required

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -225,13 +225,17 @@ kanidm system oauth2 update-scope-map nextcloud nextcloud_users email profile op
 > - **email** - email, email_verified
 > - **address** - address
 > - **phone** - phone_number, phone_number_verified
+> - **groups** - groups
 
 <!-- this is just to split the templates up -->
 
 > [!WARNING]
 >
-> If you are creating an OpenID Connect (OIDC) client you **MUST** provide a scope map named
+> If you are creating an OpenID Connect (OIDC) client you **MUST** provide a scope map containing
 > `openid`. Without this, OpenID Connect clients **WILL NOT WORK**!
+> ```bash
+> kanidm system oauth2 update-scope-map nextcloud nextcloud_users openid
+> ```
 
 You can create a supplemental scope map with:
 

--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -210,7 +210,7 @@ You can create a scope map with:
 
 ```bash
 kanidm system oauth2 update-scope-map <name> <kanidm_group_name> [scopes]...
-kanidm system oauth2 update-scope-map nextcloud nextcloud_admins admin
+kanidm system oauth2 update-scope-map nextcloud nextcloud_users email profile openid
 ```
 
 > [!TIP]

--- a/tools/cli/src/cli/oauth2.rs
+++ b/tools/cli/src/cli/oauth2.rs
@@ -140,12 +140,6 @@ impl Oauth2Opt {
                 }
             }
             Oauth2Opt::UpdateScopeMap(cbopt) => {
-                // This should not be required, It should tbe verified by num_args but apparently that isn't working ¯\_(ツ)_/¯
-                if cbopt.scopes.is_empty() {
-                    eprintln!("Scopes cannot be empty");
-                    return;
-                }
-
                 let client = cbopt.nopt.copt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update_scope_map(

--- a/tools/cli/src/cli/oauth2.rs
+++ b/tools/cli/src/cli/oauth2.rs
@@ -140,6 +140,12 @@ impl Oauth2Opt {
                 }
             }
             Oauth2Opt::UpdateScopeMap(cbopt) => {
+                // This should not be required, It should tbe verified by num_args but apparently that isn't working ¯\_(ツ)_/¯
+                if cbopt.scopes.is_empty() {
+                    eprintln!("Scopes cannot be empty");
+                    return;
+                }
+
                 let client = cbopt.nopt.copt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update_scope_map(

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -943,7 +943,7 @@ pub struct Oauth2CreateScopeMapOpt {
     nopt: Named,
     #[clap(name = "group")]
     group: String,
-    #[clap(name = "scopes", num_args = 1..)]
+    #[clap(name = "scopes", required = true)]
     scopes: Vec<String>,
 }
 

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -943,7 +943,7 @@ pub struct Oauth2CreateScopeMapOpt {
     nopt: Named,
     #[clap(name = "group")]
     group: String,
-    #[clap(name = "scopes")]
+    #[clap(name = "scopes", num_args = 1..)]
     scopes: Vec<String>,
 }
 


### PR DESCRIPTION
# Change summary

the cli now requires the scopes to be provided. This ensures that empty scope maps aren't accidentally created and helps remove confusion

Fixes: My Sanity

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
