### PR TITLE
Trying to clean up order of operations in kanidm_unixd_tasks

### DIFF
--- a/proto/src/scim_v1/mod.rs
+++ b/proto/src/scim_v1/mod.rs
@@ -735,7 +735,7 @@ mod tests {
     #[test]
     fn test_scimfilter_group() {
         let f = scimfilter::parse("(mail eq \"dcba\")");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
         assert!(
             f == Ok(ScimFilter::Equal(
                 AttrPath {
@@ -750,7 +750,7 @@ mod tests {
     #[test]
     fn test_scimfilter_not() {
         let f = scimfilter::parse("not (mail eq \"dcba\")");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::Not(Box::new(ScimFilter::Equal(
@@ -766,7 +766,7 @@ mod tests {
     #[test]
     fn test_scimfilter_and() {
         let f = scimfilter::parse("mail eq \"dcba\" and name ne \"1234\"");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::And(
@@ -791,7 +791,7 @@ mod tests {
     #[test]
     fn test_scimfilter_or() {
         let f = scimfilter::parse("mail eq \"dcba\" or name ne \"1234\"");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::Or(
@@ -816,11 +816,11 @@ mod tests {
     #[test]
     fn test_scimfilter_complex() {
         let f = scimfilter::parse("mail[type eq \"work\"]");
-        eprintln!("-- {:?}", f);
+        eprintln!("-- {f:?}");
         assert!(f.is_ok());
 
         let f = scimfilter::parse("mail[type eq \"work\" and value co \"@example.com\"] or testattr[type eq \"xmpp\" and value co \"@foo.com\"]");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert_eq!(
             f,
@@ -859,7 +859,7 @@ mod tests {
     fn test_scimfilter_precedence_1() {
         let f =
             scimfilter::parse("testattr_a pr or testattr_b pr and testattr_c pr or testattr_d pr");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::Or(
@@ -891,7 +891,7 @@ mod tests {
     fn test_scimfilter_precedence_2() {
         let f =
             scimfilter::parse("testattr_a pr and testattr_b pr or testattr_c pr and testattr_d pr");
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::Or(
@@ -924,7 +924,7 @@ mod tests {
         let f = scimfilter::parse(
             "testattr_a pr and (testattr_b pr or testattr_c pr) and testattr_d pr",
         );
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::And(
@@ -957,7 +957,7 @@ mod tests {
         let f = scimfilter::parse(
             "testattr_a pr and not (testattr_b pr or testattr_c pr) and testattr_d pr",
         );
-        eprintln!("{:?}", f);
+        eprintln!("{f:?}");
 
         assert!(
             f == Ok(ScimFilter::And(

--- a/server/testkit/tests/testkit/ldap_basic.rs
+++ b/server/testkit/tests/testkit/ldap_basic.rs
@@ -195,7 +195,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     let mut ldap_client = LdapClientBuilder::new(ldap_url).build().await.unwrap();
     ldap_client
         .bind(
-            format!("name={},app={}", TEST_PERSON, APPLICATION_1_NAME),
+            format!("name={TEST_PERSON},app={APPLICATION_1_NAME}"),
             application_1_password_create_1.secret.clone(),
         )
         .await
@@ -204,10 +204,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     let mut ldap_client = LdapClientBuilder::new(ldap_url).build().await.unwrap();
     ldap_client
         .bind(
-            format!(
-                "name={},app={},dc=localhost",
-                TEST_PERSON, APPLICATION_1_NAME
-            ),
+            format!("name={TEST_PERSON},app={APPLICATION_1_NAME},dc=localhost"),
             application_1_password_create_2.secret.clone(),
         )
         .await
@@ -216,10 +213,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     let mut ldap_client = LdapClientBuilder::new(ldap_url).build().await.unwrap();
     ldap_client
         .bind(
-            format!(
-                "name={},app={},dc=localhost",
-                TEST_PERSON, APPLICATION_2_NAME
-            ),
+            format!("name={TEST_PERSON},app={APPLICATION_2_NAME},dc=localhost"),
             application_2_password_create_1.secret.clone(),
         )
         .await
@@ -230,7 +224,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     // Using application 2 password!!!
     ldap_client
         .bind(
-            format!("name={},app={}", TEST_PERSON, APPLICATION_1_NAME),
+            format!("name={TEST_PERSON},app={APPLICATION_1_NAME},dc=localhost"),
             application_2_password_create_1.secret.clone(),
         )
         .await
@@ -240,7 +234,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     // Using application 2 password!!!
     ldap_client
         .bind(
-            format!("name={},app={}", TEST_PERSON, APPLICATION_2_NAME),
+            format!("name={TEST_PERSON},app={APPLICATION_2_NAME}"),
             application_1_password_create_1.secret.clone(),
         )
         .await
@@ -258,10 +252,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     let mut ldap_client = LdapClientBuilder::new(ldap_url).build().await.unwrap();
     ldap_client
         .bind(
-            format!(
-                "name={},app={},dc=localhost",
-                TEST_PERSON, APPLICATION_1_NAME
-            ),
+            format!("name={TEST_PERSON},app={APPLICATION_1_NAME},dc=localhost"),
             application_1_password_create_2.secret.clone(),
         )
         .await
@@ -277,7 +268,7 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     let mut ldap_client = LdapClientBuilder::new(ldap_url).build().await.unwrap();
     ldap_client
         .bind(
-            format!("name={},app={}", TEST_PERSON, APPLICATION_1_NAME),
+            format!("name={TEST_PERSON},app={APPLICATION_1_NAME},dc=localhost"),
             application_1_password_create_1.secret.clone(),
         )
         .await

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -336,7 +336,7 @@ async fn handle_unixd_request(
             }
         }
         other => {
-            error!("Error -> {:?}", other);
+            error!("Error -> got un-handled Request Frame {other:?}");
             Err(())
         }
     }

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -589,7 +589,7 @@ async fn main() -> ExitCode {
 
             let (shadow_data_watch_tx, mut shadow_data_watch_rx) = watch::channel(etc_db);
 
-            let _shadow_task: tokio::task::JoinHandle<()> = tokio::spawn(async move {
+            let _shadow_task = tokio::spawn(async move {
                 shadow_reload_task(
                     shadow_data_watch_tx, shadow_broadcast_rx
                 ).await


### PR DESCRIPTION
# Change summary

Did some making-clippy-happy because noise.

Reorganised the handle_tasks loop of `kanidm_unixd_tasks` a little by making the task types into their own functions, then breaking it out so the handle to the socket is only written to in one place - after the `tokio::select`. I can't prove it, but it looked a lot like there was a race there.

It also forces the shadow message to be sent to UNIXd before listening for a task...

Refers #3620 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
