### PR TITLE
doc(book): Add  option to Nextcloud Oauth2.0 example

### DIFF
--- a/book/src/integrations/oauth2/examples.md
+++ b/book/src/integrations/oauth2/examples.md
@@ -536,6 +536,7 @@ You may optionally choose to add:
 
 ```php
 'allow_user_to_change_display_name' => false,
+'allow_user_to_change_email' => false,
 'lost_password_link' => 'disabled',
 ```
 


### PR DESCRIPTION
# Change summary

This option was added in https://github.com/nextcloud/server/pull/51745 (by me) and separates whether a user can change their display name and their email. Before both were controlled by the single option. The default behavior of `allow_user_to_change_email` is to fall back to the behavior of `allow_user_to_change_display_name`, so there is no breaking change, but I still think it's nice for admins to be aware of it.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
