### PR TITLE
fix: Improve unixd & unixd-tasks startup coupling

### DIFF
--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -4,7 +4,9 @@
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target suspend.target kanidm-unixd.service
-Wants=kanidm-unixd.service
+# This prevents starting unixd-tasks before unixd is running and
+# has created the socket necessary for communication.
+ConditionPathExists=/var/run/kanidm-unixd/task_sock
 
 [Service]
 User=root

--- a/platform/opensuse/kanidm-unixd-tasks.service
+++ b/platform/opensuse/kanidm-unixd-tasks.service
@@ -4,9 +4,12 @@
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target suspend.target kanidm-unixd.service
+
 # This prevents starting unixd-tasks before unixd is running and
 # has created the socket necessary for communication.
-ConditionPathExists=/var/run/kanidm-unixd/task_sock
+# We need the check so that fs namespacing used by`ReadWritePaths` has a 
+# strict enough target to namespace. Without the check it fails in a more confusing way.
+ConditionPathExists=/run/kanidm-unixd/task_sock
 
 [Service]
 User=root
@@ -16,7 +19,7 @@ ExecStart=/usr/sbin/kanidm_unixd_tasks
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 ProtectSystem=strict
-ReadWritePaths=/home /var/run/kanidm-unixd
+ReadWritePaths=/home /run/kanidm-unixd
 RestrictAddressFamilies=AF_UNIX
 NoNewPrivileges=true
 PrivateTmp=true
@@ -29,7 +32,3 @@ ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
 MemoryDenyWriteExecute=true
-
-[Install]
-WantedBy=multi-user.target
-

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -9,8 +9,9 @@ Wants=nss-user-lookup.target
 # While it seems confusing, we need to be after nscd.service so that the
 # Conflicts will trigger and then automatically stop it.
 Conflicts=nscd.service
-# Upholding ensures that unixd-tasks is not only started but kept running.
-# This allows for a repeatable & fast way of starting unixd-tasks at the right time.
+# `Upholds` like a `Wants` directive ensures that unixd-tasks is started but also 
+# ensures it's kept running. This allows for a repeatable & fast way of starting 
+# unixd-tasks at the right time.
 Upholds=kanidm-unixd-tasks.service
 
 [Service]

--- a/platform/opensuse/kanidm-unixd.service
+++ b/platform/opensuse/kanidm-unixd.service
@@ -1,4 +1,4 @@
-# You should not need to edit this file. Instead, use a drop-in file:
+# You should not need to edit this file. Instead, use a drop-in file by running:
 #   systemctl edit kanidm-unixd.service
 
 [Unit]
@@ -9,6 +9,9 @@ Wants=nss-user-lookup.target
 # While it seems confusing, we need to be after nscd.service so that the
 # Conflicts will trigger and then automatically stop it.
 Conflicts=nscd.service
+# Upholding ensures that unixd-tasks is not only started but kept running.
+# This allows for a repeatable & fast way of starting unixd-tasks at the right time.
+Upholds=kanidm-unixd-tasks.service
 
 [Service]
 DynamicUser=yes
@@ -18,12 +21,17 @@ CacheDirectory=kanidm-unixd
 RuntimeDirectory=kanidm-unixd
 StateDirectory=kanidm-unixd
 
+
 Type=notify
 ExecStart=/usr/sbin/kanidm_unixd
 
 ## If you wish to setup an external HSM pin you should set:
 # LoadCredential=hsmpin:/etc/kanidm/kanidm-unixd-hsm-pin
 # Environment=KANIDM_HSM_PIN_PATH=%d/hsmpin
+
+# auth going down is bad, but infinite speedlooping is worse
+Restart=always
+RestartSec=30
 
 # Implied by dynamic user.
 # ProtectHome=
@@ -37,7 +45,6 @@ PrivateTmp=true
 PrivateDevices=false
 # Older versions of systemd require this to be explicitly allowed.
 DeviceAllow=/dev/tpmrm0 rw
-
 ProtectHostname=true
 ProtectClock=true
 ProtectKernelTunables=true

--- a/server/daemon/debian/kanidmd.service
+++ b/server/daemon/debian/kanidmd.service
@@ -23,6 +23,11 @@ ExecStart=/usr/bin/kanidmd server
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
+# If OOM occurs, request a clean stop
+OOMPolicy=stop
+# Adjust our weight toward *not* being killed under pressure.
+OOMScoreAdjust=-100
+
 NoNewPrivileges=true
 PrivateTmp=true
 PrivateDevices=true

--- a/unix_integration/resolver/debian/kanidm-unixd-tasks.service
+++ b/unix_integration/resolver/debian/kanidm-unixd-tasks.service
@@ -3,18 +3,15 @@
 
 [Unit]
 Description=Kanidm Local Tasks
-After=chronyd.service ntpd.service network-online.target kanidm-unixd.service
-Wants=kanidm-unixd.service
+After=chronyd.service ntpd.service network-online.target suspend.target kanidm-unixd.service
+# This prevents starting unixd-tasks before unixd is running and
+# has created the socket necessary for communication.
+ConditionPathExists=/var/run/kanidm-unixd/task_sock
 
 [Service]
 User=root
 Type=notify
 ExecStart=/usr/sbin/kanidm_unixd_tasks
-
-# because kanidm-unixd might have failed for some reason but we need to try again later
-Restart=always
-RestartSec=30
-
 
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync

--- a/unix_integration/resolver/debian/kanidm-unixd-tasks.service
+++ b/unix_integration/resolver/debian/kanidm-unixd-tasks.service
@@ -4,9 +4,12 @@
 [Unit]
 Description=Kanidm Local Tasks
 After=chronyd.service ntpd.service network-online.target suspend.target kanidm-unixd.service
+
 # This prevents starting unixd-tasks before unixd is running and
 # has created the socket necessary for communication.
-ConditionPathExists=/var/run/kanidm-unixd/task_sock
+# We need the check so that fs namespacing used by`ReadWritePaths` has a 
+# strict enough target to namespace. Without the check it fails in a more confusing way.
+ConditionPathExists=/run/kanidm-unixd/task_sock
 
 [Service]
 User=root
@@ -16,7 +19,7 @@ ExecStart=/usr/sbin/kanidm_unixd_tasks
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 ProtectSystem=strict
-ReadWritePaths=/home /var/run/kanidm-unixd
+ReadWritePaths=/home /run/kanidm-unixd
 RestrictAddressFamilies=AF_UNIX
 NoNewPrivileges=true
 PrivateTmp=true
@@ -29,7 +32,3 @@ ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
 MemoryDenyWriteExecute=true
-
-[Install]
-WantedBy=multi-user.target
-

--- a/unix_integration/resolver/debian/kanidm-unixd.service
+++ b/unix_integration/resolver/debian/kanidm-unixd.service
@@ -3,12 +3,15 @@
 
 [Unit]
 Description=Kanidm Local Client Resolver
-After=chronyd.service nscd.service ntpd.service network-online.target
+After=chronyd.service nscd.service ntpd.service network-online.target suspend.target
 Before=systemd-user-sessions.service sshd.service nss-user-lookup.target
 Wants=nss-user-lookup.target
 # While it seems confusing, we need to be after nscd.service so that the
 # Conflicts will trigger and then automatically stop it.
 Conflicts=nscd.service
+# Upholding ensures that unixd-tasks is not only started but kept running.
+# This allows for a repeatable & fast way of starting unixd-tasks at the right time.
+Upholds=kanidm-unixd-tasks.service
 
 [Service]
 DynamicUser=yes
@@ -21,6 +24,11 @@ StateDirectory=kanidm-unixd
 
 Type=notify
 ExecStart=/usr/sbin/kanidm_unixd
+
+## If you wish to setup an external HSM pin you should set:
+# LoadCredential=hsmpin:/etc/kanidm/kanidm-unixd-hsm-pin
+# Environment=KANIDM_HSM_PIN_PATH=%d/hsmpin
+
 # auth going down is bad, but infinite speedlooping is worse
 Restart=always
 RestartSec=30

--- a/unix_integration/resolver/debian/kanidm-unixd.service
+++ b/unix_integration/resolver/debian/kanidm-unixd.service
@@ -9,8 +9,9 @@ Wants=nss-user-lookup.target
 # While it seems confusing, we need to be after nscd.service so that the
 # Conflicts will trigger and then automatically stop it.
 Conflicts=nscd.service
-# Upholding ensures that unixd-tasks is not only started but kept running.
-# This allows for a repeatable & fast way of starting unixd-tasks at the right time.
+# `Upholds` like a `Wants` directive ensures that unixd-tasks is started but also 
+# ensures it's kept running. This allows for a repeatable & fast way of starting 
+# unixd-tasks at the right time.
 Upholds=kanidm-unixd-tasks.service
 
 [Service]


### PR DESCRIPTION
# Change summary

Due to a complex interplay of the hardening present in both services, the unixd-tasks service fails to start on a systemd technicality if  unixd hasn't started first and created the /run/kanidm-unixd dir.

While previous methods probably should've achieved the correct result, practical testing time and time again proved that wasn't the case all the time and we had a race condition.

This change disallows unixd-tasks from starting if the requisite socket doesn't exist that unixd creates. In turn unixd ensures via an Upholds directive unixd-tasks is always running which provides a very  quick & controlled retry logic.

Related to and mitigates #3620

I'm leaving this as a draft because I still need to remove auto startup of the unixd-tasks service to avoid useless journal errors. And, I haven't tested this on SUSE, so that might be a good idea! I'll definitely have a go at it later.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
