### PR TITLE
Swap bytes mut at buffer limits

### DIFF
--- a/server/core/src/repl/codec.rs
+++ b/server/core/src/repl/codec.rs
@@ -84,7 +84,7 @@ impl Encoder<SupplierResponse> for SupplierCodec {
 fn encode_length_checked_json<R: Serialize>(msg: R, dst: &mut BytesMut) -> Result<(), io::Error> {
     // If the outgoing buffer is empty AND greater than our allocation limit, we
     // want to attempt to free space.
-    if dst.len() == 0 && dst.capacity() >= CODEC_BYTESMUT_ALLOCATION_LIMIT {
+    if dst.is_empty() && dst.capacity() >= CODEC_BYTESMUT_ALLOCATION_LIMIT {
         dst.clear();
         let mut buf = BytesMut::with_capacity(CODEC_MIMIMUM_BYTESMUT_ALLOCATION);
         std::mem::swap(&mut buf, dst);

--- a/server/core/src/repl/codec.rs
+++ b/server/core/src/repl/codec.rs
@@ -6,7 +6,7 @@ use tokio_util::codec::{Decoder, Encoder};
 use kanidmd_lib::repl::proto::{ReplIncrementalContext, ReplRefreshContext, ReplRuvRange};
 
 // The minimum size of a buffer for the replication codec (1MB)
-pub const CODEC_MIMIMUM_BYTESMUT_ALLOCATION: usize = 1 * 1024 * 1024;
+pub const CODEC_MIMIMUM_BYTESMUT_ALLOCATION: usize = 1024 * 1024;
 // If the codec buffer exceeds this limit, then we swap the buffer
 // with a fresh one to prevent memory explosions.
 pub const CODEC_BYTESMUT_ALLOCATION_LIMIT: usize = 8 * 1024 * 1024;

--- a/server/core/src/repl/codec.rs
+++ b/server/core/src/repl/codec.rs
@@ -5,6 +5,12 @@ use tokio_util::codec::{Decoder, Encoder};
 
 use kanidmd_lib::repl::proto::{ReplIncrementalContext, ReplRefreshContext, ReplRuvRange};
 
+// The minimum size of a buffer for the replication codec (1MB)
+pub const CODEC_MIMIMUM_BYTESMUT_ALLOCATION: usize = 1 * 1024 * 1024;
+// If the codec buffer exceeds this limit, then we swap the buffer
+// with a fresh one to prevent memory explosions.
+pub const CODEC_BYTESMUT_ALLOCATION_LIMIT: usize = 8 * 1024 * 1024;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ConsumerRequest {
     Ping,
@@ -76,6 +82,14 @@ impl Encoder<SupplierResponse> for SupplierCodec {
 }
 
 fn encode_length_checked_json<R: Serialize>(msg: R, dst: &mut BytesMut) -> Result<(), io::Error> {
+    // If the outgoing buffer is empty AND greater than our allocation limit, we
+    // want to attempt to free space.
+    if dst.len() == 0 && dst.capacity() >= CODEC_BYTESMUT_ALLOCATION_LIMIT {
+        dst.clear();
+        let mut buf = BytesMut::with_capacity(CODEC_MIMIMUM_BYTESMUT_ALLOCATION);
+        std::mem::swap(&mut buf, dst);
+    }
+
     // First, if there is anything already in dst, we should split past it.
     let mut work = dst.split_off(dst.len());
 
@@ -176,6 +190,10 @@ fn decode_length_checked_json<T: DeserializeOwned>(
     // Trim to length.
     if src.len() as u64 == req_len {
         src.clear();
+        if src.capacity() >= CODEC_BYTESMUT_ALLOCATION_LIMIT {
+            let mut buf = BytesMut::with_capacity(CODEC_MIMIMUM_BYTESMUT_ALLOCATION);
+            std::mem::swap(&mut buf, src);
+        }
     } else {
         src.advance((8 + req_len) as usize);
     };

--- a/unix_integration/common/src/constants.rs
+++ b/unix_integration/common/src/constants.rs
@@ -28,4 +28,4 @@ pub const DEFAULT_SHELL_SEARCH_PATHS: &[&str] = &["/bin", "/usr/local/bin"];
 pub const CODEC_MIMIMUM_BYTESMUT_ALLOCATION: usize = 64;
 // If the codec buffer exceeds this limit, then we swap the buffer
 // with a fresh one to prevent memory explosions.
-pub const CODEC_BYTESMUT_ALLOCATION_LIMIT: usize = 1 * 1024 * 1024;
+pub const CODEC_BYTESMUT_ALLOCATION_LIMIT: usize = 1024 * 1024;

--- a/unix_integration/common/src/constants.rs
+++ b/unix_integration/common/src/constants.rs
@@ -23,3 +23,9 @@ pub const DEFAULT_SHELL_SEARCH_PATHS: &[&str] = &["/bin"];
 
 #[cfg(all(target_family = "unix", target_os = "freebsd"))]
 pub const DEFAULT_SHELL_SEARCH_PATHS: &[&str] = &["/bin", "/usr/local/bin"];
+
+// The minimum size of a buffer for the unix stream codec
+pub const CODEC_MIMIMUM_BYTESMUT_ALLOCATION: usize = 64;
+// If the codec buffer exceeds this limit, then we swap the buffer
+// with a fresh one to prevent memory explosions.
+pub const CODEC_BYTESMUT_ALLOCATION_LIMIT: usize = 1 * 1024 * 1024;


### PR DESCRIPTION
# Change summary

- tokio-util (codec) and bytes mut do NOT make it clear, that bytes mut NEVER SHRINKS and will eventually grow to 2x the size of the largest input you have been sent. This causes a huge explosion of memory on long lived connections, and especially when you have some protocol messages that are large while the rest are small.

Mostly this affects the *receive* side, in unixd and the server. In this situation, once we decode a message, if the buffer exceeds some capacity limit, then we swap the buffer with a new one (because the bytes mut devs made it clear there is no way to free memory in a bytes mut without doing a swap to a new struct). 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
