### PR TITLE
20250205 3369 firefox pin

### DIFF
--- a/proto/src/internal/credupdate.rs
+++ b/proto/src/internal/credupdate.rs
@@ -160,6 +160,7 @@ pub enum CURegWarning {
     AttestedResidentKeyRequired,
     Unsatisfiable,
     WebauthnAttestationUnsatisfiable,
+    WebauthnUserVerificationRequired,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -380,11 +380,20 @@ pub(crate) async fn finish_passkey(
                 }
             };
 
-            let cu_status = state
+            let cu_result = state
                 .qe_r_ref
                 .handle_idmcredentialupdate(cu_session_token, cu_request, kopid.eventid)
-                .map_err(|op_err| HtmxError::new(&kopid, op_err, domain_info.clone()))
-                .await?;
+                .await;
+
+            let cu_status = match cu_result {
+                Ok(cu_status) => cu_status,
+                Err(OperationError::CU0003WebauthnUserNotVerified) => {
+                    todo!();
+                }
+                Err(op_err) => {
+                    Err(HtmxError::new(&kopid, op_err, domain_info.clone()))
+                }
+            };
 
             Ok(get_cu_partial_response(cu_status))
         }

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -391,7 +391,7 @@ pub(crate) async fn finish_passkey(
                     todo!();
                 }
                 Err(op_err) => {
-                    Err(HtmxError::new(&kopid, op_err, domain_info.clone()))
+                    return Err(HtmxError::new(&kopid, op_err, domain_info.clone()))
                 }
             };
 

--- a/server/core/templates/credentials_update_partial.html
+++ b/server/core/templates/credentials_update_partial.html
@@ -49,6 +49,9 @@
                 (% when CURegWarning::Unsatisfiable %)
                 An account policy conflict has occurred and you will not be able
                 to save your credentials.
+                (% when CURegWarning::WebauthnUserVerificationRequired %)
+                The passkey you attempted to register did not provide user verification. Please
+                ensure that you have a PIN or alternative configured on your authenticator.
                 (% endmatch %)
 
                 (% if is_danger %)
@@ -158,7 +161,7 @@
                                 type="submit"
                                 hx-post="/ui/api/cu_commit"
                                 hx-boost="false"
-                                (% if !warnings.is_empty() %)disabled(% endif
+                                (% if !can_commit %)disabled(% endif
                                 %)>Save Changes</button>
                         </span>
                     </div>

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -2155,11 +2155,11 @@ impl IdmServerCredUpdateTransaction<'_> {
         &self,
         cust: &CredentialUpdateSessionToken,
         ct: Duration,
-        label: String,
-        reg: &RegisterPublicKeyCredential,
+        _label: String,
+        _reg: &RegisterPublicKeyCredential,
     ) -> Result<CredentialUpdateSessionStatus, OperationError> {
         let session_handle = self.get_current_session(cust, ct)?;
-        let mut session = session_handle.try_lock().map_err(|_| {
+        let session = session_handle.try_lock().map_err(|_| {
             admin_error!("Session already locked, unable to proceed.");
             OperationError::InvalidState
         })?;
@@ -2171,7 +2171,9 @@ impl IdmServerCredUpdateTransaction<'_> {
         };
 
         match &session.mfaregstate {
-            MfaRegState::Passkey(_ccr, pk_reg) => {
+            MfaRegState::Passkey(_ccr, _pk_reg) => {
+                Err(OperationError::CU0003WebauthnUserNotVerified)
+                /*
                 let result = self
                     .webauthn
                     .finish_passkey_registration(reg, pk_reg)
@@ -2194,6 +2196,7 @@ impl IdmServerCredUpdateTransaction<'_> {
                 session.passkeys.insert(pk_id, (label, passkey));
 
                 Ok(session.deref().into())
+                */
             }
             invalid_state => {
                 warn!(?invalid_state);

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -2195,7 +2195,10 @@ impl IdmServerCredUpdateTransaction<'_> {
 
                 Ok(session.deref().into())
             }
-            _ => Err(OperationError::InvalidRequestState),
+            invalid_state => {
+                warn!(?invalid_state);
+                Err(OperationError::InvalidRequestState)
+            }
         }
     }
 

--- a/tools/cli/src/cli/lib.rs
+++ b/tools/cli/src/cli/lib.rs
@@ -74,7 +74,9 @@ pub(crate) fn handle_group_account_policy_error(response: ClientError, _output_m
     use kanidm_proto::internal::OperationError::SchemaViolation;
     use kanidm_proto::internal::SchemaError::AttributeNotValidForClass;
 
-    if let ClientError::Http(_status, Some(SchemaViolation(AttributeNotValidForClass(att))), opid) = response {
+    if let ClientError::Http(_status, Some(SchemaViolation(AttributeNotValidForClass(att))), opid) =
+        response
+    {
         error!("OperationId: {:?}", opid);
         error!("Cannot update account-policy attribute {att}. Is account-policy enabled on this group?");
     } else {

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -1282,6 +1282,11 @@ fn display_warnings(warnings: &[CURegWarning]) {
             CURegWarning::Unsatisfiable => {
                 println!("Account policy is unsatisfiable. Contact your administrator.");
             }
+            CURegWarning::WebauthnUserVerificationRequired => {
+                println!(
+                    "The passkey you attempted to register did not provide user verification."
+                );
+            }
         }
     }
 }

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -1284,7 +1284,7 @@ fn display_warnings(warnings: &[CURegWarning]) {
             }
             CURegWarning::WebauthnUserVerificationRequired => {
                 println!(
-                    "The passkey you attempted to register did not provide user verification."
+                    "The passkey you attempted to register did not provide user verification, please ensure a PIN or equivalent is set."
                 );
             }
         }


### PR DESCRIPTION
    Improve error message when passkey is missing PIN

    Firefox still doesn't support setting a PIN on new devices. Because
    of this we need a way to return a better error message for devices
    that don't have UV configured.

Fixes #3369

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
