### PR TITLE
Add user facing SCIM pagination / sorting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,13 +13,11 @@ You can report a security vulnerability in two ways:
 - via email to our core team: [William](mailto:william@blackhats.net.au) and
   [James](mailto:james+kanidm@terminaloutcomes.com)
 
-If you have found an issue where you're not sure whether it is a "real security
-bug", please report it as a security bug. We can re-triage the issue as a
-regular issue if it turns out to not have security impacts.
+If you have found an issue where you're not sure whether it is a "real security bug", please report it as a security
+bug. We can re-triage the issue as a regular issue if it turns out to not have security impacts.
 
-We expect all reports to have been verified by a human before submission.
-Properly triaging and investigating all issues (not just security relevant)
-takes up time, and we are a volunteer-driven project.
+We expect all reports to have been verified by a human before submission. Properly triaging and investigating all issues
+(not just security relevant) takes up time, and we are a volunteer-driven project.
 
 We will endeavour to respond to your request as soon as possible.
 

--- a/book/src/developers/designs/scim_pagination.md
+++ b/book/src/developers/designs/scim_pagination.md
@@ -1,0 +1,94 @@
+# SCIM Pagination
+
+SCIM Pagination is important for Kanidm to limit the size of responses to clients, and to allow
+effecient UI's to exist that show results over multiple pages for large datasets (such as users)
+
+The default pagination in the [SCIM rfc](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.4)
+has many limitations in how we arrange the items, indexes and other details. The important limitation
+of this is related to access controls.
+
+[SCIM cursor based pagination](https://datatracker.ietf.org/doc/draft-ietf-scim-cursor-pagination/) is
+an alternative, but also has some issues that may prevent us being able to use it.
+
+To satisfy our requirements, we should implement virtual list views.
+
+## SCIM RFC Pagination Limitations
+
+The major limitation of the SCIM RFC pagination is related to *access controls*.
+
+Say that we have 100 users. Our request is only allowed to access a subset of these users, and should
+only be able to see a total of 50 users.
+
+When Kanidm queries our backend we get a candidate set that matches the filter, but to apply the access
+controls we actually need to fully load the entry in question and determine if it is or is not part
+of this result set.
+
+So this then raises a problem - how do we actually do this *effeciently*?. Since the RFC pagination
+only works based on startIndex relative to the final access control applied result set, when we go
+to the next page, we don't know as a server where to position the results to start.
+We may need to skip the first 5 entries due to access control, then another 10 which we can see, to
+position the cursor at index 10, before we can start to access the remaining entries. As we go further through
+the pages we would effectively need to check the access of the whole set in the end, just to access
+only a few entries at the end of the set.
+
+## SCIM Cursor Based Pagination
+
+Cursor Based Pagination works by adding a nextCursor and previousCursor value to any results that
+are return. This allows us to indicate the offset into the candidate result set.
+
+Lets say that our candidate set has the same 100 entries as before. We skip the first 5, and the next
+10 are returned. We then store the value 16 into the nextCurser. On the next request, Kanidm can skip
+the first 15 entries then start to apply access controls again from the 16th entry in the candidate
+set. This way we delay the scanning until that point. When we return the next results, we can list the
+previous page as previousCursor 0 (and the first 15 entries will be checked again), and the nextCursor
+at offset 28 (supposing we return 10 entries and skipped 2).
+
+Important here in this scheme is that the next and previous cursor values must be encrypted. This is
+because we don't want an external user to be able to determine how many entries they *can't* see. In some
+cases this could be used to determine the value of some attributes by repeatedly querying and bisecting to
+determine that something must exist between two values.
+
+This scheme also is good for security as we don't encode anything in the cursor that would allow a
+replay attack. If the user was to "go back" to the first page, and a new entry was added that now
+is valid within the first page, it would be rendered (and the nextCursor would show the now bumped
+entry). But were the person to replay a cursor that pointed later into the list, it won't reveal
+any new entries, all it can do is cause a number of entries to be skipped.
+
+The major limitation of this approach is you can't arbitrarily offset to a specific page of results.
+Where you can with the RFC Pagination, since the number of results is known ahead of time, in this
+method you only know that there are more pages, until they run out. For example, if someone wanted
+to skip to page 5, with 10 results per page, we would need to effectively scan and apply access controls
+of the first 40 entries to generate the correct cursor values for the request. While possible,
+
+Another issue/limitation is how we would calculate the number of totalResults. To calculate
+totalResults implies we applied access controls to all the affected entries, leaving us back at the start
+of this problem.
+
+## Virtual List Views
+
+Since security is the primary blocker to the former two implementations, the answer is to precompile the lists
+that the user can see. This way only users which are allowed to access the virtual list view are able to
+make the request, and we already know they have access to the attributes in question for the list view. These
+list views also satisfy another requirement - sorting.
+
+This also then removes the need for cursors since with a precompiled list, we can directly offset to any
+location in the list, since we already know that any value in that list is allowed to be accessed by the
+user.
+
+To maintain the ordering of these lists, each named list view would have a b+tree of values where the
+keys are inserted and sorted. After an update is completed, the b+tree (which is optimised for sorting)
+would be extracted to a vector (optimised for offset/scanning).
+
+This will require a new index type (sorting), a new access / vlv definition type that contains the
+query that can be used for listing.
+
+
+
+
+
+
+
+
+
+
+

--- a/book/src/developers/designs/scim_pagination.md
+++ b/book/src/developers/designs/scim_pagination.md
@@ -1,94 +1,85 @@
 # SCIM Pagination
 
-SCIM Pagination is important for Kanidm to limit the size of responses to clients, and to allow
-effecient UI's to exist that show results over multiple pages for large datasets (such as users)
+SCIM Pagination is important for Kanidm to limit the size of responses to clients, and to allow effecient UI's to exist
+that show results over multiple pages for large datasets (such as users)
 
-The default pagination in the [SCIM rfc](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.4)
-has many limitations in how we arrange the items, indexes and other details. The important limitation
-of this is related to access controls.
+The default pagination in the [SCIM rfc](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.4) has many limitations in
+how we arrange the items, indexes and other details. The important limitation of this is related to access controls.
 
-[SCIM cursor based pagination](https://datatracker.ietf.org/doc/draft-ietf-scim-cursor-pagination/) is
-an alternative, but also has some issues that may prevent us being able to use it.
+[SCIM cursor based pagination](https://datatracker.ietf.org/doc/draft-ietf-scim-cursor-pagination/) is an alternative,
+but also has some issues that may prevent us being able to use it.
 
 To satisfy our requirements, we should implement virtual list views.
 
 ## SCIM RFC Pagination Limitations
 
-The major limitation of the SCIM RFC pagination is related to *access controls*.
+The major limitation of the SCIM RFC pagination is related to _access controls_.
 
-Say that we have 100 users. Our request is only allowed to access a subset of these users, and should
-only be able to see a total of 50 users.
+Say that we have 100 users. Our request is only allowed to access a subset of these users, and should only be able to
+see a total of 50 users.
 
-When Kanidm queries our backend we get a candidate set that matches the filter, but to apply the access
-controls we actually need to fully load the entry in question and determine if it is or is not part
-of this result set.
+When Kanidm queries our backend we get a candidate set that matches the filter, but to apply the access controls we
+actually need to fully load the entry in question and determine if it is or is not part of this result set.
 
-So this then raises a problem - how do we actually do this *effeciently*?. Since the RFC pagination
-only works based on startIndex relative to the final access control applied result set, when we go
-to the next page, we don't know as a server where to position the results to start.
-We may need to skip the first 5 entries due to access control, then another 10 which we can see, to
-position the cursor at index 10, before we can start to access the remaining entries. As we go further through
-the pages we would effectively need to check the access of the whole set in the end, just to access
-only a few entries at the end of the set.
+So this then raises a problem - how do we actually do this _effeciently_?. Since the RFC pagination only works based on
+startIndex relative to the final access control applied result set, when we go to the next page, we don't know as a
+server where to position the results to start. We may need to skip the first 5 entries due to access control, then
+another 10 which we can see, to position the cursor at index 10, before we can start to access the remaining entries. As
+we go further through the pages we would effectively need to check the access of the whole set in the end, just to
+access only a few entries at the end of the set.
 
 ## SCIM Cursor Based Pagination
 
-Cursor Based Pagination works by adding a nextCursor and previousCursor value to any results that
-are return. This allows us to indicate the offset into the candidate result set.
+Cursor Based Pagination works by adding a nextCursor and previousCursor value to any results that are returned. This
+allows us to indicate the offset into the candidate result set, even without access controls being applied.
 
-Lets say that our candidate set has the same 100 entries as before. We skip the first 5, and the next
-10 are returned. We then store the value 16 into the nextCurser. On the next request, Kanidm can skip
-the first 15 entries then start to apply access controls again from the 16th entry in the candidate
-set. This way we delay the scanning until that point. When we return the next results, we can list the
-previous page as previousCursor 0 (and the first 15 entries will be checked again), and the nextCursor
-at offset 28 (supposing we return 10 entries and skipped 2).
+Lets say that our candidate set has the same 100 entries as before. We skip the first 5, and the next 10 are returned.
+We then store the value 16 into the nextCurser. On the next request, Kanidm can skip the first 15 entries then start to
+apply access controls again from the 16th entry in the candidate set. This way we delay the scanning until that point.
+When we return the next results, we can list the previous page as previousCursor 0 (and the first 15 entries will be
+checked again), and the nextCursor at offset 28 (supposing we return 10 entries and skipped 2).
 
-Important here in this scheme is that the next and previous cursor values must be encrypted. This is
-because we don't want an external user to be able to determine how many entries they *can't* see. In some
-cases this could be used to determine the value of some attributes by repeatedly querying and bisecting to
-determine that something must exist between two values.
+Important here in this scheme is that the next and previous cursor values must be encrypted. This is because we don't
+want an external user to be able to determine how many entries they _can't_ see. In some cases this could be used to
+determine the value of some attributes by repeatedly querying and bisecting to determine that something must exist
+between two values.
 
-This scheme also is good for security as we don't encode anything in the cursor that would allow a
-replay attack. If the user was to "go back" to the first page, and a new entry was added that now
-is valid within the first page, it would be rendered (and the nextCursor would show the now bumped
-entry). But were the person to replay a cursor that pointed later into the list, it won't reveal
-any new entries, all it can do is cause a number of entries to be skipped.
+This scheme also is good for security as we don't encode anything in the cursor that would allow a replay attack. If the
+user was to "go back" to the first page, and a new entry was added that now is valid within the first page, it would be
+rendered (and the nextCursor would show the now bumped entry). But were the person to replay a cursor that pointed later
+into the list, it won't reveal any new entries, all it can do is cause a number of entries to be skipped.
 
-The major limitation of this approach is you can't arbitrarily offset to a specific page of results.
-Where you can with the RFC Pagination, since the number of results is known ahead of time, in this
-method you only know that there are more pages, until they run out. For example, if someone wanted
-to skip to page 5, with 10 results per page, we would need to effectively scan and apply access controls
-of the first 40 entries to generate the correct cursor values for the request. While possible,
+The major limitation of this approach is you can't arbitrarily offset to a specific page of results. Where you can with
+the RFC Pagination, since the number of results is known ahead of time, in this method you only know that there are more
+pages, until they run out. For example, if someone wanted to skip to page 5, with 10 results per page, we would need to
+effectively scan and apply access controls of the first 40 entries to generate the correct cursor values for the
+request. While possible,
 
-Another issue/limitation is how we would calculate the number of totalResults. To calculate
-totalResults implies we applied access controls to all the affected entries, leaving us back at the start
-of this problem.
+Another issue/limitation is how we would calculate the number of totalResults. To calculate totalResults implies we
+applied access controls to all the affected entries, leaving us back at the start of this problem.
 
-## Virtual List Views
+## Virtual List Views / Pre Authentication
 
-Since security is the primary blocker to the former two implementations, the answer is to precompile the lists
-that the user can see. This way only users which are allowed to access the virtual list view are able to
-make the request, and we already know they have access to the attributes in question for the list view. These
-list views also satisfy another requirement - sorting.
+Since security is the primary blocker to the former two implementations, the answer is to precompile the lists that the
+user can see. This way only users which are allowed to access the virtual list view are able to make the request, and we
+already know they have access to the attributes in question for the list view. These list views also satisfy another
+requirement - sorting.
 
-This also then removes the need for cursors since with a precompiled list, we can directly offset to any
-location in the list, since we already know that any value in that list is allowed to be accessed by the
-user.
+This also then removes the need for cursors since with a precompiled list, we can directly offset to any location in the
+list, since we already know that any value in that list is allowed to be accessed by the user.
 
-To maintain the ordering of these lists, each named list view would have a b+tree of values where the
-keys are inserted and sorted. After an update is completed, the b+tree (which is optimised for sorting)
-would be extracted to a vector (optimised for offset/scanning).
+To maintain the ordering of these lists, each named list view would have a b+tree of values where the keys are inserted
+and sorted. After an update is completed, the b+tree (which is optimised for sorting) would be extracted to a vector
+(optimised for offset/scanning).
 
-This will require a new index type (sorting), a new access / vlv definition type that contains the
-query that can be used for listing.
+This will require a new index type (sorting), a new access / vlv definition type that contains the query that can be
+used for listing.
 
+In the case that a user makes a request where they don't have access to the list view _or_ they are making a query that
+does NOT have a list view associated, then the current search process will be taken with a simple sort / result
+truncate. Since we have an enforced set of limits on database results then in many cases, this limit window will be hit
+unless the result set is small. This way on small searches we will be able to page, but on large requests it will be
+denied due to limits.
 
-
-
-
-
-
-
-
-
-
+This also works well with our UiHint framework, where access to the VLV grants access to the listing pages for various
+types.

--- a/proto/src/internal/error.rs
+++ b/proto/src/internal/error.rs
@@ -216,6 +216,7 @@ pub enum OperationError {
     SC0026Utf8SyntaxInvalid,
     SC0027ClassSetInvalid,
     SC0028CreatedUuidsInvalid,
+    SC0029PaginationOutOfBounds,
     // Migration
     MG0001InvalidReMigrationLevel,
     MG0002RaiseDomainLevelExceedsMaximum,
@@ -559,6 +560,7 @@ impl OperationError {
             Self::SC0026Utf8SyntaxInvalid => Some("A SCIM Utf8 String Scope Map contained invalid syntax".into()),
             Self::SC0027ClassSetInvalid => Some("The internal set of class templates used in this create operation was invalid. THIS IS A BUG.".into()),
             Self::SC0028CreatedUuidsInvalid => Some("The internal create query did not return the set of created UUIDs. THIS IS A BUG".into()),
+            Self::SC0029PaginationOutOfBounds => Some("The requested range for pagination was out of bounds of the result set".into()),
 
             Self::UI0001ChallengeSerialisation => Some("The WebAuthn challenge was unable to be serialised.".into()),
             Self::UI0002InvalidState => Some("The credential update process returned an invalid state transition.".into()),

--- a/proto/src/scim_v1/client.rs
+++ b/proto/src/scim_v1/client.rs
@@ -10,6 +10,7 @@ use serde_with::OneOrMany;
 use serde_with::{base64, formats, serde_as, skip_serializing_none};
 use sshkey_attest::proto::PublicKey as SshPublicKey;
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU64;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use utoipa::ToSchema;
@@ -120,9 +121,12 @@ pub struct ScimEntryApplication {
 
 #[serde_as]
 #[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ScimListApplication {
     pub schemas: Vec<String>,
     pub total_results: u64,
+    pub items_per_page: Option<NonZeroU64>,
+    pub start_index: Option<NonZeroU64>,
     pub resources: Vec<ScimEntryApplication>,
 }
 

--- a/proto/src/scim_v1/server.rs
+++ b/proto/src/scim_v1/server.rs
@@ -7,6 +7,7 @@ use scim_proto::ScimEntryHeader;
 use serde::Serialize;
 use serde_with::{base64, formats, hex::Hex, serde_as, skip_serializing_none};
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU64;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use url::Url;
@@ -19,6 +20,7 @@ use uuid::Uuid;
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Debug, Clone, ToSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ScimEntryKanidm {
     #[serde(flatten)]
     pub header: ScimEntryHeader,
@@ -31,9 +33,12 @@ pub struct ScimEntryKanidm {
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Clone, Debug, Default)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ScimListResponse {
     pub schemas: Vec<String>,
     pub total_results: u64,
+    pub items_per_page: Option<NonZeroU64>,
+    pub start_index: Option<NonZeroU64>,
     pub resources: Vec<ScimEntryKanidm>,
 }
 
@@ -247,13 +252,14 @@ pub enum ScimValueKanidm {
     Integer(i64),
     Decimal(f64),
     String(String),
+
+    // Other strong outbound types.
     DateTime(#[serde_as(as = "Rfc3339")] OffsetDateTime),
     Reference(Url),
     Uuid(Uuid),
     EntryReference(ScimReference),
     EntryReferences(Vec<ScimReference>),
 
-    // Other strong outbound types.
     ArrayString(Vec<String>),
     ArrayDateTime(#[serde_as(as = "Vec<Rfc3339>")] Vec<OffsetDateTime>),
     ArrayUuid(Vec<Uuid>),

--- a/server/core/src/https/views/admin/groups.rs
+++ b/server/core/src/https/views/admin/groups.rs
@@ -142,6 +142,7 @@ pub async fn get_group_info(
             ScimEntryGetQuery {
                 attributes: Some(Vec::from(GROUP_ATTRIBUTES)),
                 ext_access_check: true,
+                ..Default::default()
             },
         )
         .await?;
@@ -169,20 +170,18 @@ async fn get_groups_info(
             ScimEntryGetQuery {
                 attributes: Some(Vec::from(GROUP_ATTRIBUTES)),
                 ext_access_check: true,
+                sort_by: Some(Attribute::Name),
+                ..Default::default()
             },
         )
         .await?;
 
-    // TODO: inefficient to sort here
-    let mut groups: Vec<_> = base
+    let groups: Vec<_> = base
         .resources
         .into_iter()
         // TODO: Filtering away unsuccessful entries may not be desired.
         .filter_map(scimentry_into_groupinfo)
         .collect();
-
-    groups.sort_by_key(|(sp, _)| sp.uuid);
-    groups.reverse();
 
     Ok(groups)
 }

--- a/server/core/src/https/views/admin/persons.rs
+++ b/server/core/src/https/views/admin/persons.rs
@@ -136,6 +136,7 @@ pub async fn get_person_info(
             ScimEntryGetQuery {
                 attributes: Some(Vec::from(PERSON_ATTRIBUTES)),
                 ext_access_check: true,
+                ..Default::default()
             },
         )
         .await?;
@@ -163,20 +164,18 @@ async fn get_persons_info(
             ScimEntryGetQuery {
                 attributes: Some(Vec::from(PERSON_ATTRIBUTES)),
                 ext_access_check: true,
+                sort_by: Some(Attribute::Name),
+                ..Default::default()
             },
         )
         .await?;
 
-    // TODO: inefficient to sort here
-    let mut persons: Vec<_> = base
+    let persons: Vec<_> = base
         .resources
         .into_iter()
         // TODO: Filtering away unsuccessful entries may not be desired.
         .filter_map(scimentry_into_personinfo)
         .collect();
-
-    persons.sort_by_key(|(sp, _)| sp.uuid);
-    persons.reverse();
 
     Ok(persons)
 }

--- a/server/lib/src/valueset/iname.rs
+++ b/server/lib/src/valueset/iname.rs
@@ -4,6 +4,7 @@ use crate::utils::trigraph_iter;
 use crate::valueset::ScimResolveStatus;
 use crate::valueset::{DbValueSetV2, ValueSet, ValueSetResolveStatus, ValueSetScimPut};
 use kanidm_proto::scim_v1::JsonValue;
+use std::cmp::Ordering;
 
 use std::collections::BTreeSet;
 
@@ -185,6 +186,15 @@ impl ValueSetT for ValueSetIname {
         } else {
             debug_assert!(false);
             false
+        }
+    }
+
+    fn cmp(&self, other: &ValueSet) -> Ordering {
+        if let Some(other) = other.as_iname_set() {
+            self.set.cmp(other)
+        } else {
+            debug_assert!(false);
+            Ordering::Equal
         }
     }
 

--- a/server/lib/src/valueset/mod.rs
+++ b/server/lib/src/valueset/mod.rs
@@ -20,6 +20,7 @@ use openssl::pkey::Private;
 use openssl::pkey::Public;
 use smolset::SmolSet;
 use sshkey_attest::proto::PublicKey as SshPublicKey;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use time::OffsetDateTime;
 use webauthn_rs::prelude::AttestationCaList;
@@ -154,6 +155,15 @@ pub trait ValueSetT: std::fmt::Debug + DynClone {
     fn to_value_iter(&self) -> Box<dyn Iterator<Item = Value> + '_>;
 
     fn equal(&self, other: &ValueSet) -> bool;
+
+    fn cmp(&self, _other: &ValueSet) -> Ordering {
+        // IMPORTANT - in the case we attempt to compare the ordering of two value sets
+        // that are different syntaxs or types, the CORRECT and reliable thing to do is
+        // report them as equal such that any sorting function wont rearrange the values.
+        error!("cmp should not be called on {:?}", self.syntax());
+        debug_assert!(false);
+        Ordering::Equal
+    }
 
     fn merge(&mut self, other: &ValueSet) -> Result<(), OperationError>;
 


### PR DESCRIPTION
This adds the user facing parts of SCIM pagination and sorting. Currently it's done in a very "simple" way, with sorting and truncating the result vector. This won't be the long term approach however, we need to add a proper set of listing and sorting indexes to the backend. But having some working tests is always good to show where we want to go with this.

Part of the problem is that sorting and pagination indexes are hard to do, so I need to think more about the best way to add them :)

# Change summary

-

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
