### PR TITLE
Proceed when config path is missing for environment

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -106,4 +106,4 @@ HEALTHCHECK \
     --retries=3 \
     CMD [ "/sbin/kanidmd", "healthcheck", "-c", "/data/server.toml"]
 
-CMD [ "/sbin/kanidmd", "server", "-c", "/data/server.toml"]
+CMD [ "/sbin/kanidmd", "server"]


### PR DESCRIPTION
# Change summary

When a configuration path is specified then the server will force it to be used, and will error if it can't be found. The container previously manually specified this path on the command line which forced the configuration to need to exist.

Remove the configuration from the docker cli, the default config path test will discover if the file exists or not and will correctly handle the flow when the file is absent and environment only configuration is used. 

Fixes #3617

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
