### PR TITLE
Add error message when account-policy attribute is set on group without account-policy enabled

### DIFF
--- a/tools/cli/src/cli/group/account_policy.rs
+++ b/tools/cli/src/cli/group/account_policy.rs
@@ -1,5 +1,5 @@
 use crate::common::OpType;
-use crate::{handle_client_error, GroupAccountPolicyOpt};
+use crate::{handle_client_error, handle_group_account_policy_error, GroupAccountPolicyOpt};
 
 impl GroupAccountPolicyOpt {
     pub fn debug(&self) -> bool {
@@ -38,7 +38,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_authsession_expiry_set(name, *expiry)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated authsession expiry.");
                 }
@@ -50,7 +50,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_authsession_expiry_reset(name)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Successfully reset authsession expiry.");
                 }
@@ -62,7 +62,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_credential_type_minimum_set(name, value.as_str())
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated credential type minimum.");
                 }
@@ -73,7 +73,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_password_minimum_length_set(name, *length)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated password minimum length.");
                 }
@@ -84,7 +84,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_password_minimum_length_reset(name)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Successfully reset password minimum length.");
                 }
@@ -95,7 +95,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_privilege_expiry_set(name, *expiry)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated privilege session expiry.");
                 }
@@ -106,7 +106,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_privilege_expiry_reset(name)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Successfully reset privilege session expiry.");
                 }
@@ -126,7 +126,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_webauthn_attestation_set(name, &json)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated webauthn attestation CA list.");
                 }
@@ -138,7 +138,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_webauthn_attestation_reset(name)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Successfully reset webauthn attestation CA list.");
                 }
@@ -154,7 +154,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_limit_search_max_results(name, *maximum)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated search maximum results limit.");
                 }
@@ -165,7 +165,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_limit_search_max_results_reset(name)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Successfully reset search maximum results limit to default.");
                 }
@@ -180,7 +180,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_limit_search_max_filter_test(name, *maximum)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated search maximum filter test limit.");
                 }
@@ -191,7 +191,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_limit_search_max_filter_test_reset(name)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Successfully reset search maximum filter test limit.");
                 }
@@ -202,7 +202,7 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_allow_primary_cred_fallback(name, *allow)
                     .await
                 {
-                    handle_client_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, copt.output_mode);
                 } else {
                     println!("Updated primary credential fallback policy.");
                 }


### PR DESCRIPTION
# Change summary
- Add an error message prompting the user to check if account-policy is enabled on the group.

Closes #2616

## Checklist
- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
