### PR TITLE
Minor - Cleanup unused features

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -74,29 +74,23 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 url = { workspace = true }
 
+## See src/cli/webauthn/mod.rs for which features are
+## required for which target_os here
 [target."cfg(target_os = \"windows\")".dependencies.webauthn-authenticator-rs]
 workspace = true
 features = ["win10"]
 
 [target."cfg(target_os = \"linux\")".dependencies.webauthn-authenticator-rs]
 workspace = true
-features = [
-    "u2fhid",
-    "mozilla",
-]
+features = ["u2fhid"]
 
 [target."cfg(target_os = \"macos\")".dependencies.webauthn-authenticator-rs]
 workspace = true
-features = [
-    "u2fhid",
-    "mozilla",
-]
+features = ["mozilla"]
 
 [target."cfg(target_os = \"freebsd\")".dependencies.webauthn-authenticator-rs]
 workspace = true
-features = [
-    "mozilla",
-]
+features = ["mozilla"]
 
 ## Debian packaging
 [package.metadata.deb]


### PR DESCRIPTION
# Change summary

While improving the webauthn feature handling yesterday I accidentally left mozilla enabled on linux which doesn't need it and u2fhid on macos.

In the future the plan is to swap fully to u2fhid, but in the mean time we need mozilla for freebsd support. That's something I'll need to work on later with @micolous.  


Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
