### PR TITLE
Book: Added small section on primary cred fallback

### DIFF
--- a/book/src/accounts/account_policy.md
+++ b/book/src/accounts/account_policy.md
@@ -193,7 +193,7 @@ kanidm group account-policy webauthn-attestation-ca-list idm_all_persons trusted
 The primary credential fallback enables behavior which allows authenticating
 using the primary account password when logging in via LDAP.
 
-If both a LDAP and primary password are specified it will only accept the LDAP password.
+If both an LDAP and primary password are specified, Kanidm will only accept the LDAP password.
 
 ```bash
 kanidm group account-policy allow-primary-cred-fallback <group name> <enabled>

--- a/book/src/accounts/account_policy.md
+++ b/book/src/accounts/account_policy.md
@@ -188,6 +188,17 @@ account policy for a group. For example, to set the allowlist for all persons, r
 kanidm group account-policy webauthn-attestation-ca-list idm_all_persons trusted-authenticators
 ```
 
+### Setting Primary Credential Fallback
+
+The primary credential fallback enables behavior which allows authenticating
+using the primary account password when logging in via LDAP.
+
+If both a LDAP and primary password are specified it will only accept the LDAP password.
+
+```bash
+kanidm group account-policy allow-primary-cred-fallback <group name> <enabled>
+```
+
 ## Global Settings
 
 There are a small number of account policy settings that are set globally rather than on a per group

--- a/book/src/accounts/account_policy.md
+++ b/book/src/accounts/account_policy.md
@@ -199,6 +199,12 @@ If both an LDAP and primary password are specified, Kanidm will only accept the 
 kanidm group account-policy allow-primary-cred-fallback <group name> <enabled>
 ```
 
+to disable it for a group you would run:
+
+```bash
+kanidm group account-policy allow-primary-cred-fallback <group name> false
+```
+
 ## Global Settings
 
 There are a small number of account policy settings that are set globally rather than on a per group


### PR DESCRIPTION
# Change summary
Forgot to add a book chapter when raising the PR for the primary credential feedback. This makes good on that mistake.

Amends #3067

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
