### PR TITLE
Uncomment section headers in example configs

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -87,7 +87,7 @@ origin = "https://idm.example.com:8443"
 #   format the information is provided in.
 #   Defaults to "none" (no trusted sources)
 #   Only one option can be used at a time.
-# [http_client_address_info]
+[http_client_address_info]
 # proxy-v2 = ["127.0.0.1"]
 #   # OR
 # x-forward-for = ["127.0.0.1"]
@@ -99,7 +99,7 @@ origin = "https://idm.example.com:8443"
 #   IPs which can supply this header information, and which
 #   format the information is provided in.
 #   Defaults to "none" (no trusted sources)
-# [ldap_client_address_info]
+[ldap_client_address_info]
 # proxy-v2 = ["127.0.0.1"]
 
 [online_backup]

--- a/examples/server_container.toml
+++ b/examples/server_container.toml
@@ -86,7 +86,7 @@ origin = "https://idm.example.com:8443"
 #   format the information is provided in.
 #   Defaults to "none" (no trusted sources)
 #   Only one option can be used at a time.
-# [http_client_address_info]
+[http_client_address_info]
 # proxy-v2 = ["127.0.0.1"]
 #   # OR
 # x-forward-for = ["127.0.0.1"]
@@ -98,7 +98,7 @@ origin = "https://idm.example.com:8443"
 #   IPs which can supply this header information, and which
 #   format the information is provided in.
 #   Defaults to "none" (no trusted sources)
-# [ldap_client_address_info]
+[ldap_client_address_info]
 # proxy-v2 = ["127.0.0.1"]
 
 [online_backup]


### PR DESCRIPTION
# Change summary

This PR uncomments the headers for the new http_client_address_info and ldap_client_address_info sections in the example configs.

This makes it easier for users to configure these settings by just uncommenting the `proxy-v2` or `x-forwarded-for` example settings.

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
