### PR TITLE
fix typo in documentation: tls_path to tls_key

### DIFF
--- a/book/src/server_configuration.md
+++ b/book/src/server_configuration.md
@@ -17,7 +17,7 @@ docs page for your particular build.
 
 > [!WARNING]
 >
-> You MUST set the `domain`, `origin`, `tls_chain` and `tls_path` options via one method or the other, or the server
+> You MUST set the `domain`, `origin`, `tls_chain` and `tls_key` options via one method or the other, or the server
 > cannot start!
 
 The following is a commented example configuration.


### PR DESCRIPTION
# Change summary

- renamed the `tls_path` config variable referenced in the docs [here](https://kanidm.github.io/kanidm/stable/server_configuration.html) to `tls_key`.
  `tls_path` does not exist, `tls_key` exists and is required for service startup. https://github.com/kanidm/kanidm/blob/85ca751a9d50831090ed745bbf0e9587305e5f89/server/core/src/config.rs#L238


Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
