### PR TITLE
Reduce memory usage on unixd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,6 @@ dependencies = [
  "kanidmd_testkit",
  "libc",
  "lru 0.14.0",
- "mimalloc",
  "notify-debouncer-full",
  "prctl",
  "rusqlite",

--- a/server/daemon/Cargo.toml
+++ b/server/daemon/Cargo.toml
@@ -42,15 +42,13 @@ serde_json = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-notify = { workspace = true }
 prctl = { workspace = true }
+mimalloc = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 whoami = { workspace = true }
 
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
-
-[target.'cfg(not(target_os = "illumos"))'.dependencies]
-mimalloc = { workspace = true }
 
 [build-dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -10,7 +10,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-#[cfg(not(any(feature = "dhat-heap", target_os = "illumos")))]
+#[cfg(all(not(feature = "dhat-heap"), target_os = "linux"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/unix_integration/resolver/Cargo.toml
+++ b/unix_integration/resolver/Cargo.toml
@@ -98,8 +98,8 @@ prctl = { workspace = true }
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
 
-[target.'cfg(not(target_os = "illumos"))'.dependencies]
-mimalloc = { workspace = true }
+# [target.'cfg(not(target_os = "illumos"))'.dependencies]
+# mimalloc = { workspace = true }
 
 [dev-dependencies]
 kanidmd_core = { workspace = true }

--- a/unix_integration/resolver/Cargo.toml
+++ b/unix_integration/resolver/Cargo.toml
@@ -98,9 +98,6 @@ prctl = { workspace = true }
 [target.'cfg(not(target_family = "windows"))'.dependencies]
 kanidm_utils_users = { workspace = true }
 
-# [target.'cfg(not(target_os = "illumos"))'.dependencies]
-# mimalloc = { workspace = true }
-
 [dev-dependencies]
 kanidmd_core = { workspace = true }
 kanidmd_testkit = { workspace = true }

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -59,12 +59,6 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
-/*
- * #[cfg(not(any(feature = "dhat-heap", target_os = "illumos")))]
- * #[global_allocator]
- * static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
- */
-
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -59,9 +59,11 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
-#[cfg(not(any(feature = "dhat-heap", target_os = "illumos")))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+/*
+ * #[cfg(not(any(feature = "dhat-heap", target_os = "illumos")))]
+ * #[global_allocator]
+ * static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+ */
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]


### PR DESCRIPTION
This introduces two more changes to reduce memory consumption with kanidm-unixd.

The first is that there is a potential issue with mimalloc where it can cause the RSS to be elevated. As unixd is not as performance sensitive as the main server, we limit mimalloc only to linux for the main server daemon instead, as glibc malloc has a number of issues when under high demand workloads.

The second was that due to pbkdf2 benchmarking at server startup, the memory reports from dhat were reporting those blocks as high usage. Since pbkdf is NOT a format we use, we now statically allocate it's round numbers in the unlikely case we do ever use it. The important algorithm remains argon2id for our applications.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
