### PR TITLE
Add crypt formats for password import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,10 +2978,12 @@ dependencies = [
  "hex",
  "kanidm-hsm-crypto",
  "kanidm_proto",
+ "md-5",
  "openssl",
  "openssl-sys",
  "rand",
  "serde",
+ "sha-crypt",
  "sha2",
  "sketching",
  "tracing",
@@ -3526,6 +3528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a42bf938e4c9a6ad581cf528d5606eb50c5458ac759ca23719291e2f6499bec"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ libsqlite3-sys = "^0.25.2"
 lodepng = "3.11.0"
 lru = "^0.12.5"
 mathru = "^0.13.0"
+md-5 = "0.10.6"
 mimalloc = "0.1.43"
 notify-debouncer-full = { version = "0.1" }
 num_enum = "^0.5.11"

--- a/libs/crypto/Cargo.toml
+++ b/libs/crypto/Cargo.toml
@@ -33,6 +33,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 x509-cert = { workspace = true, features = ["pem"] }
 
+md-5 = { workspace = true }
+sha-crypt = { workspace = true }
+
 [dev-dependencies]
 sketching = { workspace = true }
 

--- a/libs/crypto/src/crypt_md5.rs
+++ b/libs/crypto/src/crypt_md5.rs
@@ -1,0 +1,99 @@
+use md5::{Digest, Md5};
+use std::cmp::min;
+
+/// Maximium salt length.
+const MD5_MAGIC: &str = "$1$";
+const MD5_TRANSPOSE: &[u8] = b"\x0c\x06\x00\x0d\x07\x01\x0e\x08\x02\x0f\x09\x03\x05\x0a\x04\x0b";
+
+const CRYPT_HASH64: &[u8] = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+pub fn md5_sha2_hash64_encode(bs: &[u8]) -> String {
+    let ngroups = (bs.len() + 2) / 3;
+    let mut out = String::with_capacity(ngroups * 4);
+    for g in 0..ngroups {
+        let mut g_idx = g * 3;
+        let mut enc = 0u32;
+        for _ in 0..3 {
+            let b = (if g_idx < bs.len() { bs[g_idx] } else { 0 }) as u32;
+            enc >>= 8;
+            enc |= b << 16;
+            g_idx += 1;
+        }
+        for _ in 0..4 {
+            out.push(char::from_u32(CRYPT_HASH64[(enc & 0x3F) as usize] as u32).unwrap_or('!'));
+            enc >>= 6;
+        }
+    }
+    match bs.len() % 3 {
+        1 => {
+            out.pop();
+            out.pop();
+        }
+        2 => {
+            out.pop();
+        }
+        _ => (),
+    }
+    out
+}
+
+pub fn do_md5_crypt(pass: &[u8], salt: &[u8]) -> Vec<u8> {
+    let mut dgst_b = Md5::new();
+    dgst_b.update(pass);
+    dgst_b.update(salt);
+    dgst_b.update(pass);
+    let mut hash_b = dgst_b.finalize();
+
+    let mut dgst_a = Md5::new();
+    dgst_a.update(pass);
+    dgst_a.update(MD5_MAGIC.as_bytes());
+    dgst_a.update(salt);
+
+    let mut plen = pass.len();
+    while plen > 0 {
+        dgst_a.update(&hash_b[..min(plen, 16)]);
+        if plen < 16 {
+            break;
+        }
+        plen -= 16;
+    }
+
+    plen = pass.len();
+    while plen > 0 {
+        if plen & 1 == 0 {
+            dgst_a.update(&pass[..1])
+        } else {
+            dgst_a.update([0u8])
+        }
+        plen >>= 1;
+    }
+
+    let mut hash_a = dgst_a.finalize();
+
+    for r in 0..1000 {
+        let mut dgst_a = Md5::new();
+        if r % 2 == 1 {
+            dgst_a.update(pass);
+        } else {
+            dgst_a.update(hash_a);
+        }
+        if r % 3 > 0 {
+            dgst_a.update(salt);
+        }
+        if r % 7 > 0 {
+            dgst_a.update(pass);
+        }
+        if r % 2 == 0 {
+            dgst_a.update(pass);
+        } else {
+            dgst_a.update(hash_a);
+        }
+        hash_a = dgst_a.finalize();
+    }
+
+    for (i, &ti) in MD5_TRANSPOSE.iter().enumerate() {
+        hash_b[i] = hash_a[ti as usize];
+    }
+
+    md5_sha2_hash64_encode(&hash_b).into_bytes()
+}


### PR DESCRIPTION
Adds crypt md5, sha256 and sha512 allowing import of legacy credentials from external ldap servers.

Fixes #3457

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
