### PR TITLE
Use correct oauth2 manage acp

### DIFF
--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -1,5 +1,3 @@
-
-
 use crate::prelude::*;
 
 use kanidm_proto::internal::{

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+
 
 use crate::prelude::*;
 
@@ -708,7 +708,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
                 .clone()
                 .into(),
             IDM_ACP_MAIL_SERVERS_DL8.clone().into(),
-            IDM_ACP_OAUTH2_MANAGE_DL9.clone().into(),
+            IDM_ACP_OAUTH2_MANAGE_DL7.clone().into(),
             IDM_ACP_PEOPLE_CREATE_DL6.clone().into(),
             IDM_ACP_PEOPLE_CREDENTIAL_RESET_V1.clone().into(),
             IDM_ACP_PEOPLE_DELETE_V1.clone().into(),


### PR DESCRIPTION
# Change summary

- The incorrect oauth2 manage acp version was used in the previous PR. 

Fixes #

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
