### PR TITLE
Resolve reload of oauth2 on startup

### DIFF
--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -114,8 +114,13 @@ async fn setup_qs_idms(
 
     // We generate a SINGLE idms only!
     let is_integration_test = config.integration_test_config.is_some();
-    let (idms, idms_delayed, idms_audit) =
-        IdmServer::new(query_server.clone(), &config.origin, is_integration_test).await?;
+    let (idms, idms_delayed, idms_audit) = IdmServer::new(
+        query_server.clone(),
+        &config.origin,
+        is_integration_test,
+        curtime,
+    )
+    .await?;
 
     Ok((query_server, idms, idms_delayed, idms_audit))
 }

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -525,6 +525,7 @@ impl Oauth2ResourceServers {
 }
 
 impl Oauth2ResourceServersWriteTransaction<'_> {
+    #[instrument(level = "debug", name = "oauth2::reload", skip_all)]
     pub fn reload(
         &mut self,
         value: Vec<Arc<EntrySealedCommitted>>,

--- a/server/lib/src/testkit.rs
+++ b/server/lib/src/testkit.rs
@@ -96,7 +96,12 @@ pub async fn setup_idm_test(
 ) -> (IdmServer, IdmServerDelayed, IdmServerAudit) {
     let qs = setup_test(config).await;
 
-    IdmServer::new(qs, "https://idm.example.com", true)
-        .await
-        .expect("Failed to setup idms")
+    IdmServer::new(
+        qs,
+        "https://idm.example.com",
+        true,
+        duration_from_epoch_now(),
+    )
+    .await
+    .expect("Failed to setup idms")
 }


### PR DESCRIPTION
# Change summary

As part of 1.6.0 we changed how we stored cryptographic keys related to OAuth2 clients. As part of this change, we had to modify the way in which we load OAuth2 client definitions from the DB into memory for clients. 

When you upgrade the server, everything "works" because the changes to all the cryptographic items triggers the oauth2 servers to reload. However, on subsequent restarts, OAuth2 clients would not load because there was no trigger to load them. 

This manually adds the trigger back in, rather than it being dependent on the other event triggers to load OAuth2 clients. 

Fixes #3598

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
