### PR TITLE
fix(web): Preserve SSH key content on form validation error

### DIFF
--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -121,6 +121,7 @@ struct SetUnixCredPartial {
 struct AddSshPublicKeyPartial {
     title_error: Option<String>,
     key_error: Option<String>,
+    key_value: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -902,6 +903,7 @@ pub(crate) async fn view_add_ssh_publickey(
             return Ok((AddSshPublicKeyPartial {
                 title_error: None,
                 key_error: None,
+                key_value: None,
             },)
                 .into_response());
         }
@@ -920,6 +922,7 @@ pub(crate) async fn view_add_ssh_publickey(
                 return Ok((AddSshPublicKeyPartial {
                     title_error: None,
                     key_error: Some("Key cannot be parsed".to_string()),
+                    key_value: Some(new_key.key),
                 },)
                     .into_response());
             }
@@ -965,6 +968,7 @@ pub(crate) async fn view_add_ssh_publickey(
         AddSshPublicKeyPartial {
             title_error,
             key_error,
+            key_value: Some(new_key.key),
         },
     )
         .into_response())

--- a/server/core/templates/credential_update_add_ssh_publickey_partial.html
+++ b/server/core/templates/credential_update_add_ssh_publickey_partial.html
@@ -16,7 +16,7 @@
             <textarea class="form-control(% if let Some(_) = key_error %) is-invalid(% endif %)" id="key-content" rows="5" name="key"
                 aria-describedby="key-validation-feedback"
                 placeholder="Begins with 'ssh-rsa', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-ed25519', 'sk-ecdsa-sha2-nistp256@openssh.com', or 'sk-ssh-ed25519@openssh.com'"
-            ></textarea>
+            >(% if let Some(key_value) = key_value %)(( key_value ))(% endif %)</textarea>
             <div id="key-validation-feedback" class="invalid-feedback">
                 (% if let Some(key_error) = key_error %)(( key_error ))(% endif %)
             </div>


### PR DESCRIPTION
## Issue Fixed

Closes #3570

#Description
When adding a new SSH public key via the web UI, if the user submitted the form without providing a title, the form would redisplay with a validation error, but the SSH key content previously entered would be lost. This required the user to re-paste their key.

This PR fixes the issue by:
1.  Modifying the `AddSshPublicKeyPartial` template context struct in `server/core/src/https/views/reset.rs` to include an optional `key_value` field.
2.  Updating the `view_add_ssh_publickey` handler function to populate this `key_value` field with the submitted key when returning the form due to a validation error (either invalid key format or missing/duplicate title).
3.  Updating the `credential_update_add_ssh_publickey_partial.html` template to render the content of `key_value` within the `<textarea>` if it's present.

Now, if the form submission fails due to a missing title or other validation error, the key content is preserved in the form, allowing the user to correct the error without needing to re-enter the key.
Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
#3570 