### PR TITLE
Show the admin page in the navbar when the user has experiment ui hint.

### DIFF
--- a/server/core/src/https/views/constants.rs
+++ b/server/core/src/https/views/constants.rs
@@ -33,6 +33,7 @@ pub(crate) enum Urls {
     Ui,
     WellKnownChangePassword,
     Radius,
+    Admin,
 }
 
 impl AsRef<str> for Urls {
@@ -48,6 +49,7 @@ impl AsRef<str> for Urls {
             Self::Ui => "/ui",
             Self::WellKnownChangePassword => "/.well-known/change-password",
             Self::Radius => "/ui/radius",
+            Self::Admin => "/ui/admin/persons",
         }
     }
 }

--- a/server/core/src/https/views/enrol.rs
+++ b/server/core/src/https/views/enrol.rs
@@ -81,7 +81,7 @@ pub(crate) async fn view_enrol_get(
     let cu_intent = state
         .qe_w_ref
         .handle_idmcredentialupdateintent(
-            client_auth_info,
+            client_auth_info.clone(),
             spn,
             Some(Duration::from_secs(900)),
             kopid.eventid,
@@ -104,7 +104,7 @@ pub(crate) async fn view_enrol_get(
     };
 
     Ok(ProfileView {
-        navbar_ctx: NavbarCtx { domain_info },
+        navbar_ctx: NavbarCtx::new(domain_info, &uat.ui_hints),
 
         profile_partial: EnrolDeviceView {
             menu_active_item: ProfileMenuItems::EnrolDevice,

--- a/server/core/src/https/views/navbar.rs
+++ b/server/core/src/https/views/navbar.rs
@@ -1,5 +1,18 @@
 use crate::https::extractors::DomainInfoRead;
+use kanidm_proto::internal::UiHint;
+use std::collections::BTreeSet;
 
 pub struct NavbarCtx {
     pub domain_info: DomainInfoRead,
+    pub ui_hints: BTreeSet<UiHint>,
+}
+
+impl NavbarCtx {
+    /// Clones ui_hints
+    pub(crate) fn new(domain_info: DomainInfoRead, ui_hints: &BTreeSet<UiHint>) -> NavbarCtx {
+        NavbarCtx {
+            domain_info,
+            ui_hints: ui_hints.clone(),
+        }
+    }
 }

--- a/server/core/src/https/views/profile.rs
+++ b/server/core/src/https/views/profile.rs
@@ -129,7 +129,7 @@ pub(crate) async fn view_profile_get(
         rehook_email_removal_buttons,
         HxPushUrl(Uri::from_static("/ui/profile")),
         ProfileView {
-            navbar_ctx: NavbarCtx { domain_info },
+            navbar_ctx: NavbarCtx::new(domain_info, &uat.ui_hints),
             profile_partial: ProfilePartialView {
                 menu_active_item: ProfileMenuItems::UserProfile,
                 can_rw,

--- a/server/core/src/https/views/radius.rs
+++ b/server/core/src/https/views/radius.rs
@@ -72,7 +72,7 @@ pub(crate) async fn view_radius_get(
         .map_err(|op_err| HtmxError::new(&kopid, op_err, domain_info.clone()))?;
 
     Ok(ProfileView {
-        navbar_ctx: NavbarCtx { domain_info },
+        navbar_ctx: NavbarCtx::new(domain_info, &uat.ui_hints),
         profile_partial: RadiusPartialView {
             menu_active_item: ProfileMenuItems::Radius,
             radius_password,

--- a/server/core/templates/navbar.html
+++ b/server/core/templates/navbar.html
@@ -31,6 +31,12 @@
                     <a class="nav-link" href=((Urls::Profile))>
                         <span data-feather="file"></span>Profile</a>
                 </li>
+                (% if navbar_ctx.ui_hints.contains(kanidm_proto::internal::UiHint::ExperimentalFeatures|as_ref) %)
+                <li>
+                    <a class="nav-link" href=((Urls::Admin))>
+                        <span data-feather="file"></span>Admin</a>
+                </li>
+                (% endif %)
             </ul>
             <ul class="navbar-nav ms-md-auto">
                 <li>


### PR DESCRIPTION
# Change summary
Shows the admin page in the navbar when the user has experiment ui hint.

❗currently UiHint::Experimental not obtained via the `idm_ui_enable_experimental_features` group. 
Probably worth fixing in the pr too.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
