### PR TITLE
TOTP label verification

### DIFF
--- a/proto/src/internal/credupdate.rs
+++ b/proto/src/internal/credupdate.rs
@@ -130,6 +130,7 @@ pub enum CURegState {
     None,
     TotpCheck(TotpSecret),
     TotpTryAgain,
+    TotpNameTryAgain(String),
     TotpInvalidSha1,
     BackupCodes(Vec<String>),
     Passkey(CreationChallengeResponse),

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -1396,6 +1396,14 @@ pub async fn credential_update_update(
             return Err(WebError::InternalServerError(errmsg));
         }
     };
+
+    if matches!(scr, CURequest::TotpVerify(_, ref label) if label.trim().is_empty()) {
+        // I'd really rather have a 400 here. Do I add a WebError::HttpError(u16, String)?
+        return Err(WebError::InternalServerError(
+            "Label must not be empty".into(),
+        ));
+    }
+
     let session_token = match serde_json::from_value(cubody[1].clone()) {
         Ok(val) => val,
         Err(err) => {
@@ -1406,6 +1414,7 @@ pub async fn credential_update_update(
     };
     debug!("session_token: {:?}", session_token);
     debug!("scr: {:?}", scr);
+
     state
         .qe_r_ref
         .handle_idmcredentialupdate(session_token, scr, kopid.eventid)

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -1397,13 +1397,6 @@ pub async fn credential_update_update(
         }
     };
 
-    if matches!(scr, CURequest::TotpVerify(_, ref label) if label.trim().is_empty()) {
-        // I'd really rather have a 400 here. Do I add a WebError::HttpError(u16, String)?
-        return Err(WebError::InternalServerError(
-            "Label must not be empty".into(),
-        ));
-    }
-
     let session_token = match serde_json::from_value(cubody[1].clone()) {
         Ok(val) => val,
         Err(err) => {

--- a/server/core/templates/credential_update_add_totp_partial.html
+++ b/server/core/templates/credential_update_add_totp_partial.html
@@ -19,7 +19,8 @@
             <label for="new-totp-name" class="form-label">Enter a name for your TOTP</label>
             <input
                     aria-describedby="totp-name-validation-feedback"
-                    class="form-control"
+                    class="form-control (%- if let Some(_) = check.taken_name -%)is-invalid(%- endif -%)
+                           (%- if check.bad_name -%)is-invalid(%- endif -%)"
                     name="name"
                     id="new-totp-name"
                     value="(( totp_name ))"
@@ -49,6 +50,18 @@
                 <div id="neq-totp-validation-feedback">
                     <ul>
                         <li>Incorrect TOTP code - Please try again</li>
+                    </ul>
+                </div>
+            (% else if check.bad_name %)
+                <div id="neq-totp-validation-feedback">
+                    <ul>
+                        <li>The name you provided was empty or blank. Please provide a proper name</li>
+                    </ul>
+                </div>
+            (% else if let Some(name) = check.taken_name %)
+                <div id="neq-totp-validation-feedback">
+                    <ul>
+                        <li>The name "((name))" is already taken, Please pick a different one</li>
                     </ul>
                 </div>
             (% endif %)

--- a/server/core/templates/credential_update_add_totp_partial.html
+++ b/server/core/templates/credential_update_add_totp_partial.html
@@ -61,7 +61,7 @@
             (% else if let Some(name) = check.taken_name %)
                 <div id="neq-totp-validation-feedback">
                     <ul>
-                        <li>The name "((name))" is already taken, Please pick a different one</li>
+                        <li>The name "((name))" is either invalid or already taken, Please pick a different one</li>
                     </ul>
                 </div>
             (% endif %)

--- a/server/lib/src/credential/mod.rs
+++ b/server/lib/src/credential/mod.rs
@@ -505,6 +505,15 @@ impl Credential {
         })
     }
 
+    //TODO: Add validation for securitykey label
+    #[allow(dead_code)]
+    pub(crate) fn has_securitykey_by_name(&self, label: &str) -> bool {
+        match &self.type_ {
+            CredentialType::PasswordMfa(_, _, wan, _) => wan.contains_key(label),
+            _ => false,
+        }
+    }
+
     #[allow(clippy::ptr_arg)]
     /// After a successful authentication with Webauthn, we need to advance the credentials
     /// counter value to prevent certain classes of replay attacks.
@@ -699,6 +708,13 @@ impl Credential {
             type_,
             // Rotate the credential id on any change to invalidate sessions.
             uuid: Uuid::new_v4(),
+        }
+    }
+
+    pub(crate) fn has_totp_by_name(&self, label: &str) -> bool {
+        match &self.type_ {
+            CredentialType::PasswordMfa(_, totp, _, _) => totp.contains_key(label),
+            _ => false,
         }
     }
 

--- a/server/lib/src/credential/mod.rs
+++ b/server/lib/src/credential/mod.rs
@@ -505,15 +505,6 @@ impl Credential {
         })
     }
 
-    //TODO: Add validation for securitykey label
-    #[allow(dead_code)]
-    pub(crate) fn has_securitykey_by_name(&self, label: &str) -> bool {
-        match &self.type_ {
-            CredentialType::PasswordMfa(_, _, wan, _) => wan.contains_key(label),
-            _ => false,
-        }
-    }
-
     #[allow(clippy::ptr_arg)]
     /// After a successful authentication with Webauthn, we need to advance the credentials
     /// counter value to prevent certain classes of replay attacks.

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -3391,30 +3391,39 @@ mod tests {
             .credential_primary_check_totp(&cust, ct, chal + 1, "totp")
             .expect("Failed to update the primary cred totp");
 
-        assert!(matches!(
-            c_status.mfaregstate,
-            MfaRegStateStatus::TotpTryAgain
-        ), "{:?}", c_status.mfaregstate);
+        assert!(
+            matches!(c_status.mfaregstate, MfaRegStateStatus::TotpTryAgain),
+            "{:?}",
+            c_status.mfaregstate
+        );
 
         // Check that the user actually put something into the label
         let c_status = cutxn
             .credential_primary_check_totp(&cust, ct, chal, "")
             .expect("Failed to update the primary cred totp");
 
-        assert!(matches!(
-            c_status.mfaregstate,
-            MfaRegStateStatus::TotpNameTryAgain(ref val) if val == ""
-        ), "{:?}", c_status.mfaregstate);
+        assert!(
+            matches!(
+                c_status.mfaregstate,
+                MfaRegStateStatus::TotpNameTryAgain(ref val) if val == ""
+            ),
+            "{:?}",
+            c_status.mfaregstate
+        );
 
         // Okay, Now they are trying to be smart...
         let c_status = cutxn
             .credential_primary_check_totp(&cust, ct, chal, "           ")
             .expect("Failed to update the primary cred totp");
 
-        assert!(matches!(
-            c_status.mfaregstate,
-            MfaRegStateStatus::TotpNameTryAgain(ref val) if val == "           "
-        ), "{:?}", c_status.mfaregstate);
+        assert!(
+            matches!(
+                c_status.mfaregstate,
+                MfaRegStateStatus::TotpNameTryAgain(ref val) if val == "           "
+            ),
+            "{:?}",
+            c_status.mfaregstate
+        );
 
         let c_status = cutxn
             .credential_primary_check_totp(&cust, ct, chal, "totp")
@@ -3448,10 +3457,14 @@ mod tests {
                 .credential_primary_check_totp(&cust, ct, chal, "totp")
                 .expect("Failed to update the primary cred totp");
 
-            assert!(matches!(
-                c_status.mfaregstate,
-                MfaRegStateStatus::TotpNameTryAgain(ref val) if val == "totp"
-            ), "{:?}", c_status.mfaregstate);
+            assert!(
+                matches!(
+                    c_status.mfaregstate,
+                    MfaRegStateStatus::TotpNameTryAgain(ref val) if val == "totp"
+                ),
+                "{:?}",
+                c_status.mfaregstate
+            );
 
             assert!(cutxn.credential_update_cancel_mfareg(&cust, ct).is_ok())
         }

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -831,6 +831,13 @@ async fn totp_enroll_prompt(session_token: &CUSessionToken, client: &KanidmClien
 
     let label: String = Input::new()
         .with_prompt("TOTP Label")
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if input.trim().is_empty() {
+                Err("Label cannot be empty")
+            } else {
+                Ok(())
+            }
+        })
         .interact_text()
         .expect("Failed to interact with interactive session");
 
@@ -917,6 +924,13 @@ async fn totp_enroll_prompt(session_token: &CUSessionToken, client: &KanidmClien
             }) => {
                 // Wrong code! Try again.
                 eprintln!("Incorrect TOTP code entered. Please try again.");
+                continue;
+            }
+            Ok(CUStatus {
+                mfaregstate: CURegState::TotpNameTryAgain(label),
+                ..
+            }) => {
+                eprintln!("{label} is either invalid or already taken. Please try again.");
                 continue;
             }
             Ok(CUStatus {


### PR DESCRIPTION
# Change summary

Adds the verification for TOTP Labels. Ensuring they are both not empty (or blank), as well as unique.

Fixes #2920

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
