### PR TITLE
Update whatwg email validation regex

### DIFF
--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -105,7 +105,8 @@ lazy_static! {
     /// this regex validates for valid emails.
     pub static ref VALIDATE_EMAIL_RE: Regex = {
         #[allow(clippy::expect_used)]
-        Regex::new(r"^[a-zA-Z0-9.!#$%&'*+=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$").expect("Invalid singleline regex found")
+        Regex::new(r"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+            .expect("Invalid singleline regex found")
     };
 
     // Formerly checked with


### PR DESCRIPTION
The regex was updated to contain a `\/`  https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
