### PR TITLE
Dark mode improvements

### DIFF
--- a/libs/scim_proto/src/filter.rs
+++ b/libs/scim_proto/src/filter.rs
@@ -743,7 +743,10 @@ mod test {
         assert_eq!(
             scimfilter::parse(r#"name eq """#),
             Ok(ScimFilter::Equal(
-                AttrPath { a: "name".to_string(), s: None },
+                AttrPath {
+                    a: "name".to_string(),
+                    s: None
+                },
                 Value::String("".to_string())
             ))
         );

--- a/server/core/static/style.css
+++ b/server/core/static/style.css
@@ -1,6 +1,13 @@
 :root {
   --totp-width-and-height: 30px;
   --totp-stroke-width: 60px;
+  --navbar-colors-transition:
+    color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  --navbar-colors-transition: none;
 }
 
 html,
@@ -65,9 +72,11 @@ body {
 .navbar-toggle-icon {
   width: 30px;
   height: 30px;
+  transition: var(--navbar-colors-transition);
 }
 nav a.navbar-brand {
   color: var(--bs-navbar-color);
+  transition: var(--navbar-colors-transition);
 }
 
 .kanidm_logo {

--- a/server/core/static/style.css
+++ b/server/core/static/style.css
@@ -60,37 +60,14 @@ body {
 }
 
 /*
- * Personal Settings sidemenu
- */
-
-/*
  * Navbar
  */
-nav.kanidm_navbar {
-  background-color: var(--bs-navbar-brand-color);
+.navbar-toggler-icon {
+    width: 30px;
+    height: 30px;
 }
-
-nav a.navbar-brand,
-nav a.nav-link {
-  color: var(--bs-body-bg);
-}
-
-nav a.navbar-brand:hover,
-nav a.nav-link:hover {
-  color: var(--bs-secondary-bg);
-}
-
-/* Bootstrap v5.3.3 fixes for our inverted navbar */
-[data-bs-theme="dark"] nav span.navbar-toggler-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2833, 37, 41, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-}
-
-[data-bs-theme="light"] nav span.navbar-toggler-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28222, 222, 222, 0.9%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-}
-
-footer {
-  background-color: var(--bs-tertiary-bg);
+nav a.navbar-brand {
+    color: var(--bs-navbar-color);
 }
 
 .kanidm_logo {

--- a/server/core/static/style.css
+++ b/server/core/static/style.css
@@ -1,9 +1,8 @@
 :root {
   --totp-width-and-height: 30px;
   --totp-stroke-width: 60px;
-  --navbar-colors-transition:
-    color 0.15s ease-in-out, background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out;
+  --navbar-colors-transition: color 0.15s ease-in-out,
+    background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/server/core/static/style.css
+++ b/server/core/static/style.css
@@ -62,12 +62,12 @@ body {
 /*
  * Navbar
  */
-.navbar-toggler-icon {
-    width: 30px;
-    height: 30px;
+.navbar-toggle-icon {
+  width: 30px;
+  height: 30px;
 }
 nav a.navbar-brand {
-    color: var(--bs-navbar-color);
+  color: var(--bs-navbar-color);
 }
 
 .kanidm_logo {

--- a/server/core/templates/base.html
+++ b/server/core/templates/base.html
@@ -25,7 +25,7 @@
 	</head>
 	<body class="flex-column d-flex h-100">
 		(% block body %)(% endblock %)
-		<footer class="footer mt-auto py-3 bs-secondary-bg text-end">
+		<footer class="footer mt-auto py-3 bg-body-tertiary text-end">
 			<div class="container">
 				<span class="text-muted">Powered by <a
 						href="https://kanidm.com">Kanidm</a></span>

--- a/server/core/templates/base_htmx.html
+++ b/server/core/templates/base_htmx.html
@@ -30,7 +30,7 @@
 	<body hx-boost="true" class="flex-column d-flex h-100">
 		(% block nav %)(% endblock %)
 		(% block body %)(% endblock %)
-		<footer class="footer mt-auto py-3 bs-secondary-bg text-end">
+		<footer class="footer mt-auto py-3 bg-body-tertiary text-end">
 			<div class="container">
 				<span class="text-muted">Powered by <a
 						href="https://kanidm.com">Kanidm</a></span>

--- a/server/core/templates/credentials_update_partial.html
+++ b/server/core/templates/credentials_update_partial.html
@@ -172,13 +172,13 @@
             <p>There are no SSH keys associated with your account.</p>
             (% endif %)
             <div class="mt-3">
-                <button class="btn btn-primary" type="button" 
+                <button class="btn btn-primary" type="button"
                     hx-post="/ui/reset/add_ssh_publickey"
                     hx-target="#credentialUpdateDynamicSection">
                     Add SSH Key
                 </button>
             </div>
-            
+
             (% when CUCredState::DeleteOnly %)
             (% when CUCredState::AccessDeny %)
             (% when CUCredState::PolicyDeny %)
@@ -186,7 +186,7 @@
 
 
             <hr class="my-4" />
-            <div id="cred-update-commit-bar" class="toast bs-emphasis-color bs-secondary-bg">
+            <div id="cred-update-commit-bar" class="toast bs-emphasis-color bg-body-tertiary">
                 <div class="toast-body">
                     <span class="d-flex align-items-center">
                         <div>

--- a/server/core/templates/navbar.html
+++ b/server/core/templates/navbar.html
@@ -1,4 +1,4 @@
-<nav hx-boost="false" class="navbar navbar-expand-md kanidm_navbar mb-4">
+<nav hx-boost="false" class="navbar bg-body-tertiary navbar-expand-md mb-4">
     <div class="container-lg">
         <a class="navbar-brand d-flex align-items-center" href="/ui/apps">
             (% if navbar_ctx.domain_info.image().is_some() %)
@@ -13,11 +13,12 @@
         </a>
 
         <!-- this shows a button on mobile devices to open the menu-->
-        <button class="navbar-toggler" type="button"
+        <button class="navbar-toggler navbar-brand" type="button"
             data-bs-toggle="collapse" data-bs-target="#navbarCollapse"
             aria-controls="navbarCollapse" aria-expanded="false"
             aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
+            <svg class="navbar-toggler-icon" xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'>
+                <path stroke='currentColor' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>
         </button>
 
         <div class="collapse navbar-collapse" id="navbarCollapse">

--- a/server/core/templates/navbar.html
+++ b/server/core/templates/navbar.html
@@ -17,8 +17,8 @@
             data-bs-toggle="collapse" data-bs-target="#navbarCollapse"
             aria-controls="navbarCollapse" aria-expanded="false"
             aria-label="Toggle navigation">
-            <svg class="navbar-toggler-icon" xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'>
-                <path stroke='currentColor' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>
+            <svg class="navbar-toggle-icon" xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'>
+                <path stroke='currentColor' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>
         </button>
 
         <div class="collapse navbar-collapse" id="navbarCollapse">


### PR DESCRIPTION
# Change summary

- dark mode: header is now dark
- dark mode: save partial is now dark
![image](https://github.com/user-attachments/assets/b01af18f-fde7-4241-ab56-e4a627e30fbb)
- replaced some invalid classes with valid ones
- drastically simplified header css

Checklist

- [x ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)