### PR TITLE
Add kanidm_ssh_authorizedkeys_direct to client deb

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -113,6 +113,11 @@ assets = [
         "755",
     ],
     [
+        "target/release/kanidm_ssh_authorizedkeys_direct",
+        "usr/bin/",
+        "755",
+    ],
+    [
         "../../examples/config",
         "usr/share/kanidm/",
         "444",


### PR DESCRIPTION
# Change summary

- Include the `kanidm_ssh_authorizedkeys_direct` binary in the client deb. This ensures consistency with other packages (suse, cargo, etc.).

Fixes #3584

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
