### PR TITLE
Add setup-oras step to include ORAS CLI for container builds on ubuntu-24.04.

### DIFF
--- a/.github/workflows/docker_build_kanidm.yml
+++ b/.github/workflows/docker_build_kanidm.yml
@@ -71,7 +71,8 @@ jobs:
         with:
           name: kanidm-docker
           path: /tmp
-
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@v1
       - name: Push image to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -88,7 +88,8 @@ jobs:
         with:
           name: kanidmd-docker
           path: /tmp
-
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@v1
       - name: Push image to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \

--- a/.github/workflows/docker_build_radiusd.yml
+++ b/.github/workflows/docker_build_radiusd.yml
@@ -70,7 +70,8 @@ jobs:
         with:
           name: radius-docker
           path: /tmp
-
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@v1
       # Docker won't directly import OCI images and keep their multi-arch
       # features, but ORAS will: https://oras.land/docs/commands/oras_copy
       - name: Push image to GHCR


### PR DESCRIPTION
# Change summary
The image used by GitHub actions is `ubuntu-latest` which now refers to `ubuntu-24.04`. `ubuntu-24.04` no longer includes the `oras` CLI by default so container pushes are failing. Include the GitHub action to add `oras` 1.2.2 (which is what was previously used with `ubuntu-22.04`. 

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
