### PR TITLE
Support redirect uris with query parameters

### DIFF
--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -264,7 +264,7 @@ impl AuthorisePermitSuccess {
             ResponseMode::Fragment => {
                 redirect_uri.set_query(None);
 
-                // We can't set query pairs on fragments, only query.
+                // Per [the RFC](https://www.rfc-editor.org/rfc/rfc6749#section-3.1.2), we can't set query pairs on fragment-containing redirects, only query ones.
                 let mut uri_builder = url::form_urlencoded::Serializer::new(String::new());
                 uri_builder.append_pair("code", &self.code);
                 if let Some(state) = self.state.as_ref() {


### PR DESCRIPTION
RFC 6749 once again reminds us that given the room to do silly things, RFC authors absolutely will. In this case, it's query parameters in redirection uris which are absolutely horrifying and yet, here we are.

We strictly match the query pairs during the redirection to ensure that if a query pair did allow open redirection, then we prevent it.

Fixes #3420

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
