### PR TITLE
fix(kanidmd): Print replication cert to stdout

### DIFF
--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -172,7 +172,7 @@ async fn submit_admin_req(path: &str, req: AdminTaskRequest, output_mode: Consol
         },
         Some(Ok(AdminTaskResponse::ShowReplicationCertificate { cert })) => match output_mode {
             ConsoleOutputMode::JSON => {
-                eprintln!("{{\"certificate\":\"{}\"}}", cert)
+                println!("{{\"certificate\":\"{}\"}}", cert)
             }
             ConsoleOutputMode::Text => {
                 info!(certificate = ?cert)


### PR DESCRIPTION
# Change summary

ShowReplicationCertificate was printing the certificate to stderr, which is inconsistent with the rest of the output commands.

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
