### PR TITLE
build: Create daemon image from scratch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ kanidmd/sampledata
 Makefile
 target
 test.db
+Dockerfile

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -54,7 +54,7 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
         --release; \
     sccache -s
 
-# Find and copy dynalcially linked libraries using ldd
+# Find and copy dynamically linked libraries using ldd
 # caveat: this actually partially runs the binary, so it doesn't work for cross-compilation
 RUN <<EOF
     mkdir -p /out/libs

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -54,20 +54,43 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
         --release; \
     sccache -s
 
+# Find and copy dynalcially linked libraries using ldd
+# caveat: this actually partially runs the binary, so it doesn't work for cross-compilation
+RUN <<EOF
+    mkdir -p /out/libs
+    mkdir -p /out/libs-root
+    ldd /usr/src/kanidm/target/release/kanidmd
+    ldd /usr/src/kanidm/target/release/kanidmd | grep -v 'linux-vdso.so' | awk '{print $(NF-1) " " $1}' | sort -u -k 1,1 | awk '{print "install", "-D", $1, (($2 ~ /^\//) ? "/out/libs-root" $2 : "/out/libs/" $2)}' | xargs -I {} sh -c {}
+    ls -Rla /out/libs
+    ls -Rla /out/libs-root
+EOF
+
 # ======================
 
-FROM repos
-RUN \
-    --mount=type=cache,id=zypp,target=/var/cache/zypp \
-    zypper install -y \
-        timezone \
-        openssl-3 \
-        sqlite3 \
-        pam
+FROM scratch
 
-COPY --from=builder /usr/src/kanidm/target/release/kanidmd /sbin/
-COPY --from=builder /usr/src/kanidm/server/core/static /hpkg
-RUN chmod +x /sbin/kanidmd
+WORKDIR /
+
+# Copy root certs for tls into image
+# You can also mount the certs from the host
+# --volume /etc/ssl/certs:/etc/ssl/certs:ro
+COPY --from=repos /etc/ssl/certs /etc/ssl/certs
+
+# Copy our build
+COPY --from=builder --chmod=0755 /usr/src/kanidm/target/release/kanidmd /sbin/
+# Web assets
+COPY --from=builder /usr/src/kanidm/server/core/static /hpkg/
+
+# Copy fixed-path dynamic libraries to their position
+COPY --from=builder /out/libs-root/ /
+COPY --from=builder /out/libs/ /lib/
+
+# Inform loader where to find libraries
+# This is necessary because opensuse searches for libraries in /lib64 or /lib depending on the architecture, but we don't know which one we're on.
+# Alternatively, we could symlink /lib64 to /lib, and /usr/lib64 to /usr/lib, etc.
+# We could always fix this by invoking the loader on the host (which works in a cross build it seems), but this is easier.
+# On debian, it always searches for libraries in /lib.
+ENV LD_LIBRARY_PATH=/lib
 
 WORKDIR /data
 


### PR DESCRIPTION
# Change summary

The daemon's final image is now based on a scratch image. This moves the compressed size from 196.74 MB to 141.67 MB (the vast majority being the kanidmd binary)

This doesn't contain any special support for cross compilation, and it relies on ldd to detect dynamic library dependencies (which works by kind of pseudo-running the binary, and therefore doesn't work for non-emulated crossbuilds). 

#3380 pulled in [lddtree](https://github.com/messense/lddtree-rs), a rust CLI using goblin, which does work for cross-compilation, but isn't packaged anywhere. There are also shell scripts that use scanelf that work in a similar way. However, considering cross-compilation isn't a priority, this was simpler for now.

I've not touched the tools image or the Orca image, as they rely on the fido tool. After some thinking, I think that that should be built in its own docker image and then the final result from that should be copied into orca and tools - however, I'm not sure if that should live in this repo or the webauthn-rs repo.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
