### PR TITLE
Update traefik.md

### DIFF
--- a/book/src/examples/traefik.md
+++ b/book/src/examples/traefik.md
@@ -54,7 +54,6 @@ services:
       - traefik.http.routers.kanidm.entrypoints=websecure
       - traefik.http.routers.kanidm.rule=Host(`idm.example.com`)
       - traefik.http.routers.kanidm.service=kanidm
-      - traefik.http.serversTransports.kanidm.insecureSkipVerify=true
       - traefik.http.services.kanidm.loadbalancer.server.port=8443
       - traefik.http.services.kanidm.loadbalancer.server.scheme=https
 volumes:


### PR DESCRIPTION
Remove non-existent Traefik label config

# Change summary
- Removes misleading non-working Traefik config docker label from docs

Traefik logs show that no configs for serversTransports are picked up from docker
```
traefik-1  | 2025-03-13T03:47:03Z DBG github.com/traefik/traefik/v3/pkg/server/configurationwatcher.go:227 > Configuration received config={"http":{"routers":{"kanidm":{"entryPoints":["websecure"],"rule":"Host(`sso.deciph.red`)","service":"kanidm"}},"services":{"kanidm":{"loadBalancer":{"passHostHeader":true,"responseForwarding":{"flushInterval":"100ms"},"servers":[{"url":"https://172.20.0.2:8443"}]}}}},"tcp":{},"tls":{},"udp":{}} providerName=docker
```
It's also not in the traefik documentation: https://doc.traefik.io/traefik/routing/providers/docker/

Old issue mentioning that you need to define it in a file (traefik v2, but i think is still accurate) https://github.com/traefik/traefik/issues/7893




Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
