### PR TITLE
doc: fix formatting of URL table, remove Caddyfile instructions

### DIFF
--- a/book/src/integrations/oauth2.md
+++ b/book/src/integrations/oauth2.md
@@ -70,30 +70,21 @@ anything special for Kanidm (or another provider).
 **Note:** some apps automatically append `/.well-known/openid-configuration` to
 the end of an OIDC Discovery URL, so you may need to omit that.
 
+<dt>
 
-<dl>
-<dt>[Webfinger](https://datatracker.ietf.org/doc/html/rfc7033) URL</dt>
+[WebFinger](https://datatracker.ietf.org/doc/html/rfc7033) URL
+
+</dt>
 
 <dd>
 
 `https://idm.example.com/oauth2/openid/:client_id:/.well-known/webfinger`
 
-The webfinger URL is implemented for each OpenID client, under its specific endpoint, giving full control to the administrator regarding which to use.
+The WebFinger URL is implemented for each OpenID client, under its specific endpoint, giving full control to the administrator regarding which to use.
 
 To make this compliant with the standard, it must be made available under the correct [well-known endpoint](https://datatracker.ietf.org/doc/html/rfc7033#section-10.1) (e.g `example.com/.well-known/webfinger`), typically via a reverse proxy or similar. Kanidm doesn't currently provide a mechanism for this URI rewrite.
 
 One example would be dedicating one client as the "primary" or "default" and redirecting all requests to that. Alternatively, source IP or other request metadata could be used to decide which client to forward the request to.
-
-### Caddy
-`Caddyfile`
-```caddy
-# assuming a kanidm service with domain "example.com"
-example.com {
-  redir /.well-known/webfinger https://idm.example.com/oauth2/openid/:client_id:{uri} 307
-}
-```
-**Note:** the `{uri}` is important as it preserves the original request past the redirect.
-
 
 </dd>
 


### PR DESCRIPTION
# Change summary

Fixes broken formatting of OAuth2 URLs definition list:

<img width="811" alt="Screenshot 2025-02-19 at 10 24 38" src="https://github.com/user-attachments/assets/15f3cfdd-3c38-4593-aa03-05251dd85cf5" />

This also removes the `Caddyfile`-specific instructions for rewriting URLs, because it bloats the rest of the definition list.

I have some other thoughts about WebFinger – it makes a number of assumptions about OAuth2 / OpenID client configuration which don't hold true for Kanidm. But I will leave that for a later PR. 😄 

## Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
