### PR TITLE
Feat: Allowing spn query with non-spn structured data in LDAP

### DIFF
--- a/book/src/integrations/ldap.md
+++ b/book/src/integrations/ldap.md
@@ -69,6 +69,11 @@ As the POSIX password is not equivalent in strength to the primary credentials o
 most cases is multi-factor authentication), the LDAP bind does not grant rights to elevated read
 permissions. All binds have the permissions of "anonymous" even if the anonymous account is locked.
 
+> As the POSIX password is not equivalent in strength to the primary credentials of Kanidm
+
+This is no longer necessarily true (thanks to the fallback). Would it be possible to  enable elevated read permissions
+specifically for the the account being logged into?
+
 The exception is service accounts which can use api-tokens during an LDAP bind for elevated read
 permissions.
 
@@ -145,7 +150,8 @@ with a dn of `dn=token` and provide the api token in the password.
 > [!NOTE]
 >
 > The `dn=token` keyword is guaranteed to not be used by any other entry, which is why it was chosen
-> as the keyword to initiate api token binds.
+> as the keyword to initiate api token binds. Additionally it is not required, leaving the field empty
+> will fall back to the service-account if a "password" is provided
 
 ```bash
 ldapwhoami -H ldaps://URL -x -D "dn=token" -w "TOKEN"

--- a/book/src/integrations/ldap.md
+++ b/book/src/integrations/ldap.md
@@ -69,11 +69,6 @@ As the POSIX password is not equivalent in strength to the primary credentials o
 most cases is multi-factor authentication), the LDAP bind does not grant rights to elevated read
 permissions. All binds have the permissions of "anonymous" even if the anonymous account is locked.
 
-> As the POSIX password is not equivalent in strength to the primary credentials of Kanidm
-
-This is no longer necessarily true (thanks to the fallback). Would it be possible to  enable elevated read permissions
-specifically for the the account being logged into?
-
 The exception is service accounts which can use api-tokens during an LDAP bind for elevated read
 permissions.
 
@@ -240,6 +235,7 @@ ldapwhoami ... -x -D '22a65b6c-80c8-4e1a-9b76-3f3afdff8400'
 ldapwhoami ... -x -D 'spn=test1@idm.example.com,dc=idm,dc=example,dc=com'
 ldapwhoami ... -x -D 'name=test1,dc=idm,dc=example,dc=com'
 ```
+<sub>in fact, the key of the bind isn't used at all so `googoogaaga=test1` is entirely valid</sub> ;)
 
 ## Troubleshooting
 

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -572,7 +572,7 @@ pub trait BackendTransaction {
                 (IdList::Indexed(IDLBitRange::new()), FilterPlan::Invalid)
             }
             FilterResolved::Invalid(_) => {
-                // Partial is the only one that doesn't run the risk of being cancelled due to resource constraint
+                // Indexed since it is always false and we don't want to influence filter testing
                 (IdList::Indexed(IDLBitRange::new()), FilterPlan::Invalid)
             }
         })

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -573,7 +573,7 @@ pub trait BackendTransaction {
             }
             FilterResolved::Invalid(_) => {
                 // Partial is the only one that doesn't run the risk of being cancelled due to resource constraint
-                (IdList::Partial(IDLBitRange::new()), FilterPlan::Invalid)
+                (IdList::Indexed(IDLBitRange::new()), FilterPlan::Invalid)
             }
         })
     }

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -571,6 +571,10 @@ pub trait BackendTransaction {
                 filter_error!("Requested a top level or isolated AndNot, returning empty");
                 (IdList::Indexed(IDLBitRange::new()), FilterPlan::Invalid)
             }
+            FilterResolved::Invalid(_) => {
+                // Partial is the only one that doesn't run the risk of being cancelled due to resource constraint
+                (IdList::Partial(IDLBitRange::new()), FilterPlan::Invalid)
+            }
         })
     }
 

--- a/server/lib/src/be/mod.rs
+++ b/server/lib/src/be/mod.rs
@@ -2395,9 +2395,12 @@ mod tests {
 
             let single_result = be.create(&CID_ZERO, vec![e]);
             assert!(single_result.is_ok());
-            
+
             // Test Search with or condition including invalid attribute
-            let filt = filter_resolved!(f_or(vec![f_eq(Attribute::UserId, PartialValue::new_utf8s("bagel")), f_invalid(Attribute::UserId)]));
+            let filt = filter_resolved!(f_or(vec![
+                f_eq(Attribute::UserId, PartialValue::new_utf8s("bagel")),
+                f_invalid(Attribute::UserId)
+            ]));
 
             let lims = Limits::unlimited();
 
@@ -2405,7 +2408,10 @@ mod tests {
             assert!(r.expect("Search failed!").len() == 1);
 
             // Test Search with or condition including invalid attribute
-            let filt = filter_resolved!(f_and(vec![f_eq(Attribute::UserId, PartialValue::new_utf8s("bagel")), f_invalid(Attribute::UserId)]));
+            let filt = filter_resolved!(f_and(vec![
+                f_eq(Attribute::UserId, PartialValue::new_utf8s("bagel")),
+                f_invalid(Attribute::UserId)
+            ]));
 
             let lims = Limits::unlimited();
 

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2912,9 +2912,7 @@ impl<VALID, STATE> Entry<VALID, STATE> {
                 false
             }
             FilterResolved::AndNot(f, _) => !self.entry_match_no_index_inner(f),
-            FilterResolved::Invalid(_) => {
-                false
-            }
+            FilterResolved::Invalid(_) => false,
         }
     }
 

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2912,6 +2912,9 @@ impl<VALID, STATE> Entry<VALID, STATE> {
                 false
             }
             FilterResolved::AndNot(f, _) => !self.entry_match_no_index_inner(f),
+            FilterResolved::Invalid(_) => {
+                false
+            }
         }
     }
 

--- a/server/lib/src/filter.rs
+++ b/server/lib/src/filter.rs
@@ -83,6 +83,10 @@ pub fn f_self() -> FC {
     FC::SelfUuid
 }
 
+pub fn f_invalid(a: Attribute) -> FC {
+    FC::Invalid(a)
+}
+
 pub fn f_id(uuid: &str) -> FC {
     let uf = Uuid::parse_str(uuid)
         .ok()
@@ -117,6 +121,7 @@ pub enum FC {
     Inclusion(Vec<FC>),
     AndNot(Box<FC>),
     SelfUuid,
+    Invalid(Attribute),
     // Not(Box<FC>),
 }
 
@@ -135,6 +140,7 @@ enum FilterComp {
     Inclusion(Vec<FilterComp>),
     AndNot(Box<FilterComp>),
     SelfUuid,
+    Invalid(Attribute),
     // Does this mean we can add a true not to the type now?
     // Not(Box<FilterComp>),
 }
@@ -196,12 +202,15 @@ impl fmt::Debug for FilterComp {
             FilterComp::SelfUuid => {
                 write!(f, "uuid eq self")
             }
+            FilterComp::Invalid(attr) => {
+                write!(f, "invalid ( {:?} )", attr)
+            }
         }
     }
 }
 
 /// This is the fully resolved internal representation. Note the lack of Not and selfUUID
-/// because these are resolved into And(Pres(class), AndNot(term)) and Eq(uuid, ...).
+/// because these are resolved into And(Pres(class), AndNot(term)) and Eq(uuid, ...) respectively.
 /// Importantly, we make this accessible to Entry so that it can then match on filters
 /// internally.
 ///
@@ -221,6 +230,7 @@ pub enum FilterResolved {
     LessThan(Attribute, PartialValue, Option<NonZeroU8>),
     Or(Vec<FilterResolved>, Option<NonZeroU8>),
     And(Vec<FilterResolved>, Option<NonZeroU8>),
+    Invalid(Attribute),
     // All terms must have 1 or more items, or the inclusion is false!
     Inclusion(Vec<FilterResolved>, Option<NonZeroU8>),
     AndNot(Box<FilterResolved>, Option<NonZeroU8>),
@@ -309,6 +319,9 @@ impl fmt::Debug for FilterResolved {
             }
             FilterResolved::AndNot(inner, idx) => {
                 write!(f, "not (s{} {:?})", idx.unwrap_or(NonZeroU8::MAX), inner)
+            }
+            FilterResolved::Invalid(attr) => {
+                write!(f, "{} inv", attr)
             }
         }
     }
@@ -777,6 +790,7 @@ impl FilterComp {
             FC::Inclusion(v) => FilterComp::Inclusion(v.into_iter().map(FilterComp::new).collect()),
             FC::AndNot(b) => FilterComp::AndNot(Box::new(FilterComp::new(*b))),
             FC::SelfUuid => FilterComp::SelfUuid,
+            FC::Invalid(a) => FilterComp::Invalid(a),
         }
     }
 
@@ -804,7 +818,8 @@ impl FilterComp {
             | FilterComp::Stw(attr, _)
             | FilterComp::Enw(attr, _)
             | FilterComp::Pres(attr)
-            | FilterComp::LessThan(attr, _) => {
+            | FilterComp::LessThan(attr, _)
+            | FilterComp::Invalid(attr) => {
                 r_set.insert(attr.clone());
             }
             FilterComp::Or(vs) => vs.iter().for_each(|f| f.get_attr_set(r_set)),
@@ -951,6 +966,10 @@ impl FilterComp {
             FilterComp::SelfUuid => {
                 // Pretty hard to mess this one up ;)
                 Ok(FilterComp::SelfUuid)
+            }
+            FilterComp::Invalid(attr) => {
+                // This is a special case, we can't validate it.
+                Ok(FilterComp::Invalid(attr.clone()))
             }
         }
     }
@@ -1099,11 +1118,9 @@ impl FilterComp {
                 let a = ldap_attr_filter_map(a);
                 let pv = qs.clone_partialvalue(&a, v);
                 let Ok(pv) = pv else {
-                    // This is a massive hack to get around the fact that we can't to do a equality check on the spn
-                    // without providing a valid spn string `e.g spn=username`. I'd rather be solving this by creating a `FilterComp::Constant(bool)`
-                    // To allow us to embed an always false value given we need to return a filter comp.
+                    // This is to prevent a badly formed spn from causing the query to fail
                     if a == Attribute::Spn {
-                        return Ok(FilterComp::Eq(a, PartialValue::Spn("invalid".into(), "spn".into())));
+                        return Ok(FilterComp::Invalid(a));
                     }
                     
                     // Hate the unwrap but can't think of a better way :(
@@ -1278,6 +1295,7 @@ impl FilterResolved {
                 FilterResolved::Eq(a, v, idx)
             }
             FilterComp::SelfUuid => panic!("Not possible to resolve SelfUuid in from_invalid!"),
+            FilterComp::Invalid(_) => panic!("Not possible to resolve Invalid in from_invalid!"),
             FilterComp::Cnt(a, v) => {
                 let idx = idxmeta.contains(&(&a, &IndexType::SubString));
                 let idx = NonZeroU8::new(idx as u8);
@@ -1351,6 +1369,7 @@ impl FilterResolved {
             | FilterComp::Stw(..)
             | FilterComp::Enw(..)
             | FilterComp::Pres(_)
+            | FilterComp::Invalid(_)
             | FilterComp::LessThan(..) => true,
         }
     }
@@ -1446,6 +1465,9 @@ impl FilterResolved {
                 FilterResolved::resolve_idx((*f).clone(), ev, idxmeta)
                     .map(|fi| FilterResolved::AndNot(Box::new(fi), None))
             }
+            FilterComp::Invalid(attr) => {
+                Some(FilterResolved::Invalid(attr))
+            },
         }
     }
 
@@ -1504,6 +1526,7 @@ impl FilterResolved {
                 FilterResolved::resolve_no_idx((*f).clone(), ev)
                     .map(|fi| FilterResolved::AndNot(Box::new(fi), None))
             }
+            FilterComp::Invalid(_) => None,
         }
     }
 
@@ -1643,6 +1666,7 @@ impl FilterResolved {
             | FilterResolved::And(_, sf)
             | FilterResolved::Inclusion(_, sf)
             | FilterResolved::AndNot(_, sf) => *sf,
+            FilterResolved::Invalid(_) => Some(NonZeroU8::new(1).unwrap()),
         }
     }
 }

--- a/server/lib/src/filter.rs
+++ b/server/lib/src/filter.rs
@@ -1522,7 +1522,7 @@ impl FilterResolved {
                 FilterResolved::resolve_no_idx((*f).clone(), ev)
                     .map(|fi| FilterResolved::AndNot(Box::new(fi), None))
             }
-            FilterComp::Invalid(_) => None,
+            FilterComp::Invalid(attr) => Some(FilterResolved::Invalid(attr)),
         }
     }
 

--- a/server/lib/src/filter.rs
+++ b/server/lib/src/filter.rs
@@ -969,7 +969,7 @@ impl FilterComp {
             }
             FilterComp::Invalid(attr) => {
                 // FilterComp may be invalid but Invalid is still a valid value.
-                // we continue the evaluation so OR queries can still succeed 
+                // we continue the evaluation so OR queries can still succeed
                 Ok(FilterComp::Invalid(attr.clone()))
             }
         }
@@ -1119,10 +1119,10 @@ impl FilterComp {
                 let a = ldap_attr_filter_map(a);
                 let pv = qs.clone_partialvalue(&a, v);
 
-                match pv {  
-                    Ok(pv) => FilterComp::Eq(a, pv),  
-                    Err(_) if a == Attribute::Spn => FilterComp::Invalid(a),  
-                    Err(err) => return Err(err), 
+                match pv {
+                    Ok(pv) => FilterComp::Eq(a, pv),
+                    Err(_) if a == Attribute::Spn => FilterComp::Invalid(a),
+                    Err(err) => return Err(err),
                 }
             }
             LdapFilter::Present(a) => FilterComp::Pres(ldap_attr_filter_map(a)),
@@ -1462,9 +1462,7 @@ impl FilterResolved {
                 FilterResolved::resolve_idx((*f).clone(), ev, idxmeta)
                     .map(|fi| FilterResolved::AndNot(Box::new(fi), None))
             }
-            FilterComp::Invalid(attr) => {
-                Some(FilterResolved::Invalid(attr))
-            },
+            FilterComp::Invalid(attr) => Some(FilterResolved::Invalid(attr)),
         }
     }
 

--- a/server/lib/src/filter.rs
+++ b/server/lib/src/filter.rs
@@ -1662,7 +1662,7 @@ impl FilterResolved {
             | FilterResolved::Inclusion(_, sf)
             | FilterResolved::AndNot(_, sf) => *sf,
             // We hard code 1 because there is no slope for an invlid filter
-            FilterResolved::Invalid(_) => Some(NonZeroU8::new(1).expect("1 is always valid")),
+            FilterResolved::Invalid(_) => NonZeroU8::new(1),
         }
     }
 }

--- a/server/lib/src/filter.rs
+++ b/server/lib/src/filter.rs
@@ -968,7 +968,8 @@ impl FilterComp {
                 Ok(FilterComp::SelfUuid)
             }
             FilterComp::Invalid(attr) => {
-                // This is a special case, we can't validate it.
+                // FilterComp may be invalid but Invalid is still a valid value.
+                // we continue the evaluation so OR queries can still succeed 
                 Ok(FilterComp::Invalid(attr.clone()))
             }
         }

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -239,8 +239,7 @@ impl LdapServer {
             let mut all_attrs = false;
             let mut all_op_attrs = false;
 
-            // TODO #67: limit the number of attributes here!
-            // Is this still needed?
+            // TODO #3406: limit the number of attributes here!
             if sr.attrs.is_empty() {
                 // If [], then "all" attrs
                 all_attrs = true;
@@ -1208,10 +1207,11 @@ mod tests {
         let result = ldaps
             .do_search(idms, &sr, &anon_t, Source::Internal)
             .await
+            .map(|r| r.into_iter().filter(|r| matches!(r.op, LdapOp::SearchResultEntry(_))).collect::<Vec<_>>())
             .unwrap();
-
+        
         assert!(!result.is_empty());
-
+        
         let sr = SearchRequest {
             msgid: 1,
             base: format!("dc=example,dc=com"),
@@ -1226,6 +1226,7 @@ mod tests {
         let empty_result = ldaps
             .do_search(idms, &sr, &anon_t, Source::Internal)
             .await
+            .map(|r| r.into_iter().filter(|r| matches!(r.op, LdapOp::SearchResultEntry(_))).collect::<Vec<_>>())
             .unwrap();
 
         assert!(empty_result.is_empty());

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -1157,7 +1157,7 @@ mod tests {
         assert!(!r1.is_empty());
         assert_eq!(r1.len(), r2.len());
     }
-    
+
     #[idm_test]
     async fn test_ldap_spn_search(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
         let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
@@ -1207,11 +1207,15 @@ mod tests {
         let result = ldaps
             .do_search(idms, &sr, &anon_t, Source::Internal)
             .await
-            .map(|r| r.into_iter().filter(|r| matches!(r.op, LdapOp::SearchResultEntry(_))).collect::<Vec<_>>())
+            .map(|r| {
+                r.into_iter()
+                    .filter(|r| matches!(r.op, LdapOp::SearchResultEntry(_)))
+                    .collect::<Vec<_>>()
+            })
             .unwrap();
-        
+
         assert!(!result.is_empty());
-        
+
         let sr = SearchRequest {
             msgid: 1,
             base: format!("dc=example,dc=com"),
@@ -1226,7 +1230,11 @@ mod tests {
         let empty_result = ldaps
             .do_search(idms, &sr, &anon_t, Source::Internal)
             .await
-            .map(|r| r.into_iter().filter(|r| matches!(r.op, LdapOp::SearchResultEntry(_))).collect::<Vec<_>>())
+            .map(|r| {
+                r.into_iter()
+                    .filter(|r| matches!(r.op, LdapOp::SearchResultEntry(_)))
+                    .collect::<Vec<_>>()
+            })
             .unwrap();
 
         assert!(empty_result.is_empty());

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -205,9 +205,9 @@ impl LdapServer {
             // Map the Some(a,v) to ...?
 
             let ext_filter = match (&sr.scope, req_dn) {
-                // OneLevel and Child searches are veerrrryyy similar for us because child
+                // OneLevel and Child searches are **very** similar for us because child
                 // is a "subtree search excluding base". Because we don't have a tree structure at
-                // all, this is the same as a onelevel (ald children of base excludeing base).
+                // all, this is the same as a one level (all children of base excluding base).
                 (LdapSearchScope::Children, Some(_r)) | (LdapSearchScope::OneLevel, Some(_r)) => {
                     return Ok(vec![sr.gen_success()])
                 }
@@ -240,6 +240,7 @@ impl LdapServer {
             let mut all_op_attrs = false;
 
             // TODO #67: limit the number of attributes here!
+            // Is this still needed?
             if sr.attrs.is_empty() {
                 // If [], then "all" attrs
                 all_attrs = true;
@@ -1156,6 +1157,78 @@ mod tests {
             .unwrap();
         assert!(!r1.is_empty());
         assert_eq!(r1.len(), r2.len());
+    }
+    
+    #[idm_test]
+    async fn test_ldap_spn_search(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
+        let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
+
+        let usr_uuid = Uuid::new_v4();
+        let usr_name = "panko";
+
+        // Setup person, group and application
+        {
+            let e1: Entry<EntryInit, EntryNew> = entry_init!(
+                (Attribute::Class, EntryClass::Object.to_value()),
+                (Attribute::Class, EntryClass::Account.to_value()),
+                (Attribute::Class, EntryClass::Person.to_value()),
+                (Attribute::Name, Value::new_iname(usr_name)),
+                (Attribute::Uuid, Value::Uuid(usr_uuid)),
+                (Attribute::DisplayName, Value::new_utf8s(usr_name))
+            );
+
+            let ct = duration_from_epoch_now();
+            let mut server_txn = idms.proxy_write(ct).await.unwrap();
+            assert!(server_txn
+                .qs_write
+                .internal_create(vec![e1])
+                .and_then(|_| server_txn.commit())
+                .is_ok());
+        }
+
+        // Setup the anonymous login
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        assert_eq!(
+            anon_t.effective_session,
+            LdapSession::UnixBind(UUID_ANONYMOUS)
+        );
+
+        // Searching a malformed spn shouldn't cause the query to fail
+        let sr = SearchRequest {
+            msgid: 1,
+            base: format!("dc=example,dc=com"),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Or(vec![
+                LdapFilter::Equality(Attribute::Name.to_string(), usr_name.to_string()),
+                LdapFilter::Equality(Attribute::Spn.to_string(), usr_name.to_string()),
+            ]),
+            attrs: vec!["*".to_string()],
+        };
+
+        let result = ldaps
+            .do_search(idms, &sr, &anon_t, Source::Internal)
+            .await
+            .unwrap();
+
+        assert!(!result.is_empty());
+
+        let sr = SearchRequest {
+            msgid: 1,
+            base: format!("dc=example,dc=com"),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::And(vec![
+                LdapFilter::Equality(Attribute::Name.to_string(), usr_name.to_string()),
+                LdapFilter::Equality(Attribute::Spn.to_string(), usr_name.to_string()),
+            ]),
+            attrs: vec!["*".to_string()],
+        };
+
+        let empty_result = ldaps
+            .do_search(idms, &sr, &anon_t, Source::Internal)
+            .await
+            .unwrap();
+
+        assert!(empty_result.is_empty());
     }
 
     #[idm_test]

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -89,7 +89,7 @@ pub mod prelude {
     };
     pub use crate::event::{CreateEvent, DeleteEvent, ExistsEvent, ModifyEvent, SearchEvent};
     pub use crate::filter::{
-        f_and, f_andnot, f_eq, f_id, f_inc, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub, Filter,
+        f_and, f_andnot, f_eq, f_id, f_inc, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub, f_invalid, Filter,
         FilterInvalid, FilterValid, FC,
     };
     pub use crate::idm::server::{IdmServer, IdmServerAudit, IdmServerDelayed};

--- a/server/lib/src/lib.rs
+++ b/server/lib/src/lib.rs
@@ -89,8 +89,8 @@ pub mod prelude {
     };
     pub use crate::event::{CreateEvent, DeleteEvent, ExistsEvent, ModifyEvent, SearchEvent};
     pub use crate::filter::{
-        f_and, f_andnot, f_eq, f_id, f_inc, f_lt, f_or, f_pres, f_self, f_spn_name, f_sub, f_invalid, Filter,
-        FilterInvalid, FilterValid, FC,
+        f_and, f_andnot, f_eq, f_id, f_inc, f_invalid, f_lt, f_or, f_pres, f_self, f_spn_name,
+        f_sub, Filter, FilterInvalid, FilterValid, FC,
     };
     pub use crate::idm::server::{IdmServer, IdmServerAudit, IdmServerDelayed};
     pub use crate::idm::{ClientAuthInfo, ClientCertInfo};


### PR DESCRIPTION
# Change summary

- Adding ability to provide non spn formatted ([user]@[host]) text when query ldap for the spn
- Adding some additional documentation / cleaning up

Fixes #3390

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
