### PR TITLE
implement notify-reload protocol correctly

### DIFF
--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -764,7 +764,7 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
                                                     #[cfg(target_os = "linux")]
                                                     {
                                 if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
-                                else {
+                               } else {
                                     error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
                                 };
                                                     let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading, monotonic_usec]);

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -737,82 +737,80 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
                             {
                                 let mut listener = sctx.subscribe();
                                 tokio::select! {
-                                                Ok(()) = tokio::signal::ctrl_c() => {
-                                                    break
-                                                }
-                                                Some(()) = async move {
-                                                    let sigterm = tokio::signal::unix::SignalKind::terminate();
-                                                    #[allow(clippy::unwrap_used)]
-                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                } => {
-                                                    break
-                                                }
-                                                Some(()) = async move {
-                                                    let sigterm = tokio::signal::unix::SignalKind::alarm();
-                                                    #[allow(clippy::unwrap_used)]
-                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                } => {
-                                                    // Ignore
-                                                }
-                                                Some(()) = async move {
-                                                    let sigterm = tokio::signal::unix::SignalKind::hangup();
-                                                    #[allow(clippy::unwrap_used)]
-                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                } => {
-                                                    // Reload TLS certificates
-                                                    // systemd has a special reload handler for this.
-                                                    #[cfg(target_os = "linux")]
-                                                    {
-                                if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
-                                } else {
-                                    error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
-                                };
-                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading, monotonic_usec]);
-                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reloading ...")]);
-                                                    }
+                                    Ok(()) = tokio::signal::ctrl_c() => {
+                                        break
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::terminate();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        break
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::alarm();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::hangup();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Reload TLS certificates
+                                        // systemd has a special reload handler for this.
+                                        #[cfg(target_os = "linux")]
+                                        {
+                                            if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
+                                                let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading, monotonic_usec]);
+                                                let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reloading ...")]);
+                                            } else {
+                                                error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
+                                            };
+                                        }
 
-                                                    sctx.tls_acceptor_reload().await;
+                                        sctx.tls_acceptor_reload().await;
 
-                                                    // Systemd freaks out if you send the ready state too fast after the
-                                                    // reload state and can kill Kanidmd as a result.
-                                                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                                        // Systemd freaks out if you send the ready state too fast after the
+                                        // reload state and can kill Kanidmd as a result.
+                                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-                                                    #[cfg(target_os = "linux")]
-                                                    {
-                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
-                                if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
-                                let _ =
-                                    sd_notify::notify(true, &[monotonic_usec]);
-                                } else {
-                                    error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
-                                };
-                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reload Success")]);
-                                                    }
+                                        #[cfg(target_os = "linux")]
+                                        {
+                                            if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
+                                                let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready, monotonic_usec]);
+                                                let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reload Success")]);
+                                            } else {
+                                                error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
+                                            };
+                                        }
 
-                                                    info!("Reload complete");
-                                                }
-                                                Some(()) = async move {
-                                                    let sigterm = tokio::signal::unix::SignalKind::user_defined1();
-                                                    #[allow(clippy::unwrap_used)]
-                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                } => {
-                                                    // Ignore
-                                                }
-                                                Some(()) = async move {
-                                                    let sigterm = tokio::signal::unix::SignalKind::user_defined2();
-                                                    #[allow(clippy::unwrap_used)]
-                                                    tokio::signal::unix::signal(sigterm).unwrap().recv().await
-                                                } => {
-                                                    // Ignore
-                                                }
-                                                // we got a message on thr broadcast from somewhere else
-                                                Ok(msg) = async move {
-                                                    listener.recv().await
-                                                } => {
-                                                    debug!("Main loop received message: {:?}", msg);
-                                                    break
-                                                }
-                                            }
+                                        info!("Reload complete");
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::user_defined1();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    Some(()) = async move {
+                                        let sigterm = tokio::signal::unix::SignalKind::user_defined2();
+                                        #[allow(clippy::unwrap_used)]
+                                        tokio::signal::unix::signal(sigterm).unwrap().recv().await
+                                    } => {
+                                        // Ignore
+                                    }
+                                    // we got a message on thr broadcast from somewhere else
+                                    Ok(msg) = async move {
+                                        listener.recv().await
+                                    } => {
+                                        debug!("Main loop received message: {:?}", msg);
+                                        break
+                                    }
+                                }
                             }
                             #[cfg(target_family = "windows")]
                             {

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -764,7 +764,7 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
                                                     #[cfg(target_os = "linux")]
                                                     {
                                 if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
-                               } else {
+                                } else {
                                     error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
                                 };
                                                     let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading, monotonic_usec]);

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -724,14 +724,6 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
                 #[cfg(target_os = "linux")]
                 {
                     let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
-                    // Undocumented systemd feature - all messages should have a monotonic usec sent
-                    // with them. In some cases like "reloading" messages, it is undocumented but
-                    // failure to send this message causes the reload to fail.
-                    if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
-                        let _ = sd_notify::notify(true, &[monotonic_usec]);
-                    } else {
-                        error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
-                    };
                     let _ = sd_notify::notify(
                         true,
                         &[sd_notify::NotifyState::Status("Started Kanidm 🦀")],
@@ -771,15 +763,11 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
                                                     // systemd has a special reload handler for this.
                                                     #[cfg(target_os = "linux")]
                                                     {
-                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading]);
-                                                    // CRITICAL - if you do not send a monotonic usec message after a reloading
-                                                    // message, your service WILL BE KILLED.
                                 if let Ok(monotonic_usec) = sd_notify::NotifyState::monotonic_usec_now() {
-                                let _ =
-                                    sd_notify::notify(true, &[monotonic_usec]);
-                                } else {
+                                else {
                                     error!("CRITICAL!!! Unable to access clock monotonic time. SYSTEMD WILL KILL US.");
                                 };
+                                                    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Reloading, monotonic_usec]);
                                                     let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Status("Reloading ...")]);
                                                     }
 


### PR DESCRIPTION
I edited this in my browser.  The indentation of this file looks really broken. not sure why

# Change summary
See https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html

which now has a full python  and C example of the wire protocol

You should be setting `MONOTONIC_TIMESTAMP` in the same message as `RELOADING=1` not separate message


so:


```
sd_notify("RELOADING=1\nMONOTONIC_TIMESTAMP=xxxx")
sleep(5)
sd_notify("READY=1")
```

as opposed to what you're doing now:

```
sd_notify("RELOADING=1")
sd_notify("MONOTONIC_TIMESTAMP=xxxx")
sleep(5)
sd_notify("READY=1")
sd_notify("MONOTONIC_TIMESTAMP=xxxx")
```


Fixes maybe #3534 

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
