### PR TITLE
book: fix command example in pam_and_nsswitch.md

### DIFF
--- a/book/src/integrations/pam_and_nsswitch.md
+++ b/book/src/integrations/pam_and_nsswitch.md
@@ -118,7 +118,7 @@ testgroup:x:2439676479:testunix
 > [!HINT]
 >
 > Remember to also create a UNIX password with something like
-> `kanidm account posix set_password --name idm_admin demo_user`. Otherwise there will be no credential for the account
+> `kanidm person posix set-password --name idm_admin demo_user`. Otherwise there will be no credential for the account
 > to authenticate with.
 
 ## PAM


### PR DESCRIPTION
# Change summary

"kanidm account ..." doesn't exist and "... set_password" was changed to
"... set-password" in 2022/2023.

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
