### PR TITLE
Use constants for /etc/shadow and related paths

### DIFF
--- a/unix_integration/common/src/constants.rs
+++ b/unix_integration/common/src/constants.rs
@@ -29,3 +29,12 @@ pub const CODEC_MIMIMUM_BYTESMUT_ALLOCATION: usize = 64;
 // If the codec buffer exceeds this limit, then we swap the buffer
 // with a fresh one to prevent memory explosions.
 pub const CODEC_BYTESMUT_ALLOCATION_LIMIT: usize = 1024 * 1024;
+
+#[cfg(all(target_family = "unix", not(target_os = "freebsd")))]
+pub const SYSTEM_SHADOW_PATH: &str = "/etc/shadow";
+
+#[cfg(all(target_family = "unix", target_os = "freebsd"))]
+pub const SYSTEM_SHADOW_PATH: &str = "/etc/master.passwd";
+
+pub const SYSTEM_PASSWD_PATH: &str = "/etc/passwd";
+pub const SYSTEM_GROUP_PATH: &str = "/etc/group";

--- a/unix_integration/nss_kanidm/src/core.rs
+++ b/unix_integration/nss_kanidm/src/core.rs
@@ -1,4 +1,5 @@
 use kanidm_unix_common::client_sync::DaemonClientBlocking;
+use kanidm_unix_common::constants::{SYSTEM_GROUP_PATH, SYSTEM_PASSWD_PATH};
 use kanidm_unix_common::unix_config::PamNssConfig;
 use kanidm_unix_common::unix_passwd::{
     read_etc_group_file, read_etc_passwd_file, EtcGroup, EtcUser,
@@ -47,9 +48,9 @@ impl RequestOptions {
                 if let Some(client) = maybe_client {
                     Source::Daemon(client)
                 } else {
-                    let users = read_etc_passwd_file("/etc/passwd").unwrap_or_default();
+                    let users = read_etc_passwd_file(SYSTEM_PASSWD_PATH).unwrap_or_default();
 
-                    let groups = read_etc_group_file("/etc/group").unwrap_or_default();
+                    let groups = read_etc_group_file(SYSTEM_GROUP_PATH).unwrap_or_default();
 
                     Source::Fallback { users, groups }
                 }

--- a/unix_integration/pam_kanidm/src/core.rs
+++ b/unix_integration/pam_kanidm/src/core.rs
@@ -2,6 +2,7 @@ use crate::constants::PamResultCode;
 use crate::module::PamResult;
 use crate::pam::ModuleOptions;
 use kanidm_unix_common::client_sync::DaemonClientBlocking;
+use kanidm_unix_common::constants::{SYSTEM_PASSWD_PATH, SYSTEM_SHADOW_PATH};
 use kanidm_unix_common::unix_config::PamNssConfig;
 use kanidm_unix_common::unix_passwd::{
     read_etc_passwd_file, read_etc_shadow_file, EtcShadow, EtcUser,
@@ -55,9 +56,9 @@ impl RequestOptions {
                 if let Some(client) = maybe_client {
                     Source::Daemon(client)
                 } else {
-                    let users = read_etc_passwd_file("/etc/passwd").unwrap_or_default();
-                    // let groups = read_etc_group_file("/etc/group").unwrap_or_default();
-                    let shadow = read_etc_shadow_file("/etc/shadow").unwrap_or_default();
+                    let users = read_etc_passwd_file(SYSTEM_PASSWD_PATH).unwrap_or_default();
+                    // let groups = read_etc_group_file(SYSTEM_GROUP_PATH).unwrap_or_default();
+                    let shadow = read_etc_shadow_file(SYSTEM_SHADOW_PATH).unwrap_or_default();
                     Source::Fallback {
                         users,
                         // groups,

--- a/unix_integration/resolver/src/idprovider/interface.rs
+++ b/unix_integration/resolver/src/idprovider/interface.rs
@@ -71,7 +71,7 @@ pub enum ProviderOrigin {
     // causes these items to be nixed.
     #[default]
     Ignore,
-    /// Provided by /etc/passwd or /etc/group
+    /// Provided by local files, commonly /etc/passwd, /etc/group and /etc/shadow
     System,
     Kanidm,
 }

--- a/unix_integration/resolver/src/resolver.rs
+++ b/unix_integration/resolver/src/resolver.rs
@@ -18,7 +18,7 @@ use crate::idprovider::system::{
 };
 use hashbrown::HashMap;
 use kanidm_hsm_crypto::provider::BoxedDynTpm;
-use kanidm_unix_common::constants::DEFAULT_SHELL_SEARCH_PATHS;
+use kanidm_unix_common::constants::{DEFAULT_SHELL_SEARCH_PATHS, SYSTEM_SHADOW_PATH};
 use kanidm_unix_common::unix_config::{HomeAttr, UidAttr};
 use kanidm_unix_common::unix_passwd::{EtcGroup, EtcShadow, EtcUser};
 use kanidm_unix_common::unix_proto::{
@@ -914,7 +914,7 @@ impl Resolver {
             SystemProviderAuthInit::ShadowMissing => {
                 warn!(
                     ?account_id,
-                    "Resolver unable to proceed, /etc/shadow was not accessible."
+                    "Resolver unable to proceed, {SYSTEM_SHADOW_PATH} was not accessible."
                 );
                 return Ok((AuthSession::Denied, PamAuthResponse::Unknown));
             }


### PR DESCRIPTION
Different unix-like platforms have different paths for where the "shadow" file is located. Making this a constant allows us to set this per platform.

Fixes #3739

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
