### PR TITLE
Add ppc64le support for docker images

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native", "-C", "force-
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native", "-C", "force-frame-pointers=yes"]
+
+[target.powerpc64le-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Ctarget-cpu=native", "-C", "force-frame-pointers=yes"]

--- a/rlm_python/Dockerfile
+++ b/rlm_python/Dockerfile
@@ -55,11 +55,13 @@ RUN mkdir -p /pkg/pykanidm/
 COPY pykanidm/ /pkg/pykanidm/
 
 # install the package and its dependencies
-RUN python3 -m pip install \
+RUN zypper install -y gcc openssl-devel && \
+    python3 -m pip install \
     --break-system-packages \
     --no-cache-dir \
     --no-warn-script-location \
-    /pkg/pykanidm
+    /pkg/pykanidm && \
+    zypper remove -y gcc openssl-devel
 
 COPY rlm_python/radius_entrypoint.py /radius_entrypoint.py
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -22,6 +22,7 @@ RUN \
         sccache \
         cargo \
         clang \
+        cmake \
         gawk \
         make \
         automake \


### PR DESCRIPTION
# Change summary

This adds support for 64-bit little endian PowerPC in the Docker images. The `rlm_python` Dockerfile needs to explicitly install gcc and openssl-devel in order to build `cryptography` from source and the server needs cmake in order to compile `aws_lc_rs`. That aside, everything builds just fine (ignoring tools/orca, that doesn't build with the rust compiler used in the Dockerfile but unrelated to the architecture).

ppc64le is a very modern baseline and implies altivec support, so no special logic is required to detect or enable extra CPU features.

Answering the why?: I want to run kanidm on my ppc64le machine and since it's very little effort to support it, having official Docker images for ppc64le would be nice.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
