### PR TITLE
Allow deferring spans in unixd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,11 +6177,10 @@ dependencies = [
 [[package]]
 name = "tracing-forest"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
+source = "git+https://github.com/Firstyear/tracing-forest.git?rev=a04c79e049ee31fcc6965091181a5e427196db9b#a04c79e049ee31fcc6965091181a5e427196db9b"
 dependencies = [
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,8 @@ sshkeys = { git = "https://github.com/Firstyear/rust-sshkeys.git", rev = "49cb53
 # as main is currently working to drop openssl and may need more work before
 # we commit to that change here.
 compact_jwt = { git = "https://github.com/Firstyear/compact-jwt.git", rev = "043976842773dd035fe394261347edeb644e3091" }
+# Allow deferring spans unless they have a child span
+tracing-forest = { git = "https://github.com/Firstyear/tracing-forest.git", rev = "a04c79e049ee31fcc6965091181a5e427196db9b" }
 
 [workspace.dependencies]
 kanidmd_core = { path = "./server/core", version = "=1.7.0-dev" }

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -275,7 +275,7 @@ async fn handle_client(
     drop(_enter);
 
     while let Some(Ok(req)) = reqs.next().await {
-        let span = span!(Level::INFO, "client request", uuid = %conn_id);
+        let span = span!(Level::INFO, "client request", uuid = %conn_id, defer = true);
         let _enter = span.enter();
 
         let resp = match req {


### PR DESCRIPTION
To prevent a lot of log noise, we can defer the parent span unless it has attached child events.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
