### PR TITLE
Provide correct access for RADIUS service accounts

### DIFF
--- a/server/lib/src/migration_data/dl12/access.rs
+++ b/server/lib/src/migration_data/dl12/access.rs
@@ -898,6 +898,8 @@ lazy_static! {
         search_attrs: vec![
             Attribute::Class,
             Attribute::Name,
+            Attribute::DisplayName,
+            Attribute::MemberOf,
             Attribute::Spn,
             Attribute::Uuid,
             Attribute::RadiusSecret,


### PR DESCRIPTION
After the changes in the unixd access token PR, the default unix read ACP was modified. This meant that RADIUS service accounts no longer could read the memberOf or displayName attributes of users preventing RADIUS logins.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
