### PR TITLE
Add json codec wrapper for unix integration

### DIFF
--- a/unix_integration/common/src/client_sync.rs
+++ b/unix_integration/common/src/client_sync.rs
@@ -1,13 +1,19 @@
 use crate::constants::DEFAULT_CONN_TIMEOUT;
+use crate::json_codec::JsonCodec;
 use crate::unix_proto::{ClientRequest, ClientResponse};
+use bytes::BytesMut;
 use std::error::Error;
-use std::io::{Error as IoError, Read, Write};
+use std::io::{self, Read, Write};
 use std::time::{Duration, SystemTime};
+use tokio_util::codec::{Decoder, Encoder};
 
 pub use std::os::unix::net::UnixStream;
 
+type ClientCodec = JsonCodec<ClientResponse, ClientRequest>;
+
 pub struct DaemonClientBlocking {
     stream: UnixStream,
+    codec: ClientCodec,
     default_timeout: u64,
 }
 
@@ -15,6 +21,7 @@ impl From<UnixStream> for DaemonClientBlocking {
     fn from(stream: UnixStream) -> Self {
         DaemonClientBlocking {
             stream,
+            codec: ClientCodec::default(),
             default_timeout: DEFAULT_CONN_TIMEOUT,
         }
     }
@@ -36,21 +43,21 @@ impl DaemonClientBlocking {
 
         Ok(DaemonClientBlocking {
             stream,
+            codec: ClientCodec::default(),
             default_timeout,
         })
     }
 
     pub fn call_and_wait(
         &mut self,
-        req: &ClientRequest,
+        req: ClientRequest,
         timeout: Option<u64>,
     ) -> Result<ClientResponse, Box<dyn Error>> {
         let timeout = Duration::from_secs(timeout.unwrap_or(self.default_timeout));
 
-        let data = serde_json::to_vec(&req).map_err(|e| {
-            error!("socket encoding error -> {:?}", e);
-            Box::new(IoError::other("JSON encode error"))
-        })?;
+        let mut data = BytesMut::new();
+
+        self.codec.encode(req, &mut data).map_err(Box::new)?;
 
         match self.stream.set_read_timeout(Some(timeout)) {
             Ok(()) => {}
@@ -74,7 +81,7 @@ impl DaemonClientBlocking {
         };
 
         self.stream
-            .write_all(data.as_slice())
+            .write_all(&data)
             .and_then(|_| self.stream.flush())
             .map_err(|e| {
                 error!("stream write error -> {:?}", e);
@@ -83,27 +90,28 @@ impl DaemonClientBlocking {
             .map_err(Box::new)?;
 
         // Now wait on the response.
+        data.clear();
         let start = SystemTime::now();
         let mut read_started = false;
-        let mut data = Vec::with_capacity(1024);
-        let mut counter = 0;
 
         loop {
-            let mut buffer = [0; 1024];
             let durr = SystemTime::now().duration_since(start).map_err(Box::new)?;
             if durr > timeout {
                 error!("Socket timeout");
                 // timed out, not enough activity.
-                break;
+                return Err(Box::new(io::Error::other("Timeout")));
             }
+
+            let mut buffer = [0; 1024];
+
             // Would be a lot easier if we had peek ...
             // https://github.com/rust-lang/rust/issues/76923
             match self.stream.read(&mut buffer) {
                 Ok(0) => {
                     if read_started {
-                        debug!("read_started true, we have completed");
+                        debug!("read_started true, no bytes read");
                         // We're done, no more bytes.
-                        break;
+                        // break;
                     } else {
                         debug!("Waiting ...");
                         // Still can wait ...
@@ -111,18 +119,8 @@ impl DaemonClientBlocking {
                     }
                 }
                 Ok(count) => {
-                    data.extend_from_slice(&buffer);
-                    counter += count;
-                    if count == 1024 {
-                        debug!("Filled 1024 bytes, looping ...");
-                        // We have filled the buffer, we need to copy and loop again.
-                        read_started = true;
-                        continue;
-                    } else {
-                        debug!("Filled {} bytes, complete", count);
-                        // We have a partial read, so we are complete.
-                        break;
-                    }
+                    read_started = true;
+                    data.extend_from_slice(&buffer[..count]);
                 }
                 Err(e) => {
                     error!("Stream read failure from {:?} -> {:?}", &self.stream, e);
@@ -130,17 +128,13 @@ impl DaemonClientBlocking {
                     return Err(Box::new(e));
                 }
             }
+
+            match self.codec.decode(&mut data) {
+                Ok(Some(cr)) => return Ok(cr),
+                // Need more data
+                Ok(None) => continue,
+                Err(e) => return Err(Box::new(e)),
+            }
         }
-
-        // Extend from slice fills with 0's, so we need to truncate now.
-        data.truncate(counter);
-
-        // Now attempt to decode.
-        let cr = serde_json::from_slice::<ClientResponse>(data.as_slice()).map_err(|e| {
-            error!("socket encoding error -> {:?}", e);
-            Box::new(IoError::other("JSON decode error"))
-        })?;
-
-        Ok(cr)
     }
 }

--- a/unix_integration/common/src/client_sync.rs
+++ b/unix_integration/common/src/client_sync.rs
@@ -110,8 +110,9 @@ impl DaemonClientBlocking {
                 Ok(0) => {
                     if read_started {
                         debug!("read_started true, no bytes read");
-                        // We're done, no more bytes.
-                        // break;
+                        // We're done, no more bytes. This will now
+                        // fall through to the codec decode to double
+                        // check this assertion.
                     } else {
                         debug!("Waiting ...");
                         // Still can wait ...

--- a/unix_integration/common/src/json_codec.rs
+++ b/unix_integration/common/src/json_codec.rs
@@ -1,0 +1,163 @@
+use crate::constants::{CODEC_BYTESMUT_ALLOCATION_LIMIT, CODEC_MIMIMUM_BYTESMUT_ALLOCATION};
+use bytes::{BufMut, BytesMut};
+use serde::{de::DeserializeOwned, Serialize};
+use std::io;
+use std::marker::PhantomData;
+use tokio_util::codec::{Decoder, Encoder};
+
+const U32_WIDTH: usize = 4;
+
+pub struct JsonCodec<D, E> {
+    phantom_d: PhantomData<D>,
+    phantom_e: PhantomData<E>,
+}
+
+impl<D, E> Default for JsonCodec<D, E> {
+    fn default() -> Self {
+        Self {
+            phantom_d: PhantomData,
+            phantom_e: PhantomData,
+        }
+    }
+}
+
+impl<D, E> Decoder for JsonCodec<D, E>
+where
+    D: DeserializeOwned,
+{
+    type Error = io::Error;
+    type Item = D;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.len() < U32_WIDTH {
+            // Need more data, at least U32_WIDTH bytes for len
+            return Ok(None);
+        }
+
+        let mut len = [0u8; U32_WIDTH];
+        len.copy_from_slice(&src[0..U32_WIDTH]);
+
+        let len = u32::from_be_bytes(len);
+        let frame_len = U32_WIDTH + len as usize;
+
+        if src.len() < frame_len {
+            // Need more data, at least U32_WIDTH bytes for len, plus the frame size.
+            return Ok(None);
+        }
+
+        // We have the data, lets go.
+        let buffer = src.split_to(frame_len);
+        // This is the frame bytes now.
+        let frame = &buffer[U32_WIDTH..];
+
+        let response = match serde_json::from_slice::<D>(frame) {
+            Ok(msg) => Ok(Some(msg)),
+            Err(json_err) => {
+                error!(?json_err);
+                Err(io::Error::other("Invalid JSON frame"))
+            }
+        };
+
+        // Manage the buffer.
+        if src.is_empty() && src.capacity() >= CODEC_BYTESMUT_ALLOCATION_LIMIT {
+            trace!("buffer trim");
+            let mut empty = BytesMut::with_capacity(CODEC_MIMIMUM_BYTESMUT_ALLOCATION);
+            std::mem::swap(&mut empty, src);
+        }
+
+        response
+    }
+}
+
+impl<D, E> Encoder<E> for JsonCodec<D, E>
+where
+    E: Serialize,
+{
+    type Error = io::Error;
+
+    fn encode(&mut self, msg: E, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let data = serde_json::to_vec(&msg).map_err(|e| {
+            error!("socket encoding error -> {:?}", e);
+            io::Error::other("JSON encode error")
+        })?;
+
+        // Encode how many bytes we wrote
+        let len = data.len() as u32;
+
+        if len == 0 {
+            warn!("refusing to write empty frame.");
+            return Ok(());
+        }
+
+        dst.put(len.to_be_bytes().as_slice());
+        dst.put(data.as_slice());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JsonCodec, U32_WIDTH};
+    use bytes::BytesMut;
+    use serde::{Deserialize, Serialize};
+    use tokio_util::codec::{Decoder, Encoder};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    enum Msg {
+        Test,
+    }
+
+    #[test]
+    fn test_json_codec() {
+        let mut codec: JsonCodec<Msg, Msg> = JsonCodec::default();
+        let mut buffer = BytesMut::new();
+
+        // There should be nothing by default
+        let out = codec.decode(&mut buffer);
+        assert!(matches!(out, Ok(None)));
+
+        // Write a frame
+        codec
+            .encode(Msg::Test, &mut buffer)
+            .expect("Failed to encode");
+
+        // Buffer should have bytes.
+        assert_eq!(buffer.len(), U32_WIDTH + 6);
+
+        // Decode
+        let out = codec.decode(&mut buffer);
+        assert!(matches!(out, Ok(Some(Msg::Test))));
+
+        // Buffer should be trimmed.
+        assert_eq!(buffer.len(), 0);
+
+        // Queue up multiple messages.
+        codec
+            .encode(Msg::Test, &mut buffer)
+            .expect("Failed to encode");
+        codec
+            .encode(Msg::Test, &mut buffer)
+            .expect("Failed to encode");
+        codec
+            .encode(Msg::Test, &mut buffer)
+            .expect("Failed to encode");
+
+        assert_eq!(buffer.len(), (U32_WIDTH + 6) * 3);
+
+        // Decode the first
+        let out = codec.decode(&mut buffer);
+        assert!(matches!(out, Ok(Some(Msg::Test))));
+
+        // Do we have more data?
+        assert_eq!(buffer.len(), (U32_WIDTH + 6) * 2);
+
+        // Pull out the rest
+        let out = codec.decode(&mut buffer);
+        assert!(matches!(out, Ok(Some(Msg::Test))));
+        let out = codec.decode(&mut buffer);
+        assert!(matches!(out, Ok(Some(Msg::Test))));
+
+        // Done!
+        assert_eq!(buffer.len(), 0);
+    }
+}

--- a/unix_integration/common/src/lib.rs
+++ b/unix_integration/common/src/lib.rs
@@ -27,5 +27,7 @@ pub mod unix_passwd;
 #[cfg(target_family = "unix")]
 pub mod unix_proto;
 
+pub mod json_codec;
+
 #[cfg(all(target_family = "unix", feature = "selinux"))]
 pub mod selinux_util;

--- a/unix_integration/nss_kanidm/src/core.rs
+++ b/unix_integration/nss_kanidm/src/core.rs
@@ -77,7 +77,7 @@ pub fn get_all_user_entries(req_options: RequestOptions) -> Response<Vec<Passwd>
             let req = ClientRequest::NssAccounts;
 
             daemon_client
-                .call_and_wait(&req, None)
+                .call_and_wait(req, None)
                 .map(|r| match r {
                     ClientResponse::NssAccounts(l) => {
                         l.into_iter().map(passwd_from_nssuser).collect()
@@ -104,7 +104,7 @@ pub fn get_user_entry_by_uid(uid: libc::uid_t, req_options: RequestOptions) -> R
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::NssAccountByUid(uid);
             daemon_client
-                .call_and_wait(&req, None)
+                .call_and_wait(req, None)
                 .map(|r| match r {
                     ClientResponse::NssAccount(opt) => opt
                         .map(passwd_from_nssuser)
@@ -144,7 +144,7 @@ pub fn get_user_entry_by_name(name: String, req_options: RequestOptions) -> Resp
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::NssAccountByName(name);
             daemon_client
-                .call_and_wait(&req, None)
+                .call_and_wait(req, None)
                 .map(|r| match r {
                     ClientResponse::NssAccount(opt) => opt
                         .map(passwd_from_nssuser)
@@ -184,7 +184,7 @@ pub fn get_all_group_entries(req_options: RequestOptions) -> Response<Vec<Group>
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::NssGroups;
             daemon_client
-                .call_and_wait(&req, None)
+                .call_and_wait(req, None)
                 .map(|r| match r {
                     ClientResponse::NssGroups(l) => {
                         l.into_iter().map(group_from_nssgroup).collect()
@@ -211,7 +211,7 @@ pub fn get_group_entry_by_gid(gid: libc::gid_t, req_options: RequestOptions) -> 
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::NssGroupByGid(gid);
             daemon_client
-                .call_and_wait(&req, None)
+                .call_and_wait(req, None)
                 .map(|r| match r {
                     ClientResponse::NssGroup(opt) => opt
                         .map(group_from_nssgroup)
@@ -251,7 +251,7 @@ pub fn get_group_entry_by_name(name: String, req_options: RequestOptions) -> Res
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::NssGroupByName(name);
             daemon_client
-                .call_and_wait(&req, None)
+                .call_and_wait(req, None)
                 .map(|r| match r {
                     ClientResponse::NssGroup(opt) => opt
                         .map(group_from_nssgroup)

--- a/unix_integration/pam_kanidm/src/core.rs
+++ b/unix_integration/pam_kanidm/src/core.rs
@@ -138,7 +138,7 @@ pub fn sm_authenticate_connected<P: PamHandler>(
     let mut req = ClientRequest::PamAuthenticateInit { account_id, info };
 
     loop {
-        let client_response = match daemon_client.call_and_wait(&req, timeout) {
+        let client_response = match daemon_client.call_and_wait(req, timeout) {
             Ok(r) => r,
             Err(err) => {
                 // Something unrecoverable occurred, bail and stop everything
@@ -418,7 +418,7 @@ pub fn acct_mgmt<P: PamHandler>(
     match req_opt.connect_to_daemon() {
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::PamAccountAllowed(account_id);
-            match daemon_client.call_and_wait(&req, None) {
+            match daemon_client.call_and_wait(req, None) {
                 Ok(r) => match r {
                     ClientResponse::PamStatus(Some(true)) => {
                         debug!("PamResultCode::PAM_SUCCESS");
@@ -500,7 +500,7 @@ pub fn sm_open_session<P: PamHandler>(
         Source::Daemon(mut daemon_client) => {
             let req = ClientRequest::PamAccountBeginSession(account_id);
 
-            match daemon_client.call_and_wait(&req, None) {
+            match daemon_client.call_and_wait(req, None) {
                 Ok(ClientResponse::Ok) => {
                     debug!("PAM_SUCCESS");
                     PamResultCode::PAM_SUCCESS

--- a/unix_integration/resolver/src/bin/kanidm-unix.rs
+++ b/unix_integration/resolver/src/bin/kanidm-unix.rs
@@ -104,7 +104,7 @@ async fn main() -> ExitCode {
                 },
             };
             loop {
-                match daemon_client.call(&req, None).await {
+                match daemon_client.call(req, None).await {
                     Ok(r) => match r {
                         ClientResponse::PamAuthenticateStepResponse(PamAuthResponse::Success) => {
                             println!("auth success!");
@@ -165,7 +165,7 @@ async fn main() -> ExitCode {
 
             let sereq = ClientRequest::PamAccountAllowed(account_id);
 
-            match daemon_client.call(&sereq, None).await {
+            match daemon_client.call(sereq, None).await {
                 Ok(r) => match r {
                     ClientResponse::PamStatus(Some(true)) => {
                         println!("account success!");
@@ -199,7 +199,7 @@ async fn main() -> ExitCode {
 
             let req = ClientRequest::ClearCache;
 
-            match daemon_client.call(&req, None).await {
+            match daemon_client.call(req, None).await {
                 Ok(r) => match r {
                     ClientResponse::Ok => info!("success"),
                     _ => {
@@ -220,7 +220,7 @@ async fn main() -> ExitCode {
 
             let req = ClientRequest::InvalidateCache;
 
-            match daemon_client.call(&req, None).await {
+            match daemon_client.call(req, None).await {
                 Ok(r) => match r {
                     ClientResponse::Ok => info!("success"),
                     _ => {
@@ -240,7 +240,7 @@ async fn main() -> ExitCode {
             let mut daemon_client = setup_client!();
             let req = ClientRequest::Status;
 
-            match daemon_client.call(&req, None).await {
+            match daemon_client.call(req, None).await {
                 Ok(r) => match r {
                     ClientResponse::ProviderStatus(results) => {
                         for provider in results {

--- a/unix_integration/resolver/src/bin/kanidm_ssh_authorizedkeys.rs
+++ b/unix_integration/resolver/src/bin/kanidm_ssh_authorizedkeys.rs
@@ -82,7 +82,7 @@ async fn main() -> ExitCode {
     // safe because we've already thrown an error if it's not there
     let req = ClientRequest::SshKey(opt.account_id.unwrap_or("".to_string()));
 
-    match daemon_client.call(&req, None).await {
+    match daemon_client.call(req, None).await {
         Ok(ClientResponse::SshKeys(sk)) => {
             sk.iter().for_each(|k| {
                 println!("{k}");


### PR DESCRIPTION
Previously our IPC was simple JSON over UnixStreams. This has worked well enough for a long time, but as we have expanded the capabilities of tasks and the resolver, there is now much more traffic between the two.

This can lead to a situation where when writing or decoding frames, the buffer if it contains multiple frames will only read the first frame and then clear() itself. This causes message loss resulting in odd behaviour and dropped events.

To resolve this, we cleanup codec handling and make a generic JsonCodec wrapper. This wrapper now prepends a length to each message so that we can properly remove the bytes of the frame without affecting subsequent frames that may be present.

Fixes #3620

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
