### PR TITLE
Fix std::fmt::Display for some objects

### DIFF
--- a/proto/src/v1/unix.rs
+++ b/proto/src/v1/unix.rs
@@ -49,10 +49,11 @@ pub struct UnixGroupToken {
 
 impl fmt::Display for UnixGroupToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[ spn: {}, ", self.spn)?;
-        write!(f, "gidnumber: {} ", self.gidnumber)?;
-        write!(f, "name: {}, ", self.name)?;
-        write!(f, "uuid: {} ]", self.uuid)
+        write!(
+            f,
+            "[ spn: {}, gidnumber: {}, name: {}, uuid: {} ]",
+            self.spn, self.gidnumber, self.name, self.uuid
+        )
     }
 }
 

--- a/proto/src/v1/unix.rs
+++ b/proto/src/v1/unix.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sshkey_attest::proto::PublicKey as SshPublicKey;
 use sshkeys::{KeyType, KeyTypeKind, PublicKeyKind};
-use std::fmt;
+use std::fmt::{self, Display};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -47,7 +47,7 @@ pub struct UnixGroupToken {
     pub gidnumber: u32,
 }
 
-impl fmt::Display for UnixGroupToken {
+impl Display for UnixGroupToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -80,7 +80,7 @@ pub struct UnixUserToken {
     pub valid: bool,
 }
 
-impl fmt::Display for UnixUserToken {
+impl Display for UnixUserToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "---")?;
         writeln!(f, "spn: {}", self.spn)?;

--- a/proto/src/v1/unix.rs
+++ b/proto/src/v1/unix.rs
@@ -87,6 +87,7 @@ impl fmt::Display for UnixUserToken {
         writeln!(f, "name: {}", self.name)?;
         writeln!(f, "displayname: {}", self.displayname)?;
         writeln!(f, "uuid: {}", self.uuid)?;
+        writeln!(f, "gidnumber: {}", self.gidnumber)?;
         match &self.shell {
             Some(s) => writeln!(f, "shell: {}", s)?,
             None => writeln!(f, "shell: <none>")?,


### PR DESCRIPTION
# Change summary

- fixed missing comma in UnixGroupToken
- missing gidnumber on display for UnixUserToken


Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
