### PR TITLE
Resolve incorrect handling of rhost in pam

### DIFF
--- a/unix_integration/common/src/unix_proto.rs
+++ b/unix_integration/common/src/unix_proto.rs
@@ -107,7 +107,8 @@ pub enum PamAuthRequest {
 pub struct PamServiceInfo {
     pub service: String,
     pub tty: String,
-    pub rhost: String,
+    // Only set if it really is a remote host?
+    pub rhost: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -144,7 +145,10 @@ impl ClientRequest {
             ClientRequest::NssGroupByName(id) => format!("NssGroupByName({})", id),
             ClientRequest::PamAuthenticateInit { account_id, info } => format!(
                 "PamAuthenticateInit{{ account_id={} tty={} pam_secvice{} rhost={} }}",
-                account_id, info.service, info.tty, info.rhost
+                account_id,
+                info.service,
+                info.tty,
+                info.rhost.as_deref().unwrap_or("")
             ),
             ClientRequest::PamAuthenticateStep(_) => "PamAuthenticateStep".to_string(),
             ClientRequest::PamAccountAllowed(id) => {

--- a/unix_integration/pam_kanidm/src/pam/module.rs
+++ b/unix_integration/pam_kanidm/src/pam/module.rs
@@ -256,7 +256,7 @@ impl PamHandle {
         tracing::debug!(?maybe_tty, ?maybe_rhost, ?maybe_service);
 
         match (maybe_tty, maybe_rhost, maybe_service) {
-            (Some(tty), Some(rhost), Some(service)) => Ok(PamServiceInfo {
+            (Some(tty), rhost, Some(service)) => Ok(PamServiceInfo {
                 service,
                 tty,
                 rhost,

--- a/unix_integration/resolver/src/bin/kanidm-unix.rs
+++ b/unix_integration/resolver/src/bin/kanidm-unix.rs
@@ -68,7 +68,7 @@ async fn main() -> ExitCode {
                 info: PamServiceInfo {
                     service: "kanidm-unix".to_string(),
                     tty: "/dev/null".to_string(),
-                    rhost: "localhost".to_string(),
+                    rhost: None,
                 },
             };
             loop {

--- a/unix_integration/resolver/src/resolver.rs
+++ b/unix_integration/resolver/src/resolver.rs
@@ -1087,7 +1087,7 @@ impl Resolver {
         let pam_info = PamServiceInfo {
             service: "kanidm-unix-test".to_string(),
             tty: "/dev/null".to_string(),
-            rhost: "localhost".to_string(),
+            rhost: None,
         };
 
         let mut auth_session = match self


### PR DESCRIPTION
# Change summary

- Rhost in my testing was always present, leading me to incorrectly assume it was always present. In some configurations it may be None, leading to pam_conv_error in sudo authentication contexts.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
