### PR TITLE
Incorrect member name in groups

### DIFF
--- a/proto/src/scim_v1/synch.rs
+++ b/proto/src/scim_v1/synch.rs
@@ -230,7 +230,7 @@ pub struct ScimSyncGroup {
     pub name: String,
     pub description: Option<String>,
     pub gidnumber: Option<u32>,
-    pub members: Vec<ScimExternalMember>,
+    pub member: Vec<ScimExternalMember>,
 }
 
 impl TryInto<ScimEntry> for ScimSyncGroup {
@@ -260,7 +260,7 @@ impl ScimSyncGroup {
                 name,
                 description: None,
                 gidnumber: None,
-                members: Vec::with_capacity(0),
+                member: Vec::with_capacity(0),
             },
         }
     }
@@ -289,7 +289,7 @@ impl ScimSyncGroupBuilder {
     where
         I: Iterator<Item = String>,
     {
-        self.inner.members = member_iter
+        self.inner.member = member_iter
             .map(|external_id| ScimExternalMember { external_id })
             .collect();
         self


### PR DESCRIPTION
Member was accidentally set to members which prevented group synchronisation.

Fixes #3299

This error never should have happened and I believe it's indicative of a lack of testing of the proto bindings into the scim sync paths. I need to add more testing. 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
