### PR TITLE
Investigate and reduce memory consumption of unixd

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,8 +4,8 @@
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native", "-C", "force-frame-pointers=yes"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native", "-C", "force-frame-pointers=yes"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "bytes",
  "clap",
  "clap_complete",
+ "dhat",
  "dialoguer",
  "futures",
  "hashbrown 0.15.3",

--- a/unix_integration/resolver/Cargo.toml
+++ b/unix_integration/resolver/Cargo.toml
@@ -16,6 +16,8 @@ default = ["unix"]
 unix = []
 selinux = ["dep:selinux", "kanidm_unix_common/selinux"]
 tpm = ["kanidm-hsm-crypto/tpm", "kanidm_unix_common/tpm"]
+dhat-heap = ["dep:dhat"]
+dhat-ad-hoc = ["dep:dhat"]
 
 [[bin]]
 name = "kanidm_unixd"
@@ -56,6 +58,7 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 dialoguer = { workspace = true }
+dhat = { workspace = true, optional = true }
 futures = { workspace = true }
 hashbrown = { workspace = true }
 libc = { workspace = true }

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -563,7 +563,7 @@ async fn main() -> ExitCode {
     // We need enough backtrace depth to find leak sources if they exist.
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::builder()
-        .file_name(format!("/var/run/kanidm-unixd/heap-{}.json", std::process::id());)
+        .file_name(format!("/var/run/kanidm-unixd/heap-{}.json", std::process::id()))
         .trim_backtraces(Some(40))
         .build();
 

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -563,7 +563,10 @@ async fn main() -> ExitCode {
     // We need enough backtrace depth to find leak sources if they exist.
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::builder()
-        .file_name(format!("/var/cache/kanidm-unixd/heap-{}.json", std::process::id()))
+        .file_name(format!(
+            "/var/cache/kanidm-unixd/heap-{}.json",
+            std::process::id()
+        ))
         .trim_backtraces(Some(40))
         .build();
 

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -563,7 +563,7 @@ async fn main() -> ExitCode {
     // We need enough backtrace depth to find leak sources if they exist.
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::builder()
-        .file_name(format!("/var/run/kanidm-unixd/heap-{}.json", std::process::id()))
+        .file_name(format!("/var/cache/kanidm-unixd/heap-{}.json", std::process::id()))
         .trim_backtraces(Some(40))
         .build();
 

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -56,9 +56,13 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
-#[cfg(not(target_os = "illumos"))]
+#[cfg(not(any(feature = "dhat-heap", target_os = "illumos")))]
 #[global_allocator]
-static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
 
 //=== the codec
 
@@ -555,6 +559,10 @@ async fn main() -> ExitCode {
         error!(?code, "CRITICAL: Unable to set prctl flags");
         return ExitCode::FAILURE;
     }
+
+    // We need enough backtrace depth to find leak sources if they exist.
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::builder().trim_backtraces(Some(40)).build();
 
     let cuid = get_current_uid();
     let ceuid = get_effective_uid();

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -562,7 +562,10 @@ async fn main() -> ExitCode {
 
     // We need enough backtrace depth to find leak sources if they exist.
     #[cfg(feature = "dhat-heap")]
-    let _profiler = dhat::Profiler::builder().trim_backtraces(Some(40)).build();
+    let _profiler = dhat::Profiler::builder()
+        .file_name(format!("/var/run/kanidm-unixd/heap-{}.json", std::process::id());)
+        .trim_backtraces(Some(40))
+        .build();
 
     let cuid = get_current_uid();
     let ceuid = get_effective_uid();

--- a/unix_integration/resolver/src/db.rs
+++ b/unix_integration/resolver/src/db.rs
@@ -15,7 +15,7 @@ use kanidm_hsm_crypto::{LoadableHmacKey, LoadableMachineKey};
 const DBV_MAIN: &str = "main";
 // This is in *pages* for sqlite. The default page size is 4096 bytes. So to achieve
 // 32MB we need to divide by this.
-const CACHE_SIZE: usize = (32 * 1024 * 1024) / 4096;
+const CACHE_SIZE: usize = 32 * ((1024 * 1024) / 4096);
 
 #[async_trait]
 pub trait Cache {

--- a/unix_integration/resolver/src/db.rs
+++ b/unix_integration/resolver/src/db.rs
@@ -13,8 +13,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use kanidm_hsm_crypto::{LoadableHmacKey, LoadableMachineKey};
 
 const DBV_MAIN: &str = "main";
-// 10MB default to try to limit memory usage
-const CACHE_SIZE: usize = 10 * 1024 * 1024;
+// This is in *pages* for sqlite. The default page size is 4096 bytes. So to achieve
+// 32MB we need to divide by this.
+const CACHE_SIZE: usize = (32 * 1024 * 1024) / 4096;
 
 #[async_trait]
 pub trait Cache {

--- a/unix_integration/resolver/src/idprovider/kanidm.rs
+++ b/unix_integration/resolver/src/idprovider/kanidm.rs
@@ -89,6 +89,7 @@ impl KanidmProvider {
             })?;
 
         let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(250));
+        // let crypto_policy = CryptoPolicy::minimum();
 
         let pam_allow_groups = config.pam_allowed_login_groups.iter().cloned().collect();
 

--- a/unix_integration/resolver/src/idprovider/kanidm.rs
+++ b/unix_integration/resolver/src/idprovider/kanidm.rs
@@ -88,8 +88,8 @@ impl KanidmProvider {
                 IdpError::Tpm
             })?;
 
-        let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(250));
-        // let crypto_policy = CryptoPolicy::minimum();
+        // let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(250));
+        let crypto_policy = CryptoPolicy::minimum();
 
         let pam_allow_groups = config.pam_allowed_login_groups.iter().cloned().collect();
 

--- a/unix_integration/resolver/src/idprovider/kanidm.rs
+++ b/unix_integration/resolver/src/idprovider/kanidm.rs
@@ -88,8 +88,7 @@ impl KanidmProvider {
                 IdpError::Tpm
             })?;
 
-        // let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(250));
-        let crypto_policy = CryptoPolicy::minimum();
+        let crypto_policy = CryptoPolicy::time_target(Duration::from_millis(250));
 
         let pam_allow_groups = config.pam_allowed_login_groups.iter().cloned().collect();
 


### PR DESCRIPTION
# Change summary

It was noted by @tacerus that 1.6 unixd uses significantly more memory than previously. This integrates dhat to investigate why (and then fixes to come shortly).

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
