### PR TITLE
Fix /var/run/kanidm-unixd permission

### DIFF
--- a/platform/freebsd/client/pkg-plist
+++ b/platform/freebsd/client/pkg-plist
@@ -10,4 +10,4 @@ libexec/kanidm_unixd_tasks
 @dir /var/lib
 @dir(_kanidm_unixd,_kanidm_unixd,750) /var/cache/kanidm-unixd
 @dir(_kanidm_unixd,_kanidm_unixd,750) /var/lib/kanidm-unixd
-@dir(_kanidm_unixd,_kanidm_unixd,750) /var/run/kanidm-unixd
+@dir(_kanidm_unixd,_kanidm_unixd,755) /var/run/kanidm-unixd


### PR DESCRIPTION
This folder was set to 750 which prevented non-root users from reading the localhost unixd socket which is required for nss/pam to operate.


Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
