### PR TITLE
security - low - fault in migrations

### DIFF
--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2944,10 +2944,19 @@ impl<VALID, STATE> Entry<VALID, STATE> {
             match schema.is_multivalue(k) {
                 Ok(r) => {
                     // As this is single value, purge then present to maintain this
-                    // invariant. The other situation we purge is within schema with
-                    // the system types where we need to be able to express REMOVAL
-                    // of attributes, thus we need the purge.
-                    if !r || *k == Attribute::SystemMust || *k == Attribute::SystemMay {
+                    // invariant.
+                    if !r ||
+                        // we need to be able to express REMOVAL of attributes, so we
+                        // purge here for migrations of certain system attributes.
+                        *k == Attribute::AcpReceiverGroup ||
+                        *k == Attribute::AcpCreateAttr ||
+                        *k == Attribute::AcpCreateClass ||
+                        *k == Attribute::AcpModifyPresentAttr ||
+                        *k == Attribute::AcpModifyRemovedAttr ||
+                        *k == Attribute::AcpModifyClass ||
+                        *k == Attribute::SystemMust ||
+                        *k == Attribute::SystemMay
+                    {
                         mods.push_mod(Modify::Purged(k.clone()));
                     }
                 }

--- a/server/lib/src/server/access/mod.rs
+++ b/server/lib/src/server/access/mod.rs
@@ -137,7 +137,10 @@ fn resolve_access_conditions(
         AccessControlReceiver::Group(groups) => {
             let group_check = ident_memberof
                 // Have at least one group allowed.
-                .map(|imo| imo.intersection(groups).next().is_some())
+                .map(|imo| {
+                    trace!(?imo, ?groups);
+                    imo.intersection(groups).next().is_some()
+                })
                 .unwrap_or_default();
 
             if group_check {
@@ -401,6 +404,7 @@ pub trait AccessControlsTransaction<'a> {
         let related_acp: Vec<_> = modify_state
             .iter()
             .filter_map(|acs| {
+                trace!(acs_name = ?acs.acp.name);
                 let (receiver_condition, target_condition) = resolve_access_conditions(
                     ident,
                     ident_memberof,


### PR DESCRIPTION
A fault existed in the server's internal migration code, where attributes that were multivalued would be merged rather than replaced in certain contexts. This migration path is used for access controls, meaning that on upgrades, attributes that were meant to be removed from access controls or changes to access control target groups were not reflected during the upgrade process.

This has a potentially low security impact as it may have allowed users to change their name/displayname even if the administrator had disable the name_self_write access control.

Fixes #3178

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
