### PR TITLE
Update shell.nix to work with stable nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,13 @@
-{ pkgs ? import <nixpkgs> {} }:
-	let
-	overrides = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml));
+let
+	rust-overlay = (import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz"));
 in
-pkgs.mkShellNoCC rec {
+{ pkgs ? import <nixpkgs> { overlays = [ rust-overlay ]; } }:
+pkgs.mkShellNoCC {
 	# Kanidm dependencies
 	buildInputs = with pkgs; [
 		pkg-config
 		
-		cargo
-		rustc
+		(rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 
 		clang
 		llvmPackages.bintools
@@ -19,7 +18,6 @@ pkgs.mkShellNoCC rec {
 		linux-pam
 	];
 	
-	RUSTC_VERSION = overrides.toolchain.channel;
 	# https://github.com/rust-lang/rust-bindgen#environment-variables
 	LIBCLANG_PATH = pkgs.lib.makeLibraryPath [ pkgs.llvmPackages_latest.libclang.lib ];
 }


### PR DESCRIPTION
# Change summary

The existing shell.nix uses whatever versions of rustc and cargo are in the system nixpkgs. In the current stable nixpkgs version (24.11), this is rustc 1.82.0. Unfortunately, we depend on the `strict_provenance` feature, which was unstable before 1.84.0. (See: kanidm/concread#132)

This patch makes minimal changes to shell.nix to overlay nixpkgs with the rustc version defined in rust-toolchain.toml, enabling Kanidm to build locally on stable versions of NixOS.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
