### PR TITLE
Always advertise PKCE code challenges methods supported even if PKCE is disabled in kanidm for a client.

### DIFF
--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2512,11 +2512,7 @@ impl IdmServerProxyReadTransaction<'_> {
 
         let service_documentation = Some(URL_SERVICE_DOCUMENTATION.clone());
 
-        let code_challenge_methods_supported = if o2rs.require_pkce() {
-            vec![PkceAlg::S256]
-        } else {
-            Vec::with_capacity(0)
-        };
+        let code_challenge_methods_supported = vec![PkceAlg::S256];
 
         Ok(Oauth2Rfc8414MetadataResponse {
             issuer,
@@ -2587,11 +2583,7 @@ impl IdmServerProxyReadTransaction<'_> {
         let claims_supported = None;
         let service_documentation = Some(URL_SERVICE_DOCUMENTATION.clone());
 
-        let code_challenge_methods_supported = if o2rs.require_pkce() {
-            vec![PkceAlg::S256]
-        } else {
-            Vec::with_capacity(0)
-        };
+        let code_challenge_methods_supported = vec![PkceAlg::S256];
 
         // The following are extensions allowed by the oidc specification.
 


### PR DESCRIPTION
# Change summary
Per RFC8414 the authorization server should include metadata of supported code challenge methods. _If omitted, the authorization server does not support PKCE._

Clients and libraries should be able to check the well known endpoint and attempt PKCE if the auth server supports it.

Lastly this is a minor info leak if not always shown.

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
