### PR TITLE
Groups WebUI, modify description

### DIFF
--- a/proto/src/scim_v1/server.rs
+++ b/proto/src/scim_v1/server.rs
@@ -30,6 +30,15 @@ pub struct ScimEntryKanidm {
     pub attrs: BTreeMap<Attribute, ScimValueKanidm>,
 }
 
+impl ScimEntryKanidm {
+    fn get_string_attr(&self, attr: &Attribute) -> Option<&String> {
+        self.attrs.get(attr).and_then(|v| match v {
+            ScimValueKanidm::String(s) => Some(s),
+            _ => None,
+        })
+    }
+}
+
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Clone, Debug, Default)]
@@ -300,39 +309,18 @@ impl TryFrom<ScimEntryKanidm> for ScimPerson {
     fn try_from(scim_entry: ScimEntryKanidm) -> Result<Self, Self::Error> {
         let uuid = scim_entry.header.id;
         let name = scim_entry
-            .attrs
-            .get(&Attribute::Name)
-            .and_then(|v| match v {
-                ScimValueKanidm::String(s) => Some(s.clone()),
-                _ => None,
-            })
+            .get_string_attr(&Attribute::Name)
+            .cloned()
             .ok_or(())?;
-
         let displayname = scim_entry
-            .attrs
-            .get(&Attribute::DisplayName)
-            .and_then(|v| match v {
-                ScimValueKanidm::String(s) => Some(s.clone()),
-                _ => None,
-            })
+            .get_string_attr(&Attribute::DisplayName)
+            .cloned()
             .ok_or(())?;
-
         let spn = scim_entry
-            .attrs
-            .get(&Attribute::Spn)
-            .and_then(|v| match v {
-                ScimValueKanidm::String(s) => Some(s.clone()),
-                _ => None,
-            })
+            .get_string_attr(&Attribute::Spn)
+            .cloned()
             .ok_or(())?;
-
-        let description = scim_entry
-            .attrs
-            .get(&Attribute::Description)
-            .and_then(|v| match v {
-                ScimValueKanidm::String(s) => Some(s.clone()),
-                _ => None,
-            });
+        let description = scim_entry.get_string_attr(&Attribute::Description).cloned();
 
         let mails = scim_entry
             .attrs
@@ -378,6 +366,7 @@ impl TryFrom<ScimEntryKanidm> for ScimPerson {
 pub struct ScimGroup {
     pub uuid: Uuid,
     pub name: String,
+    pub description: Option<String>,
 }
 
 impl TryFrom<ScimEntryKanidm> for ScimGroup {
@@ -386,15 +375,16 @@ impl TryFrom<ScimEntryKanidm> for ScimGroup {
     fn try_from(scim_entry: ScimEntryKanidm) -> Result<Self, Self::Error> {
         let uuid = scim_entry.header.id;
         let name = scim_entry
-            .attrs
-            .get(&Attribute::Name)
-            .and_then(|v| match v {
-                ScimValueKanidm::String(s) => Some(s.clone()),
-                _ => None,
-            })
+            .get_string_attr(&Attribute::Name)
+            .cloned()
             .ok_or(())?;
+        let description = scim_entry.get_string_attr(&Attribute::Description).cloned();
 
-        Ok(ScimGroup { uuid, name })
+        Ok(ScimGroup {
+            uuid,
+            name,
+            description,
+        })
     }
 }
 

--- a/server/core/src/https/views/admin/mod.rs
+++ b/server/core/src/https/views/admin/mod.rs
@@ -22,7 +22,7 @@ pub fn admin_router() -> Router<ServerState> {
 }
 
 pub fn admin_api_router() -> Router<ServerState> {
-    let unguarded_router = Router::new().route("/edit_group", post(groups::edit_group));
+    let unguarded_router = Router::new().route("/group/:group_uuid", post(groups::edit_group));
 
     let guarded_router = Router::new().layer(HxRequestGuardLayer::new("/ui"));
 

--- a/server/core/templates/admin/admin_group_view_partial.html
+++ b/server/core/templates/admin/admin_group_view_partial.html
@@ -3,22 +3,22 @@
 (% block groups_item_extra_classes %)active(% endblock %)
 
 (% macro string_attr(dispname, name, value, can_modify_any_attr, attribute) %)
-(% if scim_effective_access.search.check(attribute|as_ref) %)
+(% if scim_effective_access.search.check(attribute|as_ref) -%)
 <div class="row mt-3">
-    (% if can_rw && can_modify_any_attr %)
+    (% if can_rw && can_modify_any_attr -%)
     <label for="group(( name ))" class="col-12 col-md-3 col-lg-2 col-form-label fw-bold py-0 py-md-2">(( dispname ))</label>
-    (% else %)
+    (% else -%)
     <label for="group(( name ))" class="col-12 col-md-3 col-lg-2 col-form-label fw-bold py-0">(( dispname ))</label>
-    (% endif %)
+    (% endif -%)
     <div class="col-12 col-md-8 col-lg-6">
-        (% if scim_effective_access.modify_present.check(attribute|as_ref) %)
-        <input class="form-control py-0" id="group(( name ))" name="(( name ))" value="(( value ))">
-        (% else %)
-        <input readonly class="form-control-plaintext py-0" id="group(( name ))" name="(( name ))" value="(( value ))">
-        (% endif %)
+        (% if scim_effective_access.modify_present.check(attribute|as_ref) -%)
+        <input class="form-control py-0" id="group(( name ))" name="(( name ))" value="(( value ))"/>
+        (% else -%)
+        (( value ))
+        (% endif -%)
     </div>
 </div>
-(% endif %)
+(% endif -%)
 (% endmacro %)
 
 
@@ -36,26 +36,30 @@ let can_modify_any_attr = scim_effective_access.modify_present.check_any(
 </nav>
 
 <form id="user_settings_container" class="needs-validation"
-      hx-post="/ui/api/admin/edit_group"
+      hx-post="/ui/api/admin/group/(( group.uuid ))"
       hx-swap="beforeend"
       hx-target=".toast-container"
       hx-validate="true"
       hx-ext="bs-validation"
       novalidate>
 
-    (% if can_modify_any_attr %)
-        (% if can_rw %)
+    (% if can_modify_any_attr -%)
+        (% if can_rw -%)
             <button type="submit" class="btn btn-primary">Save</button>
-        (% else %)
+        (% else -%)
             <a hx-boost="false" href="/ui/unlock">
                 <button type="button" class="btn btn-secondary">Unlock Edit 🔒</button>
             </a>
-        (% endif %)
-    (% endif %)
+        (% endif -%)
+    (% endif -%)
 
-    (% call string_attr("UUID", "uuid", group.uuid, can_modify_any_attr, Attribute::Uuid) %)
-    (% call string_attr("Name", "name", group.name, can_modify_any_attr, Attribute::Name) %)
-
+    (% call string_attr("UUID", "uuid", group.uuid, can_modify_any_attr, Attribute::Uuid) -%)
+    (% call string_attr("Name", "name", group.name, can_modify_any_attr, Attribute::Name) -%)
+    (% if let Some(description) = group.description -%)
+        (% call string_attr("Description", "description", description, can_modify_any_attr, Attribute::Description) -%)
+    (% else -%)
+        (% call string_attr("Description", "description", "", can_modify_any_attr, Attribute::Description) -%)
+    (% endif -%)
 </form>
 
 <div class="toast-container position-fixed bottom-0 end-0 p-3">

--- a/server/core/templates/admin/admin_group_view_partial.html
+++ b/server/core/templates/admin/admin_group_view_partial.html
@@ -55,11 +55,8 @@ let can_modify_any_attr = scim_effective_access.modify_present.check_any(
 
     (% call string_attr("UUID", "uuid", group.uuid, can_modify_any_attr, Attribute::Uuid) -%)
     (% call string_attr("Name", "name", group.name, can_modify_any_attr, Attribute::Name) -%)
-    (% if let Some(description) = group.description -%)
-        (% call string_attr("Description", "description", description, can_modify_any_attr, Attribute::Description) -%)
-    (% else -%)
-        (% call string_attr("Description", "description", "", can_modify_any_attr, Attribute::Description) -%)
-    (% endif -%)
+    (% let description = group.description.clone().unwrap_or(String::new()) %)
+    (% call string_attr("Description", "description", description, can_modify_any_attr, Attribute::Description) -%)
 </form>
 
 <div class="toast-container position-fixed bottom-0 end-0 p-3">


### PR DESCRIPTION
# Change summary
- Adds the description attribute to the Groups webadmin page.
- This attribute can be modified if the person has access.

# Issues
- Firefox ignores value="" on the description input after page refresh. Resulting in an empty description even though the DOM shows it, submitting the form in this state also sends an empty description.
- Long descriptions make the input scroll which is not very clear. Descriptions can currently not be multi-line though. Other solutions would involve non-input workarounds.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
