### PR TITLE
Allow POST on oauth userinfo

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@
 - Christopher-Robin (cebbinghaus)
 - Fabian Kammel (datosh)
 - Andris Raugulis (arthepsy)
+- Jason (argonaut0)
 
 ## Acknowledgements
 

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -775,8 +775,8 @@ pub fn route_setup(state: ServerState) -> Router<ServerState> {
         .route(
             "/oauth2/openid/:client_id/userinfo",
             get(oauth2_openid_userinfo_get)
-            .post(oauth2_openid_userinfo_get)
-            .options(oauth2_preflight_options),
+                .post(oauth2_openid_userinfo_get)
+                .options(oauth2_preflight_options),
         )
         // // ⚠️  ⚠️   WARNING  ⚠️  ⚠️
         // // IF YOU CHANGE THESE VALUES YOU MUST UPDATE OIDC DISCOVERY URLS

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -774,7 +774,9 @@ pub fn route_setup(state: ServerState) -> Router<ServerState> {
         // // IF YOU CHANGE THESE VALUES YOU MUST UPDATE OIDC DISCOVERY URLS
         .route(
             "/oauth2/openid/:client_id/userinfo",
-            get(oauth2_openid_userinfo_get).options(oauth2_preflight_options),
+            get(oauth2_openid_userinfo_get)
+            .post(oauth2_openid_userinfo_get)
+            .options(oauth2_preflight_options),
         )
         // // ⚠️  ⚠️   WARNING  ⚠️  ⚠️
         // // IF YOU CHANGE THESE VALUES YOU MUST UPDATE OIDC DISCOVERY URLS

--- a/server/testkit/tests/oauth2_test.rs
+++ b/server/testkit/tests/oauth2_test.rs
@@ -447,6 +447,24 @@ async fn test_oauth2_openid_basic_flow_impl(
 
     assert_eq!(userinfo, oidc);
 
+    let response = client
+        .post(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+        .bearer_auth(atr.access_token.clone())
+        .send()
+        .await
+        .expect("Failed to send userinfo POST request.");
+
+    tracing::trace!("{:?}", response.headers());
+    assert!(
+        response.headers().get(CONTENT_TYPE) == Some(&HeaderValue::from_static(APPLICATION_JSON))
+    );
+    let userinfo_post = response
+        .json::<OidcToken>()
+        .await
+        .expect("Unable to decode OidcToken from POST userinfo");
+
+    assert_eq!(userinfo_post, userinfo);
+
     // Step 6 - Show that our client can perform a client credentials grant
 
     let form_req: AccessTokenRequest = GrantTypeReq::ClientCredentials {


### PR DESCRIPTION
# Change summary
Allows `oauth/openid/:client_id:/userinfo` to accept `POST` as a request method as required by [spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
)

Fixes #3394 

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
