### PR TITLE
Make it clearer that the http address section is needed

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -90,6 +90,7 @@ origin = "https://idm.example.com:8443"
 # [http_client_address_info]
 # proxy-v2 = ["127.0.0.1", "127.0.0.0/8"]
 #   # OR
+# [http_client_address_info]
 # x-forward-for = ["127.0.0.1", "127.0.0.0/8"]
 
 #   LDAPS requests can be reverse proxied by a loadbalancer.

--- a/examples/server_container.toml
+++ b/examples/server_container.toml
@@ -89,6 +89,7 @@ origin = "https://idm.example.com:8443"
 # [http_client_address_info]
 # proxy-v2 = ["127.0.0.1", "127.0.0.0/8"]
 #   # OR
+# [http_client_address_info]
 # x-forward-for = ["127.0.0.1", "127.0.0.0/8"]
 
 #   LDAPS requests can be reverse proxied by a loadbalancer.


### PR DESCRIPTION

Fixes #3607

This makes it clear that the section header is required in the OR condition of the example configuration. 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
