### PR TITLE
Handle IP addresses in replication SAN field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "rand 0.9.2",
+ "rustls",
  "serde",
  "sha-crypt",
  "sha2 0.10.9",

--- a/libs/crypto/Cargo.toml
+++ b/libs/crypto/Cargo.toml
@@ -21,7 +21,6 @@ base64urlsafedata = { workspace = true }
 hex = { workspace = true }
 kanidm_proto = { workspace = true }
 kanidm-hsm-crypto = { workspace = true }
-
 # We need to explicitly ask for openssl-sys so that we get the version propagated
 # into the build.rs for legacy feature checks.
 openssl-sys = { workspace = true }
@@ -33,9 +32,9 @@ serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
 x509-cert = { workspace = true, features = ["pem"] }
-
 md-5 = { workspace = true }
 sha-crypt = { workspace = true }
+rustls = { workspace = true }
 
 [dev-dependencies]
 sketching = { workspace = true }

--- a/libs/crypto/src/lib.rs
+++ b/libs/crypto/src/lib.rs
@@ -86,6 +86,7 @@ pub enum CryptoError {
     Argon2Version,
     Argon2Parameters,
     Crypt,
+    InvalidServerName,
 }
 
 impl From<OpenSSLErrorStack> for CryptoError {


### PR DESCRIPTION
# Change summary

- Rustls more strictly handles SAN's in TLS connections than OpenSSL does. When we changed, we were accidentally relying on OpenSSL's lax handling where it would accept Ip addresses in a dns name field. Rustls does not allow this.

When we issue our self-signed replication certificate, we should issue it with the correct ip or name setting on the cert SAN

Fixes #3809

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
