### PR TITLE
Break-glass account disable command

### DIFF
--- a/server/core/src/actors/internal.rs
+++ b/server/core/src/actors/internal.rs
@@ -189,6 +189,23 @@ impl QueryServerWriteV1 {
 
     #[instrument(
         level = "info",
+        skip(self, eventid),
+        fields(uuid = ?eventid)
+    )]
+    pub(crate) async fn handle_admin_disable_account(
+        &self,
+        name: String,
+        eventid: Uuid,
+    ) -> Result<(), OperationError> {
+        let ct = duration_from_epoch_now();
+        let mut idms_prox_write = self.idms.proxy_write(ct).await?;
+        idms_prox_write.disable_account(name.as_str())?;
+
+        idms_prox_write.commit()
+    }
+
+    #[instrument(
+        level = "info",
         skip_all,
         fields(uuid = ?eventid)
     )]

--- a/server/core/src/admin.rs
+++ b/server/core/src/admin.rs
@@ -25,6 +25,7 @@ pub use kanidm_proto::internal::{
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AdminTaskRequest {
     RecoverAccount { name: String },
+    DisableAccount { name: String },
     ShowReplicationCertificate,
     RenewReplicationCertificate,
     RefreshReplicationConsumer,
@@ -314,6 +315,15 @@ async fn handle_client(
                         Ok(password) => AdminTaskResponse::RecoverAccount { password },
                         Err(e) => {
                             error!(err = ?e, "error during recover-account");
+                            AdminTaskResponse::Error
+                        }
+                    }
+                }
+                AdminTaskRequest::DisableAccount { name } => {
+                    match server_rw.handle_admin_disable_account(name, eventid).await {
+                        Ok(()) => AdminTaskResponse::Success,
+                        Err(e) => {
+                            error!(err = ?e, "error during disable-account");
                             AdminTaskResponse::Error
                         }
                     }

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -87,6 +87,7 @@ impl KanidmdOpt {
             | KanidmdOpt::RenewReplicationCertificate { commonopts }
             | KanidmdOpt::RefreshReplicationConsumer { commonopts, .. } => commonopts,
             KanidmdOpt::RecoverAccount { commonopts, .. } => commonopts,
+            KanidmdOpt::DisableAccount { commonopts, .. } => commonopts,
             KanidmdOpt::DbScan {
                 commands: DbScanOpt::ListIndex(dopt),
             } => &dopt.commonopts,
@@ -471,6 +472,7 @@ async fn start_daemon(opt: KanidmdParser, config: Configuration) -> ExitCode {
         | KanidmdOpt::RenewReplicationCertificate { .. }
         | KanidmdOpt::RefreshReplicationConsumer { .. }
         | KanidmdOpt::RecoverAccount { .. }
+        | KanidmdOpt::DisableAccount { .. }
         | KanidmdOpt::HealthCheck(_) => None,
         _ => {
             // Okay - Lets now create our lock and go.
@@ -929,6 +931,18 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
             submit_admin_req(
                 config.adminbindpath.as_str(),
                 AdminTaskRequest::RecoverAccount {
+                    name: name.to_owned(),
+                },
+                output_mode,
+            )
+            .await;
+        }
+        KanidmdOpt::DisableAccount { name, commonopts } => {
+            info!("Running account disable ...");
+            let output_mode: ConsoleOutputMode = commonopts.output_mode.to_owned().into();
+            submit_admin_req(
+                config.adminbindpath.as_str(),
+                AdminTaskRequest::DisableAccount {
                     name: name.to_owned(),
                 },
                 output_mode,

--- a/server/daemon/src/opt.rs
+++ b/server/daemon/src/opt.rs
@@ -171,7 +171,9 @@ impl KanidmdParser {
             KanidmdOpt::Server(ref c) => c.config_path.clone(),
             KanidmdOpt::ConfigTest(ref c) => c.config_path.clone(),
             KanidmdOpt::CertGenerate(ref c) => c.config_path.clone(),
-            KanidmdOpt::RecoverAccount { ref commonopts, .. } => commonopts.config_path.clone(),
+            KanidmdOpt::RecoverAccount { ref commonopts, .. } |
+            KanidmdOpt::DisableAccount { ref commonopts, .. }
+                => commonopts.config_path.clone(),
             KanidmdOpt::ShowReplicationCertificate { ref commonopts, .. } => {
                 commonopts.config_path.clone()
             }
@@ -235,6 +237,15 @@ enum KanidmdOpt {
     RecoverAccount {
         #[clap(value_parser)]
         /// The account name to recover credentials for.
+        name: String,
+        #[clap(flatten)]
+        commonopts: CommonOpt,
+    },
+    #[clap(name = "disable-account")]
+    /// Disable an account so that it can not be used. This can be reset with `recover-account`.
+    DisableAccount {
+        #[clap(value_parser)]
+        /// The account name to disable.
         name: String,
         #[clap(flatten)]
         commonopts: CommonOpt,

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1882,9 +1882,8 @@ impl IdmServerProxyWriteTransaction<'_> {
         cleartext: Option<&str>,
     ) -> Result<String, OperationError> {
         // name to uuid
-        let target = self.qs_write.name_to_uuid(name).map_err(|e| {
-            admin_error!(?e, "name to uuid failed");
-            e
+        let target = self.qs_write.name_to_uuid(name).inspect_err(|err| {
+            error!(?err, "name to uuid failed");
         })?;
 
         let cleartext = cleartext
@@ -1892,13 +1891,17 @@ impl IdmServerProxyWriteTransaction<'_> {
             .unwrap_or_else(password_from_random);
 
         let ncred = Credential::new_generatedpassword_only(self.crypto_policy, &cleartext)
-            .map_err(|e| {
-                admin_error!("Unable to generate password mod {:?}", e);
-                e
+            .inspect_err(|err| {
+                error!(?err, "unable to generate password modification");
             })?;
         let vcred = Value::new_credential("primary", ncred);
-        // We need to remove other credentials too.
+        let v_valid_from = Value::new_datetime_epoch(self.qs_write.get_curtime());
+
         let modlist = ModifyList::new_list(vec![
+            // Ensure the account is valid from *now*, and that the expiry is unset.
+            m_purge(Attribute::AccountExpire),
+            Modify::Present(Attribute::AccountValidFrom, v_valid_from),
+            // We need to remove other credentials too.
             m_purge(Attribute::PassKeys),
             m_purge(Attribute::PrimaryCredential),
             Modify::Present(Attribute::PrimaryCredential, vcred),
@@ -1912,12 +1915,41 @@ impl IdmServerProxyWriteTransaction<'_> {
                 &filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(target))),
                 &modlist,
             )
-            .map_err(|e| {
-                request_error!(error = ?e);
-                e
+            .inspect_err(|err| {
+                error!(?err);
             })?;
 
         Ok(cleartext)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub fn disable_account(&mut self, name: &str) -> Result<(), OperationError> {
+        // name to uuid
+        let target = self.qs_write.name_to_uuid(name).inspect_err(|err| {
+            error!(?err, "name to uuid failed");
+        })?;
+
+        let v_expire = Value::new_datetime_epoch(self.qs_write.get_curtime());
+
+        let modlist = ModifyList::new_list(vec![
+            // Ensure that the account has no validity, and the expiry is now.
+            m_purge(Attribute::AccountValidFrom),
+            Modify::Present(Attribute::AccountExpire, v_expire),
+        ]);
+
+        trace!(?modlist, "processing change");
+
+        self.qs_write
+            .internal_modify(
+                // Filter as executed
+                &filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(target))),
+                &modlist,
+            )
+            .inspect_err(|err| {
+                error!(?err);
+            })?;
+
+        Ok(())
     }
 
     #[instrument(level = "debug", skip_all)]


### PR DESCRIPTION
# Change summary

- Recover-account now un-expires an account
- A disable-account command is added that can disable the builtin accounts, immediately invalidating all existing sessions.

Fixes #3763

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
