### PR TITLE
Prevent Invalid MFA Reg States

### DIFF
--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -1849,7 +1849,7 @@ impl<'a> IdmServerCredUpdateTransaction<'a> {
 
         // Is there something else in progress? Cancel it if so.
         if !matches!(session.mfaregstate, MfaRegState::None) {
-            debug!("Cancelling abandoned mfareg");
+            debug!("Clearing incomplete mfareg");
         }
 
         // Generate the TOTP.
@@ -2131,7 +2131,7 @@ impl<'a> IdmServerCredUpdateTransaction<'a> {
         };
 
         if !matches!(session.mfaregstate, MfaRegState::None) {
-            debug!("Cancelling abandoned mfareg");
+            debug!("Clearing incomplete mfareg");
         }
 
         let (ccr, pk_reg) = self


### PR DESCRIPTION
* If an MFA reg was abandoned, we just overwrite it rather than error
* Make cred max_ttl validity checking a bit clearer in the flow
* Review session timeout handling

Fixes #2940 Fixes #2977 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
