### PR TITLE
Set `private` in Cache-Control header for `dont_cache_me` middleware

### DIFF
--- a/server/core/src/https/middleware/caching.rs
+++ b/server/core/src/https/middleware/caching.rs
@@ -10,7 +10,7 @@ pub async fn dont_cache_me(request: Request<Body>, next: Next) -> Response {
     let mut response = next.run(request).await;
     response.headers_mut().insert(
         header::CACHE_CONTROL,
-        HeaderValue::from_static("no-store, no-cache, max-age=0"),
+        HeaderValue::from_static("private, no-store, no-cache, max-age=0"),
     );
     response
         .headers_mut()


### PR DESCRIPTION
# Change summary

- set `private` in Cache-Control header

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

This is a fix for something incredibly niche... I have a Kanidm deployment behind Cloudflare, and I've set a fairly aggressive caching policy for it. The policy is set to override `Cache-Control` header's `no-store` `no-cache` directive and have all contents eligible for cache.

After logging in my browser, the Cloudflare will cache private routes like `/ui/apps`, such that even an anonymous user can see the applications I've configured on my Kanidm instance (but they can't bypass authentication, even if they click on one of the apps, Kanidm will redirect to the login page).

So for private routes, I think it'd be sensible to set `private` in Cache-Control header to make sure no CDN services can actually cache the page contents even if Kanidm users set dumb rules like I am...

Note that some routes don't have the caching middleware hooked to them, would it be better to have `dont_cache_me` to guard all routes that currently don't have any middleware?