### PR TITLE
Support binding on Unix sockets

### DIFF
--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -1112,8 +1112,13 @@ impl ConfigurationBuilder {
                 client_ca,
             }),
             _ => {
-                eprintln!("ERROR: Tls Private Key and Certificate Chain are required.");
-                return None;
+                match bindaddress {
+                    Some(ref bindaddress) if bindaddress.starts_with("/") => None,
+                    _ => {
+                        eprintln!("ERROR: Tls Private Key and Certificate Chain are required.");
+                        return None;
+                    }
+                }
             }
         };
 

--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -798,7 +798,7 @@ pub async fn create_server_core(
     if config.integration_test_config.is_some() {
         warn!("RUNNING IN INTEGRATION TEST MODE.");
         warn!("IF YOU SEE THIS IN PRODUCTION YOU MUST CONTACT SUPPORT IMMEDIATELY.");
-    } else if config.tls_config.is_none() {
+    } else if config.tls_config.is_none() && !config.address.starts_with("/") {
         // TLS is great! We won't run without it.
         error!("Running without TLS is not supported! Quitting!");
         return Err(());


### PR DESCRIPTION
# Change summary

- `bindaddress` can now be set to a path, binding the web server to a unix domain socket

Fixes #2771

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
