### PR TITLE
Correct path to kanidm config example in documentation.

### DIFF
--- a/examples/kanidm-safe-default
+++ b/examples/kanidm-safe-default
@@ -1,5 +1,5 @@
 # Kanidm minimal Service Configuration - /etc/kanidm/config
-# For a full example and documentation, see /usr/share/kanidm/kanidm
+# For a full example and documentation, see /usr/share/kanidm/config
 # or `example/kanidm` in the source repository.
 
 # Replace this with your kanidmd URI and uncomment the line


### PR DESCRIPTION
# Change summary

The path to the example configuration is slightly incorrect in `/examples/kanidm-safe-default`, at least when deployed to Debian. Should be `/usr/share/kanidm/config` not `/usr/share/kanidm/kanidm`.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
