### PR TITLE
Harden transport in pam unixd

### DIFF
--- a/unix_integration/resolver/src/idprovider/kanidm.rs
+++ b/unix_integration/resolver/src/idprovider/kanidm.rs
@@ -458,7 +458,7 @@ impl IdProvider for KanidmProvider {
                         Ok(AuthResult::Denied)
                     }
                     Err(ClientError::Transport(err)) => {
-                        error!(?err);
+                        error!(?err, "A client transport error occured.");
                         Err(IdpError::Transport)
                     }
                     Err(ClientError::Http(StatusCode::UNAUTHORIZED, reason, opid)) => {

--- a/unix_integration/resolver/src/resolver.rs
+++ b/unix_integration/resolver/src/resolver.rs
@@ -1069,8 +1069,17 @@ impl Resolver {
                 Ok(PamAuthResponse::Denied)
             }
             Ok(AuthResult::Next(req)) => Ok(req.into()),
-            Err(IdpError::NotFound) => Ok(PamAuthResponse::Unknown),
-            _ => Err(()),
+            Err(IdpError::NotFound) => {
+                *auth_session = AuthSession::Denied;
+
+                Ok(PamAuthResponse::Unknown)
+            }
+            Err(err) => {
+                *auth_session = AuthSession::Denied;
+
+                error!(?err, "Unable to proceed, failing the session");
+                Err(())
+            }
         }
     }
 


### PR DESCRIPTION
In some cases if the transport drops out from underneath unixd, it can be difficult to diagnose and leads to inconsistent errors and output such as prompting for a password multiple times when it can't succeed.

This makes it clearer that the transport had an error, and it denies the inflight authsession to prevent spurious password prompts.

Relates @tacerus issue with sudo in infra.o.o

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
