### PR TITLE
Fix using wrong template when setting POSIX password (#3719)

### DIFF
--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -878,7 +878,7 @@ pub(crate) async fn view_set_unixcred(
         status,
         swapped_handler_trigger,
         HxPushUrl(Uri::from_static("/ui/reset/set_unixcred")),
-        AddPasswordPartial { check_res },
+        SetUnixCredPartial { check_res },
     )
         .into_response())
 }


### PR DESCRIPTION
# Change summary

After a failed attempt at setting the POSIX password (for instance due to the password being too short), the new attempt would actually add a new alternative password. This was due to the wrong template being sent as a response to the initial POST.

Fixes #3719 

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
