### PR TITLE
fix: don't show people's whole tokens in debugs

### DIFF
--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -1403,7 +1403,7 @@ pub async fn credential_update_update(
             return Err(WebError::InternalServerError(errmsg));
         }
     };
-    debug!("session_token: {:?}", session_token);
+    trace!("session_token: {:?}", session_token);
     debug!("scr: {:?}", scr);
 
     state

--- a/tools/cli/src/cli/common.rs
+++ b/tools/cli/src/cli/common.rs
@@ -383,7 +383,10 @@ pub fn prompt_for_username_get_values(
         Some(value) => {
             let (f_uname, f_token) = value;
             debug!("Using cached token for name {}", f_uname);
-            debug!("Cached token: {}", f_token);
+            debug!(
+                "First ten chars of cached token: {}",
+                &f_token.to_string()[..10]
+            );
             Ok((f_uname.to_string(), f_token.clone()))
         }
         None => {


### PR DESCRIPTION
# Change summary

- Don't debug whole tokens, just give people the ability to find them.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
