### PR TITLE
CLI gardening

### DIFF
--- a/proto/src/cli.rs
+++ b/proto/src/cli.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+
+use clap::{builder::PossibleValue, ValueEnum};
+use serde::Deserialize;
+
+#[derive(Debug, Copy, Clone, Deserialize)]
+pub enum OpType {
+    Read,
+    Write,
+}
+
+impl FromStr for OpType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "read" => Ok(OpType::Read),
+            "write" => Ok(OpType::Write),
+            _ => Err(format!("Invalid OpType: {}", s)),
+        }
+    }
+}
+
+impl ValueEnum for OpType {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Read, Self::Write]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::from(self.as_str()))
+    }
+}
+
+impl OpType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OpType::Read => "read",
+            OpType::Write => "write",
+        }
+    }
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -17,6 +17,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
+pub mod cli;
 pub mod constants;
 pub mod internal;
 pub mod messages;

--- a/proto/src/scim_v1/client.rs
+++ b/proto/src/scim_v1/client.rs
@@ -156,7 +156,7 @@ pub struct ScimListSchemaClass {
 }
 
 #[serde_as]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ScimEntrySchemaAttribute {
     #[serde(flatten)]

--- a/server/daemon/src/opt.rs
+++ b/server/daemon/src/opt.rs
@@ -120,7 +120,7 @@ struct KanidmdParser {
     #[command(subcommand)]
     commands: KanidmdOpt,
 
-    #[clap(short, long, env = "KANIDMD_CONFIG", global = true)]
+    #[clap(short, long, env = "KANIDM_CONFIG", global = true)]
     config_path: Option<PathBuf>,
 
     /// Output formatting

--- a/server/daemon/src/opt.rs
+++ b/server/daemon/src/opt.rs
@@ -1,20 +1,8 @@
 #[derive(Debug, Args)]
-struct CommonOpt {
-    /// Path to the server's configuration file.
-    #[clap(short, long = "config", env = "KANIDM_CONFIG")]
-    config_path: Option<PathBuf>,
-    /// Log format (still in very early development)
-    #[clap(short, long = "output", env = "KANIDM_OUTPUT", default_value = "text")]
-    output_mode: String,
-}
-
-#[derive(Debug, Args)]
 struct BackupOpt {
     #[clap(value_parser)]
     /// Output path for the backup content.
     path: PathBuf,
-    #[clap(flatten)]
-    commonopts: CommonOpt,
 }
 
 #[derive(Debug, Args)]
@@ -22,55 +10,37 @@ struct RestoreOpt {
     #[clap(value_parser)]
     /// Restore from this path. Should be created with "backup".
     path: PathBuf,
-    #[clap(flatten)]
-    commonopts: CommonOpt,
 }
 
 #[derive(Debug, Subcommand)]
 enum DomainSettingsCmds {
     /// Show the current domain
     #[clap(name = "show")]
-    Show {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
+    Show,
     /// Change the IDM domain name based on the values in the configuration
     #[clap(name = "rename")]
-    Change {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
+    Change,
     /// Perform a pre-upgrade-check of this domains content. This will report possible
     /// incompatibilities that can block a successful upgrade to the next version of
     /// Kanidm. This is a safe read only operation.
     #[clap(name = "upgrade-check")]
-    UpgradeCheck {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
-    /// ⚠️  Do not use this command unless directed by a project member. ⚠️ 
+    UpgradeCheck,
+    /// ⚠️  Do not use this command unless directed by a project member. ⚠️
     /// - Raise the functional level of this domain to the maximum available.
     #[clap(name = "raise")]
-    Raise {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
-    /// ⚠️  Do not use this command unless directed by a project member. ⚠️ 
+    Raise,
+    /// ⚠️  Do not use this command unless directed by a project member. ⚠️
     /// - Rerun migrations of this domains database, optionally nominating the level
     ///   to start from.
     #[clap(name = "remigrate")]
-    Remigrate {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-        level: Option<u32>,
-    },
+    Remigrate { level: Option<u32> },
 }
 
 #[derive(Debug, Subcommand)]
 enum DbCommands {
     #[clap(name = "vacuum")]
     /// Vacuum the database to reclaim space or change db_fs_type/page_size (offline)
-    Vacuum(CommonOpt),
+    Vacuum,
     #[clap(name = "backup")]
     /// Backup the database content (offline)
     Backup(BackupOpt),
@@ -79,18 +49,16 @@ enum DbCommands {
     Restore(RestoreOpt),
     #[clap(name = "verify")]
     /// Verify database and entity consistency.
-    Verify(CommonOpt),
+    Verify,
     #[clap(name = "reindex")]
     /// Reindex the database (offline)
-    Reindex(CommonOpt),
+    Reindex,
 }
 
 #[derive(Debug, Args)]
 struct DbScanListIndex {
     /// The name of the index to list
     index_name: String,
-    #[clap(flatten)]
-    commonopts: CommonOpt,
 }
 
 #[derive(Debug, Parser)]
@@ -101,23 +69,19 @@ struct HealthCheckArgs {
     /// Check the 'origin' URL from the server configuration file, instead of the 'address'
     #[clap(short = 'O', long, action)]
     check_origin: bool,
-    #[clap(flatten)]
-    commonopts: CommonOpt,
 }
 
 #[derive(Debug, Args)]
 struct DbScanGetId2Entry {
     /// The id of the entry to display
     id: u64,
-    #[clap(flatten)]
-    commonopts: CommonOpt,
 }
 
 #[derive(Debug, Subcommand)]
 enum DbScanOpt {
     #[clap(name = "list-all-indexes")]
     /// List all index tables that exist on the system.
-    ListIndexes(CommonOpt),
+    ListIndexes,
     #[clap(name = "list-index")]
     /// List all content of a named index
     ListIndex(DbScanListIndex),
@@ -126,34 +90,27 @@ enum DbScanOpt {
     // GetIndex(DbScanGetIndex),
     #[clap(name = "list-id2entry")]
     /// List all id2entry values with reduced entry content
-    ListId2Entry(CommonOpt),
+    ListId2Entry,
     #[clap(name = "get-id2entry")]
     /// View the data of a specific entry from id2entry
     GetId2Entry(DbScanGetId2Entry),
     #[clap(name = "list-index-analysis")]
     /// List all content of index analysis
-    ListIndexAnalysis(CommonOpt),
+    ListIndexAnalysis,
     #[clap(name = "quarantine-id2entry")]
     /// Given an entry id, quarantine the entry in a hidden db partition
     QuarantineId2Entry {
         /// The id of the entry to display
         id: u64,
-        #[clap(flatten)]
-        commonopts: CommonOpt,
     },
     #[clap(name = "list-quarantined")]
     /// List the entries in quarantine
-    ListQuarantined {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
+    ListQuarantined,
     #[clap(name = "restore-quarantined")]
     /// Given an entry id, restore the entry from the hidden db partition
     RestoreQuarantined {
         /// The id of the entry to display
         id: u64,
-        #[clap(flatten)]
-        commonopts: CommonOpt,
     },
 }
 
@@ -162,84 +119,41 @@ enum DbScanOpt {
 struct KanidmdParser {
     #[command(subcommand)]
     commands: KanidmdOpt,
+
+    #[clap(short, long, env = "KANIDMD_CONFIG", global = true)]
+    config_path: Option<PathBuf>,
+
+    /// Output formatting
+    #[clap(
+        short,
+        long = "output",
+        env = "KANIDM_OUTPUT",
+        default_value = "text",
+        global = true
+    )]
+    output_mode: String,
 }
 
-impl KanidmdParser {
-    /// Returns the configuration path that was specified on the command line, if any.
-    fn config_path(&self) -> Option<PathBuf> {
-        match self.commands {
-            KanidmdOpt::Server(ref c) => c.config_path.clone(),
-            KanidmdOpt::ConfigTest(ref c) => c.config_path.clone(),
-            KanidmdOpt::CertGenerate(ref c) => c.config_path.clone(),
-            KanidmdOpt::RecoverAccount { ref commonopts, .. } |
-            KanidmdOpt::DisableAccount { ref commonopts, .. }
-                => commonopts.config_path.clone(),
-            KanidmdOpt::ShowReplicationCertificate { ref commonopts, .. } => {
-                commonopts.config_path.clone()
-            }
-            KanidmdOpt::RenewReplicationCertificate { ref commonopts, .. } => {
-                commonopts.config_path.clone()
-            }
-            KanidmdOpt::RefreshReplicationConsumer { ref commonopts, .. } => {
-                commonopts.config_path.clone()
-            }
-            KanidmdOpt::DbScan { ref commands } => match commands {
-                DbScanOpt::ListIndexes(ref c) => c.config_path.clone(),
-                DbScanOpt::ListIndex(ref c) => c.commonopts.config_path.clone(),
-                DbScanOpt::ListId2Entry(ref c) => c.config_path.clone(),
-                DbScanOpt::GetId2Entry(ref c) => c.commonopts.config_path.clone(),
-                DbScanOpt::ListIndexAnalysis(ref c) => c.config_path.clone(),
-                DbScanOpt::QuarantineId2Entry { ref commonopts, .. } => {
-                    commonopts.config_path.clone()
-                }
-                DbScanOpt::ListQuarantined { ref commonopts } => commonopts.config_path.clone(),
-                DbScanOpt::RestoreQuarantined { ref commonopts, .. } => {
-                    commonopts.config_path.clone()
-                }
-            },
-            KanidmdOpt::Database { ref commands } => match commands {
-                DbCommands::Vacuum(ref c) => c.config_path.clone(),
-                DbCommands::Backup(ref c) => c.commonopts.config_path.clone(),
-                DbCommands::Restore(ref c) => c.commonopts.config_path.clone(),
-                DbCommands::Verify(ref c) => c.config_path.clone(),
-                DbCommands::Reindex(ref c) => c.config_path.clone(),
-            },
-            KanidmdOpt::DomainSettings { ref commands } => match commands {
-                DomainSettingsCmds::Show { ref commonopts } => commonopts.config_path.clone(),
-                DomainSettingsCmds::Change { ref commonopts } => commonopts.config_path.clone(),
-                DomainSettingsCmds::UpgradeCheck { ref commonopts } => commonopts.config_path.clone(),
-                DomainSettingsCmds::Raise { ref commonopts } => commonopts.config_path.clone(),
-                DomainSettingsCmds::Remigrate { ref commonopts, .. } => {
-                    commonopts.config_path.clone()
-                }
-            },
-            KanidmdOpt::HealthCheck(ref c) => c.commonopts.config_path.clone(),
-            KanidmdOpt::Version(ref c) => c.config_path.clone(),
-        }
-    }
-}
-
+// The main command parser for kanidmd
 #[derive(Debug, Subcommand)]
 enum KanidmdOpt {
     #[clap(name = "server")]
     /// Start the IDM Server
-    Server(CommonOpt),
+    Server,
     #[clap(name = "configtest")]
     /// Test the IDM Server configuration, without starting network listeners.
-    ConfigTest(CommonOpt),
+    ConfigTest,
     #[clap(name = "cert-generate")]
     /// Create a self-signed ca and tls certificate in the locations listed from the
     /// configuration. These certificates should *not* be used in production, they
     /// are for testing and evaluation only!
-    CertGenerate(CommonOpt),
+    CertGenerate,
     #[clap(name = "recover-account")]
     /// Recover an account's password
     RecoverAccount {
         #[clap(value_parser)]
         /// The account name to recover credentials for.
         name: String,
-        #[clap(flatten)]
-        commonopts: CommonOpt,
     },
     #[clap(name = "disable-account")]
     /// Disable an account so that it can not be used. This can be reset with `recover-account`.
@@ -247,30 +161,20 @@ enum KanidmdOpt {
         #[clap(value_parser)]
         /// The account name to disable.
         name: String,
-        #[clap(flatten)]
-        commonopts: CommonOpt,
     },
     /// Display this server's replication certificate
-    ShowReplicationCertificate {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
+    ShowReplicationCertificate,
     /// Renew this server's replication certificate
-    RenewReplicationCertificate {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
-    },
+    RenewReplicationCertificate,
     /// Refresh this servers database content with the content from a supplier. This means
     /// that all local content will be deleted and replaced with the supplier content.
     RefreshReplicationConsumer {
-        #[clap(flatten)]
-        commonopts: CommonOpt,
         /// Acknowledge that this database content will be refreshed from a supplier.
         #[clap(long = "i-want-to-refresh-this-servers-database")]
         proceed: bool,
     },
     // #[clap(name = "reset_server_id")]
-    // ResetServerId(CommonOpt),
+    // ResetServerId,
     #[clap(name = "db-scan")]
     /// Inspect the internal content of the database datastructures.
     DbScan {
@@ -296,5 +200,5 @@ enum KanidmdOpt {
 
     /// Print the program version and exit
     #[clap(name = "version")]
-    Version(CommonOpt),
+    Version,
 }

--- a/tools/cli/src/cli/domain/mod.rs
+++ b/tools/cli/src/cli/domain/mod.rs
@@ -1,73 +1,57 @@
-use crate::common::OpType;
-use crate::{handle_client_error, DomainOpt};
+use crate::{handle_client_error, DomainOpt, KanidmClientParser};
 use anyhow::{Context, Error};
-use kanidm_proto::internal::ImageValue;
+use kanidm_proto::{cli::OpType, internal::ImageValue};
 use std::fs::read;
 
 impl DomainOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            DomainOpt::SetDisplayname(copt) => copt.copt.debug,
-            DomainOpt::SetLdapBasedn { copt, .. }
-            | DomainOpt::SetImage { copt, .. }
-            | DomainOpt::RemoveImage { copt }
-            | DomainOpt::SetLdapAllowUnixPasswordBind { copt, .. }
-            | DomainOpt::SetAllowEasterEggs { copt, .. }
-            | DomainOpt::RevokeKey { copt, .. }
-            | DomainOpt::Show(copt)
-            | DomainOpt::SetLdapMaxQueryableAttrs { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            DomainOpt::SetDisplayname(opt) => {
+            DomainOpt::SetDisplayname(dopt) => {
                 eprintln!(
                     "Attempting to set the domain's display name to: {:?}",
-                    opt.new_display_name
+                    dopt.new_display_name
                 );
-                let client = opt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
-                    .idm_domain_set_display_name(&opt.new_display_name)
+                    .idm_domain_set_display_name(&dopt.new_display_name)
                     .await
                 {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, opt.copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             DomainOpt::SetLdapMaxQueryableAttrs {
-                copt,
                 new_max_queryable_attrs,
             } => {
                 eprintln!(
                     "Attempting to set the maximum number of queryable LDAP attributes to: {new_max_queryable_attrs:?}"
                 );
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_domain_set_ldap_max_queryable_attrs(*new_max_queryable_attrs)
                     .await
                 {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::SetLdapBasedn { copt, new_basedn } => {
+            DomainOpt::SetLdapBasedn { new_basedn } => {
                 eprintln!("Attempting to set the domain's ldap basedn to: {new_basedn:?}");
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_domain_set_ldap_basedn(new_basedn).await {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::SetLdapAllowUnixPasswordBind { copt, enable } => {
-                let client = copt.to_client(OpType::Write).await;
+            DomainOpt::SetLdapAllowUnixPasswordBind { enable } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_set_ldap_allow_unix_password_bind(*enable).await {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::SetAllowEasterEggs { copt, enable } => {
-                let client = copt.to_client(OpType::Write).await;
+            DomainOpt::SetAllowEasterEggs { enable } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_set_domain_allow_easter_eggs(*enable).await {
                     Ok(_) => {
                         if *enable {
@@ -76,29 +60,25 @@ impl DomainOpt {
                             println!("Success")
                         }
                     }
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::Show(copt) => {
-                let client = copt.to_client(OpType::Read).await;
+            DomainOpt::Show => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_domain_get().await {
                     Ok(e) => println!("{e}"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::RevokeKey { copt, key_id } => {
-                let client = copt.to_client(OpType::Write).await;
+            DomainOpt::RevokeKey { key_id } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_domain_revoke_key(key_id).await {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::SetImage {
-                copt,
-                path,
-                image_type,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            DomainOpt::SetImage { path, image_type } => {
+                let client = opt.to_client(OpType::Write).await;
                 let img_res: Result<ImageValue, Error> = (move || {
                     let file_name = path
                         .file_name()
@@ -122,7 +102,7 @@ impl DomainOpt {
                     match read_res {
                         Ok(data) => Ok(ImageValue::new(file_name, image_type, data)),
                         Err(err) => {
-                            if copt.debug {
+                            if opt.debug {
                                 eprintln!(
                                     "{}",
                                     kanidm_lib_file_permissions::diagnose_path(path.as_ref())
@@ -143,15 +123,15 @@ impl DomainOpt {
 
                 match client.idm_domain_update_image(img).await {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DomainOpt::RemoveImage { copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            DomainOpt::RemoveImage => {
+                let client = opt.to_client(OpType::Write).await;
 
                 match client.idm_domain_delete_image().await {
                     Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
         }

--- a/tools/cli/src/cli/graph.rs
+++ b/tools/cli/src/cli/graph.rs
@@ -1,16 +1,13 @@
-use crate::common::OpType;
-use crate::{handle_client_error, GraphCommonOpt, GraphType, ObjectType, OutputMode};
+use crate::{
+    handle_client_error, GraphCommonOpt, GraphType, KanidmClientParser, ObjectType, OutputMode,
+};
+use kanidm_proto::cli::OpType;
 use kanidm_proto::internal::Filter::{Eq, Or};
 
 impl GraphCommonOpt {
-    pub fn debug(&self) -> bool {
-        self.copt.debug
-    }
-
-    pub async fn exec(&self) {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         let gopt: &GraphCommonOpt = self;
-        let copt = &gopt.copt;
-        let client = copt.to_client(OpType::Read).await;
+        let client = opt.to_client(OpType::Read).await;
         let graph_type = &gopt.graph_type;
         let filters = &gopt.filter;
 
@@ -25,12 +22,12 @@ impl GraphCommonOpt {
         let entries = match result {
             Ok(entries) => entries,
             Err(e) => {
-                handle_client_error(e, copt.output_mode);
+                handle_client_error(e, opt.output_mode);
                 return;
             }
         };
 
-        match copt.output_mode {
+        match opt.output_mode {
             OutputMode::Json => {
                 let r_attrs: Vec<_> = entries.iter().map(|entry| &entry.attrs).collect();
                 println!(

--- a/tools/cli/src/cli/group/account_policy.rs
+++ b/tools/cli/src/cli/group/account_policy.rs
@@ -1,122 +1,111 @@
-use crate::common::OpType;
-use crate::{handle_client_error, handle_group_account_policy_error, GroupAccountPolicyOpt};
+use crate::{
+    handle_client_error, handle_group_account_policy_error, GroupAccountPolicyOpt,
+    KanidmClientParser,
+};
+use kanidm_proto::cli::OpType;
 
 impl GroupAccountPolicyOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            GroupAccountPolicyOpt::Enable { copt, .. }
-            | GroupAccountPolicyOpt::AuthSessionExpiry { copt, .. }
-            | GroupAccountPolicyOpt::CredentialTypeMinimum { copt, .. }
-            | GroupAccountPolicyOpt::PasswordMinimumLength { copt, .. }
-            | GroupAccountPolicyOpt::WebauthnAttestationCaList { copt, .. }
-            | GroupAccountPolicyOpt::LimitSearchMaxResults { copt, .. }
-            | GroupAccountPolicyOpt::LimitSearchMaxFilterTest { copt, .. }
-            | GroupAccountPolicyOpt::AllowPrimaryCredFallback { copt, .. }
-            | GroupAccountPolicyOpt::ResetWebauthnAttestationCaList { copt, .. }
-            | GroupAccountPolicyOpt::ResetAuthSessionExpiry { copt, .. }
-            | GroupAccountPolicyOpt::ResetPasswordMinimumLength { copt, .. }
-            | GroupAccountPolicyOpt::ResetPrivilegedSessionExpiry { copt, .. }
-            | GroupAccountPolicyOpt::ResetLimitSearchMaxResults { copt, .. }
-            | GroupAccountPolicyOpt::ResetLimitSearchMaxFilterTest { copt, .. }
-            | GroupAccountPolicyOpt::PrivilegedSessionExpiry { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            GroupAccountPolicyOpt::Enable { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::Enable { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client.group_account_policy_enable(name).await {
-                    handle_client_error(e, copt.output_mode);
+                    handle_client_error(e, opt.output_mode);
                 } else {
-                    println!("Group enabled for account policy.");
+                    opt.output_mode
+                        .print_message("Group enabled for account policy.");
                 }
             }
-            GroupAccountPolicyOpt::AuthSessionExpiry { name, expiry, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::AuthSessionExpiry { name, expiry } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_authsession_expiry_set(name, *expiry)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated authsession expiry.");
+                    opt.output_mode.print_message("Updated authsession expiry.");
                 }
             }
 
-            GroupAccountPolicyOpt::ResetAuthSessionExpiry { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::ResetAuthSessionExpiry { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_authsession_expiry_reset(name)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Successfully reset authsession expiry.");
+                    opt.output_mode
+                        .print_message("Successfully reset authsession expiry.");
                 }
             }
 
-            GroupAccountPolicyOpt::CredentialTypeMinimum { name, value, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::CredentialTypeMinimum { name, value } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_credential_type_minimum_set(name, value.as_str())
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated credential type minimum.");
+                    opt.output_mode
+                        .print_message("Updated credential type minimum.");
                 }
             }
-            GroupAccountPolicyOpt::PasswordMinimumLength { name, length, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::PasswordMinimumLength { name, length } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_password_minimum_length_set(name, *length)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated password minimum length.");
+                    opt.output_mode
+                        .print_message("Updated password minimum length.");
                 }
             }
-            GroupAccountPolicyOpt::ResetPasswordMinimumLength { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::ResetPasswordMinimumLength { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_password_minimum_length_reset(name)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Successfully reset password minimum length.");
+                    opt.output_mode
+                        .print_message("Successfully reset password minimum length.");
                 }
             }
-            GroupAccountPolicyOpt::PrivilegedSessionExpiry { name, expiry, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::PrivilegedSessionExpiry { name, expiry } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_privilege_expiry_set(name, *expiry)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated privilege session expiry.");
+                    opt.output_mode
+                        .print_message("Updated privilege session expiry.");
                 }
             }
-            GroupAccountPolicyOpt::ResetPrivilegedSessionExpiry { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::ResetPrivilegedSessionExpiry { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_privilege_expiry_reset(name)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Successfully reset privilege session expiry.");
+                    opt.output_mode
+                        .print_message("Successfully reset privilege session expiry.");
                 }
             }
             GroupAccountPolicyOpt::WebauthnAttestationCaList {
                 name,
                 attestation_ca_list_json_file,
-                copt,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 let json = std::fs::read_to_string(attestation_ca_list_json_file).unwrap_or_else(|e| {
                     error!("Could not read attestation CA list JSON file {attestation_ca_list_json_file:?}: {e:?}");
                     std::process::exit(1);
@@ -126,85 +115,85 @@ impl GroupAccountPolicyOpt {
                     .group_account_policy_webauthn_attestation_set(name, &json)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated webauthn attestation CA list.");
+                    opt.output_mode
+                        .print_message("Updated webauthn attestation CA list.");
                 }
             }
 
-            GroupAccountPolicyOpt::ResetWebauthnAttestationCaList { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::ResetWebauthnAttestationCaList { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_webauthn_attestation_reset(name)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Successfully reset webauthn attestation CA list.");
+                    opt.output_mode
+                        .print_message("Successfully reset webauthn attestation CA list.");
                 }
             }
 
-            GroupAccountPolicyOpt::LimitSearchMaxResults {
-                name,
-                maximum,
-                copt,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::LimitSearchMaxResults { name, maximum } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_limit_search_max_results(name, *maximum)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated search maximum results limit.");
+                    opt.output_mode
+                        .print_message("Updated search maximum results limit.");
                 }
             }
-            GroupAccountPolicyOpt::ResetLimitSearchMaxResults { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::ResetLimitSearchMaxResults { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_limit_search_max_results_reset(name)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Successfully reset search maximum results limit to default.");
+                    opt.output_mode.print_message(
+                        "Successfully reset search maximum results limit to default.",
+                    );
                 }
             }
-            GroupAccountPolicyOpt::LimitSearchMaxFilterTest {
-                name,
-                maximum,
-                copt,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::LimitSearchMaxFilterTest { name, maximum } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_limit_search_max_filter_test(name, *maximum)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated search maximum filter test limit.");
+                    opt.output_mode
+                        .print_message("Updated search maximum filter test limit.");
                 }
             }
-            GroupAccountPolicyOpt::ResetLimitSearchMaxFilterTest { name, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::ResetLimitSearchMaxFilterTest { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_limit_search_max_filter_test_reset(name)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Successfully reset search maximum filter test limit.");
+                    opt.output_mode
+                        .print_message("Successfully reset search maximum filter test limit.");
                 }
             }
-            GroupAccountPolicyOpt::AllowPrimaryCredFallback { name, allow, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupAccountPolicyOpt::AllowPrimaryCredFallback { name, allow } => {
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client
                     .group_account_policy_allow_primary_cred_fallback(name, *allow)
                     .await
                 {
-                    handle_group_account_policy_error(e, copt.output_mode);
+                    handle_group_account_policy_error(e, opt.output_mode);
                 } else {
-                    println!("Updated primary credential fallback policy.");
+                    opt.output_mode
+                        .print_message("Updated primary credential fallback policy.");
                 }
             }
         }

--- a/tools/cli/src/cli/group/mod.rs
+++ b/tools/cli/src/cli/group/mod.rs
@@ -1,39 +1,16 @@
-use crate::common::OpType;
-use crate::{handle_client_error, GroupOpt, GroupPosix, OutputMode};
+use crate::{handle_client_error, GroupOpt, GroupPosix, KanidmClientParser, OutputMode};
+use kanidm_proto::cli::OpType;
 use kanidm_proto::constants::ATTR_GIDNUMBER;
 
 mod account_policy;
 
 impl GroupOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            GroupOpt::List(copt) | GroupOpt::Search { copt, .. } => copt.debug,
-            GroupOpt::Get(gcopt) => gcopt.copt.debug,
-            GroupOpt::SetEntryManagedBy { copt, .. } | GroupOpt::Create { copt, .. } => copt.debug,
-            GroupOpt::Delete(gcopt) => gcopt.copt.debug,
-            GroupOpt::ListMembers(gcopt) => gcopt.copt.debug,
-            GroupOpt::AddMembers(gcopt) => gcopt.copt.debug,
-            GroupOpt::RemoveMembers(gcopt) => gcopt.copt.debug,
-            GroupOpt::SetMembers(gcopt) => gcopt.copt.debug,
-            GroupOpt::PurgeMembers(gcopt) => gcopt.copt.debug,
-            GroupOpt::SetDescription { copt, .. }
-            | GroupOpt::Rename { copt, .. }
-            | GroupOpt::SetMail { copt, .. } => copt.debug,
-            GroupOpt::Posix { commands } => match commands {
-                GroupPosix::Show(gcopt) => gcopt.copt.debug,
-                GroupPosix::Set(gcopt) => gcopt.copt.debug,
-                GroupPosix::ResetGidnumber { copt, .. } => copt.debug,
-            },
-            GroupOpt::AccountPolicy { commands } => commands.debug(),
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            GroupOpt::List(copt) => {
-                let client = copt.to_client(OpType::Read).await;
+            GroupOpt::List => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_group_list().await {
-                    Ok(r) => match copt.output_mode {
+                    Ok(r) => match opt.output_mode {
                         OutputMode::Json => {
                             let r_attrs: Vec<_> = r.iter().map(|entry| &entry.attrs).collect();
                             println!(
@@ -43,13 +20,13 @@ impl GroupOpt {
                         }
                         OutputMode::Text => r.iter().for_each(|ent| println!("{ent}")),
                     },
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            GroupOpt::Search { copt, name } => {
-                let client = copt.to_client(OpType::Read).await;
+            GroupOpt::Search { name } => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_group_search(name).await {
-                    Ok(r) => match copt.output_mode {
+                    Ok(r) => match opt.output_mode {
                         OutputMode::Json => {
                             let r_attrs: Vec<_> = r.iter().map(|entry| &entry.attrs).collect();
                             println!(
@@ -59,32 +36,25 @@ impl GroupOpt {
                         }
                         OutputMode::Text => r.iter().for_each(|ent| println!("{ent}")),
                     },
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             GroupOpt::Get(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
                 // idm_group_get
                 match client.idm_group_get(gcopt.name.as_str()).await {
-                    Ok(Some(e)) => match gcopt.copt.output_mode {
-                        OutputMode::Json => {
-                            println!(
-                                "{}",
-                                serde_json::to_string(&e.attrs).expect("Failed to serialise json")
-                            );
-                        }
-                        OutputMode::Text => println!("{e}"),
-                    },
-                    Ok(None) => warn!("No matching group '{}'", gcopt.name.as_str()),
-                    Err(e) => handle_client_error(e, gcopt.copt.output_mode),
+                    Ok(Some(e)) => opt.output_mode.print_message(e),
+                    Ok(None) => opt
+                        .output_mode
+                        .print_message(format!("No matching group '{}'", gcopt.name.as_str())),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             GroupOpt::Create {
-                copt,
                 name,
                 entry_managed_by,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_group_create(name.as_str(), entry_managed_by.as_deref())
                     .await
@@ -92,53 +62,67 @@ impl GroupOpt {
                     Err(err) => {
                         error!("Error -> {:?}", err)
                     }
-                    Ok(_) => println!("Successfully created group '{}'", name.as_str()),
+                    Ok(_) => opt
+                        .output_mode
+                        .print_message(format!("Successfully created group '{}'", name.as_str())),
                 }
             }
             GroupOpt::Delete(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_group_delete(gcopt.name.as_str()).await {
-                    Err(e) => handle_client_error(e, gcopt.copt.output_mode),
-                    Ok(_) => println!("Successfully deleted group {}", gcopt.name.as_str()),
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt.output_mode.print_message(format!(
+                        "Successfully deleted group {}",
+                        gcopt.name.as_str()
+                    )),
                 }
             }
             GroupOpt::PurgeMembers(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_group_purge_members(gcopt.name.as_str()).await {
-                    Err(e) => handle_client_error(e, gcopt.copt.output_mode),
-                    Ok(_) => println!(
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt.output_mode.print_message(format!(
                         "Successfully purged members of group {}",
                         gcopt.name.as_str()
-                    ),
+                    )),
                 }
             }
             GroupOpt::ListMembers(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_group_get_members(gcopt.name.as_str()).await {
-                    Ok(Some(groups)) => groups.iter().for_each(|m| println!("{m:?}")),
+                    Ok(Some(groups)) => match opt.output_mode {
+                        OutputMode::Json => {
+                            println!(
+                                "{}",
+                                serde_json::to_string(&groups)
+                                    .expect("Failed to serialise groups to JSON")
+                            );
+                        }
+                        OutputMode::Text => groups.iter().for_each(|m| println!("{m:?}")),
+                    },
                     Ok(None) => warn!("No members in group {}", gcopt.name.as_str()),
-                    Err(e) => handle_client_error(e, gcopt.copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             GroupOpt::AddMembers(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 let new_members: Vec<&str> = gcopt.members.iter().map(String::as_str).collect();
 
                 match client
                     .idm_group_add_members(gcopt.name.as_str(), &new_members)
                     .await
                 {
-                    Err(e) => handle_client_error(e, gcopt.copt.output_mode),
-                    Ok(_) => println!(
+                    Ok(_) => opt.output_mode.print_message(format!(
                         "Successfully added {:?} to group \"{}\"",
                         &new_members,
                         gcopt.name.as_str()
-                    ),
+                    )),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
 
             GroupOpt::RemoveMembers(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 let remove_members: Vec<&str> = gcopt.members.iter().map(String::as_str).collect();
 
                 match client
@@ -147,25 +131,31 @@ impl GroupOpt {
                 {
                     Err(e) => {
                         error!("Failed to remove members!");
-                        handle_client_error(e, gcopt.copt.output_mode)
+                        handle_client_error(e, opt.output_mode)
                     }
-                    Ok(_) => println!("Successfully removed members from {}", gcopt.name.as_str()),
+                    Ok(_) => opt.output_mode.print_message(format!(
+                        "Successfully removed members from group {}",
+                        gcopt.name
+                    )),
                 }
             }
             GroupOpt::SetMembers(gcopt) => {
-                let client = gcopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 let new_members: Vec<&str> = gcopt.members.iter().map(String::as_str).collect();
 
                 match client
                     .idm_group_set_members(gcopt.name.as_str(), &new_members)
                     .await
                 {
-                    Err(e) => handle_client_error(e, gcopt.copt.output_mode),
-                    Ok(_) => println!("Successfully set members for group {}", gcopt.name.as_str()),
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt.output_mode.print_message(format!(
+                        "Successfully set members for group {}",
+                        gcopt.name
+                    )),
                 }
             }
-            GroupOpt::SetMail { copt, name, mail } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupOpt::SetMail { name, mail } => {
+                let client = opt.to_client(OpType::Write).await;
 
                 let result = if mail.is_empty() {
                     client.idm_group_purge_mail(name.as_str()).await
@@ -176,16 +166,15 @@ impl GroupOpt {
                 };
 
                 match result {
-                    Err(e) => handle_client_error(e, copt.output_mode),
-                    Ok(_) => println!("Successfully set mail for group {}", name.as_str()),
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt.output_mode.print_message(format!(
+                        "Successfully set mail for group {}",
+                        name.as_str()
+                    )),
                 }
             }
-            GroupOpt::SetDescription {
-                copt,
-                name,
-                description,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupOpt::SetDescription { name, description } => {
+                let client = opt.to_client(OpType::Write).await;
 
                 let result = if let Some(description) = description {
                     client
@@ -196,73 +185,73 @@ impl GroupOpt {
                 };
 
                 match result {
-                    Err(e) => handle_client_error(e, copt.output_mode),
-                    Ok(_) => println!("Successfully set description for group {}", name.as_str()),
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt.output_mode.print_message(format!(
+                        "Successfully set description for group {}",
+                        name.as_str()
+                    )),
                 }
             }
-            GroupOpt::Rename {
-                copt,
-                name,
-                new_name,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            GroupOpt::Rename { name, new_name } => {
+                let client = opt.to_client(OpType::Write).await;
 
                 let result = client.group_rename(name.as_str(), new_name.as_str()).await;
 
                 match result {
-                    Err(e) => handle_client_error(e, copt.output_mode),
-                    Ok(_) => println!("Successfully renamed group {name} to {new_name}"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt
+                        .output_mode
+                        .print_message(format!("Successfully renamed group {name} to {new_name}")),
                 }
             }
             GroupOpt::SetEntryManagedBy {
                 name,
                 entry_managed_by,
-                copt,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
 
                 match client
                     .idm_group_set_entry_managed_by(name, entry_managed_by)
                     .await
                 {
-                    Err(e) => handle_client_error(e, copt.output_mode),
-                    Ok(_) => println!(
+                    Err(e) => handle_client_error(e, opt.output_mode),
+                    Ok(_) => opt.output_mode.print_message(format!(
                         "Successfully set entry manager to '{entry_managed_by}' for group '{name}'"
-                    ),
+                    )),
                 }
             }
             GroupOpt::Posix { commands } => match commands {
                 GroupPosix::Show(gcopt) => {
-                    let client = gcopt.copt.to_client(OpType::Read).await;
+                    let client = opt.to_client(OpType::Read).await;
                     match client.idm_group_unix_token_get(gcopt.name.as_str()).await {
-                        Ok(token) => println!("{token}"),
-                        Err(e) => handle_client_error(e, gcopt.copt.output_mode),
+                        Ok(token) => opt.output_mode.print_message(token),
+                        Err(e) => handle_client_error(e, opt.output_mode),
                     }
                 }
                 GroupPosix::Set(gcopt) => {
-                    let client = gcopt.copt.to_client(OpType::Write).await;
+                    let client = opt.to_client(OpType::Write).await;
                     match client
                         .idm_group_unix_extend(gcopt.name.as_str(), gcopt.gidnumber)
                         .await
                     {
-                        Err(e) => handle_client_error(e, gcopt.copt.output_mode),
-                        Ok(_) => println!(
+                        Err(e) => handle_client_error(e, opt.output_mode),
+                        Ok(_) => opt.output_mode.print_message(format!(
                             "Success adding POSIX configuration for group {}",
-                            gcopt.name.as_str()
-                        ),
+                            gcopt.name
+                        )),
                     }
                 }
-                GroupPosix::ResetGidnumber { copt, group_id } => {
-                    let client = copt.to_client(OpType::Write).await;
+                GroupPosix::ResetGidnumber { group_id } => {
+                    let client = opt.to_client(OpType::Write).await;
                     if let Err(e) = client
                         .idm_group_purge_attr(group_id.as_str(), ATTR_GIDNUMBER)
                         .await
                     {
-                        handle_client_error(e, copt.output_mode)
+                        handle_client_error(e, opt.output_mode)
                     }
                 }
             },
-            GroupOpt::AccountPolicy { commands } => commands.exec().await,
+            GroupOpt::AccountPolicy { commands } => commands.exec(opt).await,
         } // end match
     }
 }

--- a/tools/cli/src/cli/main.rs
+++ b/tools/cli/src/cli/main.rs
@@ -50,7 +50,7 @@ async fn signal_handler(opt: KanidmClientParser) -> ExitCode {
 
 #[cfg(target_family = "windows")]
 async fn signal_handler(opt: KanidmClientParser) -> ExitCode {
-    opt.commands.exec().await;
+    opt.exec().await;
     ExitCode::SUCCESS
 }
 

--- a/tools/cli/src/cli/main.rs
+++ b/tools/cli/src/cli/main.rs
@@ -33,7 +33,7 @@ async fn signal_handler(opt: KanidmClientParser) -> ExitCode {
     let mut signal_pipe = signal(SignalKind::pipe()).expect("Invalid Signal");
 
     tokio::select! {
-        _ = opt.commands.exec() => {
+        _ = opt.exec() => {
             ExitCode::SUCCESS
         }
         _ = signal_quit.recv() => {
@@ -59,7 +59,7 @@ fn main() -> ExitCode {
 
     let fmt_layer = fmt::layer().with_writer(std::io::stderr);
 
-    let filter_layer = if opt.commands.debug() {
+    let filter_layer = if opt.debug {
         match EnvFilter::try_new("kanidm=debug,kanidm_client=debug,webauthn=debug,kanidm_cli=debug")
         {
             Ok(f) => f,

--- a/tools/cli/src/cli/oauth2.rs
+++ b/tools/cli/src/cli/oauth2.rs
@@ -1,87 +1,42 @@
-use crate::common::OpType;
-use crate::Oauth2ClaimMapJoin;
 use crate::{handle_client_error, Oauth2Opt, OutputMode};
+use crate::{KanidmClientParser, Oauth2ClaimMapJoin};
 use anyhow::{Context, Error};
+use kanidm_proto::cli::OpType;
 use kanidm_proto::internal::{ImageValue, Oauth2ClaimMapJoin as ProtoOauth2ClaimMapJoin};
 use std::fs::read;
 use std::process::exit;
 
 impl Oauth2Opt {
-    pub fn debug(&self) -> bool {
-        match self {
-            Oauth2Opt::List(copt) => copt.debug,
-            Oauth2Opt::Get(nopt) => nopt.copt.debug,
-            Oauth2Opt::UpdateScopeMap(cbopt) => cbopt.nopt.copt.debug,
-            Oauth2Opt::DeleteScopeMap(cbopt) => cbopt.nopt.copt.debug,
-            Oauth2Opt::UpdateSupScopeMap(cbopt) => cbopt.nopt.copt.debug,
-            Oauth2Opt::DeleteSupScopeMap(cbopt) => cbopt.nopt.copt.debug,
-            Oauth2Opt::ResetSecrets(cbopt) => cbopt.copt.debug,
-            // Should this be renamed to show client id? client secrets?
-            Oauth2Opt::ShowBasicSecret(nopt) => nopt.copt.debug,
-            Oauth2Opt::Delete(nopt) => nopt.copt.debug,
-            Oauth2Opt::SetDisplayname(cbopt) => cbopt.nopt.copt.debug,
-            Oauth2Opt::SetName { nopt, .. } => nopt.copt.debug,
-            Oauth2Opt::SetLandingUrl { nopt, .. } => nopt.copt.debug,
-            Oauth2Opt::SetImage { nopt, .. } => nopt.copt.debug,
-            Oauth2Opt::RemoveImage(nopt) => nopt.copt.debug,
-            Oauth2Opt::EnablePkce(nopt) => nopt.copt.debug,
-            Oauth2Opt::DisablePkce(nopt) => nopt.copt.debug,
-            Oauth2Opt::EnableLegacyCrypto(nopt) => nopt.copt.debug,
-            Oauth2Opt::DisableLegacyCrypto(nopt) => nopt.copt.debug,
-            Oauth2Opt::PreferShortUsername(nopt) => nopt.copt.debug,
-            Oauth2Opt::PreferSPNUsername(nopt) => nopt.copt.debug,
-
-            #[cfg(feature = "dev-oauth2-device-flow")]
-            Oauth2Opt::DeviceFlowDisable(nopt) => nopt.copt.debug,
-
-            #[cfg(feature = "dev-oauth2-device-flow")]
-            Oauth2Opt::DeviceFlowEnable(nopt) => nopt.copt.debug,
-            Oauth2Opt::CreateBasic { copt, .. }
-            | Oauth2Opt::CreatePublic { copt, .. }
-            | Oauth2Opt::UpdateClaimMap { copt, .. }
-            | Oauth2Opt::UpdateClaimMapJoin { copt, .. }
-            | Oauth2Opt::DeleteClaimMap { copt, .. }
-            | Oauth2Opt::EnablePublicLocalhost { copt, .. }
-            | Oauth2Opt::DisablePublicLocalhost { copt, .. }
-            | Oauth2Opt::EnableStrictRedirectUri { copt, .. }
-            | Oauth2Opt::DisableStrictRedirectUri { copt, .. }
-            | Oauth2Opt::AddOrigin { copt, .. }
-            | Oauth2Opt::RemoveOrigin { copt, .. }
-            | Oauth2Opt::RotateCryptographicKeys { copt, .. }
-            | Oauth2Opt::RevokeCryptographicKey { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
             #[cfg(feature = "dev-oauth2-device-flow")]
             Oauth2Opt::DeviceFlowDisable(nopt) => {
                 // TODO: finish the CLI bits for DeviceFlowDisable
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_client_device_flow_update(&nopt.name, true)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             #[cfg(feature = "dev-oauth2-device-flow")]
             Oauth2Opt::DeviceFlowEnable(nopt) => {
                 // TODO: finish the CLI bits for DeviceFlowEnable
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_client_device_flow_update(&nopt.name, true)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            Oauth2Opt::List(copt) => {
-                let client = copt.to_client(OpType::Read).await;
+            Oauth2Opt::List => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_oauth2_rs_list().await {
-                    Ok(r) => match copt.output_mode {
+                    Ok(r) => match opt.output_mode {
                         OutputMode::Json => {
                             let r_attrs: Vec<_> = r.iter().map(|entry| &entry.attrs).collect();
                             println!(
@@ -91,24 +46,23 @@ impl Oauth2Opt {
                         }
                         OutputMode::Text => r.iter().for_each(|ent| println!("{ent}")),
                     },
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::Get(nopt) => {
-                let client = nopt.copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_oauth2_rs_get(nopt.name.as_str()).await {
-                    Ok(Some(e)) => println!("{e}"),
-                    Ok(None) => println!("No matching entries"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(Some(e)) => opt.output_mode.print_message(e),
+                    Ok(None) => opt.output_mode.print_message("No matching entries"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::CreateBasic {
                 name,
                 displayname,
                 origin,
-                copt,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_basic_create(
                         name.as_str(),
@@ -117,17 +71,16 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::CreatePublic {
                 name,
                 displayname,
                 origin,
-                copt,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_public_create(
                         name.as_str(),
@@ -136,12 +89,12 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::UpdateScopeMap(cbopt) => {
-                let client = cbopt.nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update_scope_map(
                         cbopt.nopt.name.as_str(),
@@ -150,22 +103,22 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, cbopt.nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::DeleteScopeMap(cbopt) => {
-                let client = cbopt.nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_delete_scope_map(cbopt.nopt.name.as_str(), cbopt.group.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, cbopt.nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::UpdateSupScopeMap(cbopt) => {
-                let client = cbopt.nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update_sup_scope_map(
                         cbopt.nopt.name.as_str(),
@@ -174,7 +127,7 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
+                    Ok(_) => opt.output_mode.print_message("Success"),
                     Err(e) => {
                         error!("Error -> {:?}", e);
                         exit(1)
@@ -182,7 +135,7 @@ impl Oauth2Opt {
                 }
             }
             Oauth2Opt::DeleteSupScopeMap(cbopt) => {
-                let client = cbopt.nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_delete_sup_scope_map(
                         cbopt.nopt.name.as_str(),
@@ -190,48 +143,48 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, cbopt.nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::ResetSecrets(cbopt) => {
-                let client = cbopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update(cbopt.name.as_str(), None, None, None, true)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, cbopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::ShowBasicSecret(nopt) => {
-                let client = nopt.copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
                 match client
                     .idm_oauth2_rs_get_basic_secret(nopt.name.as_str())
                     .await
                 {
                     Ok(Some(secret)) => {
-                        match nopt.copt.output_mode {
+                        match opt.output_mode {
                             OutputMode::Text => println!("{secret}"),
                             OutputMode::Json => println!("{{\"secret\": \"{secret}\"}}"),
                         }
-                        eprintln!("Success");
+                        opt.output_mode.print_message("Success");
                     }
                     Ok(None) => {
-                        eprintln!("No secret configured");
+                        opt.output_mode.print_message("No secret configured");
                     }
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::Delete(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_oauth2_rs_delete(nopt.name.as_str()).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::SetDisplayname(cbopt) => {
-                let client = cbopt.nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update(
                         cbopt.nopt.name.as_str(),
@@ -242,12 +195,12 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, cbopt.nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::SetName { nopt, name } => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update(
                         nopt.name.as_str(),
@@ -258,18 +211,18 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::SetLandingUrl { nopt, url } => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update(nopt.name.as_str(), None, None, Some(url.as_str()), false)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::SetImage {
@@ -300,7 +253,7 @@ impl Oauth2Opt {
                     match read_res {
                         Ok(data) => Ok(ImageValue::new(file_name, image_type, data)),
                         Err(err) => {
-                            if nopt.copt.debug {
+                            if opt.debug {
                                 eprintln!(
                                     "{}",
                                     kanidm_lib_file_permissions::diagnose_path(path.as_ref())
@@ -319,101 +272,100 @@ impl Oauth2Opt {
                     }
                 };
 
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
 
                 match client
                     .idm_oauth2_rs_update_image(nopt.name.as_str(), img)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::RemoveImage(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
 
                 match client.idm_oauth2_rs_delete_image(nopt.name.as_str()).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::EnablePkce(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_oauth2_rs_enable_pkce(nopt.name.as_str()).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::DisablePkce(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_oauth2_rs_disable_pkce(nopt.name.as_str()).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::EnableLegacyCrypto(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_enable_legacy_crypto(nopt.name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::DisableLegacyCrypto(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_disable_legacy_crypto(nopt.name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::PreferShortUsername(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_prefer_short_username(nopt.name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::PreferSPNUsername(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_prefer_spn_username(nopt.name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
 
-            Oauth2Opt::AddOrigin { name, origin, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::AddOrigin { name, origin } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_oauth2_client_add_origin(name, origin).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            Oauth2Opt::RemoveOrigin { name, origin, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::RemoveOrigin { name, origin } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_oauth2_client_remove_origin(name, origin).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::UpdateClaimMap {
-                copt,
                 name,
                 group,
                 claim_name,
                 values,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_update_claim_map(
                         name.as_str(),
@@ -423,17 +375,16 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::UpdateClaimMapJoin {
-                copt,
                 name,
                 claim_name,
                 join,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
 
                 let join = match join {
                     Oauth2ClaimMapJoin::Csv => ProtoOauth2ClaimMapJoin::Csv,
@@ -445,17 +396,16 @@ impl Oauth2Opt {
                     .idm_oauth2_rs_update_claim_map_join(name.as_str(), claim_name.as_str(), join)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             Oauth2Opt::DeleteClaimMap {
-                copt,
                 name,
                 claim_name,
                 group,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_delete_claim_map(
                         name.as_str(),
@@ -464,75 +414,71 @@ impl Oauth2Opt {
                     )
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
 
-            Oauth2Opt::EnablePublicLocalhost { copt, name } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::EnablePublicLocalhost { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_enable_public_localhost_redirect(name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
 
-            Oauth2Opt::DisablePublicLocalhost { copt, name } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::DisablePublicLocalhost { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_disable_public_localhost_redirect(name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            Oauth2Opt::EnableStrictRedirectUri { copt, name } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::EnableStrictRedirectUri { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_enable_strict_redirect_uri(name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
 
-            Oauth2Opt::DisableStrictRedirectUri { copt, name } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::DisableStrictRedirectUri { name } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_disable_strict_redirect_uri(name.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            Oauth2Opt::RotateCryptographicKeys {
-                copt,
-                name,
-                rotate_at,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::RotateCryptographicKeys { name, rotate_at } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_rotate_keys(name.as_str(), *rotate_at)
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            Oauth2Opt::RevokeCryptographicKey { copt, name, key_id } => {
-                let client = copt.to_client(OpType::Write).await;
+            Oauth2Opt::RevokeCryptographicKey { name, key_id } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_oauth2_rs_revoke_key(name.as_str(), key_id.as_str())
                     .await
                 {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
         }

--- a/tools/cli/src/cli/recycle.rs
+++ b/tools/cli/src/cli/recycle.rs
@@ -1,36 +1,28 @@
-use crate::common::OpType;
-use crate::{handle_client_error, RecycleOpt};
+use kanidm_proto::cli::OpType;
+use crate::{handle_client_error, KanidmClientParser, RecycleOpt};
 
 impl RecycleOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            RecycleOpt::List(copt) => copt.debug,
-            RecycleOpt::Get(nopt) => nopt.copt.debug,
-            RecycleOpt::Revive(nopt) => nopt.copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            RecycleOpt::List(copt) => {
-                let client = copt.to_client(OpType::Read).await;
+            RecycleOpt::List => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.recycle_bin_list().await {
                     Ok(r) => r.iter().for_each(|e| println!("{e}")),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             RecycleOpt::Get(nopt) => {
-                let client = nopt.copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
                 match client.recycle_bin_get(nopt.name.as_str()).await {
                     Ok(Some(e)) => println!("{e}"),
                     Ok(None) => println!("No matching entries"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             RecycleOpt::Revive(nopt) => {
-                let client = nopt.copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 if let Err(e) = client.recycle_bin_revive(nopt.name.as_str()).await {
-                    handle_client_error(e, nopt.copt.output_mode)
+                    handle_client_error(e, opt.output_mode)
                 }
             }
         }

--- a/tools/cli/src/cli/recycle.rs
+++ b/tools/cli/src/cli/recycle.rs
@@ -1,5 +1,5 @@
-use kanidm_proto::cli::OpType;
 use crate::{handle_client_error, KanidmClientParser, RecycleOpt};
+use kanidm_proto::cli::OpType;
 
 impl RecycleOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {

--- a/tools/cli/src/cli/schema/attr.rs
+++ b/tools/cli/src/cli/schema/attr.rs
@@ -1,23 +1,17 @@
-use crate::{handle_client_error, OpType, SchemaAttrOpt};
+use crate::{handle_client_error, KanidmClientParser, OpType, OutputMode, SchemaAttrOpt};
 use kanidm_proto::scim_v1::{ScimEntryGetQuery, ScimFilter};
 use std::str::FromStr;
 
 impl SchemaAttrOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            Self::List { copt } | Self::Search { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            Self::List { copt } => {
-                let client = copt.to_client(OpType::Read).await;
+            Self::List => {
+                let client = opt.to_client(OpType::Read).await;
 
                 let attrs = match client.scim_schema_attribute_list(None).await {
                     Ok(attrs) => attrs,
                     Err(e) => {
-                        handle_client_error(e, copt.output_mode);
+                        handle_client_error(e, opt.output_mode);
                         return;
                     }
                 };
@@ -32,7 +26,7 @@ impl SchemaAttrOpt {
                     println!("syntax: {}", attr.syntax);
                 }
             }
-            Self::Search { copt, query } => {
+            Self::Search { query } => {
                 let query = match ScimFilter::from_str(query) {
                     Ok(query) => query,
                     Err(err) => {
@@ -47,24 +41,37 @@ impl SchemaAttrOpt {
                     ..Default::default()
                 };
 
-                let client = copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
 
                 let attrs = match client.scim_schema_attribute_list(Some(get_query)).await {
                     Ok(attrs) => attrs,
                     Err(e) => {
-                        handle_client_error(e, copt.output_mode);
+                        handle_client_error(e, opt.output_mode);
                         return;
                     }
                 };
-
-                for attr in attrs.resources {
-                    println!("---");
-                    println!("uuid: {}", attr.header.id);
-                    println!("attribute_name: {}", attr.attributename);
-                    println!("description: {}", attr.description);
-                    println!("multivalue: {}", attr.multivalue);
-                    println!("unique: {}", attr.unique);
-                    println!("syntax: {}", attr.syntax);
+                match opt.output_mode {
+                    OutputMode::Json => {
+                        println!(
+                            "{}",
+                            serde_json::to_string(&attrs.resources)
+                                .expect("Failed to serialise attributes to JSON")
+                        );
+                    }
+                    OutputMode::Text => {
+                        let total = attrs.resources.len();
+                        for (index, attr) in attrs.resources.iter().enumerate() {
+                            println!("uuid: {}", attr.header.id);
+                            println!("attribute_name: {}", attr.attributename);
+                            println!("description: {}", attr.description);
+                            println!("multivalue: {}", attr.multivalue);
+                            println!("unique: {}", attr.unique);
+                            println!("syntax: {}", attr.syntax);
+                            if index < total - 1 {
+                                println!("---");
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tools/cli/src/cli/synch.rs
+++ b/tools/cli/src/cli/synch.rs
@@ -1,143 +1,115 @@
-use crate::common::OpType;
-use crate::{handle_client_error, SynchOpt};
+use kanidm_proto::cli::OpType;
+use crate::{handle_client_error, KanidmClientParser, SynchOpt};
 use dialoguer::Confirm;
 
 impl SynchOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            SynchOpt::List(copt) => copt.debug,
-            SynchOpt::Get(nopt) => nopt.copt.debug,
-            SynchOpt::Create { copt, .. }
-            | SynchOpt::GenerateToken { copt, .. }
-            | SynchOpt::DestroyToken { copt, .. }
-            | SynchOpt::ForceRefresh { copt, .. }
-            | SynchOpt::Finalise { copt, .. }
-            | SynchOpt::Terminate { copt, .. }
-            | SynchOpt::SetYieldAttributes { copt, .. }
-            | SynchOpt::SetCredentialPortal { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            SynchOpt::List(copt) => {
-                let client = copt.to_client(OpType::Read).await;
+            SynchOpt::List => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_sync_account_list().await {
                     Ok(r) => r.iter().for_each(|ent| println!("{ent}")),
 
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             SynchOpt::Get(nopt) => {
-                let client = nopt.copt.to_client(OpType::Read).await;
+                let client = opt.to_client(OpType::Read).await;
                 match client.idm_sync_account_get(nopt.name.as_str()).await {
                     Ok(Some(e)) => println!("{e}"),
                     Ok(None) => println!("No matching entries"),
-                    Err(e) => handle_client_error(e, nopt.copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::SetCredentialPortal {
-                account_id,
-                copt,
-                url,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            SynchOpt::SetCredentialPortal { account_id, url } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_sync_account_set_credential_portal(account_id, url.as_ref())
                     .await
                 {
                     Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
             SynchOpt::Create {
                 account_id,
-                copt,
                 description,
             } => {
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_sync_account_create(account_id, description.as_deref())
                     .await
                 {
                     Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::GenerateToken {
-                account_id,
-                label,
-                copt,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            SynchOpt::GenerateToken { account_id, label } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_sync_account_generate_token(account_id, label)
                     .await
                 {
                     Ok(token) => println!("token: {token}"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::DestroyToken { account_id, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            SynchOpt::DestroyToken { account_id } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_sync_account_destroy_token(account_id).await {
-                    Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(()) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::SetYieldAttributes {
-                account_id,
-                copt,
-                attrs,
-            } => {
-                let client = copt.to_client(OpType::Write).await;
+            SynchOpt::SetYieldAttributes { account_id, attrs } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client
                     .idm_sync_account_set_yield_attributes(account_id, attrs)
                     .await
                 {
-                    Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(()) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::ForceRefresh { account_id, copt } => {
-                let client = copt.to_client(OpType::Write).await;
+            SynchOpt::ForceRefresh { account_id } => {
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_sync_account_force_refresh(account_id).await {
-                    Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(()) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::Finalise { account_id, copt } => {
+            SynchOpt::Finalise { account_id } => {
                 if !Confirm::new()
                     .default(false)
                     .with_prompt("Do you want to continue? This operation can NOT be undone.")
                     .interact()
                     .expect("Failed to get a valid response!")
                 {
-                    info!("No changes were made");
+                    opt.output_mode.print_message("No changes were made");
                     return;
                 }
 
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_sync_account_finalise(account_id).await {
-                    Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(()) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            SynchOpt::Terminate { account_id, copt } => {
+            SynchOpt::Terminate { account_id } => {
                 if !Confirm::new()
                     .default(false)
                     .with_prompt("Do you want to continue? This operation can NOT be undone.")
                     .interact()
                     .expect("Failed to get a valid response!")
                 {
-                    info!("No changes were made");
+                    opt.output_mode.print_message("No changes were made");
                     return;
                 }
 
-                let client = copt.to_client(OpType::Write).await;
+                let client = opt.to_client(OpType::Write).await;
                 match client.idm_sync_account_terminate(account_id).await {
-                    Ok(()) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(()) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
         }

--- a/tools/cli/src/cli/synch.rs
+++ b/tools/cli/src/cli/synch.rs
@@ -1,6 +1,6 @@
-use kanidm_proto::cli::OpType;
 use crate::{handle_client_error, KanidmClientParser, SynchOpt};
 use dialoguer::Confirm;
+use kanidm_proto::cli::OpType;
 
 impl SynchOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {

--- a/tools/cli/src/cli/system_config/api.rs
+++ b/tools/cli/src/cli/system_config/api.rs
@@ -1,17 +1,11 @@
-use crate::ApiOpt;
+use crate::{ApiOpt, KanidmClientParser};
 use std::io::IsTerminal;
 
 impl ApiOpt {
-    pub fn debug(&self) -> bool {
-        match self {
-            ApiOpt::DownloadSchema(asdo) => asdo.copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
             ApiOpt::DownloadSchema(aopt) => {
-                let client = aopt.copt.to_unauth_client();
+                let client = opt.to_unauth_client();
                 // check if the output file already exists
                 if aopt.filename.exists() {
                     debug!("Output file {} already exists", aopt.filename.display());

--- a/tools/cli/src/cli/system_config/badlist.rs
+++ b/tools/cli/src/cli/system_config/badlist.rs
@@ -1,5 +1,5 @@
-use crate::common::OpType;
-use crate::{handle_client_error, PwBadlistOpt};
+use crate::{handle_client_error, KanidmClientParser, OutputMode, PwBadlistOpt};
+use kanidm_proto::cli::OpType;
 
 // use std::thread;
 use std::fs::File;
@@ -10,34 +10,32 @@ use zxcvbn::Score;
 const CHUNK_SIZE: usize = 1000;
 
 impl PwBadlistOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            PwBadlistOpt::Show(copt) => copt.debug,
-            PwBadlistOpt::Upload { copt, .. } => copt.debug,
-            PwBadlistOpt::Remove { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            PwBadlistOpt::Show(copt) => {
-                let client = copt.to_client(OpType::Read).await;
+            PwBadlistOpt::Show => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.system_password_badlist_get().await {
                     Ok(list) => {
-                        for i in list {
-                            println!("{i}");
+                        match opt.output_mode {
+                            OutputMode::Json => {
+                                let json = serde_json::to_string(&list)
+                                    .expect("Failed to serialise list to JSON!");
+                                println!("{json}");
+                            }
+                            OutputMode::Text => {
+                                // Print each entry on a new line
+                                list.iter().for_each(|entry| {
+                                    println!("{entry}");
+                                });
+                                eprintln!("--");
+                                eprintln!("Success");
+                            }
                         }
-                        eprintln!("--");
-                        eprintln!("Success");
                     }
-                    Err(e) => crate::handle_client_error(e, copt.output_mode),
+                    Err(e) => crate::handle_client_error(e, opt.output_mode),
                 }
             }
-            PwBadlistOpt::Upload {
-                copt,
-                paths,
-                dryrun,
-            } => {
+            PwBadlistOpt::Upload { paths, dryrun } => {
                 info!("pre-processing - this may take a while ...");
 
                 let mut pwset: Vec<String> = Vec::new();
@@ -111,15 +109,15 @@ impl PwBadlistOpt {
                         println!("{pw}");
                     }
                 } else {
-                    let client = copt.to_client(OpType::Write).await;
+                    let client = opt.to_client(OpType::Write).await;
                     match client.system_password_badlist_append(filt_pwset).await {
                         Ok(_) => println!("Success"),
-                        Err(e) => handle_client_error(e, copt.output_mode),
+                        Err(e) => handle_client_error(e, opt.output_mode),
                     }
                 }
             } // End Upload
-            PwBadlistOpt::Remove { copt, paths } => {
-                let client = copt.to_client(OpType::Write).await;
+            PwBadlistOpt::Remove { paths } => {
+                let client = opt.to_client(OpType::Write).await;
 
                 let mut pwset: Vec<String> = Vec::new();
 
@@ -147,13 +145,13 @@ impl PwBadlistOpt {
                 pwset.dedup();
 
                 if pwset.is_empty() {
-                    eprintln!("No entries to remove?");
+                    opt.output_mode.print_message("No entries to remove?");
                     return;
                 }
 
                 match client.system_password_badlist_remove(pwset).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             } // End Remove
         }

--- a/tools/cli/src/cli/system_config/denied_names.rs
+++ b/tools/cli/src/cli/system_config/denied_names.rs
@@ -1,45 +1,44 @@
-use crate::common::OpType;
+use kanidm_proto::cli::OpType;
 
-use crate::{handle_client_error, DeniedNamesOpt};
+use crate::{handle_client_error, DeniedNamesOpt, KanidmClientParser, OutputMode};
 
 impl DeniedNamesOpt {
-    pub fn debug(&self) -> bool {
+    pub async fn exec(&self, opt: KanidmClientParser) {
         match self {
-            DeniedNamesOpt::Show { copt }
-            | DeniedNamesOpt::Append { copt, .. }
-            | DeniedNamesOpt::Remove { copt, .. } => copt.debug,
-        }
-    }
-
-    pub async fn exec(&self) {
-        match self {
-            DeniedNamesOpt::Show { copt } => {
-                let client = copt.to_client(OpType::Read).await;
+            DeniedNamesOpt::Show => {
+                let client = opt.to_client(OpType::Read).await;
                 match client.system_denied_names_get().await {
-                    Ok(list) => {
-                        for i in list {
-                            println!("{i}");
+                    Ok(list) => match opt.output_mode {
+                        OutputMode::Json => {
+                            let json = serde_json::to_string(&list)
+                                .expect("Failed to serialise list to JSON!");
+                            println!("{json}");
                         }
-                        eprintln!("--");
-                        eprintln!("Success");
-                    }
-                    Err(e) => crate::handle_client_error(e, copt.output_mode),
+                        OutputMode::Text => {
+                            for i in list {
+                                println!("{i}");
+                            }
+                            eprintln!("--");
+                            eprintln!("Success");
+                        }
+                    },
+                    Err(e) => crate::handle_client_error(e, opt.output_mode),
                 }
             }
-            DeniedNamesOpt::Append { copt, names } => {
-                let client = copt.to_client(OpType::Write).await;
+            DeniedNamesOpt::Append { names } => {
+                let client = opt.to_client(OpType::Write).await;
 
                 match client.system_denied_names_append(names).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
-            DeniedNamesOpt::Remove { copt, names } => {
-                let client = copt.to_client(OpType::Write).await;
+            DeniedNamesOpt::Remove { names } => {
+                let client = opt.to_client(OpType::Write).await;
 
                 match client.system_denied_names_remove(names).await {
-                    Ok(_) => println!("Success"),
-                    Err(e) => handle_client_error(e, copt.output_mode),
+                    Ok(_) => opt.output_mode.print_message("Success"),
+                    Err(e) => handle_client_error(e, opt.output_mode),
                 }
             }
         }

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -1496,8 +1496,13 @@ pub struct KanidmClientParser {
     value_parser = clap::builder::NonEmptyStringValueParser::new())]
     token_cache_path: Option<String>,
 
-    #[clap(short, long, env = "KANIDM_PASSWORD", hide = true,
-    value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    #[clap(
+        short,
+        long,
+        env = "KANIDM_PASSWORD",
+        hide = true,
+        global = true,
+        value_parser = clap::builder::NonEmptyStringValueParser::new())]
     /// Supply a password to the login option
     password: Option<String>,
 }

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -25,11 +25,21 @@ pub struct DebugOpt {
     pub debug: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 /// The CLI output mode, either text or json, falls back to text if you ask for something other than text/json
 pub enum OutputMode {
+    #[default]
     Text,
     Json,
+}
+
+impl Into<clap::builder::OsStr> for OutputMode {
+    fn into(self) -> clap::builder::OsStr {
+        match self {
+            OutputMode::Text => "text".into(),
+            OutputMode::Json => "json".into(),
+        }
+    }
 }
 
 impl std::str::FromStr for OutputMode {
@@ -1456,14 +1466,8 @@ pub struct KanidmClientParser {
         global = true
     )]
     pub ca_path: Option<PathBuf>,
-    /// Log format (still in very early development)
-    #[clap(
-        short,
-        long = "output",
-        env = "KANIDM_OUTPUT",
-        default_value = "text",
-        global = true
-    )]
+    /// Log format
+    #[clap(short, long = "output", env = "KANIDM_OUTPUT", global = true, default_value=OutputMode::default())]
     output_mode: OutputMode,
     /// Skip hostname verification
     #[clap(

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -33,9 +33,9 @@ pub enum OutputMode {
     Json,
 }
 
-impl Into<clap::builder::OsStr> for OutputMode {
-    fn into(self) -> clap::builder::OsStr {
-        match self {
+impl From<OutputMode> for clap::builder::OsStr {
+    fn from(output_mode: OutputMode) -> Self {
+        match output_mode {
             OutputMode::Text => "text".into(),
             OutputMode::Json => "json".into(),
         }


### PR DESCRIPTION
There was a lot of unnecessary mess in how we were building the clap CLI handlers, I did some gardening.

# Change summary

- pushed all the "commonopt" things up to the parent CLI handlers for `kanidm` and `kanidmd` so we no longer have to make those big match statements or nested calls to get the common things
- output supports JSON for basically everything that's sensible now in `kanidm`, I'm sure I missed something, PRs welcome. :smile:

Fixes #n/a

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
