### PR TITLE
Allow group managers to modify entry-managed-by

### DIFF
--- a/server/lib/src/constants/acp.rs
+++ b/server/lib/src/constants/acp.rs
@@ -1798,6 +1798,68 @@ lazy_static! {
 }
 
 lazy_static! {
+    pub static ref IDM_ACP_GROUP_MANAGE_DL9: BuiltinAcp = BuiltinAcp{
+        classes: vec![
+            EntryClass::Object,
+            EntryClass::AccessControlProfile,
+            EntryClass::AccessControlCreate,
+            EntryClass::AccessControlDelete,
+            EntryClass::AccessControlModify,
+            EntryClass::AccessControlSearch
+            ],
+        name: "idm_acp_group_manage",
+        uuid: UUID_IDM_ACP_GROUP_MANAGE_V1,
+        description: "Builtin IDM Control for creating and deleting groups in the directory",
+        receiver: BuiltinAcpReceiver::Group ( vec![UUID_IDM_GROUP_ADMINS] ),
+         // group which is not in HP, Recycled, Tombstone
+         target: BuiltinAcpTarget::Filter( ProtoFilter::And(vec![
+            match_class_filter!(EntryClass::Group),
+            FILTER_ANDNOT_HP_OR_RECYCLED_OR_TOMBSTONE.clone(),
+        ])),
+        search_attrs: vec![
+            Attribute::Class,
+            Attribute::Name,
+            Attribute::Uuid,
+            Attribute::Spn,
+            Attribute::Uuid,
+            Attribute::Description,
+            Attribute::Mail,
+            Attribute::Member,
+            Attribute::DynMember,
+            Attribute::EntryManagedBy,
+        ],
+        create_attrs: vec![
+            Attribute::Class,
+            Attribute::Name,
+            Attribute::Uuid,
+            Attribute::Description,
+            Attribute::Mail,
+            Attribute::Member,
+            Attribute::EntryManagedBy,
+        ],
+        create_classes: vec![
+            EntryClass::Object,
+            EntryClass::Group,
+        ],
+        modify_present_attrs: vec![
+            Attribute::Name,
+            Attribute::Description,
+            Attribute::Mail,
+            Attribute::Member,
+            Attribute::EntryManagedBy,
+        ],
+        modify_removed_attrs: vec![
+            Attribute::Name,
+            Attribute::Description,
+            Attribute::Mail,
+            Attribute::Member,
+            Attribute::EntryManagedBy,
+        ],
+        ..Default::default()
+    };
+}
+
+lazy_static! {
     pub static ref IDM_ACP_GROUP_UNIX_MANAGE_V1: BuiltinAcp = BuiltinAcp {
         classes: vec![
             EntryClass::Object,

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -660,7 +660,10 @@ impl QueryServerWriteTransaction<'_> {
 
         self.reload()?;
 
-        let idm_data = [IDM_ACP_OAUTH2_MANAGE_DL9.clone().into()];
+        let idm_data = [
+            IDM_ACP_OAUTH2_MANAGE_DL9.clone().into(),
+            IDM_ACP_GROUP_MANAGE_DL9.clone().into(),
+        ];
 
         idm_data
             .into_iter()


### PR DESCRIPTION
# Change summary

When we added entry-managed-by, we allowed it to be set on group creation but not post-group-creation. The idea was to *delegate* ownership of the group. However, this has the obvious trap that an account group like idm_admins can't alter entry-managed-by post creation, needing the use of the admin account which has access control privs, or a delete and recreate of the entry. 

Since the idm admin could delete and recreate the group with a new entry manager, there is functionally no difference to allowing them to modify the entry-managed-by here of *low* priv groups. This changes the group manager access control by default to allow this. 

Fixes #3270

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
