### PR TITLE
Allow reseting account policy values to defaults

### DIFF
--- a/libs/client/src/group.rs
+++ b/libs/client/src/group.rs
@@ -37,6 +37,14 @@ impl KanidmClient {
         .await
     }
 
+    pub async fn group_account_policy_authsession_expiry_reset(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        self.perform_delete_request(&format!("/v1/group/{}/_attr/authsession_expiry", id))
+            .await
+    }
+
     pub async fn group_account_policy_credential_type_minimum_set(
         &self,
         id: &str,
@@ -61,6 +69,17 @@ impl KanidmClient {
         .await
     }
 
+    pub async fn group_account_policy_password_minimum_length_reset(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        self.perform_delete_request(&format!(
+            "/v1/group/{}/_attr/auth_password_minimum_length",
+            id
+        ))
+        .await
+    }
+
     pub async fn group_account_policy_privilege_expiry_set(
         &self,
         id: &str,
@@ -73,6 +92,14 @@ impl KanidmClient {
         .await
     }
 
+    pub async fn group_account_policy_privilege_expiry_reset(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        self.perform_delete_request(&format!("/v1/group/{}/_attr/privilege_expiry", id))
+            .await
+    }
+
     pub async fn group_account_policy_webauthn_attestation_set(
         &self,
         id: &str,
@@ -82,6 +109,17 @@ impl KanidmClient {
             &format!("/v1/group/{}/_attr/webauthn_attestation_ca_list", id),
             vec![att_ca_list.to_string()],
         )
+        .await
+    }
+
+    pub async fn group_account_policy_webauthn_attestation_reset(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        self.perform_delete_request(&format!(
+            "/v1/group/{}/_attr/webauthn_attestation_ca_list",
+            id
+        ))
         .await
     }
 
@@ -97,6 +135,14 @@ impl KanidmClient {
         .await
     }
 
+    pub async fn group_account_policy_limit_search_max_results_reset(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        self.perform_delete_request(&format!("/v1/group/{}/_attr/limit_search_max_results", id))
+            .await
+    }
+
     pub async fn group_account_policy_limit_search_max_filter_test(
         &self,
         id: &str,
@@ -106,6 +152,17 @@ impl KanidmClient {
             &format!("/v1/group/{}/_attr/limit_search_max_filter_test", id),
             vec![maximum.to_string()],
         )
+        .await
+    }
+
+    pub async fn group_account_policy_limit_search_max_filter_test_reset(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        self.perform_delete_request(&format!(
+            "/v1/group/{}/_attr/limit_search_max_filter_test",
+            id
+        ))
         .await
     }
 

--- a/tools/cli/src/cli/group/account_policy.rs
+++ b/tools/cli/src/cli/group/account_policy.rs
@@ -52,7 +52,7 @@ impl GroupAccountPolicyOpt {
                 {
                     handle_client_error(e, copt.output_mode);
                 } else {
-                    println!("Reset authsession expiry.");
+                    println!("Successfully reset authsession expiry.");
                 }
             }
 
@@ -86,7 +86,7 @@ impl GroupAccountPolicyOpt {
                 {
                     handle_client_error(e, copt.output_mode);
                 } else {
-                    println!("Reset password minimum length.");
+                    println!("Successfully reset password minimum length.");
                 }
             }
             GroupAccountPolicyOpt::PrivilegedSessionExpiry { name, expiry, copt } => {
@@ -108,7 +108,7 @@ impl GroupAccountPolicyOpt {
                 {
                     handle_client_error(e, copt.output_mode);
                 } else {
-                    println!("Reset privilege session expiry.");
+                    println!("Successfully reset privilege session expiry.");
                 }
             }
             GroupAccountPolicyOpt::WebauthnAttestationCaList {
@@ -135,7 +135,7 @@ impl GroupAccountPolicyOpt {
                 {
                     handle_client_error(e, copt.output_mode);
                 } else {
-                    println!("Reset webauthn attestation CA list.");
+                    println!("Successfully reset webauthn attestation CA list.");
                 }
             }
 
@@ -162,7 +162,7 @@ impl GroupAccountPolicyOpt {
                 {
                     handle_client_error(e, copt.output_mode);
                 } else {
-                    println!("Reset search maximum results limit.");
+                    println!("Successfully reset search maximum results limit to default.");
                 }
             }
             GroupAccountPolicyOpt::LimitSearchMaxFilterTest {
@@ -188,7 +188,7 @@ impl GroupAccountPolicyOpt {
                 {
                     handle_client_error(e, copt.output_mode);
                 } else {
-                    println!("Reset search maximum filter test limit.");
+                    println!("Successfully reset search maximum filter test limit.");
                 }
             }
             GroupAccountPolicyOpt::AllowPrimaryCredFallback { name, allow, copt } => {

--- a/tools/cli/src/cli/group/account_policy.rs
+++ b/tools/cli/src/cli/group/account_policy.rs
@@ -12,6 +12,12 @@ impl GroupAccountPolicyOpt {
             | GroupAccountPolicyOpt::LimitSearchMaxResults { copt, .. }
             | GroupAccountPolicyOpt::LimitSearchMaxFilterTest { copt, .. }
             | GroupAccountPolicyOpt::AllowPrimaryCredFallback { copt, .. }
+            | GroupAccountPolicyOpt::ResetWebauthnAttestationCaList { copt, .. }
+            | GroupAccountPolicyOpt::ResetAuthSessionExpiry { copt, .. }
+            | GroupAccountPolicyOpt::ResetPasswordMinimumLength { copt, .. }
+            | GroupAccountPolicyOpt::ResetPrivilegedSessionExpiry { copt, .. }
+            | GroupAccountPolicyOpt::ResetLimitSearchMaxResults { copt, .. }
+            | GroupAccountPolicyOpt::ResetLimitSearchMaxFilterTest { copt, .. }
             | GroupAccountPolicyOpt::PrivilegedSessionExpiry { copt, .. } => copt.debug,
         }
     }
@@ -37,6 +43,19 @@ impl GroupAccountPolicyOpt {
                     println!("Updated authsession expiry.");
                 }
             }
+
+            GroupAccountPolicyOpt::ResetAuthSessionExpiry { name, copt } => {
+                let client = copt.to_client(OpType::Write).await;
+                if let Err(e) = client
+                    .group_account_policy_authsession_expiry_reset(name)
+                    .await
+                {
+                    handle_client_error(e, copt.output_mode);
+                } else {
+                    println!("Reset authsession expiry.");
+                }
+            }
+
             GroupAccountPolicyOpt::CredentialTypeMinimum { name, value, copt } => {
                 let client = copt.to_client(OpType::Write).await;
                 if let Err(e) = client
@@ -59,6 +78,17 @@ impl GroupAccountPolicyOpt {
                     println!("Updated password minimum length.");
                 }
             }
+            GroupAccountPolicyOpt::ResetPasswordMinimumLength { name, copt } => {
+                let client = copt.to_client(OpType::Write).await;
+                if let Err(e) = client
+                    .group_account_policy_password_minimum_length_reset(name)
+                    .await
+                {
+                    handle_client_error(e, copt.output_mode);
+                } else {
+                    println!("Reset password minimum length.");
+                }
+            }
             GroupAccountPolicyOpt::PrivilegedSessionExpiry { name, expiry, copt } => {
                 let client = copt.to_client(OpType::Write).await;
                 if let Err(e) = client
@@ -68,6 +98,17 @@ impl GroupAccountPolicyOpt {
                     handle_client_error(e, copt.output_mode);
                 } else {
                     println!("Updated privilege session expiry.");
+                }
+            }
+            GroupAccountPolicyOpt::ResetPrivilegedSessionExpiry { name, copt } => {
+                let client = copt.to_client(OpType::Write).await;
+                if let Err(e) = client
+                    .group_account_policy_privilege_expiry_reset(name)
+                    .await
+                {
+                    handle_client_error(e, copt.output_mode);
+                } else {
+                    println!("Reset privilege session expiry.");
                 }
             }
             GroupAccountPolicyOpt::WebauthnAttestationCaList {
@@ -85,6 +126,19 @@ impl GroupAccountPolicyOpt {
                     println!("Updated webauthn attestation CA list.");
                 }
             }
+
+            GroupAccountPolicyOpt::ResetWebauthnAttestationCaList { name, copt } => {
+                let client = copt.to_client(OpType::Write).await;
+                if let Err(e) = client
+                    .group_account_policy_webauthn_attestation_reset(name)
+                    .await
+                {
+                    handle_client_error(e, copt.output_mode);
+                } else {
+                    println!("Reset webauthn attestation CA list.");
+                }
+            }
+
             GroupAccountPolicyOpt::LimitSearchMaxResults {
                 name,
                 maximum,
@@ -100,6 +154,17 @@ impl GroupAccountPolicyOpt {
                     println!("Updated search maximum results limit.");
                 }
             }
+            GroupAccountPolicyOpt::ResetLimitSearchMaxResults { name, copt } => {
+                let client = copt.to_client(OpType::Write).await;
+                if let Err(e) = client
+                    .group_account_policy_limit_search_max_results_reset(name)
+                    .await
+                {
+                    handle_client_error(e, copt.output_mode);
+                } else {
+                    println!("Reset search maximum results limit.");
+                }
+            }
             GroupAccountPolicyOpt::LimitSearchMaxFilterTest {
                 name,
                 maximum,
@@ -113,6 +178,17 @@ impl GroupAccountPolicyOpt {
                     handle_client_error(e, copt.output_mode);
                 } else {
                     println!("Updated search maximum filter test limit.");
+                }
+            }
+            GroupAccountPolicyOpt::ResetLimitSearchMaxFilterTest { name, copt } => {
+                let client = copt.to_client(OpType::Write).await;
+                if let Err(e) = client
+                    .group_account_policy_limit_search_max_filter_test_reset(name)
+                    .await
+                {
+                    handle_client_error(e, copt.output_mode);
+                } else {
+                    println!("Reset search maximum filter test limit.");
                 }
             }
             GroupAccountPolicyOpt::AllowPrimaryCredFallback { name, allow, copt } => {

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -251,28 +251,28 @@ pub enum GroupAccountPolicyOpt {
         copt: CommonOpt,
     },
 
-    /// Reset the maximum time for session expiry to it's default value
+    /// Reset the maximum time for session expiry to its default value
     #[clap(name = "reset-auth-expiry")]
     ResetAuthSessionExpiry {
         name: String,
         #[clap(flatten)]
         copt: CommonOpt,
     },
-    /// Reset the minimum character length of passwords to it's default value.
+    /// Reset the minimum character length of passwords to its default value.
     #[clap(name = "reset-password-minimum-length")]
     ResetPasswordMinimumLength {
         name: String,
         #[clap(flatten)]
         copt: CommonOpt,
     },
-    /// Reset the maximum time for privilege session expiry to it's default value.
+    /// Reset the maximum time for privilege session expiry to its default value.
     #[clap(name = "reset-privilege-expiry")]
     ResetPrivilegedSessionExpiry {
         name: String,
         #[clap(flatten)]
         copt: CommonOpt,
     },
-    /// Reset the WebAuthn attestation CA list to it's default value
+    /// Reset the WebAuthn attestation CA list to its default value
     /// allowing any passkey to be used by members of this group.
     #[clap(name = "reset-webauthn-attestation-ca-list")]
     ResetWebauthnAttestationCaList {
@@ -280,14 +280,14 @@ pub enum GroupAccountPolicyOpt {
         #[clap(flatten)]
         copt: CommonOpt,
     },
-    /// Reset the searche maxmium results limit to it's default value.
+    /// Reset the searche maxmium results limit to its default value.
     #[clap(name = "reset-limit-search-max-results")]
     ResetLimitSearchMaxResults {
         name: String,
         #[clap(flatten)]
         copt: CommonOpt,
     },
-    /// Reset the max filter test limit to it's default value.
+    /// Reset the max filter test limit to its default value.
     #[clap(name = "reset-limit-search-max-filter-test")]
     ResetLimitSearchMaxFilterTest {
         name: String,

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -197,6 +197,8 @@ pub enum GroupAccountPolicyOpt {
         #[clap(flatten)]
         copt: CommonOpt,
     },
+
+
     /// Set the maximum time for privilege session expiry in seconds.
     #[clap(name = "privilege-expiry")]
     PrivilegedSessionExpiry {
@@ -205,6 +207,8 @@ pub enum GroupAccountPolicyOpt {
         #[clap(flatten)]
         copt: CommonOpt,
     },
+
+
     /// The WebAuthn attestation CA list that should be enforced
     /// on members of this group. Prevents use of passkeys that are
     /// not in this list. To create this list, use `fido-mds-tool`
@@ -216,6 +220,7 @@ pub enum GroupAccountPolicyOpt {
         #[clap(flatten)]
         copt: CommonOpt,
     },
+
     /// Sets the maximum number of entries that may be returned in a
     /// search operation.
     #[clap(name = "limit-search-max-results")]
@@ -245,6 +250,51 @@ pub enum GroupAccountPolicyOpt {
         #[clap(flatten)]
         copt: CommonOpt,
     },
+
+    /// Reset the maximum time for session expiry to it's default value
+    #[clap(name = "reset-auth-expiry")]
+    ResetAuthSessionExpiry {
+        name: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+    /// Reset the minimum character length of passwords to it's default value.
+    #[clap(name = "reset-password-minimum-length")]
+    ResetPasswordMinimumLength {
+        name: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+    /// Reset the maximum time for privilege session expiry to it's default value.
+    #[clap(name = "reset-privilege-expiry")]
+    ResetPrivilegedSessionExpiry {
+        name: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+    /// Reset the WebAuthn attestation CA list to it's default value
+    /// allowing any passkey to be used by members of this group.
+    #[clap(name = "reset-webauthn-attestation-ca-list")]
+    ResetWebauthnAttestationCaList {
+        name: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+    /// Reset the searche maxmium results limit to it's default value.
+    #[clap(name = "reset-limit-search-max-results")]
+    ResetLimitSearchMaxResults {
+        name: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+    /// Reset the max filter test limit to it's default value.
+    #[clap(name = "reset-limit-search-max-filter-test")]
+    ResetLimitSearchMaxFilterTest {
+        name: String,
+        #[clap(flatten)]
+        copt: CommonOpt,
+    },
+
 }
 
 #[derive(Debug, Subcommand)]


### PR DESCRIPTION
This allows the admin cli to reset account policy values to defaults by clearing them. Due to how account policy resolves a lack of value implies the default.

Fixes #3233 
Fixes #3287 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
