### PR TITLE
OpenBSD support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,6 +45,7 @@
 - Chris Olstrom (colstrom)
 - Christopher-Robin (cebbinghaus)
 - Fabian Kammel (datosh)
+- Andris Raugulis (arthepsy)
 
 ## Acknowledgements
 

--- a/libs/file_permissions/src/unix.rs
+++ b/libs/file_permissions/src/unix.rs
@@ -3,6 +3,9 @@ use std::fs::Metadata;
 #[cfg(target_os = "freebsd")]
 use std::os::freebsd::fs::MetadataExt;
 
+#[cfg(target_os = "openbsd")]
+use std::os::openbsd::fs::MetadataExt;
+
 #[cfg(target_os = "linux")]
 use std::os::linux::fs::MetadataExt;
 

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -93,6 +93,10 @@ features = ["mozilla"]
 workspace = true
 features = ["mozilla"]
 
+[target."cfg(target_os = \"openbsd\")".dependencies.webauthn-authenticator-rs]
+workspace = true
+features = ["mozilla"]
+
 ## Debian packaging
 [package.metadata.deb]
 name = "kanidm"

--- a/tools/cli/src/cli/webauthn/mod.rs
+++ b/tools/cli/src/cli/webauthn/mod.rs
@@ -13,6 +13,11 @@ mod mozilla;
 #[cfg(target_os = "freebsd")]
 use mozilla::get_authenticator_backend;
 
+#[cfg(target_os = "openbsd")]
+mod mozilla;
+#[cfg(target_os = "openbsd")]
+use mozilla::get_authenticator_backend;
+
 #[cfg(target_os = "windows")]
 mod win10;
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
# Implement OpenBSD support

With this patch compiles and runs fine on OpenBSD 7.6, rust 1.81.0. Did basic tests, all good, no issues.
Had to install `openssl-3.3.2`, because there were multiple failures (in various dependencies) using OpenBSD's `libressl`, but that's about it.

Only exception is `unix_integrations/pam_kanidm` (OpenBSD doesn't have built-in PAM), which I just commented out in `Cargo.toml`, when building and everything was build successfully.

Regarding this, I had an idea to rework `Cargo.toml` to exclude this while building on OpenBSD, but it seems that it isn't supported by cargo (read multiple issues by people requesting it, checked ignored pull requests, etc.) or my knowledge how to do is lacking. Maybe this can be reworked some-how (ab)using `features`, but that's to be researched. Anyhow, I think the best case would be to rework `pam_kanidm` for OpenBSD to use OpenPAM, which is available as a package. 

Please, give feedback about how to handle `pam_kanidm` for OpenBSD, so I can work on this.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
