### PR TITLE
Resolve replication show-cert issue

### DIFF
--- a/scripts/setup_dev_environment.sh
+++ b/scripts/setup_dev_environment.sh
@@ -43,7 +43,7 @@ fi
 
 # defaults
 KANIDM_CONFIG_FILE="./insecure_server.toml"
-KANIDM_URL="$(grep origin "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')"
+KANIDM_URL="$(grep -E 'origin.*https' "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')"
 KANIDM_CA_PATH="/tmp/kanidm/ca.pem"
 
 # wait for them to shut down the server if it's running...

--- a/scripts/test_run_release_server.sh
+++ b/scripts/test_run_release_server.sh
@@ -63,7 +63,7 @@ else
     echo "Config file ${KANIDM_CONFIG_FILE} not found!"
     exit 1
 fi
-KANIDM_URL="$(grep origin "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')"
+KANIDM_URL="$(grep -E '^origin.*https' "${KANIDM_CONFIG_FILE}" | awk '{print $NF}' | tr -d '"')"
 KANIDM_CA_PATH="/tmp/kanidm/ca.pem"
 
 while true; do

--- a/server/daemon/insecure_server.toml
+++ b/server/daemon/insecure_server.toml
@@ -15,7 +15,7 @@ tls_key = "/tmp/kanidm/key.pem"
 #
 # log_level = "info"
 # log_level = "debug"
-log_level = "debug"
+log_level = "trace"
 
 # otel_grpc_url = "http://localhost:4317"
 
@@ -27,3 +27,7 @@ origin = "https://localhost:8443"
 # path = "/tmp/kanidm/backups/"
 schedule = "@hourly"
 # enabled = true # default enabled
+
+[replication]
+origin = "repl://127.0.0.1:8444"
+bindaddress = "0.0.0.0:8444"


### PR DESCRIPTION
The replication show cert command relies on the replication loop being operational to display the cert. When we changed to rustls the issue is that empty cert stores are not valid for their PKI verifier, which caused the replication accept loop to never start meaning that show-cert would never complete.

This resolves that by handling the empty cert store case specially and rejecting all incomming connections when the store is empty.


Fixes #3791

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
