### PR TITLE
Add OAuth2 `response_mode=fragment`

### DIFF
--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -37,7 +37,7 @@ use kanidmd_lib::{
     idm::ldap::{LdapBoundToken, LdapResponseState},
     idm::oauth2::{
         AccessTokenIntrospectRequest, AccessTokenIntrospectResponse, AuthorisationRequest,
-        AuthoriseResponse, JwkKeySet, Oauth2Error, Oauth2Rfc8414MetadataResponse,
+        AuthoriseReject, AuthoriseResponse, JwkKeySet, Oauth2Error, Oauth2Rfc8414MetadataResponse,
         OidcDiscoveryResponse, OidcToken,
     },
     idm::server::{DomainInfoRead, IdmServerTransaction},
@@ -1441,7 +1441,7 @@ impl QueryServerReadV1 {
         client_auth_info: ClientAuthInfo,
         consent_req: String,
         eventid: Uuid,
-    ) -> Result<Url, OperationError> {
+    ) -> Result<AuthoriseReject, OperationError> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self.idms.proxy_read().await?;
         let ident = idms_prox_read

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -29,8 +29,8 @@ use kanidm_proto::oauth2::AuthorisationResponse;
 #[cfg(feature = "dev-oauth2-device-flow")]
 use kanidm_proto::oauth2::DeviceAuthorizationResponse;
 use kanidmd_lib::idm::oauth2::{
-    AccessTokenIntrospectRequest, AccessTokenRequest, AuthorisationRequest,
-    AuthoriseResponse, ErrorResponse, Oauth2Error, TokenRevokeRequest,
+    AccessTokenIntrospectRequest, AccessTokenRequest, AuthorisationRequest, AuthoriseResponse,
+    ErrorResponse, Oauth2Error, TokenRevokeRequest,
 };
 use kanidmd_lib::prelude::f_eq;
 use kanidmd_lib::prelude::*;

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2560,7 +2560,7 @@ impl IdmServerProxyReadTransaction<'_> {
         let jwks_uri = Some(o2rs.jwks_uri.clone());
         let scopes_supported = Some(o2rs.scopes_supported.iter().cloned().collect());
         let response_types_supported = vec![ResponseType::Code];
-        let response_modes_supported = vec![ResponseMode::Query];
+        let response_modes_supported = vec![ResponseMode::Query, ResponseMode::Fragment];
         let grant_types_supported = vec![GrantType::AuthorisationCode];
 
         let token_endpoint_auth_methods_supported = vec![
@@ -2631,7 +2631,7 @@ impl IdmServerProxyReadTransaction<'_> {
         let jwks_uri = o2rs.jwks_uri.clone();
         let scopes_supported = Some(o2rs.scopes_supported.iter().cloned().collect());
         let response_types_supported = vec![ResponseType::Code];
-        let response_modes_supported = vec![ResponseMode::Query];
+        let response_modes_supported = vec![ResponseMode::Query, ResponseMode::Fragment];
 
         // TODO: add device code if the rs supports it per <https://www.rfc-editor.org/rfc/rfc8628#section-4>
         // `urn:ietf:params:oauth:grant-type:device_code`
@@ -4604,7 +4604,7 @@ mod tests {
         assert_eq!(discovery.response_types_supported, vec![ResponseType::Code]);
         assert_eq!(
             discovery.response_modes_supported,
-            vec![ResponseMode::Query]
+            vec![ResponseMode::Query, ResponseMode::Fragment]
         );
         assert_eq!(
             discovery.grant_types_supported,
@@ -4764,7 +4764,7 @@ mod tests {
         assert_eq!(discovery.response_types_supported, vec![ResponseType::Code]);
         assert_eq!(
             discovery.response_modes_supported,
-            vec![ResponseMode::Query]
+            vec![ResponseMode::Query, ResponseMode::Fragment]
         );
         assert_eq!(
             discovery.grant_types_supported,

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -138,7 +138,7 @@ struct ConsentToken {
         as = "Option<serde_with::base64::Base64<serde_with::base64::UrlSafe, formats::Unpadded>>"
     )]
     pub code_challenge: Option<Vec<u8>>,
-    // Where the RS wants us to go back to.
+    // Where the client wants us to go back to.
     pub redirect_uri: Url,
     // The scopes being granted
     pub scopes: BTreeSet<String>,
@@ -232,7 +232,7 @@ pub enum AuthoriseResponse {
 
 #[derive(Debug)]
 pub struct AuthorisePermitSuccess {
-    // Where the RS wants us to go back to.
+    // Where the client wants us to go back to.
     pub redirect_uri: Url,
     // The CSRF as a string
     pub state: String,
@@ -269,7 +269,7 @@ impl AuthorisePermitSuccess {
 
 #[derive(Debug)]
 pub struct AuthoriseReject {
-    // Where the RS wants us to go back to.
+    // Where the client wants us to go back to.
     pub redirect_uri: Url,
     /// The format the response should be returned to the application in.
     pub response_mode: ResponseMode,

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -1860,6 +1860,14 @@ impl IdmServerProxyReadTransaction<'_> {
             admin_warn!("Unsupported OAuth2 response_type (should be 'code')");
             return Err(Oauth2Error::UnsupportedResponseType);
         }
+        let Some(response_mode) = auth_req.get_response_mode() else {
+            admin_warn!(
+                "Invalid response_mode {:?} for response_type {:?}",
+                auth_req.response_mode,
+                auth_req.response_type
+            );
+            return Err(Oauth2Error::InvalidRequest);
+        };
 
         /*
          * 4.1.2.1.  Error Response
@@ -2109,7 +2117,7 @@ impl IdmServerProxyReadTransaction<'_> {
                 redirect_uri: auth_req.redirect_uri.clone(),
                 state: auth_req.state.clone(),
                 code,
-                response_mode: auth_req.get_response_mode(),
+                response_mode,
             }))
         } else {
             //  Check that the scopes are the same as a previous consent (if any)
@@ -2148,7 +2156,7 @@ impl IdmServerProxyReadTransaction<'_> {
                 redirect_uri: auth_req.redirect_uri.clone(),
                 scopes: granted_scopes.iter().cloned().collect(),
                 nonce: auth_req.nonce.clone(),
-                response_mode: auth_req.get_response_mode(),
+                response_mode,
             };
 
             let consent_data = serde_json::to_vec(&consent_req).map_err(|e| {

--- a/server/testkit/tests/oauth2_test.rs
+++ b/server/testkit/tests/oauth2_test.rs
@@ -27,824 +27,880 @@ use kanidmd_testkit::{
     TEST_INTEGRATION_RS_URL,
 };
 
-macro_rules! test_oauth2_openid_basic_flows {
-    ($($name:ident: $response_mode:expr,)*) => {
-    $(
-        #[kanidmd_testkit::test]
-        async fn $name(rsclient: KanidmClient) {
-            let response_mode: Option<&str> = $response_mode;
-            let res = rsclient
-                .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
-                .await;
-            assert!(res.is_ok());
-
-            // Create an oauth2 application integration.
-            rsclient
-                .idm_oauth2_rs_basic_create(
-                    TEST_INTEGRATION_RS_ID,
-                    TEST_INTEGRATION_RS_DISPLAY,
-                    TEST_INTEGRATION_RS_URL,
-                )
-                .await
-                .expect("Failed to create oauth2 config");
-
-            rsclient
-                .idm_oauth2_client_add_origin(
-                    TEST_INTEGRATION_RS_ID,
-                    &Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
-                )
-                .await
-                .expect("Failed to update oauth2 config");
-
-            // Extend the admin account with extended details for openid claims.
-            rsclient
-                .idm_person_account_create(NOT_ADMIN_TEST_USERNAME, NOT_ADMIN_TEST_USERNAME)
-                .await
-                .expect("Failed to create account details");
-
-            rsclient
-                .idm_person_account_set_attr(
-                    NOT_ADMIN_TEST_USERNAME,
-                    Attribute::Mail.as_ref(),
-                    &[NOT_ADMIN_TEST_EMAIL],
-                )
-                .await
-                .expect("Failed to create account mail");
-
-            rsclient
-                .idm_person_account_primary_credential_set_password(
-                    NOT_ADMIN_TEST_USERNAME,
-                    NOT_ADMIN_TEST_PASSWORD,
-                )
-                .await
-                .expect("Failed to configure account password");
-
-            rsclient
-                .idm_oauth2_rs_update(TEST_INTEGRATION_RS_ID, None, None, None, true, true, true)
-                .await
-                .expect("Failed to update oauth2 config");
-
-            rsclient
-                .idm_oauth2_rs_update_scope_map(
-                    TEST_INTEGRATION_RS_ID,
-                    IDM_ALL_ACCOUNTS.name,
-                    vec![OAUTH2_SCOPE_READ, OAUTH2_SCOPE_EMAIL, OAUTH2_SCOPE_OPENID],
-                )
-                .await
-                .expect("Failed to update oauth2 scopes");
-
-            rsclient
-                .idm_oauth2_rs_update_sup_scope_map(
-                    TEST_INTEGRATION_RS_ID,
-                    IDM_ALL_ACCOUNTS.name,
-                    vec![ADMIN_TEST_USER],
-                )
-                .await
-                .expect("Failed to update oauth2 scopes");
-
-            let client_secret = rsclient
-                .idm_oauth2_rs_get_basic_secret(TEST_INTEGRATION_RS_ID)
-                .await
-                .ok()
-                .flatten()
-                .expect("Failed to retrieve test_integration basic secret");
-
-            // Get our admin's auth token for our new client.
-            // We have to re-auth to update the mail field.
-            let res = rsclient
-                .auth_simple_password(NOT_ADMIN_TEST_USERNAME, NOT_ADMIN_TEST_PASSWORD)
-                .await;
-            assert!(res.is_ok());
-            let oauth_test_uat = rsclient
-                .get_token()
-                .await
-                .expect("No user auth token found");
-
-            // We need a new reqwest client here.
-
-            // from here, we can now begin what would be a "interaction" to the oauth server.
-            // Create a new reqwest client - we'll be using this manually.
-            let client = reqwest::Client::builder()
-                .redirect(reqwest::redirect::Policy::none())
-                .no_proxy()
-                .build()
-                .expect("Failed to create client.");
-
-            // Step 0 - get the openid discovery details and the public key.
-            let response = client
-                .request(
-                    reqwest::Method::OPTIONS,
-                    rsclient.make_url("/oauth2/openid/test_integration/.well-known/openid-configuration"),
-                )
-                .send()
-                .await
-                .expect("Failed to send discovery preflight request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-            let cors_header: &str = response
-                .headers()
-                .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
-                .expect("missing access-control-allow-origin header")
-                .to_str()
-                .expect("invalid access-control-allow-origin header");
-            assert!(cors_header.eq("*"));
-
-            let response = client
-                .get(rsclient.make_url("/oauth2/openid/test_integration/.well-known/openid-configuration"))
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-            // Assert CORS on the GET too.
-            let cors_header: &str = response
-                .headers()
-                .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
-                .expect("missing access-control-allow-origin header")
-                .to_str()
-                .expect("invalid access-control-allow-origin header");
-            assert!(cors_header.eq("*"));
-
-            assert_no_cache!(response);
-
-            let discovery: OidcDiscoveryResponse = response
-                .json()
-                .await
-                .expect("Failed to access response body");
-
-            tracing::trace!(?discovery);
-
-            // Most values are checked in idm/oauth2.rs, but we want to sanity check
-            // the urls here as an extended function smoke test.
-            assert_eq!(
-                discovery.issuer,
-                rsclient.make_url("/oauth2/openid/test_integration")
-            );
-
-            assert_eq!(
-                discovery.authorization_endpoint,
-                rsclient.make_url("/ui/oauth2")
-            );
-
-            assert_eq!(
-                discovery.token_endpoint,
-                rsclient.make_url(OAUTH2_TOKEN_ENDPOINT)
-            );
-
-            assert!(
-                discovery.userinfo_endpoint
-                    == Some(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
-            );
-
-            assert!(
-                discovery.jwks_uri == rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk")
-            );
-
-            // Step 0 - get the jwks public key.
-            let response = client
-                .get(rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk"))
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            assert_no_cache!(response);
-
-            let mut jwk_set: JwkKeySet = response
-                .json()
-                .await
-                .expect("Failed to access response body");
-
-            let public_jwk = jwk_set.keys.pop().expect("No public key in set!");
-
-            let jws_validator = JwsEs256Verifier::try_from(&public_jwk).expect("failed to build validator");
-
-            // Step 1 - the Oauth2 Resource Server would send a redirect to the authorisation
-            // server, where the url contains a series of authorisation request parameters.
-            //
-            // Since we are a client, we can just "pretend" we got the redirect, and issue the
-            // get call directly. This should be a 200. (?)
-
-            let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
-
-            let mut query = vec![
-                ("response_type", "code"),
-                ("client_id", TEST_INTEGRATION_RS_ID),
-                ("state", "YWJjZGVm"),
-                ("code_challenge", pkce_code_challenge.as_str()),
-                ("code_challenge_method", "S256"),
-                ("redirect_uri", TEST_INTEGRATION_RS_REDIRECT_URL),
-                ("scope", "email read openid"),
-                ("max_age", "1"),
-            ];
-
-            if let Some(response_mode) = response_mode {
-                query.push(("response_mode", response_mode));
-            }
-
-
-            let response = client
-                .get(rsclient.make_url(OAUTH2_AUTHORISE))
-                .bearer_auth(oauth_test_uat.clone())
-                .query(&query)
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            assert_no_cache!(response);
-
-            let consent_req: AuthorisationResponse = response
-                .json()
-                .await
-                .expect("Failed to access response body");
-
-            let consent_token = if let AuthorisationResponse::ConsentRequested {
-                consent_token,
-                scopes,
-                ..
-            } = consent_req
-            {
-                // Note the supplemental scope here (admin)
-                dbg!(&scopes);
-                assert!(scopes.contains("admin"));
-                consent_token
-            } else {
-                unreachable!();
-            };
-
-            // Step 2 - we now send the consent get to the server which yields a redirect with a
-            // state and code.
-
-            let response = client
-                .get(rsclient.make_url(OAUTH2_AUTHORISE_PERMIT))
-                .bearer_auth(oauth_test_uat)
-                .query(&[("token", consent_token.as_str())])
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            // This should yield a 302 redirect with some query params.
-            assert_eq!(response.status(), reqwest::StatusCode::FOUND);
-            assert_no_cache!(response);
-
-            // And we should have a URL in the location header.
-            let redir_str = response
-                .headers()
-                .get("Location")
-                .and_then(|hv| hv.to_str().ok().map(str::to_string))
-                .expect("Invalid redirect url");
-
-            // Now check it's content
-            let redir_url = Url::parse(&redir_str).expect("Url parse failure");
-            let pairs: BTreeMap<_, _> = if response_mode == Some("fragment") {
-                assert!(redir_url.query().is_none());
-                let fragment = redir_url.fragment().expect("missing URL fragment");
-                query_parse(fragment.as_bytes()).collect()
-            } else {
-                // response_mode = query is default for response_type = code
-                assert!(redir_url.fragment().is_none());
-                redir_url.query_pairs().collect()
-            };
-
-            // We should have state and code.
-            let code = pairs.get("code").expect("code not found!");
-            let state = pairs.get("state").expect("state not found!");
-            assert_eq!(state, "YWJjZGVm");
-
-            // Step 3 - the "resource server" then uses this state and code to directly contact
-            // the authorisation server to request a token.
-
-            let form_req: AccessTokenRequest = GrantTypeReq::AuthorizationCode {
-                code: code.to_string(),
-                redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
-                code_verifier: Some(pkce_code_verifier.secret().clone()),
-            }
-            .into();
-
-            let response = client
-                .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
-                .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
-                .form(&form_req)
-                .send()
-                .await
-                .expect("Failed to send code exchange request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-            let cors_header: &str = response
-                .headers()
-                .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
-                .expect("missing access-control-allow-origin header")
-                .to_str()
-                .expect("invalid access-control-allow-origin header");
-            assert!(cors_header.eq("*"));
-
-            assert!(
-                response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
-            );
-            assert_no_cache!(response);
-
-            // The body is a json AccessTokenResponse
-
-            let atr = response
-                .json::<AccessTokenResponse>()
-                .await
-                .expect("Unable to decode AccessTokenResponse");
-
-            // Step 4 - inspect the granted token.
-            let intr_request = AccessTokenIntrospectRequest {
-                token: atr.access_token.clone(),
-                token_type_hint: None,
-            };
-
-            let response = client
-                .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
-                .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
-                .form(&intr_request)
-                .send()
-                .await
-                .expect("Failed to send token introspect request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            tracing::trace!("{:?}", response.headers());
-            assert!(
-                response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
-            );
-            assert_no_cache!(response);
-
-            let tir = response
-                .json::<AccessTokenIntrospectResponse>()
-                .await
-                .expect("Unable to decode AccessTokenIntrospectResponse");
-
-            assert!(tir.active);
-            assert!(!tir.scope.is_empty());
-            assert_eq!(tir.client_id.as_deref(), Some(TEST_INTEGRATION_RS_ID));
-            assert_eq!(
-                tir.username.as_deref(),
-                Some(format!("{}@localhost", NOT_ADMIN_TEST_USERNAME).as_str())
-            );
-            assert_eq!(tir.token_type, Some(AccessTokenType::Bearer));
-            assert!(tir.exp.is_some());
-            assert!(tir.iat.is_some());
-            assert!(tir.nbf.is_some());
-            assert!(tir.sub.is_some());
-            assert_eq!(tir.aud.as_deref(), Some(TEST_INTEGRATION_RS_ID));
-            assert!(tir.iss.is_none());
-            assert!(tir.jti.is_none());
-
-            // Step 5 - check that the id_token (openid) matches the userinfo endpoint.
-            let oidc_unverified =
-                OidcUnverified::from_str(atr.id_token.as_ref().unwrap()).expect("Failed to parse id_token");
-
-            let oidc = jws_validator
-                .verify(&oidc_unverified)
-                .expect("Failed to verify oidc")
-                .verify_exp(0)
-                .expect("Failed to check exp");
-
-            // This is mostly checked inside of idm/oauth2.rs. This is more to check the oidc
-            // token and the userinfo endpoints.
-            assert_eq!(
-                oidc.iss,
-                rsclient.make_url("/oauth2/openid/test_integration")
-            );
-            eprintln!("{:?}", oidc.s_claims.email);
-            assert_eq!(oidc.s_claims.email.as_deref(), Some(NOT_ADMIN_TEST_EMAIL));
-            assert_eq!(oidc.s_claims.email_verified, Some(true));
-
-            let response = client
-                .get(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
-                .bearer_auth(atr.access_token.clone())
-                .send()
-                .await
-                .expect("Failed to send userinfo request.");
-
-            tracing::trace!("{:?}", response.headers());
-            assert!(
-                response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
-            );
-            let userinfo = response
-                .json::<OidcToken>()
-                .await
-                .expect("Unable to decode OidcToken from userinfo");
-
-            eprintln!("userinfo {userinfo:?}");
-            eprintln!("oidc {oidc:?}");
-
-            assert_eq!(userinfo, oidc);
-
-            // Step 6 - Show that our client can perform a client credentials grant
-
-            let form_req: AccessTokenRequest = GrantTypeReq::ClientCredentials {
-                scope: Some(BTreeSet::from([
-                    "email".to_string(),
-                    "read".to_string(),
-                    "openid".to_string(),
-                ])),
-            }
-            .into();
-
-            let response = client
-                .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
-                .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
-                .form(&form_req)
-                .send()
-                .await
-                .expect("Failed to send client credentials request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-            let atr = response
-                .json::<AccessTokenResponse>()
-                .await
-                .expect("Unable to decode AccessTokenResponse");
-
-            // Step 7 - inspect the granted client credentials token.
-            let intr_request = AccessTokenIntrospectRequest {
-                token: atr.access_token.clone(),
-                token_type_hint: None,
-            };
-
-            let response = client
-                .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
-                .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret))
-                .form(&intr_request)
-                .send()
-                .await
-                .expect("Failed to send token introspect request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-            let tir = response
-                .json::<AccessTokenIntrospectResponse>()
-                .await
-                .expect("Unable to decode AccessTokenIntrospectResponse");
-
-            assert!(tir.active);
-            assert!(!tir.scope.is_empty());
-            assert_eq!(tir.client_id.as_deref(), Some(TEST_INTEGRATION_RS_ID));
-            assert_eq!(tir.username.as_deref(), Some("test_integration@localhost"));
-            assert_eq!(tir.token_type, Some(AccessTokenType::Bearer));
-
-            // auth back with admin so we can test deleting things
-            let res = rsclient
-                .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
-                .await;
-            assert!(res.is_ok());
-            rsclient
-                .idm_oauth2_rs_delete_sup_scope_map(TEST_INTEGRATION_RS_ID, TEST_INTEGRATION_RS_GROUP_ALL)
-                .await
-                .expect("Failed to update oauth2 scopes");
-        }
-    )*
+/// Tests an OAuth 2.0 / OpenID confidential client Authorisation Client flow.
+///
+/// ## Arguments
+///
+/// * `response_mode`: If `Some`, the `response_mode` parameter to pass in the
+///   `/oauth2/authorise` request.
+///
+/// * `response_in_fragment`: If `false`, use the `code` passed in the
+///   callback URI's query parameter, and require the fragment to be empty.
+///
+///   If `true`, use the `code` passed in the callback URI's fragment, and
+///   require the query parameter to be empty.
+async fn test_oauth2_openid_basic_flow_impl(
+    rsclient: KanidmClient,
+    response_mode: Option<&str>,
+    response_in_fragment: bool,
+) {
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
+    // Create an oauth2 application integration.
+    rsclient
+        .idm_oauth2_rs_basic_create(
+            TEST_INTEGRATION_RS_ID,
+            TEST_INTEGRATION_RS_DISPLAY,
+            TEST_INTEGRATION_RS_URL,
+        )
+        .await
+        .expect("Failed to create oauth2 config");
+
+    rsclient
+        .idm_oauth2_client_add_origin(
+            TEST_INTEGRATION_RS_ID,
+            &Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
+        )
+        .await
+        .expect("Failed to update oauth2 config");
+
+    // Extend the admin account with extended details for openid claims.
+    rsclient
+        .idm_person_account_create(NOT_ADMIN_TEST_USERNAME, NOT_ADMIN_TEST_USERNAME)
+        .await
+        .expect("Failed to create account details");
+
+    rsclient
+        .idm_person_account_set_attr(
+            NOT_ADMIN_TEST_USERNAME,
+            Attribute::Mail.as_ref(),
+            &[NOT_ADMIN_TEST_EMAIL],
+        )
+        .await
+        .expect("Failed to create account mail");
+
+    rsclient
+        .idm_person_account_primary_credential_set_password(
+            NOT_ADMIN_TEST_USERNAME,
+            NOT_ADMIN_TEST_PASSWORD,
+        )
+        .await
+        .expect("Failed to configure account password");
+
+    rsclient
+        .idm_oauth2_rs_update(TEST_INTEGRATION_RS_ID, None, None, None, true, true, true)
+        .await
+        .expect("Failed to update oauth2 config");
+
+    rsclient
+        .idm_oauth2_rs_update_scope_map(
+            TEST_INTEGRATION_RS_ID,
+            IDM_ALL_ACCOUNTS.name,
+            vec![OAUTH2_SCOPE_READ, OAUTH2_SCOPE_EMAIL, OAUTH2_SCOPE_OPENID],
+        )
+        .await
+        .expect("Failed to update oauth2 scopes");
+
+    rsclient
+        .idm_oauth2_rs_update_sup_scope_map(
+            TEST_INTEGRATION_RS_ID,
+            IDM_ALL_ACCOUNTS.name,
+            vec![ADMIN_TEST_USER],
+        )
+        .await
+        .expect("Failed to update oauth2 scopes");
+
+    let client_secret = rsclient
+        .idm_oauth2_rs_get_basic_secret(TEST_INTEGRATION_RS_ID)
+        .await
+        .ok()
+        .flatten()
+        .expect("Failed to retrieve test_integration basic secret");
+
+    // Get our admin's auth token for our new client.
+    // We have to re-auth to update the mail field.
+    let res = rsclient
+        .auth_simple_password(NOT_ADMIN_TEST_USERNAME, NOT_ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+    let oauth_test_uat = rsclient
+        .get_token()
+        .await
+        .expect("No user auth token found");
+
+    // We need a new reqwest client here.
+
+    // from here, we can now begin what would be a "interaction" to the oauth server.
+    // Create a new reqwest client - we'll be using this manually.
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .build()
+        .expect("Failed to create client.");
+
+    // Step 0 - get the openid discovery details and the public key.
+    let response = client
+        .request(
+            reqwest::Method::OPTIONS,
+            rsclient.make_url("/oauth2/openid/test_integration/.well-known/openid-configuration"),
+        )
+        .send()
+        .await
+        .expect("Failed to send discovery preflight request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let cors_header: &str = response
+        .headers()
+        .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("missing access-control-allow-origin header")
+        .to_str()
+        .expect("invalid access-control-allow-origin header");
+    assert!(cors_header.eq("*"));
+
+    let response = client
+        .get(rsclient.make_url("/oauth2/openid/test_integration/.well-known/openid-configuration"))
+        .send()
+        .await
+        .expect("Failed to send request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    // Assert CORS on the GET too.
+    let cors_header: &str = response
+        .headers()
+        .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("missing access-control-allow-origin header")
+        .to_str()
+        .expect("invalid access-control-allow-origin header");
+    assert!(cors_header.eq("*"));
+
+    assert_no_cache!(response);
+
+    let discovery: OidcDiscoveryResponse = response
+        .json()
+        .await
+        .expect("Failed to access response body");
+
+    tracing::trace!(?discovery);
+
+    // Most values are checked in idm/oauth2.rs, but we want to sanity check
+    // the urls here as an extended function smoke test.
+    assert_eq!(
+        discovery.issuer,
+        rsclient.make_url("/oauth2/openid/test_integration")
+    );
+
+    assert_eq!(
+        discovery.authorization_endpoint,
+        rsclient.make_url("/ui/oauth2")
+    );
+
+    assert_eq!(
+        discovery.token_endpoint,
+        rsclient.make_url(OAUTH2_TOKEN_ENDPOINT)
+    );
+
+    assert!(
+        discovery.userinfo_endpoint
+            == Some(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+    );
+
+    assert!(
+        discovery.jwks_uri == rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk")
+    );
+
+    // Step 0 - get the jwks public key.
+    let response = client
+        .get(rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk"))
+        .send()
+        .await
+        .expect("Failed to send request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_no_cache!(response);
+
+    let mut jwk_set: JwkKeySet = response
+        .json()
+        .await
+        .expect("Failed to access response body");
+
+    let public_jwk = jwk_set.keys.pop().expect("No public key in set!");
+
+    let jws_validator = JwsEs256Verifier::try_from(&public_jwk).expect("failed to build validator");
+
+    // Step 1 - the Oauth2 Resource Server would send a redirect to the authorisation
+    // server, where the url contains a series of authorisation request parameters.
+    //
+    // Since we are a client, we can just "pretend" we got the redirect, and issue the
+    // get call directly. This should be a 200. (?)
+
+    let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let mut query = vec![
+        ("response_type", "code"),
+        ("client_id", TEST_INTEGRATION_RS_ID),
+        ("state", "YWJjZGVm"),
+        ("code_challenge", pkce_code_challenge.as_str()),
+        ("code_challenge_method", "S256"),
+        ("redirect_uri", TEST_INTEGRATION_RS_REDIRECT_URL),
+        ("scope", "email read openid"),
+        ("max_age", "1"),
+    ];
+
+    if let Some(response_mode) = response_mode {
+        query.push(("response_mode", response_mode));
     }
-}
 
-test_oauth2_openid_basic_flows! {
-    test_oauth2_openid_basic_flow_mode_unset: None,
-    test_oauth2_openid_basic_flow_mode_query: Some("query"),
-    test_oauth2_openid_basic_flow_mode_fragment: Some("fragment"),
-}
+    let response = client
+        .get(rsclient.make_url(OAUTH2_AUTHORISE))
+        .bearer_auth(oauth_test_uat.clone())
+        .query(&query)
+        .send()
+        .await
+        .expect("Failed to send request.");
 
-macro_rules! test_oauth2_openid_public_flows {
-    ($($name:ident: $response_mode:expr,)*) => {
-    $(
-        #[kanidmd_testkit::test]
-        async fn $name(rsclient: KanidmClient) {
-            let response_mode: Option<&str> = $response_mode;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_no_cache!(response);
 
-            let res = rsclient
-                .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
-                .await;
-            assert!(res.is_ok());
+    let consent_req: AuthorisationResponse = response
+        .json()
+        .await
+        .expect("Failed to access response body");
 
-            // Create an oauth2 application integration.
-            rsclient
-                .idm_oauth2_rs_public_create(
-                    TEST_INTEGRATION_RS_ID,
-                    TEST_INTEGRATION_RS_DISPLAY,
-                    TEST_INTEGRATION_RS_URL,
-                )
-                .await
-                .expect("Failed to create oauth2 config");
+    let consent_token = if let AuthorisationResponse::ConsentRequested {
+        consent_token,
+        scopes,
+        ..
+    } = consent_req
+    {
+        // Note the supplemental scope here (admin)
+        dbg!(&scopes);
+        assert!(scopes.contains("admin"));
+        consent_token
+    } else {
+        unreachable!();
+    };
 
-            rsclient
-                .idm_oauth2_client_add_origin(
-                    TEST_INTEGRATION_RS_ID,
-                    &Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
-                )
-                .await
-                .expect("Failed to update oauth2 config");
+    // Step 2 - we now send the consent get to the server which yields a redirect with a
+    // state and code.
 
-            // Extend the admin account with extended details for openid claims.
-            rsclient
-                .idm_person_account_create(NOT_ADMIN_TEST_USERNAME, NOT_ADMIN_TEST_USERNAME)
-                .await
-                .expect("Failed to create account details");
+    let response = client
+        .get(rsclient.make_url(OAUTH2_AUTHORISE_PERMIT))
+        .bearer_auth(oauth_test_uat)
+        .query(&[("token", consent_token.as_str())])
+        .send()
+        .await
+        .expect("Failed to send request.");
 
-            rsclient
-                .idm_person_account_set_attr(
-                    NOT_ADMIN_TEST_USERNAME,
-                    Attribute::Mail.as_ref(),
-                    &[NOT_ADMIN_TEST_EMAIL],
-                )
-                .await
-                .expect("Failed to create account mail");
+    // This should yield a 302 redirect with some query params.
+    assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+    assert_no_cache!(response);
 
-            rsclient
-                .idm_person_account_primary_credential_set_password(
-                    NOT_ADMIN_TEST_USERNAME,
-                    ADMIN_TEST_PASSWORD,
-                )
-                .await
-                .expect("Failed to configure account password");
+    // And we should have a URL in the location header.
+    let redir_str = response
+        .headers()
+        .get("Location")
+        .and_then(|hv| hv.to_str().ok().map(str::to_string))
+        .expect("Invalid redirect url");
 
-            rsclient
-                .idm_oauth2_rs_update(TEST_INTEGRATION_RS_ID, None, None, None, true, true, true)
-                .await
-                .expect("Failed to update oauth2 config");
+    // Now check it's content
+    let redir_url = Url::parse(&redir_str).expect("Url parse failure");
+    let pairs: BTreeMap<_, _> = if response_in_fragment {
+        assert!(redir_url.query().is_none());
+        let fragment = redir_url.fragment().expect("missing URL fragment");
+        query_parse(fragment.as_bytes()).collect()
+    } else {
+        // response_mode = query is default for response_type = code
+        assert!(redir_url.fragment().is_none());
+        redir_url.query_pairs().collect()
+    };
 
-            rsclient
-                .idm_oauth2_rs_update_scope_map(
-                    TEST_INTEGRATION_RS_ID,
-                    IDM_ALL_ACCOUNTS.name,
-                    vec![OAUTH2_SCOPE_READ, OAUTH2_SCOPE_EMAIL, OAUTH2_SCOPE_OPENID],
-                )
-                .await
-                .expect("Failed to update oauth2 scopes");
+    // We should have state and code.
+    let code = pairs.get("code").expect("code not found!");
+    let state = pairs.get("state").expect("state not found!");
+    assert_eq!(state, "YWJjZGVm");
 
-            rsclient
-                .idm_oauth2_rs_update_sup_scope_map(
-                    TEST_INTEGRATION_RS_ID,
-                    IDM_ALL_ACCOUNTS.name,
-                    vec![ADMIN_TEST_USER],
-                )
-                .await
-                .expect("Failed to update oauth2 scopes");
+    // Step 3 - the "resource server" then uses this state and code to directly contact
+    // the authorisation server to request a token.
 
-            // Add a custom claim map.
-            rsclient
-                .idm_oauth2_rs_update_claim_map(
-                    TEST_INTEGRATION_RS_ID,
-                    "test_claim",
-                    IDM_ALL_ACCOUNTS.name,
-                    &["claim_a".to_string(), "claim_b".to_string()],
-                )
-                .await
-                .expect("Failed to update oauth2 claims");
-
-            // Set an alternate join
-            rsclient
-                .idm_oauth2_rs_update_claim_map_join(
-                    TEST_INTEGRATION_RS_ID,
-                    "test_claim",
-                    Oauth2ClaimMapJoin::Ssv,
-                )
-                .await
-                .expect("Failed to update oauth2 claims");
-
-            // Get our admin's auth token for our new client.
-            // We have to re-auth to update the mail field.
-            let res = rsclient
-                .auth_simple_password(NOT_ADMIN_TEST_USERNAME, ADMIN_TEST_PASSWORD)
-                .await;
-            assert!(res.is_ok());
-            let oauth_test_uat = rsclient
-                .get_token()
-                .await
-                .expect("No user auth token found");
-
-            // We need a new reqwest client here.
-
-            // from here, we can now begin what would be a "interaction" to the oauth server.
-            // Create a new reqwest client - we'll be using this manually.
-            let client = reqwest::Client::builder()
-                .redirect(reqwest::redirect::Policy::none())
-                .no_proxy()
-                .build()
-                .expect("Failed to create client.");
-
-            // Step 0 - get the jwks public key.
-            let response = client
-                .get(rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk"))
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            assert_no_cache!(response);
-
-            let mut jwk_set: JwkKeySet = response
-                .json()
-                .await
-                .expect("Failed to access response body");
-
-            let public_jwk = jwk_set.keys.pop().expect("No public key in set!");
-
-            let jws_validator = JwsEs256Verifier::try_from(&public_jwk).expect("failed to build validator");
-
-            // Step 1 - the Oauth2 Resource Server would send a redirect to the authorisation
-            // server, where the url contains a series of authorisation request parameters.
-            //
-            // Since we are a client, we can just "pretend" we got the redirect, and issue the
-            // get call directly. This should be a 200. (?)
-            let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
-
-            let mut query = vec![
-                ("response_type", "code"),
-                ("client_id", TEST_INTEGRATION_RS_ID),
-                ("state", "YWJjZGVm"),
-                ("code_challenge", pkce_code_challenge.as_str()),
-                ("code_challenge_method", "S256"),
-                ("redirect_uri", TEST_INTEGRATION_RS_REDIRECT_URL),
-                ("scope", "email read openid"),
-            ];
-
-            if let Some(response_mode) = response_mode {
-                query.push(("response_mode", response_mode));
-            }
-
-            let response = client
-                .get(rsclient.make_url(OAUTH2_AUTHORISE))
-                .bearer_auth(oauth_test_uat.clone())
-                .query(&query)
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            assert_no_cache!(response);
-
-            let consent_req: AuthorisationResponse = response
-                .json()
-                .await
-                .expect("Failed to access response body");
-
-            let consent_token = if let AuthorisationResponse::ConsentRequested {
-                consent_token,
-                scopes,
-                ..
-            } = consent_req
-            {
-                // Note the supplemental scope here (admin)
-                assert!(scopes.contains(ADMIN_TEST_USER));
-                consent_token
-            } else {
-                unreachable!();
-            };
-
-            // Step 2 - we now send the consent get to the server which yields a redirect with a
-            // state and code.
-            let response = client
-                .get(rsclient.make_url(OAUTH2_AUTHORISE_PERMIT))
-                .bearer_auth(oauth_test_uat)
-                .query(&[("token", consent_token.as_str())])
-                .send()
-                .await
-                .expect("Failed to send request.");
-
-            // This should yield a 302 redirect with some query params.
-            assert_eq!(response.status(), reqwest::StatusCode::FOUND);
-            assert_no_cache!(response);
-
-            // And we should have a URL in the location header.
-            let redir_str = response
-                .headers()
-                .get("Location")
-                .and_then(|hv| hv.to_str().ok().map(str::to_string))
-                .expect("Invalid redirect url");
-
-            // Now check it's content
-            let redir_url = Url::parse(&redir_str).expect("Url parse failure");
-
-            let pairs: BTreeMap<_, _> = if response_mode == Some("fragment") {
-                assert!(redir_url.query().is_none());
-                let fragment = redir_url.fragment().expect("missing URL fragment");
-                query_parse(fragment.as_bytes()).collect()
-            } else {
-                // response_mode = query is default for response_type = code
-                assert!(redir_url.fragment().is_none());
-                redir_url.query_pairs().collect()
-            };
-
-            // We should have state and code.
-            let code = pairs.get("code").expect("code not found!");
-            let state = pairs.get("state").expect("state not found!");
-            assert_eq!(state, "YWJjZGVm");
-
-            // Step 3 - the "resource server" then uses this state and code to directly contact
-            // the authorisation server to request a token.
-
-            let form_req = AccessTokenRequest {
-                grant_type: GrantTypeReq::AuthorizationCode {
-                    code: code.to_string(),
-                    redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
-                    code_verifier: Some(pkce_code_verifier.secret().clone()),
-                },
-                client_id: Some(TEST_INTEGRATION_RS_ID.to_string()),
-                client_secret: None,
-            };
-
-            let response = client
-                .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
-                .form(&form_req)
-                .send()
-                .await
-                .expect("Failed to send code exchange request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            assert_no_cache!(response);
-
-            // The body is a json AccessTokenResponse
-            let atr = response
-                .json::<AccessTokenResponse>()
-                .await
-                .expect("Unable to decode AccessTokenResponse");
-
-            // Step 5 - check that the id_token (openid) matches the userinfo endpoint.
-            let oidc_unverified =
-                OidcUnverified::from_str(atr.id_token.as_ref().unwrap()).expect("Failed to parse id_token");
-
-            let oidc = jws_validator
-                .verify(&oidc_unverified)
-                .expect("Failed to verify oidc")
-                .verify_exp(0)
-                .expect("Failed to check exp");
-
-            // This is mostly checked inside of idm/oauth2.rs. This is more to check the oidc
-            // token and the userinfo endpoints.
-            assert_eq!(
-                oidc.iss,
-                rsclient.make_url("/oauth2/openid/test_integration")
-            );
-            eprintln!("{:?}", oidc.s_claims.email);
-            assert_eq!(oidc.s_claims.email.as_deref(), Some(NOT_ADMIN_TEST_EMAIL));
-            assert_eq!(oidc.s_claims.email_verified, Some(true));
-
-            eprintln!("{:?}", oidc.claims);
-            assert_eq!(
-                oidc.claims.get("test_claim").and_then(|v| v.as_str()),
-                Some("claim_a claim_b")
-            );
-
-            // Check the preflight works.
-            let response = client
-                .request(
-                    reqwest::Method::OPTIONS,
-                    rsclient.make_url("/oauth2/openid/test_integration/userinfo"),
-                )
-                .send()
-                .await
-                .expect("Failed to send userinfo preflight request.");
-
-            assert_eq!(response.status(), reqwest::StatusCode::OK);
-            let cors_header: &str = response
-                .headers()
-                .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
-                .expect("missing access-control-allow-origin header")
-                .to_str()
-                .expect("invalid access-control-allow-origin header");
-            assert!(cors_header.eq("*"));
-
-            let response = client
-                .get(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
-                .bearer_auth(atr.access_token.clone())
-                .send()
-                .await
-                .expect("Failed to send userinfo request.");
-
-            let userinfo = response
-                .json::<OidcToken>()
-                .await
-                .expect("Unable to decode OidcToken from userinfo");
-
-            eprintln!("userinfo {userinfo:?}");
-            eprintln!("oidc {oidc:?}");
-
-            assert_eq!(userinfo, oidc);
-
-            // auth back with admin so we can test deleting things
-            let res = rsclient
-                .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
-                .await;
-            assert!(res.is_ok());
-            rsclient
-                .idm_oauth2_rs_delete_sup_scope_map(TEST_INTEGRATION_RS_ID, TEST_INTEGRATION_RS_GROUP_ALL)
-                .await
-                .expect("Failed to update oauth2 scopes");
-        }
-    )*
+    let form_req: AccessTokenRequest = GrantTypeReq::AuthorizationCode {
+        code: code.to_string(),
+        redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
+        code_verifier: Some(pkce_code_verifier.secret().clone()),
     }
+    .into();
+
+    let response = client
+        .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
+        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
+        .form(&form_req)
+        .send()
+        .await
+        .expect("Failed to send code exchange request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let cors_header: &str = response
+        .headers()
+        .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("missing access-control-allow-origin header")
+        .to_str()
+        .expect("invalid access-control-allow-origin header");
+    assert!(cors_header.eq("*"));
+
+    assert!(
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+    );
+    assert_no_cache!(response);
+
+    // The body is a json AccessTokenResponse
+
+    let atr = response
+        .json::<AccessTokenResponse>()
+        .await
+        .expect("Unable to decode AccessTokenResponse");
+
+    // Step 4 - inspect the granted token.
+    let intr_request = AccessTokenIntrospectRequest {
+        token: atr.access_token.clone(),
+        token_type_hint: None,
+    };
+
+    let response = client
+        .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
+        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
+        .form(&intr_request)
+        .send()
+        .await
+        .expect("Failed to send token introspect request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    tracing::trace!("{:?}", response.headers());
+    assert!(
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+    );
+    assert_no_cache!(response);
+
+    let tir = response
+        .json::<AccessTokenIntrospectResponse>()
+        .await
+        .expect("Unable to decode AccessTokenIntrospectResponse");
+
+    assert!(tir.active);
+    assert!(!tir.scope.is_empty());
+    assert_eq!(tir.client_id.as_deref(), Some(TEST_INTEGRATION_RS_ID));
+    assert_eq!(
+        tir.username.as_deref(),
+        Some(format!("{}@localhost", NOT_ADMIN_TEST_USERNAME).as_str())
+    );
+    assert_eq!(tir.token_type, Some(AccessTokenType::Bearer));
+    assert!(tir.exp.is_some());
+    assert!(tir.iat.is_some());
+    assert!(tir.nbf.is_some());
+    assert!(tir.sub.is_some());
+    assert_eq!(tir.aud.as_deref(), Some(TEST_INTEGRATION_RS_ID));
+    assert!(tir.iss.is_none());
+    assert!(tir.jti.is_none());
+
+    // Step 5 - check that the id_token (openid) matches the userinfo endpoint.
+    let oidc_unverified =
+        OidcUnverified::from_str(atr.id_token.as_ref().unwrap()).expect("Failed to parse id_token");
+
+    let oidc = jws_validator
+        .verify(&oidc_unverified)
+        .expect("Failed to verify oidc")
+        .verify_exp(0)
+        .expect("Failed to check exp");
+
+    // This is mostly checked inside of idm/oauth2.rs. This is more to check the oidc
+    // token and the userinfo endpoints.
+    assert_eq!(
+        oidc.iss,
+        rsclient.make_url("/oauth2/openid/test_integration")
+    );
+    eprintln!("{:?}", oidc.s_claims.email);
+    assert_eq!(oidc.s_claims.email.as_deref(), Some(NOT_ADMIN_TEST_EMAIL));
+    assert_eq!(oidc.s_claims.email_verified, Some(true));
+
+    let response = client
+        .get(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+        .bearer_auth(atr.access_token.clone())
+        .send()
+        .await
+        .expect("Failed to send userinfo request.");
+
+    tracing::trace!("{:?}", response.headers());
+    assert!(
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+    );
+    let userinfo = response
+        .json::<OidcToken>()
+        .await
+        .expect("Unable to decode OidcToken from userinfo");
+
+    eprintln!("userinfo {userinfo:?}");
+    eprintln!("oidc {oidc:?}");
+
+    assert_eq!(userinfo, oidc);
+
+    // Step 6 - Show that our client can perform a client credentials grant
+
+    let form_req: AccessTokenRequest = GrantTypeReq::ClientCredentials {
+        scope: Some(BTreeSet::from([
+            "email".to_string(),
+            "read".to_string(),
+            "openid".to_string(),
+        ])),
+    }
+    .into();
+
+    let response = client
+        .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
+        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
+        .form(&form_req)
+        .send()
+        .await
+        .expect("Failed to send client credentials request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let atr = response
+        .json::<AccessTokenResponse>()
+        .await
+        .expect("Unable to decode AccessTokenResponse");
+
+    // Step 7 - inspect the granted client credentials token.
+    let intr_request = AccessTokenIntrospectRequest {
+        token: atr.access_token.clone(),
+        token_type_hint: None,
+    };
+
+    let response = client
+        .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
+        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret))
+        .form(&intr_request)
+        .send()
+        .await
+        .expect("Failed to send token introspect request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let tir = response
+        .json::<AccessTokenIntrospectResponse>()
+        .await
+        .expect("Unable to decode AccessTokenIntrospectResponse");
+
+    assert!(tir.active);
+    assert!(!tir.scope.is_empty());
+    assert_eq!(tir.client_id.as_deref(), Some(TEST_INTEGRATION_RS_ID));
+    assert_eq!(tir.username.as_deref(), Some("test_integration@localhost"));
+    assert_eq!(tir.token_type, Some(AccessTokenType::Bearer));
+
+    // auth back with admin so we can test deleting things
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+    rsclient
+        .idm_oauth2_rs_delete_sup_scope_map(TEST_INTEGRATION_RS_ID, TEST_INTEGRATION_RS_GROUP_ALL)
+        .await
+        .expect("Failed to update oauth2 scopes");
 }
 
-test_oauth2_openid_public_flows! {
-    test_oauth2_openid_public_flow_mode_unset: None,
-    test_oauth2_openid_public_flow_mode_query: Some("query"),
-    test_oauth2_openid_public_flow_mode_fragment: Some("fragment"),
+/// Test an OAuth 2.0/OpenID confidential client Authorisation Code flow, with
+/// `response_mode` unset.
+///
+/// The response should be returned as a query parameter.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_mode_unset(rsclient: KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(rsclient, None, false).await;
+}
+
+/// Test an OAuth 2.0/OpenID confidential client Authorisation Code flow, with
+/// `response_mode=query`.
+///
+/// The response should be returned as a query parameter.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_mode_query(rsclient: KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(rsclient, Some("query"), false).await;
+}
+
+/// Test an OAuth 2.0/OpenID confidential client Authorisation Code flow, with
+/// `response_mode=fragment`.
+///
+/// The response should be returned in the URI's fragment.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_mode_fragment(rsclient: KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(rsclient, Some("fragment"), true).await;
+}
+
+/// Tests an OAuth 2.0 / OpenID public client Authorisation Client flow.
+///
+/// ## Arguments
+///
+/// * `response_mode`: If `Some`, the `response_mode` parameter to pass in the
+///   `/oauth2/authorise` request.
+///
+/// * `response_in_fragment`: If `false`, use the `code` passed in the
+///   callback URI's query parameter, and require the fragment to be empty.
+///
+///   If `true`, use the `code` passed in the callback URI's fragment, and
+///   require the query parameter to be empty.
+async fn test_oauth2_openid_public_flow_impl(
+    rsclient: KanidmClient,
+    response_mode: Option<&str>,
+    response_in_fragment: bool,
+) {
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
+    // Create an oauth2 application integration.
+    rsclient
+        .idm_oauth2_rs_public_create(
+            TEST_INTEGRATION_RS_ID,
+            TEST_INTEGRATION_RS_DISPLAY,
+            TEST_INTEGRATION_RS_URL,
+        )
+        .await
+        .expect("Failed to create oauth2 config");
+
+    rsclient
+        .idm_oauth2_client_add_origin(
+            TEST_INTEGRATION_RS_ID,
+            &Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
+        )
+        .await
+        .expect("Failed to update oauth2 config");
+
+    // Extend the admin account with extended details for openid claims.
+    rsclient
+        .idm_person_account_create(NOT_ADMIN_TEST_USERNAME, NOT_ADMIN_TEST_USERNAME)
+        .await
+        .expect("Failed to create account details");
+
+    rsclient
+        .idm_person_account_set_attr(
+            NOT_ADMIN_TEST_USERNAME,
+            Attribute::Mail.as_ref(),
+            &[NOT_ADMIN_TEST_EMAIL],
+        )
+        .await
+        .expect("Failed to create account mail");
+
+    rsclient
+        .idm_person_account_primary_credential_set_password(
+            NOT_ADMIN_TEST_USERNAME,
+            ADMIN_TEST_PASSWORD,
+        )
+        .await
+        .expect("Failed to configure account password");
+
+    rsclient
+        .idm_oauth2_rs_update(TEST_INTEGRATION_RS_ID, None, None, None, true, true, true)
+        .await
+        .expect("Failed to update oauth2 config");
+
+    rsclient
+        .idm_oauth2_rs_update_scope_map(
+            TEST_INTEGRATION_RS_ID,
+            IDM_ALL_ACCOUNTS.name,
+            vec![OAUTH2_SCOPE_READ, OAUTH2_SCOPE_EMAIL, OAUTH2_SCOPE_OPENID],
+        )
+        .await
+        .expect("Failed to update oauth2 scopes");
+
+    rsclient
+        .idm_oauth2_rs_update_sup_scope_map(
+            TEST_INTEGRATION_RS_ID,
+            IDM_ALL_ACCOUNTS.name,
+            vec![ADMIN_TEST_USER],
+        )
+        .await
+        .expect("Failed to update oauth2 scopes");
+
+    // Add a custom claim map.
+    rsclient
+        .idm_oauth2_rs_update_claim_map(
+            TEST_INTEGRATION_RS_ID,
+            "test_claim",
+            IDM_ALL_ACCOUNTS.name,
+            &["claim_a".to_string(), "claim_b".to_string()],
+        )
+        .await
+        .expect("Failed to update oauth2 claims");
+
+    // Set an alternate join
+    rsclient
+        .idm_oauth2_rs_update_claim_map_join(
+            TEST_INTEGRATION_RS_ID,
+            "test_claim",
+            Oauth2ClaimMapJoin::Ssv,
+        )
+        .await
+        .expect("Failed to update oauth2 claims");
+
+    // Get our admin's auth token for our new client.
+    // We have to re-auth to update the mail field.
+    let res = rsclient
+        .auth_simple_password(NOT_ADMIN_TEST_USERNAME, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+    let oauth_test_uat = rsclient
+        .get_token()
+        .await
+        .expect("No user auth token found");
+
+    // We need a new reqwest client here.
+
+    // from here, we can now begin what would be a "interaction" to the oauth server.
+    // Create a new reqwest client - we'll be using this manually.
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .build()
+        .expect("Failed to create client.");
+
+    // Step 0 - get the jwks public key.
+    let response = client
+        .get(rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk"))
+        .send()
+        .await
+        .expect("Failed to send request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_no_cache!(response);
+
+    let mut jwk_set: JwkKeySet = response
+        .json()
+        .await
+        .expect("Failed to access response body");
+
+    let public_jwk = jwk_set.keys.pop().expect("No public key in set!");
+
+    let jws_validator = JwsEs256Verifier::try_from(&public_jwk).expect("failed to build validator");
+
+    // Step 1 - the Oauth2 Resource Server would send a redirect to the authorisation
+    // server, where the url contains a series of authorisation request parameters.
+    //
+    // Since we are a client, we can just "pretend" we got the redirect, and issue the
+    // get call directly. This should be a 200. (?)
+    let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let mut query = vec![
+        ("response_type", "code"),
+        ("client_id", TEST_INTEGRATION_RS_ID),
+        ("state", "YWJjZGVm"),
+        ("code_challenge", pkce_code_challenge.as_str()),
+        ("code_challenge_method", "S256"),
+        ("redirect_uri", TEST_INTEGRATION_RS_REDIRECT_URL),
+        ("scope", "email read openid"),
+    ];
+
+    if let Some(response_mode) = response_mode {
+        query.push(("response_mode", response_mode));
+    }
+
+    let response = client
+        .get(rsclient.make_url(OAUTH2_AUTHORISE))
+        .bearer_auth(oauth_test_uat.clone())
+        .query(&query)
+        .send()
+        .await
+        .expect("Failed to send request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_no_cache!(response);
+
+    let consent_req: AuthorisationResponse = response
+        .json()
+        .await
+        .expect("Failed to access response body");
+
+    let consent_token = if let AuthorisationResponse::ConsentRequested {
+        consent_token,
+        scopes,
+        ..
+    } = consent_req
+    {
+        // Note the supplemental scope here (admin)
+        assert!(scopes.contains(ADMIN_TEST_USER));
+        consent_token
+    } else {
+        unreachable!();
+    };
+
+    // Step 2 - we now send the consent get to the server which yields a redirect with a
+    // state and code.
+    let response = client
+        .get(rsclient.make_url(OAUTH2_AUTHORISE_PERMIT))
+        .bearer_auth(oauth_test_uat)
+        .query(&[("token", consent_token.as_str())])
+        .send()
+        .await
+        .expect("Failed to send request.");
+
+    // This should yield a 302 redirect with some query params.
+    assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+    assert_no_cache!(response);
+
+    // And we should have a URL in the location header.
+    let redir_str = response
+        .headers()
+        .get("Location")
+        .and_then(|hv| hv.to_str().ok().map(str::to_string))
+        .expect("Invalid redirect url");
+
+    // Now check it's content
+    let redir_url = Url::parse(&redir_str).expect("Url parse failure");
+
+    let pairs: BTreeMap<_, _> = if response_in_fragment {
+        assert!(redir_url.query().is_none());
+        let fragment = redir_url.fragment().expect("missing URL fragment");
+        query_parse(fragment.as_bytes()).collect()
+    } else {
+        // response_mode = query is default for response_type = code
+        assert!(redir_url.fragment().is_none());
+        redir_url.query_pairs().collect()
+    };
+
+    // We should have state and code.
+    let code = pairs.get("code").expect("code not found!");
+    let state = pairs.get("state").expect("state not found!");
+    assert_eq!(state, "YWJjZGVm");
+
+    // Step 3 - the "resource server" then uses this state and code to directly contact
+    // the authorisation server to request a token.
+
+    let form_req = AccessTokenRequest {
+        grant_type: GrantTypeReq::AuthorizationCode {
+            code: code.to_string(),
+            redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
+            code_verifier: Some(pkce_code_verifier.secret().clone()),
+        },
+        client_id: Some(TEST_INTEGRATION_RS_ID.to_string()),
+        client_secret: None,
+    };
+
+    let response = client
+        .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
+        .form(&form_req)
+        .send()
+        .await
+        .expect("Failed to send code exchange request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_no_cache!(response);
+
+    // The body is a json AccessTokenResponse
+    let atr = response
+        .json::<AccessTokenResponse>()
+        .await
+        .expect("Unable to decode AccessTokenResponse");
+
+    // Step 5 - check that the id_token (openid) matches the userinfo endpoint.
+    let oidc_unverified =
+        OidcUnverified::from_str(atr.id_token.as_ref().unwrap()).expect("Failed to parse id_token");
+
+    let oidc = jws_validator
+        .verify(&oidc_unverified)
+        .expect("Failed to verify oidc")
+        .verify_exp(0)
+        .expect("Failed to check exp");
+
+    // This is mostly checked inside of idm/oauth2.rs. This is more to check the oidc
+    // token and the userinfo endpoints.
+    assert_eq!(
+        oidc.iss,
+        rsclient.make_url("/oauth2/openid/test_integration")
+    );
+    eprintln!("{:?}", oidc.s_claims.email);
+    assert_eq!(oidc.s_claims.email.as_deref(), Some(NOT_ADMIN_TEST_EMAIL));
+    assert_eq!(oidc.s_claims.email_verified, Some(true));
+
+    eprintln!("{:?}", oidc.claims);
+    assert_eq!(
+        oidc.claims.get("test_claim").and_then(|v| v.as_str()),
+        Some("claim_a claim_b")
+    );
+
+    // Check the preflight works.
+    let response = client
+        .request(
+            reqwest::Method::OPTIONS,
+            rsclient.make_url("/oauth2/openid/test_integration/userinfo"),
+        )
+        .send()
+        .await
+        .expect("Failed to send userinfo preflight request.");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let cors_header: &str = response
+        .headers()
+        .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("missing access-control-allow-origin header")
+        .to_str()
+        .expect("invalid access-control-allow-origin header");
+    assert!(cors_header.eq("*"));
+
+    let response = client
+        .get(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+        .bearer_auth(atr.access_token.clone())
+        .send()
+        .await
+        .expect("Failed to send userinfo request.");
+
+    let userinfo = response
+        .json::<OidcToken>()
+        .await
+        .expect("Unable to decode OidcToken from userinfo");
+
+    eprintln!("userinfo {userinfo:?}");
+    eprintln!("oidc {oidc:?}");
+
+    assert_eq!(userinfo, oidc);
+
+    // auth back with admin so we can test deleting things
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+    rsclient
+        .idm_oauth2_rs_delete_sup_scope_map(TEST_INTEGRATION_RS_ID, TEST_INTEGRATION_RS_GROUP_ALL)
+        .await
+        .expect("Failed to update oauth2 scopes");
+}
+
+/// Test an OAuth 2.0/OpenID public client Authorisation Code flow, with
+/// `response_mode` unset.
+///
+/// The response should be returned as a query parameter.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_public_flow_mode_unset(rsclient: KanidmClient) {
+    test_oauth2_openid_public_flow_impl(rsclient, None, false).await;
+}
+
+/// Test an OAuth 2.0/OpenID public client Authorisation Code flow, with
+/// `response_mode=query`.
+///
+/// The response should be returned as a query parameter.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_public_flow_mode_query(rsclient: KanidmClient) {
+    test_oauth2_openid_public_flow_impl(rsclient, Some("query"), false).await;
+}
+
+/// Test an OAuth 2.0/OpenID public client Authorisation Code flow, with
+/// `response_mode=fragment`.
+///
+/// The response should be returned in the URI's fragment.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_public_flow_mode_fragment(rsclient: KanidmClient) {
+    test_oauth2_openid_public_flow_impl(rsclient, Some("fragment"), true).await;
 }
 
 #[kanidmd_testkit::test]


### PR DESCRIPTION
# Change summary

Adds support for the `response_mode` parameter from [OAuth 2.0 Multiple Response Type Encoding Practices: Response Modes](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes), allowing Authorisation Code flows to use `response_mode=fragment`.

This *does not* implement the "multiple response type" functionality described by that document.

- Change `AuthorisationRequest::response_type` from `String` to `ResponseType`, so that can be plumbed through the stack more sensibly.

  This changes the way an invalid `response_type` is reported to the client, as that'll now error out on a deserialisation layer with:

  ```
  Failed to deserialize query string: unknown variant `hello`, expected one of `code`, `token`, `id_token`
  ```

  If you use `response_type=token` or `response_type=id_token`, Kanidm responds with "Unrecoverable error; Error Code: InvalidState", the same as it does with other invalid `response_type` values before this change.

- Deduplicate `AuthorisePermitSuccess` URL construction, and use the `response_mode`.

- Make `check_oauth2_authorise_reject` work similarly to the success case, and use the `response_mode`.

- Add `response_mode=fragment` to OAuth 2.0 and OpenID discovery documents.

Fixes #3334

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
