### PR TITLE
chore: Remove empty scopemaps

### DIFF
--- a/server/core/src/https/v1_oauth2.rs
+++ b/server/core/src/https/v1_oauth2.rs
@@ -201,10 +201,6 @@ pub(crate) async fn oauth2_id_scopemap_post(
 ) -> Result<Json<()>, WebError> {
     let filter = oauth2_id(&rs_name);
 
-    if scopes.is_empty() {
-        return Err(WebError::OperationError(OperationError::EmptyRequest));
-    }
-
     state
         .qe_w_ref
         .handle_oauth2_scopemap_update(client_auth_info, group, scopes, filter, kopid.eventid)

--- a/server/core/src/https/v1_oauth2.rs
+++ b/server/core/src/https/v1_oauth2.rs
@@ -200,6 +200,11 @@ pub(crate) async fn oauth2_id_scopemap_post(
     Json(scopes): Json<Vec<String>>,
 ) -> Result<Json<()>, WebError> {
     let filter = oauth2_id(&rs_name);
+
+    if scopes.is_empty() {
+        return Err(WebError::OperationError(OperationError::EmptyRequest));
+    }
+
     state
         .qe_w_ref
         .handle_oauth2_scopemap_update(client_auth_info, group, scopes, filter, kopid.eventid)

--- a/server/lib/src/valueset/oauth.rs
+++ b/server/lib/src/valueset/oauth.rs
@@ -279,6 +279,7 @@ impl ValueSetT for ValueSetOauthScopeMap {
         match value {
             Value::OauthScopeMap(u, m) => {
                 match self.map.entry(u) {
+                    // We are going to assume that a vacant entry will not be set to empty.
                     BTreeEntry::Vacant(e) => {
                         e.insert(m);
                         Ok(true)
@@ -289,7 +290,12 @@ impl ValueSetT for ValueSetOauthScopeMap {
                     // associated map state. So by always replacing on a present, we are true to
                     // the intent of the api.
                     BTreeEntry::Occupied(mut e) => {
-                        e.insert(m);
+                        if m.is_empty() {
+                            e.remove();
+                        } else {
+                            e.insert(m);
+                        }
+
                         Ok(true)
                     }
                 }


### PR DESCRIPTION
# Change summary

This change removes the ability to create or update a scope map with a list of scopes that is empty. It also deletes a scope map that is inserted and empty.

Fixes #3167
Fixes #3168

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
