### PR TITLE
Support Unix sockets and systemd socket activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
  "libc",
  "libudev",
  "log",
- "memoffset",
+ "memoffset 0.8.0",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -3742,6 +3742,7 @@ dependencies = [
  "futures",
  "futures-util",
  "haproxy-protocol",
+ "hashbrown 0.15.4",
  "hyper 1.6.0",
  "hyper-util",
  "kanidm_build_profiles",
@@ -3752,6 +3753,7 @@ dependencies = [
  "kanidmd_lib",
  "ldap3_proto",
  "libc",
+ "nix",
  "openssl",
  "opentelemetry",
  "qrcode",
@@ -4259,6 +4261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,6 +4371,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,6 +298,8 @@ utoipa = { version = "4.2.0", features = ["url", "uuid"] }
 utoipa-swagger-ui = "6.0.0"
 uuid = "^1.17.0"
 
+nix = { version = "0.30.1", default-features = false, features = ["socket", "net"] }
+
 webauthn-authenticator-rs = { version = "0.5.2", features = [
     "softpasskey",
     "softtoken",

--- a/server/core/Cargo.toml
+++ b/server/core/Cargo.toml
@@ -36,6 +36,7 @@ filetime = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 haproxy-protocol = { workspace = true, features = ["tokio"] }
+hashbrown = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 kanidm_proto = { workspace = true }
@@ -72,6 +73,7 @@ tower-http = { version = "0.6.6", features = [
 ] }
 tracing = { workspace = true, features = ["attributes"] }
 url = { workspace = true, features = ["serde"] }
+nix = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 utoipa = { workspace = true, features = [
     "axum_extras",

--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -1112,8 +1112,13 @@ impl ConfigurationBuilder {
                 client_ca,
             }),
             _ => {
-                eprintln!("ERROR: Tls Private Key and Certificate Chain are required.");
-                return None;
+                match bindaddress {
+                    Some(ref bindaddress) if bindaddress.starts_with("/") => None,
+                    _ => {
+                        eprintln!("ERROR: Tls Private Key and Certificate Chain are required.");
+                        return None;
+                    }
+                }
             }
         };
 

--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -798,7 +798,7 @@ pub async fn create_server_core(
     if config.integration_test_config.is_some() {
         warn!("RUNNING IN INTEGRATION TEST MODE.");
         warn!("IF YOU SEE THIS IN PRODUCTION YOU MUST CONTACT SUPPORT IMMEDIATELY.");
-    } else if config.tls_config.is_none() {
+    } else if config.tls_config.is_none() && !config.address.starts_with("/") {
         // TLS is great! We won't run without it.
         error!("Running without TLS is not supported! Quitting!");
         return Err(());


### PR DESCRIPTION
# Change summary

- `bindaddress` can now be set to a path, binding the web server to a unix domain socket
- A TCP or Unix socket provided using [`ListenStream=`](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html#ListenStream=) will now be inherited by Kanidm, if the address matches with `bindaddress`. This allows tighter sandboxing

Fixes #2771

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
