### PR TITLE
Display account_id during success/deny paths in unixd

### DIFF
--- a/unix_integration/resolver/src/resolver.rs
+++ b/unix_integration/resolver/src/resolver.rs
@@ -57,11 +57,15 @@ pub enum AuthSession {
         shutdown_rx: broadcast::Receiver<()>,
     },
     Offline {
+        account_id: String,
+        id: Id,
         client: Arc<dyn IdProvider + Sync + Send>,
         token: Box<UserToken>,
         cred_handler: AuthCredHandler,
     },
     System {
+        account_id: String,
+        id: Id,
         cred_handler: AuthCredHandler,
         shadow: Arc<Shadow>,
     },
@@ -818,7 +822,7 @@ impl Resolver {
         match self.system_provider.auth_init(&id, current_time).await {
             // The system provider will not take part in this authentication.
             SystemProviderAuthInit::Ignore => {
-                debug!("account unknown to system provider, continue.");
+                debug!(?account_id, "account unknown to system provider, continue.");
             }
             // The provider knows the account, and is unable to proceed,
             // We return unknown here so that pam_kanidm can be skipped and fall back
@@ -853,6 +857,8 @@ impl Resolver {
                 shadow,
             } => {
                 let auth_session = AuthSession::System {
+                    account_id: account_id.to_string(),
+                    id,
                     shadow,
                     cred_handler,
                 };
@@ -916,6 +922,8 @@ impl Resolver {
                 match init_result {
                     Ok((next_req, cred_handler)) => {
                         let auth_session = AuthSession::Offline {
+                            account_id: account_id.to_string(),
+                            id,
                             client,
                             token: Box::new(token),
                             cred_handler,
@@ -998,7 +1006,7 @@ impl Resolver {
                 ref shutdown_rx,
             } => {
                 let mut hsm_lock = self.hsm.lock().await;
-                client
+                let result = client
                     .unix_user_online_auth_step(
                         account_id,
                         cred_handler,
@@ -1006,9 +1014,26 @@ impl Resolver {
                         hsm_lock.deref_mut(),
                         shutdown_rx,
                     )
-                    .await
+                    .await;
+
+                match result {
+                    Ok(AuthResult::Success { .. }) => {
+                        info!(?account_id, "Authentication Success");
+                    }
+                    Ok(AuthResult::Denied) => {
+                        info!(?account_id, "Authentication Denied");
+                    }
+                    Ok(AuthResult::Next(_)) => {
+                        info!(?account_id, "Authentication Continue");
+                    }
+                    _ => {}
+                };
+
+                result
             }
             &mut AuthSession::Offline {
+                ref account_id,
+                id: _,
                 ref client,
                 ref token,
                 ref mut cred_handler,
@@ -1016,16 +1041,33 @@ impl Resolver {
                 // We are offline, continue. Remember, authsession should have
                 // *everything you need* to proceed here!
                 let mut hsm_lock = self.hsm.lock().await;
-                client
+                let result = client
                     .unix_user_offline_auth_step(
                         token,
                         cred_handler,
                         pam_next_req,
                         hsm_lock.deref_mut(),
                     )
-                    .await
+                    .await;
+
+                match result {
+                    Ok(AuthResult::Success { .. }) => {
+                        info!(?account_id, "Authentication Success");
+                    }
+                    Ok(AuthResult::Denied) => {
+                        info!(?account_id, "Authentication Denied");
+                    }
+                    Ok(AuthResult::Next(_)) => {
+                        info!(?account_id, "Authentication Continue");
+                    }
+                    _ => {}
+                };
+
+                result
             }
             &mut AuthSession::System {
+                ref account_id,
+                id: _,
                 ref mut cred_handler,
                 ref shadow,
             } => {
@@ -1036,11 +1078,15 @@ impl Resolver {
 
                 let next = match system_auth_result {
                     SystemAuthResult::Denied => {
+                        info!(?account_id, "Authentication Denied");
+
                         *auth_session = AuthSession::Denied;
 
                         Ok(PamAuthResponse::Denied)
                     }
                     SystemAuthResult::Success => {
+                        info!(?account_id, "Authentication Success");
+
                         *auth_session = AuthSession::Success;
 
                         Ok(PamAuthResponse::Success)
@@ -1057,7 +1103,6 @@ impl Resolver {
         match maybe_err {
             // What did the provider direct us to do next?
             Ok(AuthResult::Success { mut token }) => {
-                debug!("provider authentication success.");
                 self.set_cache_usertoken(&mut token).await?;
                 *auth_session = AuthSession::Success;
 


### PR DESCRIPTION
# Change summary

- Display account_id in success/deny paths

Fixes #3244

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
