### PR TITLE
Add a new paragraph in the installation quickstart for installing required client tools, and clarify the client tool setup paragraph

### DIFF
--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -77,7 +77,7 @@ docker exec -i -t kanidmd \
 
 This happens on your computer, not in the container.
 
-Kanidm relies on locally installed client tools on the client machines for administration. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them now.
+Kanidm requires locally installed client tools on the client machines for administration. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them now.
 
 Client tools are explained more in the [client tools](client_tools.html) chapter, but to complete setup, you will only need to follow the steps below.
 

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -83,7 +83,7 @@ Client tools are explained more in the [client tools](client_tools.html) chapter
 
 ## Setup the client tool configuration
 
-After installing the client tools, you will need a simple default config too use them.
+After installing the client tools, you will need to create a simple config file to continue.
 
 ```toml
 # ~/.config/kanidm

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -89,7 +89,7 @@ After installing the client tools, you will need to create a simple config file 
 # ~/.config/kanidm
 
 uri = "https://localhost" # The URL of the server
-verify_ca = false #disables #Whether to verify the Certificate Authority details of the server’s TLS certificate
+verify_ca = false # disables TLS certificate verification as your are using a self-signed certificate
 ```
 
 ## Check you can login

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -88,7 +88,7 @@ After installing the client tools, you will need to create a simple config file 
 ```toml
 # ~/.config/kanidm
 
-uri = "https://localhost:8443"
+uri = "https://localhost"
 verify_ca = false
 ```
 

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -83,7 +83,7 @@ Client tools are explained more in the [client tools](client_tools.html) chapter
 
 ## Setup the client tool configuration
 
-After installing the client tools, you will need to create a simple config file to continue.
+After installing the `kanidm` tool, you will need to create a configuration file to continue.
 
 ```toml
 # ~/.config/kanidm

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -88,8 +88,8 @@ After installing the client tools, you will need to create a simple config file 
 ```toml
 # ~/.config/kanidm
 
-uri = "https://localhost"
-verify_ca = false
+uri = "https://localhost" #The URL of the server
+verify_ca = false #disables #Whether to verify the Certificate Authority details of the server’s TLS certificate
 ```
 
 ## Check you can login

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -77,7 +77,7 @@ docker exec -i -t kanidmd \
 
 This happens on your computer, not in the container.
 
-Kanidm relies on locally installed client tools on the client machine for administration. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them now.
+Kanidm relies on locally installed client tools on the client machines for administration. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them now.
 
 Client tools are explained more in the [client tools](client_tools.html) chapter, but to complete setup, you will only need to follow the steps below.
 

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -77,7 +77,7 @@ docker exec -i -t kanidmd \
 
 This happens on your computer, not in the container.
 
-Kanidm requires locally installed client tools on the client machines for administration. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them now.
+Kanidm requires locally installed client tools on the system used for administration via the command line. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them before continuing.
 
 Client tools are explained more in the [client tools](client_tools.html) chapter, but to complete setup, you will only need to follow the steps below.
 

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -88,7 +88,7 @@ After installing the client tools, you will need to create a simple config file 
 ```toml
 # ~/.config/kanidm
 
-uri = "https://localhost" #The URL of the server
+uri = "https://localhost" # The URL of the server
 verify_ca = false #disables #Whether to verify the Certificate Authority details of the server’s TLS certificate
 ```
 

--- a/book/src/evaluation_quickstart.md
+++ b/book/src/evaluation_quickstart.md
@@ -73,9 +73,17 @@ docker exec -i -t kanidmd \
   kanidmd recover-account idm_admin
 ```
 
-## Setup the client configuration
+## Install the client tools
 
 This happens on your computer, not in the container.
+
+Kanidm relies on locally installed client tools on the client machine for administration. Follow the guide in the [installing client tools](installing_client_tools.html) chapter to install them now.
+
+Client tools are explained more in the [client tools](client_tools.html) chapter, but to complete setup, you will only need to follow the steps below.
+
+## Setup the client tool configuration
+
+After installing the client tools, you will need a simple default config too use them.
 
 ```toml
 # ~/.config/kanidm


### PR DESCRIPTION
# Change summary

**User friendliness changes:**

- Added an entire new **Installing client tools** paragraph, between recovering the built in administration accounts and setting up the client tools, which directs users to install the client tools first. This sends them to the installing client tools chapter, to help selecting the correct package and install steps, and makes no attempt to repeat what's already told there.
- The new **Installing client tools** paragraph opens with a brief explanation of why client tools are required. New users might expect to go to the webui (which is already running at this point) and start administration there (which is not possible). They could even login with the previously recovered built in admins, and be able to do nothing with them.
- Moved the _"This happens on your computer, not in the container."_ disclaimer to the new installation paragraph, as it is already relevant there.
- Instead of the moved disclaimer, added a line about a simple config file being needed to function to the **Setup the client tool configuration** paragraph. If I understand correctly, this is not strictly true. Every config file setting used here can be also passed as an argument in the client tools. But that's a niche advanced usecase, and it would be confusing to start explaining at this point. The guide already included a simple config for new users, I am just adding a line why.
- Added two comments in the client tool config, to clarify what the user is doing. The variable names are intuitive, this would only be a bit of extra clarity, because the user is not expected to have read the **Client Tools** chapter at this point. Might help if something goes wrong, see my next change for an example.

**Corrections:**

- The simple minimal config in the *Setup the client tool configuration** paragraph specified the URL of the server with port 8443. This is the internal docker port used in the example configs, which docker binds to port 443, the default https port on localhost, when following this same guide. Therefore no port should be specified, because a redundant port config that appears in only one place would be confusing. If this is not corrected, the server will refuse connection on port 8443 of the localhost.

Fixes #3730 

Checklist

- [X] This PR contains no AI generated code
- [X] book chapter included (if relevant)
- [ ] design document included (if relevant)
