### PR TITLE
Repair systemd reload notifications

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -27,12 +27,13 @@ jobs:
           sudo apt-get update && \
           sudo apt-get install -y \
             libpam0g-dev \
-            libudev-dev \
+            libselinux1-dev \
             libssl-dev \
             libsystemd-dev \
+            libtss2-dev \
+            libudev-dev \
             pkg-config \
-            tpm-udev \
-            libtss2-dev
+            tpm-udev
       - name: "Run clippy"
         run: cargo clippy --lib --bins --examples --all-features
   fmt:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -29,6 +29,7 @@ jobs:
             libpam0g-dev \
             libudev-dev \
             libssl-dev \
+            libsystemd-dev \
             pkg-config \
             tpm-udev \
             libtss2-dev

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -37,7 +37,8 @@ jobs:
           sudo apt-get install -y \
             libpam0g-dev \
             libudev-dev \
-            libssl-dev
+            libssl-dev \
+            libsystemd-dev
 
       - name: "Build the workspace"
         run: cargo build --workspace
@@ -84,7 +85,8 @@ jobs:
           sudo apt-get install -y \
             libpam0g-dev \
             libudev-dev \
-            libssl-dev
+            libssl-dev \
+            libsystemd-dev
 
       - name: "Build the workspace"
         run: cargo build --workspace
@@ -127,6 +129,7 @@ jobs:
             libpam0g-dev \
             libudev-dev \
             libssl-dev \
+            libsystemd-dev \
             ripgrep
       - name: "Run the release build test script"
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,12 +694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,16 +1068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if",
- "memchr",
-]
-
-[[package]]
 name = "csv"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1109,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sketching",
- "systemd",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1653,28 +1636,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1682,12 +1644,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3535,17 +3491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsystemd-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
-dependencies = [
- "build-env",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libudev"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,7 +4005,7 @@ checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -5162,8 +5107,10 @@ dependencies = [
 [[package]]
 name = "sd-notify"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be20c5f7f393ee700f8b2f28ea35812e4e212f40774b550cd2a93ea91684451"
+source = "git+https://github.com/Firstyear/sd-notify.git?rev=de1854c3afad83ae80b7df7ecb7e891e98e205f9#de1854c3afad83ae80b7df7ecb7e891e98e205f9"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "security-framework"
@@ -5634,21 +5581,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "systemd"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afec0101d9ae8ab26aedf0840109df689938ea7e538aa03df4369f1854f11562"
-dependencies = [
- "cstr-argument",
- "foreign-types 0.5.0",
- "libc",
- "libsystemd-sys",
- "log",
- "memchr",
- "utf8-cstr",
 ]
 
 [[package]]
@@ -6275,12 +6207,6 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-cstr"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1074,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if",
+ "memchr",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1125,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sketching",
+ "systemd",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1636,7 +1653,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1644,6 +1682,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3491,6 +3535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsystemd-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
+dependencies = [
+ "build-env",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libudev"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,7 +4060,7 @@ checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -5582,6 +5637,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afec0101d9ae8ab26aedf0840109df689938ea7e538aa03df4369f1854f11562"
+dependencies = [
+ "cstr-argument",
+ "foreign-types 0.5.0",
+ "libc",
+ "libsystemd-sys",
+ "log",
+ "memchr",
+ "utf8-cstr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6205,6 +6275,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-cstr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5107,7 +5107,7 @@ dependencies = [
 [[package]]
 name = "sd-notify"
 version = "0.4.3"
-source = "git+https://github.com/Firstyear/sd-notify.git?rev=de1854c3afad83ae80b7df7ecb7e891e98e205f9#de1854c3afad83ae80b7df7ecb7e891e98e205f9"
+source = "git+https://github.com/Firstyear/sd-notify.git?rev=7593c0b4d5e6caea6390507d0eedb4ead7db3f50#7593c0b4d5e6caea6390507d0eedb4ead7db3f50"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5106,8 +5106,9 @@ dependencies = [
 
 [[package]]
 name = "sd-notify"
-version = "0.4.3"
-source = "git+https://github.com/Firstyear/sd-notify.git?rev=7593c0b4d5e6caea6390507d0eedb4ead7db3f50#7593c0b4d5e6caea6390507d0eedb4ead7db3f50"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561e6b346a5e59e0b8a07894004897d7160567e3352d2ebd6c3741d4e086b6f5"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,6 @@ codegen-units = 256
 
 # kanidm-hsm-crypto = { path = "../hsm-crypto" }
 
-sd-notify = { git = "https://github.com/Firstyear/sd-notify.git", rev = "7593c0b4d5e6caea6390507d0eedb4ead7db3f50" }
-
 [workspace.dependencies]
 kanidmd_core = { path = "./server/core", version = "=1.5.0-dev" }
 kanidmd_lib = { path = "./server/lib", version = "=1.5.0-dev" }
@@ -245,7 +243,7 @@ rustls = { version = "0.23.20", default-features = false, features = [
     "aws_lc_rs",
 ] }
 
-sd-notify = "^0.4.3"
+sd-notify = "^0.4.4"
 selinux = "^0.4.6"
 serde = "^1.0.217"
 serde_cbor = { version = "0.12.0-dev", package = "serde_cbor_2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ codegen-units = 256
 
 # kanidm-hsm-crypto = { path = "../hsm-crypto" }
 
-sd-notify = { git = "https://github.com/Firstyear/sd-notify.git", rev = "de1854c3afad83ae80b7df7ecb7e891e98e205f9" }
+sd-notify = { git = "https://github.com/Firstyear/sd-notify.git", rev = "7593c0b4d5e6caea6390507d0eedb4ead7db3f50" }
 
 [workspace.dependencies]
 kanidmd_core = { path = "./server/core", version = "=1.5.0-dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,8 @@ codegen-units = 256
 
 # kanidm-hsm-crypto = { path = "../hsm-crypto" }
 
+sd-notify = { git = "https://github.com/Firstyear/sd-notify.git", rev = "de1854c3afad83ae80b7df7ecb7e891e98e205f9" }
+
 [workspace.dependencies]
 kanidmd_core = { path = "./server/core", version = "=1.5.0-dev" }
 kanidmd_lib = { path = "./server/lib", version = "=1.5.0-dev" }

--- a/book/src/developers/readme.md
+++ b/book/src/developers/readme.md
@@ -103,7 +103,7 @@ You will need [rustup](https://rustup.rs/) to install a Rust toolchain.
 You will need to install rustup and our build dependencies with:
 
 ```bash
-zypper in rustup git libudev-devel sqlite3-devel libopenssl-3-devel libselinux-devel pam-devel tpm2-0-tss-devel
+zypper in rustup git libudev-devel sqlite3-devel libopenssl-3-devel libselinux-devel pam-devel systemd-devel tpm2-0-tss-devel
 ```
 
 You can then use rustup to complete the setup of the toolchain.
@@ -157,7 +157,7 @@ You need [rustup](https://rustup.rs/) to install a Rust toolchain.
 You will also need some system libraries to build this, which can be installed by running:
 
 ```bash
-sudo apt-get install libudev-dev libssl-dev pkg-config libpam0g-dev
+sudo apt-get install libudev-dev libssl-dev libsystemd-dev pkg-config libpam0g-dev
 ```
 
 Tested with Ubuntu 20.04 and 22.04.

--- a/scripts/devcontainer_postcreate.sh
+++ b/scripts/devcontainer_postcreate.sh
@@ -18,6 +18,7 @@ sudo apt-get install -y \
     jq \
     libpam0g-dev \
     libssl-dev \
+    libsystemd-dev \
     libudev-dev \
     pkg-config \
     ripgrep

--- a/scripts/install_ubuntu_dependencies.sh
+++ b/scripts/install_ubuntu_dependencies.sh
@@ -13,6 +13,7 @@ ${SUDOCMD} apt-get update &&
         libpam0g-dev \
         libudev-dev \
         libssl-dev \
+        libsystemd-dev \
         pkg-config \
         curl \
         rsync \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -29,6 +29,7 @@ RUN \
         libopenssl-3-devel \
         pam-devel \
         sqlite3-devel \
+        systemd-devel \
         rsync \
         findutils \
         which \

--- a/server/daemon/Cargo.toml
+++ b/server/daemon/Cargo.toml
@@ -38,7 +38,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 serde_json.workspace = true
-systemd = { version = "0.10.0", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-notify.workspace = true

--- a/server/daemon/Cargo.toml
+++ b/server/daemon/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 serde_json.workspace = true
+systemd = { version = "0.10.0", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-notify.workspace = true

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -756,7 +756,11 @@ async fn kanidm_main(
                     // Undocumented systemd feature - all messages should have a monotonic usec sent
                     // with them. In some cases like "reloading" messages, it is undocumented but
                     // failure to send this message causes the reload to fail.
-                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::MonotonicUsec]);
+                    if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
+                        let _ = sd_notify::notify(true, &[monotonic_usec]);
+                    } else {
+                        error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
+                    };
                     let _ = sd_notify::notify(
                         true,
                         &[sd_notify::NotifyState::Status("Started Kanidm 🦀")],
@@ -770,76 +774,86 @@ async fn kanidm_main(
                             {
                                 let mut listener = sctx.subscribe();
                                 tokio::select! {
-                                    Ok(()) = tokio::signal::ctrl_c() => {
-                                        break
-                                    }
-                                    Some(()) = async move {
-                                        let sigterm = tokio::signal::unix::SignalKind::terminate();
-                                        #[allow(clippy::unwrap_used)]
-                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                    } => {
-                                        break
-                                    }
-                                    Some(()) = async move {
-                                        let sigterm = tokio::signal::unix::SignalKind::alarm();
-                                        #[allow(clippy::unwrap_used)]
-                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                    } => {
-                                        // Ignore
-                                    }
-                                    Some(()) = async move {
-                                        let sigterm = tokio::signal::unix::SignalKind::hangup();
-                                        #[allow(clippy::unwrap_used)]
-                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                    } => {
-                                        // Reload TLS certificates
-                                        // systemd has a special reload handler for this.
-                                        #[cfg(target_os = "linux")]
-                                        {
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading]);
-                                        // CRITICAL - if you do not send a monotonic usec message after a reloading
-                                        // message, your service WILL BE KILLED.
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::MonotonicUsec]);
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reloading ...")]);
-                                        }
+                                                Ok(()) = tokio::signal::ctrl_c() => {
+                                                    break
+                                                }
+                                                Some(()) = async move {
+                                                    let sigterm = tokio::signal::unix::SignalKind::terminate();
+                                                    #[allow(clippy::unwrap_used)]
+                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                                } => {
+                                                    break
+                                                }
+                                                Some(()) = async move {
+                                                    let sigterm = tokio::signal::unix::SignalKind::alarm();
+                                                    #[allow(clippy::unwrap_used)]
+                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                                } => {
+                                                    // Ignore
+                                                }
+                                                Some(()) = async move {
+                                                    let sigterm = tokio::signal::unix::SignalKind::hangup();
+                                                    #[allow(clippy::unwrap_used)]
+                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                                } => {
+                                                    // Reload TLS certificates
+                                                    // systemd has a special reload handler for this.
+                                                    #[cfg(target_os = "linux")]
+                                                    {
+                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading]);
+                                                    // CRITICAL - if you do not send a monotonic usec message after a reloading
+                                                    // message, your service WILL BE KILLED.
+                                if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
+                                let _ =
+                                    sd_notify::notify(true, &[monotonic_usec]);
+                                } else {
+                                    error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
+                                };
+                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reloading ...")]);
+                                                    }
 
-                                        sctx.tls_acceptor_reload().await;
+                                                    sctx.tls_acceptor_reload().await;
 
-                                        // Systemd freaks out if you send the ready state too fast after the
-                                        // reload state and can kill Kanidmd as a result.
-                                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                                                    // Systemd freaks out if you send the ready state too fast after the
+                                                    // reload state and can kill Kanidmd as a result.
+                                                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-                                        #[cfg(target_os = "linux")]
-                                        {
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::MonotonicUsec]);
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reload Success")]);
-                                        }
+                                                    #[cfg(target_os = "linux")]
+                                                    {
+                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
+                                if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
+                                let _ =
+                                    sd_notify::notify(true, &[monotonic_usec]);
+                                } else {
+                                    error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
+                                };
+                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reload Success")]);
+                                                    }
 
-                                        info!("Reload complete");
-                                    }
-                                    Some(()) = async move {
-                                        let sigterm = tokio::signal::unix::SignalKind::user_defined1();
-                                        #[allow(clippy::unwrap_used)]
-                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                    } => {
-                                        // Ignore
-                                    }
-                                    Some(()) = async move {
-                                        let sigterm = tokio::signal::unix::SignalKind::user_defined2();
-                                        #[allow(clippy::unwrap_used)]
-                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                    } => {
-                                        // Ignore
-                                    }
-                                    // we got a message on thr broadcast from somewhere else
-                                    Ok(msg) = async move {
-                                        listener.recv().await
-                                    } => {
-                                        debug!("Main loop received message: {:?}", msg);
-                                        break
-                                    }
-                                }
+                                                    info!("Reload complete");
+                                                }
+                                                Some(()) = async move {
+                                                    let sigterm = tokio::signal::unix::SignalKind::user_defined1();
+                                                    #[allow(clippy::unwrap_used)]
+                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                                } => {
+                                                    // Ignore
+                                                }
+                                                Some(()) = async move {
+                                                    let sigterm = tokio::signal::unix::SignalKind::user_defined2();
+                                                    #[allow(clippy::unwrap_used)]
+                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                                } => {
+                                                    // Ignore
+                                                }
+                                                // we got a message on thr broadcast from somewhere else
+                                                Ok(msg) = async move {
+                                                    listener.recv().await
+                                                } => {
+                                                    debug!("Main loop received message: {:?}", msg);
+                                                    break
+                                                }
+                                            }
                             }
                             #[cfg(target_family = "windows")]
                             {

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -751,7 +751,14 @@ async fn kanidm_main(
             if !config_test {
                 // On linux, notify systemd.
                 #[cfg(target_os = "linux")]
-                let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
+                let _ = systemd::daemon::notify(
+                    false,
+                    [
+                        (systemd::daemon::STATE_READY, "1"),
+                        ("STATUS", "Kanidm is operational"),
+                    ]
+                    .iter(),
+                );
 
                 match sctx {
                     Ok(mut sctx) => {
@@ -785,18 +792,33 @@ async fn kanidm_main(
                                         // Reload TLS certificates
                                         // systemd has a special reload handler for this.
                                         #[cfg(target_os = "linux")]
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading]);
+                                        // https://stackoverflow.com/a/70337205
+                                        let duration_since_epoch = match std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                                            Ok(val) => val,
+                                            Err(err) => {
+                                                error!(
+                                                  "Failed to get UNIX_EPOCH: {:?}",
+                                                  err
+                                                );
+                                                return ExitCode::FAILURE;
+                                            }
+                                        };
+                                        let timestamp_micros = duration_since_epoch.as_micros().to_string();
+
+                                        #[cfg(target_os = "linux")]
+                                        let _ = systemd::daemon::notify(false, [
+                                            (systemd::daemon::STATE_RELOADING, "1"),
+                                            ("STATUS", "Reloading TLS acceptor"),
+                                            ("MONOTONIC_USEC", &timestamp_micros),
+                                        ].iter());
 
                                         sctx.tls_acceptor_reload().await;
 
-                                        // Systemd freaks out if you send the ready state too fast after the
-                                        // reload state and can kill Kanidmd as a result.
-                                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
                                         #[cfg(target_os = "linux")]
-                                        let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
-
-                                        info!("Reload complete");
+                                        let _ = systemd::daemon::notify(false, [
+                                            (systemd::daemon::STATE_READY, "1"),
+                                            ("STATUS", "Kanidm is operational"),
+                                        ].iter());
                                     }
                                     Some(()) = async move {
                                         let sigterm = tokio::signal::unix::SignalKind::user_defined1();


### PR DESCRIPTION
# Change summary

In order for the RELOAD and the subsequent READY notifications to be correctly processed, the RELOAD notification must be accompanied with a MONOTONIC_USEC one.
Unfortunately, the sd-notify crate does not seem to support this, and I have not yet looked into implementing it.
Hence this patch is comprised of:
- replacement of sd-notify with systemd for the daemon component to support the MONOTONIC_USEC notification
- adding of the MONOTONIC_USEC notification to repair the RELOAD => READY notifications
- adding of STATUS notifications for both easier debugging of whether notifications arrive with systemd and easier user facing feedback about the current daemon status
- removal of the artificial delay, which is no longer beneficial
- disabling of unset_environment, as the preservation of $NOTIFY_SOCKET
is crucial

Fixes https://progress.opensuse.org/issues/173533 (can create accompanying issue here if you'd like).

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
