### PR TITLE
docs: document how to configure oauth2 for opkssh

### DIFF
--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -660,16 +660,7 @@ To set up OPKSSH to authenticate with Kanidm:
     kanidm system oauth2 update-scope-map opkssh opkssh_users email openid profile groups
     ```
 
-4. OPKSSH currently only supports `RS256` based signatures, so we need to enable
-    support for this algorithm in the client:
-
-    ```sh
-    kanidm system oauth2 warning-enable-legacy-crypto opkssh
-    ```
-
-    ES256 support is tracked [here](https://github.com/openpubkey/opkssh/issues/131).
-
-5. On the SSH server side, as per [offical docs](https://github.com/openpubkey/opkssh?tab=readme-ov-file#server-configuration-1):
+4. On the SSH server side, as per [offical docs](https://github.com/openpubkey/opkssh?tab=readme-ov-file#server-configuration-1):
 
     ```sh
     wget -qO- "https://raw.githubusercontent.com/openpubkey/opkssh/main/scripts/install-linux.sh" | sudo bash
@@ -678,11 +669,11 @@ To set up OPKSSH to authenticate with Kanidm:
     sudo opkssh add user alice@example.com https://idm.example.com/oauth2/openid/opkssh
     ```
 
-6. On the SSH client side, as per [official docs](https://github.com/openpubkey/opkssh?tab=readme-ov-file#custom-openid-providers-authentik-authelia-keycloak-zitadel):
+5. On the SSH client side, as per [official docs](https://github.com/openpubkey/opkssh?tab=readme-ov-file#custom-openid-providers-authentik-authelia-keycloak-zitadel):
 
     ```sh
     # Install OPKSSH
-    curl -LO https://github.com/openpubkey/opkssh/releases/download/v0.4.0/opkssh-linux-amd64
+    curl -LO https://github.com/openpubkey/opkssh/releases/download/v0.5.1/opkssh-linux-amd64
     sudo install opkssh-linux-amd64 /usr/local/bin/opkssh
     rm opkssh-linux-amd64
 
@@ -690,7 +681,7 @@ To set up OPKSSH to authenticate with Kanidm:
     opkssh login --provider=https://idm.example.com/oauth2/openid/opkssh,opkssh
     ```
 
-7. Use SSH as you would normally:
+6. Use SSH as you would normally:
 
     ```sh
     ssh user@your-server-hostname

--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -660,24 +660,18 @@ To set up OPKSSH to authenticate with Kanidm:
     kanidm system oauth2 update-scope-map opkssh opkssh_users email openid profile groups
     ```
 
-4. On the SSH server side, as per [offical docs](https://github.com/openpubkey/opkssh?tab=readme-ov-file#server-configuration-1):
+4. On the SSH server side, [install opkssh](https://github.com/openpubkey/opkssh#installing-on-a-server)
+    and allow your user to connect via:
 
     ```sh
-    wget -qO- "https://raw.githubusercontent.com/openpubkey/opkssh/main/scripts/install-linux.sh" | sudo bash
-    echo "https://idm.example.com/oauth2/openid/opkssh opkssh 24h" | sudo tee -a /etc/opk/providers
     # where 'user' is the linux user
     sudo opkssh add user alice@example.com https://idm.example.com/oauth2/openid/opkssh
     ```
 
-5. On the SSH client side, as per [official docs](https://github.com/openpubkey/opkssh?tab=readme-ov-file#custom-openid-providers-authentik-authelia-keycloak-zitadel):
+5. On the SSH client side, [install opkssh](https://github.com/openpubkey/opkssh#getting-started)
+    and login via Kanidm:
 
     ```sh
-    # Install OPKSSH
-    curl -LO https://github.com/openpubkey/opkssh/releases/download/v0.5.1/opkssh-linux-amd64
-    sudo install opkssh-linux-amd64 /usr/local/bin/opkssh
-    rm opkssh-linux-amd64
-
-    # This will open a browser to login via Kanidm
     opkssh login --provider=https://idm.example.com/oauth2/openid/opkssh,opkssh
     ```
 

--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -618,10 +618,10 @@ client_secret = "<SECRET>"
 ## OPKSSH
 
 [OPKSSH](https://github.com/openpubkey/opkssh) is a tool of the
-[OpenPubkey](https://github.com/openpubkey/openpubkey) project. It enables ssh
-to be used with OpenID Connect allowing SSH access to be managed via identities
-like alice@example.com instead of long-lived SSH keys. It does not replace SSH,
-but instead generates SSH keys on the fly, and augments the verification process
+[OpenPubkey](https://github.com/openpubkey/openpubkey) project. It enables SSH
+to be used with OpenID Connect allowing access to be managed via identities
+like `alice@example.com` instead of long-lived private keys. It does not replace SSH,
+but instead generates private keys on the fly, and augments the verification process
 on the server side.
 
 To set up OPKSSH to authenticate with Kanidm:
@@ -645,7 +645,7 @@ To set up OPKSSH to authenticate with Kanidm:
     the redirect URL, and scope access to the `opkssh_users` group:
 
     ```sh
-    # The last argument, the origin parameter, is required, but a dead link.
+    # The redirect origin is set to localhost for local callbacks
     kanidm system oauth2 create-public opkssh opkssh http://localhost:3000
 
     # Add the specific redirect URIs used by OPKSSH
@@ -677,7 +677,7 @@ To set up OPKSSH to authenticate with Kanidm:
     sudo install opkssh-linux-amd64 /usr/local/bin/opkssh
     rm opkssh-linux-amd64
 
-    # This will open a browser with consent screen
+    # This will open a browser to login via Kanidm
     opkssh login --provider=https://idm.example.com/oauth2/openid/opkssh,opkssh
     ```
 


### PR DESCRIPTION
# Change summary

- Document how to integrate [opkssh](https://github.com/openpubkey/opkssh)
- This would allow us to cross link to kanidm docs from https://github.com/openpubkey/opkssh/issues/130
- Based on the longer tutorial I have written on my [personal blog](https://blog.kammel.dev/post/opkssh/), happy to extend this PR with more content if interested, but it seems to fit other examples in scope quite nicely

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
