### PR TITLE
Forget username if user no longer wants to be remembered

### DIFF
--- a/server/core/src/https/views/login.rs
+++ b/server/core/src/https/views/login.rs
@@ -982,7 +982,7 @@ async fn view_login_step(
                             username_cookie.make_permanent();
                             jar.add(username_cookie)
                         } else {
-                            jar
+                            cookies::destroy(jar, COOKIE_USERNAME, &state)
                         };
 
                         jar = jar.add(bearer_cookie);


### PR DESCRIPTION
# Change summary
When a user selects to remember the username for future logins, a cookie with the username is set. But when the user does not want to be remembered anymore, disabling the switch had no effect and the username would be prefilled for every future login until the cookie will expire. I think it would be better to remove the cookie once the user does not want to be remembered anymore, so disabling the switch actually has an effect.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
