### PR TITLE
Update radius.md (Explain: NAS == Network Access Server)

### DIFF
--- a/book/src/integrations/radius.md
+++ b/book/src/integrations/radius.md
@@ -127,7 +127,7 @@ The configuration file (which you should mount at `/data/radius.toml`, or specif
 
 ## Moving to Production
 
-To expose this to a Wi-Fi infrastructure, add your AP in the configuration:
+To expose this to your infrastructure, add your Access Point (AP) or Network Access Server (NAS) in the configuration:
 
 ```toml
 radius_clients = [

--- a/book/src/integrations/radius.md
+++ b/book/src/integrations/radius.md
@@ -127,7 +127,7 @@ The configuration file (which you should mount at `/data/radius.toml`, or specif
 
 ## Moving to Production
 
-To expose this to a Wi-Fi infrastructure, add your NAS in the configuration:
+To expose this to a Wi-Fi infrastructure, add your AP in the configuration:
 
 ```toml
 radius_clients = [


### PR DESCRIPTION
# Change summary

- Change "NAS" to "AP" in chapter [10.4 >> Moving to Production](https://kanidm.github.io/kanidm/stable/integrations/radius.html#moving-to-production)

Fixes #

There was a typo telling users to add their NAS (Network Attached Storage) instead of their AP (Access Point) to the configuration.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
