### PR TITLE
Chore: Add locked to build

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -41,7 +41,7 @@ jobs:
             libsystemd-dev
 
       - name: "Build the workspace"
-        run: cargo build --workspace
+        run: cargo build --locked --workspace
       - name: "Check disk space and size of target, then clean it"
         run: |
           df -h
@@ -89,7 +89,7 @@ jobs:
             libsystemd-dev
 
       - name: "Build the workspace"
-        run: cargo build --workspace
+        run: cargo build --locked --workspace
       - name: "Check disk space and size of target, then clean it"
         run: |
           df -h

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -31,6 +31,6 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.7
         with:
           version: "v0.4.2"
-      - run: cargo build -p kanidm_client -p kanidm_tools --bin kanidm
+      - run: cargo build --locked -p kanidm_client -p kanidm_tools --bin kanidm
       # yamllint disable-line rule:line-length
       - run: cargo test -p kanidm_client -p kanidm_tools

--- a/scripts/test_run_release_server.sh
+++ b/scripts/test_run_release_server.sh
@@ -11,7 +11,7 @@ WAIT_TIMER=5
 
 
 echo "Building release binaries..."
-cargo build --release --bin kanidm --bin kanidmd
+cargo build --locked --release --bin kanidm --bin kanidmd
 
 if [ -d '.git' ]; then
     echo "You're in the root dir, let's move you!"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
     export SCCACHE_DIR=/sccache && \
     export RUSTC_WRAPPER=/usr/bin/sccache && \
     export CC="/usr/bin/clang" && \
-    cargo build -p daemon ${KANIDM_BUILD_OPTIONS} \
+    cargo build --locked -p daemon ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release; \

--- a/server/builder.sh
+++ b/server/builder.sh
@@ -20,7 +20,7 @@ echo $RUSTC_WRAPPER && \
 echo $RUSTFLAGS && \
 echo $CC && \
 cargo build \
-    --offline \
+    --frozen \
     --features=concread/simd_support,libsqlite3-sys/bundled \
     --release; \
 if [ "${SCCACHE_REDIS}" != "" ]; \

--- a/server/daemon/run_insecure_dev_server.sh
+++ b/server/daemon/run_insecure_dev_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -43,15 +43,15 @@ RUN \
     export SCCACHE_DIR=/sccache; \
     export RUSTC_WRAPPER=/usr/bin/sccache; \
     export CC="/usr/bin/clang"; \
-    cargo build -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
+    cargo build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \
-    cargo build -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
+    cargo build --locked -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \
-    cargo build -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
+    cargo build --locked -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \

--- a/tools/orca/Dockerfile
+++ b/tools/orca/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     export SCCACHE_DIR=/sccache; \
     export RUSTC_WRAPPER=/usr/bin/sccache; \
     export CC="/usr/bin/clang"; \
-    cargo build -p orca ${KANIDM_BUILD_OPTIONS} \
+    cargo build --locked -p orca ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \


### PR DESCRIPTION
# Change summary
Changes all CI/CD (and the release) builds to utilize `--locked`. This ensures that cargo won't automatically update the lock file and will instead exit with an error condition. This is to ensure that we know exactly what dependencies were included in which build rather than relying on every developer having run a build after updating dependencies (which we can assume but isn't guaranteed).

also changed the bang to `/bin/sh` since `/bin/bash` doesn't exist on nixos :(

Fixes: some theoretical issue that could happen in future

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
