### PR TITLE
Improve replication logging

### DIFF
--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -2672,7 +2672,7 @@ impl<'a> QueryServerWriteTransaction<'a> {
         self.be_txn.clear_cache()
     }
 
-    #[instrument(level = "info", name="qswt_commit" skip_all)]
+    #[instrument(level = "debug", name="qswt_commit" skip_all)]
     pub fn commit(mut self) -> Result<(), OperationError> {
         self.reload()?;
 


### PR DESCRIPTION
When we changed to rustls, a large number of warnings were emitted related to unclean connection closing. This resolves those warnings by closing the connections cleanly. Additionally this tweaks and improves some other small details about replication logging.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
