### PR TITLE
Handle SEC1 private key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,6 +3757,7 @@ dependencies = [
  "qrcode",
  "regex",
  "rustls",
+ "sec1",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm-ipa-sync"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm-ldap-sync"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_build_profiles"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "base64 0.22.1",
  "gix",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_client"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "compact_jwt",
  "http 1.3.1",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_device_flow"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "kanidm_proto",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_crypto"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -3591,14 +3591,14 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_file_permissions"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "kanidm_utils_users",
 ]
 
 [[package]]
 name = "kanidm_proto"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "base32",
  "base64 0.22.1",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_tools"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_unix_common"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "bytes",
  "csv",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_unix_int"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3717,14 +3717,14 @@ dependencies = [
 
 [[package]]
 name = "kanidm_utils_users"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kanidmd_core"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "askama",
  "askama_axum",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "kanidmd_lib"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "base64 0.22.1",
  "base64urlsafedata",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "kanidmd_lib_macros"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "kanidmd_testkit"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "cidr",
  "compact_jwt",
@@ -4029,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "nss_kanidm"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "cc",
  "kanidm_unix_common",
@@ -4841,7 +4841,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orca"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "pam_kanidm"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "kanidm_unix_common",
  "libc",
@@ -5444,9 +5444,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -5787,9 +5787,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "scim_proto"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "base64urlsafedata",
  "peg",
@@ -5973,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "selinux"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef2ca58174235414aee5465f5d8ef9f5833023b31484eb52ca505f306f4573c"
+checksum = "8f6af114a661557df02e60c25e5cb40779d295ec2e4ae0fd903fe414578b6191"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
@@ -6068,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "sketching"
-version = "1.7.0-pre"
+version = "1.7.0"
 dependencies = [
  "num_enum",
  "opentelemetry",
@@ -6650,9 +6650,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8128,9 +8128,9 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
+checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,8 @@ sketching = { path = "./libs/sketching", version = "=1.7.0" }
 
 kanidm-hsm-crypto = { version = "^0.3.4" }
 
+## temporary!!! until crypto-glue updates.
+sec1 = "0.7.3"
 
 anyhow = { version = "1.0.98" }
 argon2 = { version = "0.5.3", features = ["alloc"] }

--- a/server/core/Cargo.toml
+++ b/server/core/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 dev-oauth2-device-flow = []
 
 [dependencies]
+sec1 = { workspace = true }
 askama = { workspace = true, features = ["with-axum"] }
 askama_axum = { workspace = true }
 axum = { workspace = true }


### PR DESCRIPTION
# Change summary

- SEC1 and PKCS1 keys were missed during the conversion of TLS minimums checking. This adds in both formats. I have tested both locally to ensure they work. 

> NOTE: I plan to do a separate PR to main for the fix, but that relies on https://github.com/kanidm/crypto-glue/pull/11 and I don't want to bottleneck this PR. 

Fixes #3760

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
