### PR TITLE
Add /.well-known/change-password endpoint

### DIFF
--- a/server/core/src/https/generic.rs
+++ b/server/core/src/https/generic.rs
@@ -1,6 +1,6 @@
 use axum::extract::State;
 use axum::http::header::CONTENT_TYPE;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Redirect};
 use axum::{Extension, Json};
 use kanidmd_lib::status::StatusRequestEvent;
 
@@ -49,4 +49,16 @@ pub async fn robots_txt() -> impl IntoResponse {
 "#,
         ),
     )
+}
+
+#[utoipa::path(
+    get,
+    path = "/.well-known/change-password",
+    responses(
+        (status = 303, description = "See other"),
+    ),
+    tag = "ui",
+)]
+pub async fn redirect_to_update_credentials() -> impl IntoResponse {
+    Redirect::to("/ui/update_credentials")
 }

--- a/server/core/src/https/generic.rs
+++ b/server/core/src/https/generic.rs
@@ -5,6 +5,7 @@ use axum::{Extension, Json};
 use kanidmd_lib::status::StatusRequestEvent;
 
 use super::middleware::KOpId;
+use super::views::constants::Urls;
 use super::ServerState;
 
 #[utoipa::path(
@@ -53,12 +54,12 @@ pub async fn robots_txt() -> impl IntoResponse {
 
 #[utoipa::path(
     get,
-    path = "/.well-known/change-password",
+    path = Urls::WellKnownChangePassword.as_ref(),
     responses(
         (status = 303, description = "See other"),
     ),
     tag = "ui",
 )]
 pub async fn redirect_to_update_credentials() -> impl IntoResponse {
-    Redirect::to("/ui/update_credentials")
+    Redirect::to(Urls::UpdateCredentials.as_ref())
 }

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -253,7 +253,7 @@ pub async fn create_https_server(
         .merge(v1::route_setup(state.clone()))
         .route("/robots.txt", get(generic::robots_txt))
         .route(
-            "/.well-known/change-password",
+            views::constants::Urls::WellKnownChangePassword.as_ref(),
             get(generic::redirect_to_update_credentials),
         );
 

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -251,7 +251,11 @@ pub async fn create_https_server(
         .merge(oauth2::route_setup(state.clone()))
         .merge(v1_scim::route_setup())
         .merge(v1::route_setup(state.clone()))
-        .route("/robots.txt", get(generic::robots_txt));
+        .route("/robots.txt", get(generic::robots_txt))
+        .route(
+            "/.well-known/change-password",
+            get(generic::redirect_to_update_credentials),
+        );
 
     let app = match config.role {
         ServerRole::WriteReplicaNoUI => app,

--- a/server/core/src/https/views/constants.rs
+++ b/server/core/src/https/views/constants.rs
@@ -21,17 +21,16 @@ impl std::fmt::Display for UiMessage {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) enum Urls {
     Apps,
     CredReset,
-    CredResetError,
     EnrolDevice,
     Profile,
     UpdateCredentials,
     Oauth2Resume,
     Login,
     Ui,
+    WellKnownChangePassword,
 }
 
 impl AsRef<str> for Urls {
@@ -39,13 +38,13 @@ impl AsRef<str> for Urls {
         match self {
             Self::Apps => "/ui/apps",
             Self::CredReset => "/ui/reset",
-            Self::CredResetError => "/ui/reset/err",
             Self::EnrolDevice => "/ui/enrol",
             Self::Profile => "/ui/profile",
             Self::UpdateCredentials => "/ui/update_credentials",
             Self::Oauth2Resume => "/ui/oauth2/resume",
             Self::Login => "/ui/login",
             Self::Ui => "/ui",
+            Self::WellKnownChangePassword => "/.well-known/change-password",
         }
     }
 }

--- a/server/core/src/https/views/mod.rs
+++ b/server/core/src/https/views/mod.rs
@@ -17,7 +17,7 @@ use kanidmd_lib::{
 use crate::https::ServerState;
 
 mod apps;
-mod constants;
+pub(crate) mod constants;
 mod cookies;
 mod enrol;
 mod errors;


### PR DESCRIPTION
# Change summary (Fixes #2808)
- Add a redirect from `/.well-known/change-password` to `/ui/update_credentials` page.
- **Current Behaviour**: When the user is logged in, they will be asked to re-auth, and then are brought to the `update_credentials` page. When the user is not logged in, they are brought to the login page, then after auth, they are brought to the apps page.


This is my first PR, so here are some questions I had while working on this that I couldn't find clear answers to in the repo:
- _When the user is not logged in, would we want some redirect parameter to make sure the user gets to this page after logging in? (I couldn't find any redirection after auth)_ [Answered by yaleman](https://github.com/kanidm/kanidm/pull/3382#issuecomment-2629365449)
- _I saw `server/core/src/https/views/constants.rs` had a `pub(crate) enum Urls`, though it was only accessible within the `https/views` module. In my changes to `generic.rs`, I wanted to go `Urls::UpdateCredentials.as_ref()`, but I couldn't import `Urls`, though I'm also not sure about directly typing `/ui/update_credentials`. What would the maintainers opt for? Making `Urls` enum public outside the `views` module, or directly having the `/ui/update_credentials` string here?_ [Answered by yaleman](https://github.com/kanidm/kanidm/pull/3382#issuecomment-2629304165)
- _Does `https/generic.rs` seem like a reasonable place for this? Please let me know._ [Answered by yaleman](https://github.com/kanidm/kanidm/pull/3382#issuecomment-2629365449)


Checklist
- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
