### PR TITLE
extend oauth2 examples with gitea

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@
 - adamcstephens
 - Chris Olstrom (colstrom)
 - Christopher-Robin (cebbinghaus)
+- Fabian Kammel (datosh)
 
 ## Acknowledgements
 

--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -90,7 +90,7 @@ To set up a Gitea instance to authenticate with Kanidm:
 4. Gitea currently [does not support PKCE](https://github.com/go-gitea/gitea/issues/21376)
     in their OIDC implementation. If you do not perform this step, you will see an error like
     `No PKCE code challenge was provided with client in enforced PKCE mode.`
-    in your kanidm server logs. Therefore, we have to disable PKCE for Gitea:
+    in your Kanidm server logs. Therefore, we have to disable PKCE for Gitea:
 
     ```sh
     kanidm system oauth2 warning-insecure-client-disable-pkce gitea


### PR DESCRIPTION
# Change summary

Added a section in the OAuth2 examples to demonstrate how to configure Gitea.

Fixes #

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
