### PR TITLE
Move shadow processing out of task event loop

### DIFF
--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -4,7 +4,7 @@
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target suspend.target kanidm-unixd.service
-Requires=kanidm-unixd.service
+Wants=kanidm-unixd.service
 
 [Service]
 User=root

--- a/unix_integration/common/src/unix_passwd.rs
+++ b/unix_integration/common/src/unix_passwd.rs
@@ -7,14 +7,14 @@ use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct EtcDb {
     pub users: Vec<EtcUser>,
     pub shadow: Vec<EtcShadow>,
     pub groups: Vec<EtcGroup>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct EtcUser {
     pub name: String,
     pub password: String,
@@ -46,7 +46,7 @@ pub fn read_etc_passwd_file<P: AsRef<Path>>(path: P) -> Result<Vec<EtcUser>, Uni
     parse_etc_passwd(contents.as_slice()).map_err(|_| UnixIntegrationError)
 }
 
-#[derive(PartialEq, Default)]
+#[derive(PartialEq, Default, Clone)]
 pub enum CryptPw {
     Sha256(String),
     Sha512(String),
@@ -102,7 +102,7 @@ impl CryptPw {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct EtcShadow {
     pub name: String,
     #[serde_as(as = "serde_with::DisplayFromStr")]
@@ -153,7 +153,7 @@ pub fn read_etc_shadow_file<P: AsRef<Path>>(
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct EtcGroup {
     pub name: String,
     pub password: String,

--- a/unix_integration/resolver/debian/kanidm-unixd-tasks.service
+++ b/unix_integration/resolver/debian/kanidm-unixd-tasks.service
@@ -4,6 +4,7 @@
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
+Wants=kanidm-unixd.service
 
 [Service]
 User=root

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -38,6 +38,7 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tokio::net::UnixStream;
 use tokio::sync::broadcast;
+use tokio::sync::watch;
 use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 use tracing::instrument;
@@ -278,10 +279,32 @@ fn create_home_directory(
     Ok(())
 }
 
+async fn shadow_reload_task(
+    shadow_data_watch_tx: watch::Sender<EtcDb>,
+    mut shadow_broadcast_rx: broadcast::Receiver<bool>,
+) {
+    debug!("shadow reload task has started ...");
+
+    while let Ok(_) = shadow_broadcast_rx.recv().await {
+        match process_etc_passwd_group().await {
+            Ok(etc_db) => {
+                shadow_data_watch_tx.send_replace(etc_db);
+                debug!("shadow reload task sent");
+            }
+            Err(()) => {
+                error!("Unable to process etc db");
+                continue;
+            }
+        }
+    }
+
+    debug!("shadow reload task has stopped");
+}
+
 async fn handle_tasks(
     stream: UnixStream,
     ctl_broadcast_rx: &mut broadcast::Receiver<bool>,
-    shadow_broadcast_rx: &mut broadcast::Receiver<bool>,
+    shadow_data_watch_rx: &mut watch::Receiver<EtcDb>,
     cfg: &UnixdConfig,
 ) {
     let mut reqs = Framed::new(stream, TaskCodec::new());
@@ -325,23 +348,19 @@ async fn handle_tasks(
                     }
                 }
             }
-            _ = shadow_broadcast_rx.recv() => {
+            Ok(_) = shadow_data_watch_rx.changed() => {
                 debug!("Received shadow reload event.");
+                let etc_db: EtcDb = {
+                    let etc_db_ref = shadow_data_watch_rx.borrow_and_update();
+                    (*etc_db_ref).clone()
+                };
                 // process etc shadow and send it here.
-                match process_etc_passwd_group().await {
-                    Ok(etc_db) => {
-                        let resp = TaskResponse::NotifyShadowChange(etc_db);
-                        if let Err(err) = reqs.send(resp).await {
-                            error!(?err, "Unable to communicate to kanidm unixd");
-                            break;
-                        }
-                        debug!("Shadow reload OK!");
-                    }
-                    Err(()) => {
-                        error!("Unable to process etc db");
-                        continue
-                    }
+                let resp = TaskResponse::NotifyShadowChange(etc_db);
+                if let Err(err) = reqs.send(resp).await {
+                    error!(?err, "Unable to communicate to kanidm unixd");
+                    break;
                 }
+                debug!("Shadow reload OK!");
             }
         }
     }
@@ -524,12 +543,31 @@ async fn main() -> ExitCode {
 
             // This is to broadcast when we need to reload the shadow
             // files.
-            let (shadow_broadcast_tx, mut shadow_broadcast_rx) = broadcast::channel(4);
+            let (shadow_broadcast_tx, shadow_broadcast_rx) = broadcast::channel(4);
 
             let watcher = match setup_shadow_inotify_watcher(shadow_broadcast_tx.clone()) {
                 Ok(w) => w,
                 Err(exit) => return exit,
             };
+
+            // Setup the etcdb watch
+            let etc_db = match process_etc_passwd_group().await {
+                Ok(etc_db) => etc_db,
+                Err(err) => {
+                    warn!(?err, "unable to process /etc/passwd and related files.");
+                    // Return an empty set instead.
+                    EtcDb::default()
+                }
+            };
+
+            let (shadow_data_watch_tx, mut shadow_data_watch_rx) = watch::channel(etc_db);
+
+            let _shadow_task = tokio::spawn(async move {
+                shadow_reload_task(
+                    shadow_data_watch_tx, shadow_broadcast_rx
+                )
+            });
+
 
             let server = tokio::spawn(async move {
                 loop {
@@ -551,7 +589,7 @@ async fn main() -> ExitCode {
 
                                     // Yep! Now let the main handler do it's job.
                                     // If it returns (dc, etc, then we loop and try again).
-                                    handle_tasks(stream, &mut d_broadcast_rx, &mut shadow_broadcast_rx, &cfg).await;
+                                    handle_tasks(stream, &mut d_broadcast_rx, &mut shadow_data_watch_rx, &cfg).await;
                                     continue;
                                 }
                                 Err(e) => {

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -285,7 +285,7 @@ async fn shadow_reload_task(
 ) {
     debug!("shadow reload task has started ...");
 
-    while let Ok(_) = shadow_broadcast_rx.recv().await {
+    while shadow_broadcast_rx.recv().await.is_ok() {
         match process_etc_passwd_group().await {
             Ok(etc_db) => {
                 shadow_data_watch_tx.send_replace(etc_db);
@@ -568,7 +568,7 @@ async fn main() -> ExitCode {
             let _shadow_task = tokio::spawn(async move {
                 shadow_reload_task(
                     shadow_data_watch_tx, shadow_broadcast_rx
-                )
+                ).await
             });
 
             let server = tokio::spawn(async move {


### PR DESCRIPTION
# Change summary

As part of the recent unixd changes, we moved shadow processing to the privileged tasks daemon. In that move the handling of those files was moved into the event loop of the task handler itself, which could cause the daemon to become unresponsive for short or long periods, which then caused unixd to fail to make home directories.

This moves the shadow processing to a separate task, and only once it's ready the state flips and notifies the connected unixd caller. 

Fixes #3620

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
