### PR TITLE
Resolve passkey regression

### DIFF
--- a/proto/src/internal/error.rs
+++ b/proto/src/internal/error.rs
@@ -142,6 +142,13 @@ pub enum OperationError {
     DatabaseLockAcquisitionTimeout,
 
     // Specific internal errors.
+    AU0001InvalidState,
+    AU0002JwsSerialisation,
+    AU0003JwsSignature,
+    AU0004UserAuthTokenInvalid,
+    AU0005DelayedProcessFailure,
+    AU0006CredentialMayNotReauthenticate,
+    AU0007UserAuthTokenInvalid,
 
     // Kanidm Generic Errors
     KG001TaskTimeout,
@@ -371,6 +378,15 @@ impl OperationError {
             Self::TransactionAlreadyCommitted => None,
             Self::ValueDenyName => None,
             Self::DatabaseLockAcquisitionTimeout => Some("Unable to acquire a database lock - the current server may be too busy. Try again later.".into()),
+
+    Self::AU0001InvalidState => Some("Invalid authentication session state for request".into()),
+    Self::AU0002JwsSerialisation => Some("JWS serialisation failed".into()),
+    Self::AU0003JwsSignature => Some("JWS signature failed".into()),
+    Self::AU0004UserAuthTokenInvalid => Some("User auth token was unable to be generated".into()),
+    Self::AU0005DelayedProcessFailure => Some("Delaying processing failure, unable to proceed".into()),
+    Self::AU0006CredentialMayNotReauthenticate => Some("Credential may not reauthenticate".into()),
+    Self::AU0007UserAuthTokenInvalid => Some("User auth token was unable to be generated".into()),
+
             Self::CU0001WebauthnAttestationNotTrusted => None,
             Self::CU0002WebauthnRegistrationError => None,
             Self::CU0003WebauthnUserNotVerified => Some("User Verification bit not set while registering credential, you may need to configure a PIN on this device.".into()),


### PR DESCRIPTION
During other testing I noticed that passkeys no longer worked on a reauthentication. This was due to a regression in you guessed it, cookies, where the auth session id wasn't being removed properly.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
