### PR TITLE
SCIM Sync Missing Annotation

### DIFF
--- a/proto/src/scim_v1/synch.rs
+++ b/proto/src/scim_v1/synch.rs
@@ -220,6 +220,7 @@ pub struct ScimExternalMember {
     pub external_id: String,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct ScimSyncGroup {

--- a/tools/iam_migrations/freeipa/src/main.rs
+++ b/tools/iam_migrations/freeipa/src/main.rs
@@ -942,7 +942,7 @@ fn ipa_to_scim_entry(
             .build();
 
         let scim_entry_generic: ScimEntry = scim_sync_person.try_into().map_err(|json_err| {
-            error!(?json_err, "Unable to convert group to scim_sync_group");
+            error!(?json_err, "Unable to convert person to scim_sync_person");
         })?;
 
         Ok(Some(scim_entry_generic))

--- a/tools/iam_migrations/ldap/src/main.rs
+++ b/tools/iam_migrations/ldap/src/main.rs
@@ -633,7 +633,7 @@ fn ldap_to_scim_entry(
             .build();
 
         let scim_entry_generic: ScimEntry = scim_sync_person.try_into().map_err(|json_err| {
-            error!(?json_err, "Unable to convert group to scim_sync_group");
+            error!(?json_err, "Unable to convert person to scim_sync_person");
         })?;
 
         Ok(Some(scim_entry_generic))


### PR DESCRIPTION
A missing serde annotion in SCIM Sync caused groups to fail to sync unless they had a description. This resolves the failure by adding the correct annotation to skip None fields in groups.

Fixes #3298

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
