### PR TITLE
Fix for Failed to deserialize query: missing field 'state'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,9 +929,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_jwt"
-version = "0.5.2-dev"
+version = "0.5.3-dev"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeccfef8dafeba915e3d8f4a6dec2675f114fcd37b1a71a98ce87798599d709f"
+checksum = "23812e87894027686e22bc5b0940522315b1f0ba9347383cc41016ec0caf6c35"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ clap = { version = "4.5.40", features = ["derive", "env"] }
 clap_complete = "^4.5.54"
 # Forced by saffron/cron
 chrono = "^0.4.39"
-compact_jwt = "^0.5.2-dev"
+compact_jwt = "^0.5.3-dev"
 concread = "^0.5.5"
 cron = "0.15.0"
 crossbeam = "0.8.4"

--- a/proto/src/oauth2.rs
+++ b/proto/src/oauth2.rs
@@ -7,8 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::base64::{Base64, UrlSafe};
 use serde_with::formats::SpaceSeparator;
 use serde_with::{
-    formats, rust::deserialize_ignore_any, serde_as, skip_serializing_none, NoneAsEmptyString,
-    StringWithSeparator,
+    formats, rust::deserialize_ignore_any, serde_as, skip_serializing_none, StringWithSeparator,
 };
 use url::Url;
 use uuid::Uuid;
@@ -52,7 +51,6 @@ pub struct AuthorisationRequest {
     /// [OAuth 2.0 Multiple Response Type Encoding Practices: Response Modes](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes)
     pub response_mode: Option<ResponseMode>,
     pub client_id: String,
-    #[serde_as(as = "NoneAsEmptyString")]
     pub state: Option<String>,
     #[serde(flatten)]
     pub pkce_request: Option<PkceRequest>,

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -7443,7 +7443,7 @@ mod tests {
             client_id: "test_resource_server".to_string(),
             state: None,
             pkce_request: Some(PkceRequest {
-                code_challenge: code_challenge.into(),
+                code_challenge,
                 code_challenge_method: CodeChallengeMethod::S256,
             }),
             redirect_uri: Url::parse("https://demo.example.com/oauth2/result").unwrap(),

--- a/server/testkit/src/lib.rs
+++ b/server/testkit/src/lib.rs
@@ -39,6 +39,7 @@ pub const TEST_INTEGRATION_RS_GROUP_ALL: &str = "idm_all_accounts";
 pub const TEST_INTEGRATION_RS_DISPLAY: &str = "Test Integration";
 pub const TEST_INTEGRATION_RS_URL: &str = "https://demo.example.com";
 pub const TEST_INTEGRATION_RS_REDIRECT_URL: &str = "https://demo.example.com/oauth2/flow";
+pub const TEST_INTEGRATION_STATE_VALUE: &str = "KrabzRc0ol";
 
 pub use testkit_macros::test;
 use tracing::trace;

--- a/server/testkit/tests/testkit/ldap_basic.rs
+++ b/server/testkit/tests/testkit/ldap_basic.rs
@@ -166,12 +166,10 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     // Check removeal of app passwords
 
     // Delete the applications
-    let result = idm_admin_rsclient
+    idm_admin_rsclient
         .idm_application_delete(APPLICATION_1_NAME)
         .await
         .expect("Failed to delete the application");
-
-    debug!(?result);
 
     // Check that you can no longer bind.
 


### PR DESCRIPTION
Fixes #3724 and adds integration tests.

# Change summary

- the `serde_as::NoneAsEmptyString` thing was .. being weird. This makes it pass the state through without changing it in the response to the client, which matches what looks right.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
