### PR TITLE
Do not require instances to exist during optional config load

### DIFF
--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -383,7 +383,7 @@ impl KanidmClientBuilder {
 
                 // It's not an error if the instance isn't present, the build step
                 // will fail if there is insufficent information to proceed.
-                return Ok(self);
+                Ok(self)
             }
         } else {
             self.apply_config_options(config.default)

--- a/libs/client/src/lib.rs
+++ b/libs/client/src/lib.rs
@@ -375,12 +375,15 @@ impl KanidmClientBuilder {
             if let Some(instance_config) = config.instances.remove(instance_name) {
                 self.apply_config_options(instance_config)
             } else {
-                let emsg = format!(
-                    "instance {} does not exist in config file {:?}",
-                    instance_name, config_path
+                info!(
+                    "instance {} does not exist in config file {}",
+                    instance_name,
+                    config_path.as_ref().display()
                 );
-                error!(%emsg);
-                Err(ClientError::ConfigParseIssue(emsg))
+
+                // It's not an error if the instance isn't present, the build step
+                // will fail if there is insufficent information to proceed.
+                return Ok(self);
             }
         } else {
             self.apply_config_options(config.default)


### PR DESCRIPTION
We were incorrectly requiring every config file to have the named instance be present during configuration loading. This led to a situation where if /etc/kanidm/config didn't have a user configured instance from their ~/.config/kanidm, that the cli would fail to load.

Fixes #3589

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
