### PR TITLE
client_secret_post auth for oauth2 endpoints

### DIFF
--- a/proto/src/oauth2.rs
+++ b/proto/src/oauth2.rs
@@ -312,6 +312,23 @@ impl From<(&str, Option<&str>)> for ClientPostAuth {
     }
 }
 
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default)]
+/// <https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1>
+pub struct ClientAuth {
+    pub client_id: String,
+    pub client_secret: Option<String>,
+}
+
+impl From<(&str, Option<&str>)> for ClientAuth {
+    fn from((client_id, client_secret): (&str, Option<&str>)) -> Self {
+        ClientAuth {
+            client_id: client_id.to_string(),
+            client_secret: client_secret.map(|s| s.to_string()),
+        }
+    }
+}
+
 /// Request to introspect the identity of the account associated to a token.
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -892,7 +892,7 @@ impl IdmServerProxyWriteTransaction<'_> {
             .inner
             .rs_set_get(client_auth.client_id.as_str())
             .ok_or_else(|| {
-                admin_warn!("Invalid OAuth2 client_id");
+                warn!("Invalid OAuth2 client_id");
                 Oauth2Error::AuthenticationRequired
             })?;
 
@@ -900,7 +900,7 @@ impl IdmServerProxyWriteTransaction<'_> {
         match &o2rs.type_ {
             OauthRSType::Basic { authz_secret, .. } => {
                 if Some(authz_secret) != client_auth.client_secret.as_ref() {
-                    security_info!("Invalid OAuth2 client_id secret, this can happen if your RS is public but you configured a 'basic' type.");
+                    info!("Invalid OAuth2 client_id secret, this can happen if your RS is public but you configured a 'basic' type.");
                     return Err(Oauth2Error::AuthenticationRequired);
                 }
             }
@@ -1023,13 +1023,13 @@ impl IdmServerProxyWriteTransaction<'_> {
                         if authz_secret == &secret {
                             true
                         } else {
-                            security_info!("Invalid OAuth2 client_id secret");
+                            info!("Invalid OAuth2 client_id secret");
                             return Err(Oauth2Error::AuthenticationRequired);
                         }
                     }
                     None => {
                         // We can only get here if we relied on the atr for the client_id and secret
-                        security_info!(
+                        info!(
                             "Invalid OAuth2 authentication - no secret in access token request - this can happen if you're expecting a public client and configured a basic one."
                         );
                         return Err(Oauth2Error::AuthenticationRequired);
@@ -1079,7 +1079,7 @@ impl IdmServerProxyWriteTransaction<'_> {
             .inner
             .rs_set_get(client_id)
             .ok_or_else(|| {
-                admin_warn!("Invalid OAuth2 client_id {}", client_id);
+                warn!("Invalid OAuth2 client_id {}", client_id);
                 Oauth2Error::AuthenticationRequired
             })?
             .clone();
@@ -1959,7 +1959,7 @@ impl IdmServerProxyReadTransaction<'_> {
             .inner
             .rs_set_get(&auth_req.client_id)
             .ok_or_else(|| {
-                admin_warn!(
+                warn!(
                     "Invalid OAuth2 client_id ({}) Have you configured the OAuth2 resource server?",
                     &auth_req.client_id
                 );
@@ -2355,7 +2355,7 @@ impl IdmServerProxyReadTransaction<'_> {
             .inner
             .rs_set_get(&client_auth.client_id)
             .ok_or_else(|| {
-                admin_warn!("Invalid OAuth2 client_id");
+                warn!("Invalid OAuth2 client_id");
                 Oauth2Error::AuthenticationRequired
             })?;
 
@@ -2363,7 +2363,7 @@ impl IdmServerProxyReadTransaction<'_> {
         match &o2rs.type_ {
             OauthRSType::Basic { authz_secret, .. } => {
                 if Some(authz_secret) != client_auth.client_secret.as_ref() {
-                    security_info!("Invalid OAuth2 client_id secret");
+                    info!("Invalid OAuth2 client_id secret");
                     return Err(Oauth2Error::AuthenticationRequired);
                 }
             }
@@ -2555,9 +2555,7 @@ impl IdmServerProxyReadTransaction<'_> {
         // lifetime here is safe since we are the sole accessor.
         let o2rs: &Oauth2RS = unsafe {
             let s = self.oauth2rs.inner.rs_set_get(client_id).ok_or_else(|| {
-                admin_warn!(
-                    "Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)"
-                );
+                warn!("Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)");
                 Oauth2Error::InvalidClientId
             })?;
             &*(s as *const _)
@@ -2655,9 +2653,7 @@ impl IdmServerProxyReadTransaction<'_> {
         client_id: &str,
     ) -> Result<Oauth2Rfc8414MetadataResponse, OperationError> {
         let o2rs = self.oauth2rs.inner.rs_set_get(client_id).ok_or_else(|| {
-            admin_warn!(
-                "Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)"
-            );
+            warn!("Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)");
             OperationError::NoMatchingEntries
         })?;
 
@@ -2726,9 +2722,7 @@ impl IdmServerProxyReadTransaction<'_> {
         client_id: &str,
     ) -> Result<OidcDiscoveryResponse, OperationError> {
         let o2rs = self.oauth2rs.inner.rs_set_get(client_id).ok_or_else(|| {
-            admin_warn!(
-                "Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)"
-            );
+            warn!("Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)");
             OperationError::NoMatchingEntries
         })?;
 
@@ -2841,9 +2835,7 @@ impl IdmServerProxyReadTransaction<'_> {
         resource_id: &str,
     ) -> Result<OidcWebfingerResponse, OperationError> {
         let o2rs = self.oauth2rs.inner.rs_set_get(client_id).ok_or_else(|| {
-            admin_warn!(
-                "Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)"
-            );
+            warn!("Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)");
             OperationError::NoMatchingEntries
         })?;
 
@@ -2875,9 +2867,7 @@ impl IdmServerProxyReadTransaction<'_> {
     #[instrument(level = "debug", skip_all)]
     pub fn oauth2_openid_publickey(&self, client_id: &str) -> Result<JwkKeySet, OperationError> {
         let o2rs = self.oauth2rs.inner.rs_set_get(client_id).ok_or_else(|| {
-            admin_warn!(
-                "Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)"
-            );
+            warn!("Invalid OAuth2 client_id (have you configured the OAuth2 resource server?)");
             OperationError::NoMatchingEntries
         })?;
 

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -6,8 +6,8 @@ use kanidm_proto::constants::*;
 use kanidm_proto::internal::Oauth2ClaimMapJoin;
 use kanidm_proto::oauth2::{
     AccessTokenIntrospectRequest, AccessTokenIntrospectResponse, AccessTokenRequest,
-    AccessTokenResponse, AccessTokenType, AuthorisationResponse, GrantTypeReq,
-    OidcDiscoveryResponse,
+    AccessTokenResponse, AccessTokenType, AuthorisationResponse, ClientPostAuth, GrantTypeReq,
+    OidcDiscoveryResponse, TokenRevokeRequest,
 };
 use kanidmd_lib::constants::NAME_IDM_ALL_ACCOUNTS;
 use kanidmd_lib::prelude::Attribute;
@@ -26,6 +26,11 @@ use time::OffsetDateTime;
 use uri::{OAUTH2_TOKEN_ENDPOINT, OAUTH2_TOKEN_INTROSPECT_ENDPOINT, OAUTH2_TOKEN_REVOKE_ENDPOINT};
 use url::{form_urlencoded::parse as query_parse, Url};
 
+enum AuthMethod {
+    Basic,
+    ClientSecretPost,
+}
+
 /// Tests an OAuth 2.0 / OpenID confidential client Authorisation Client flow.
 ///
 /// ## Arguments
@@ -43,6 +48,7 @@ async fn test_oauth2_openid_basic_flow_impl(
     response_mode: Option<&str>,
     response_in_fragment: bool,
     state: Option<&str>,
+    auth_method: AuthMethod,
 ) {
     let res = rsclient
         .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
@@ -151,7 +157,9 @@ async fn test_oauth2_openid_basic_flow_impl(
     let response = client
         .request(
             reqwest::Method::OPTIONS,
-            rsclient.make_url("/oauth2/openid/test_integration/.well-known/openid-configuration"),
+            rsclient.make_url(&format!(
+                "/oauth2/openid/{TEST_INTEGRATION_RS_ID}/.well-known/openid-configuration",
+            )),
         )
         .send()
         .await
@@ -168,7 +176,9 @@ async fn test_oauth2_openid_basic_flow_impl(
     assert!(cors_header.eq("*"));
 
     let response = client
-        .get(rsclient.make_url("/oauth2/openid/test_integration/.well-known/openid-configuration"))
+        .get(rsclient.make_url(&format!(
+            "/oauth2/openid/{TEST_INTEGRATION_RS_ID}/.well-known/openid-configuration"
+        )))
         .send()
         .await
         .expect("Failed to send request.");
@@ -197,7 +207,7 @@ async fn test_oauth2_openid_basic_flow_impl(
     // the urls here as an extended function smoke test.
     assert_eq!(
         discovery.issuer,
-        rsclient.make_url("/oauth2/openid/test_integration")
+        rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}"))
     );
 
     assert_eq!(
@@ -212,16 +222,23 @@ async fn test_oauth2_openid_basic_flow_impl(
 
     assert!(
         discovery.userinfo_endpoint
-            == Some(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+            == Some(
+                rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}/userinfo"))
+            )
     );
 
     assert!(
-        discovery.jwks_uri == rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk")
+        discovery.jwks_uri
+            == rsclient.make_url(&format!(
+                "/oauth2/openid/{TEST_INTEGRATION_RS_ID}/public_key.jwk"
+            ))
     );
 
     // Step 0 - get the jwks public key.
     let response = client
-        .get(rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk"))
+        .get(rsclient.make_url(&format!(
+            "/oauth2/openid/{TEST_INTEGRATION_RS_ID}/public_key.jwk"
+        )))
         .send()
         .await
         .expect("Failed to send request.");
@@ -338,16 +355,28 @@ async fn test_oauth2_openid_basic_flow_impl(
     // Step 3 - the "resource server" then uses this state and code to directly contact
     // the authorisation server to request a token.
 
-    let form_req: AccessTokenRequest = GrantTypeReq::AuthorizationCode {
+    let mut form_req: AccessTokenRequest = GrantTypeReq::AuthorizationCode {
         code: code.to_string(),
         redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
         code_verifier: Some(pkce_code_verifier.secret().clone()),
     }
     .into();
 
-    let response = client
-        .post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT))
-        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
+    let mut response = client.post(rsclient.make_url(OAUTH2_TOKEN_ENDPOINT));
+
+    match auth_method {
+        AuthMethod::ClientSecretPost => {
+            form_req.client_post_auth = ClientPostAuth {
+                client_id: Some(TEST_INTEGRATION_RS_ID.to_string()),
+                client_secret: Some(client_secret.clone()),
+            }
+        }
+        AuthMethod::Basic => {
+            response = response.basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()));
+        }
+    }
+
+    let response = response
         .form(&form_req)
         .send()
         .await
@@ -376,14 +405,30 @@ async fn test_oauth2_openid_basic_flow_impl(
         .expect("Unable to decode AccessTokenResponse");
 
     // Step 4 - inspect the granted token.
-    let intr_request = AccessTokenIntrospectRequest {
+    let mut intr_request = AccessTokenIntrospectRequest {
         token: atr.access_token.clone(),
         token_type_hint: None,
+        client_post_auth: ClientPostAuth::default(),
     };
-
-    let response = client
+    // TODO: make this work with POST auth
+    let mut  response = client
         .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
-        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
+        // .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
+       ;
+
+    match auth_method {
+        AuthMethod::Basic => {
+            response = response.basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()));
+        }
+        AuthMethod::ClientSecretPost => {
+            intr_request.client_post_auth = ClientPostAuth {
+                client_id: Some(TEST_INTEGRATION_RS_ID.to_string()),
+                client_secret: Some(client_secret.clone()),
+            };
+        }
+    }
+
+    let response = response
         .form(&intr_request)
         .send()
         .await
@@ -431,14 +476,14 @@ async fn test_oauth2_openid_basic_flow_impl(
     // token and the userinfo endpoints.
     assert_eq!(
         oidc.iss,
-        rsclient.make_url("/oauth2/openid/test_integration")
+        rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}"))
     );
     eprintln!("{:?}", oidc.s_claims.email);
     assert_eq!(oidc.s_claims.email.as_deref(), Some(NOT_ADMIN_TEST_EMAIL));
     assert_eq!(oidc.s_claims.email_verified, Some(true));
 
     let response = client
-        .get(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+        .get(rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}/userinfo")))
         .bearer_auth(atr.access_token.clone())
         .send()
         .await
@@ -459,7 +504,7 @@ async fn test_oauth2_openid_basic_flow_impl(
     assert_eq!(userinfo, oidc);
 
     let response = client
-        .post(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+        .post(rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}/userinfo")))
         .bearer_auth(atr.access_token.clone())
         .send()
         .await
@@ -503,14 +548,26 @@ async fn test_oauth2_openid_basic_flow_impl(
         .expect("Unable to decode AccessTokenResponse");
 
     // Step 7 - inspect the granted client credentials token.
-    let intr_request = AccessTokenIntrospectRequest {
+    let mut intr_request = AccessTokenIntrospectRequest {
         token: atr.access_token.clone(),
         token_type_hint: None,
+        client_post_auth: ClientPostAuth::default(),
     };
+    let mut response = client.post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT));
 
-    let response = client
-        .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
-        .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret))
+    match auth_method {
+        AuthMethod::Basic => {
+            response = response.basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()));
+        }
+        AuthMethod::ClientSecretPost => {
+            intr_request.client_post_auth = ClientPostAuth::from((
+                TEST_INTEGRATION_RS_ID.to_string(),
+                Some(client_secret.clone()),
+            ));
+        }
+    }
+
+    let response = response
         .form(&intr_request)
         .send()
         .await
@@ -529,6 +586,32 @@ async fn test_oauth2_openid_basic_flow_impl(
     assert_eq!(tir.username.as_deref(), Some("test_integration@localhost"));
     assert_eq!(tir.token_type, Some(AccessTokenType::Bearer));
 
+    // revoke the token!
+    let mut req = TokenRevokeRequest {
+        token: atr.access_token,
+        token_type_hint: None,
+        client_post_auth: ClientPostAuth::default(),
+    };
+    let mut response = client.post(rsclient.make_url(OAUTH2_TOKEN_REVOKE_ENDPOINT));
+
+    match auth_method {
+        AuthMethod::Basic => {
+            response = response.basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()));
+        }
+        AuthMethod::ClientSecretPost => {
+            req.client_post_auth =
+                ClientPostAuth::from((TEST_INTEGRATION_RS_ID.to_string(), Some(client_secret)));
+        }
+    }
+
+    let response = response
+        .form(&req)
+        .send()
+        .await
+        .expect("Failed to send token revocation request.");
+
+    assert!(response.status().is_success());
+
     // auth back with admin so we can test deleting things
     let res = rsclient
         .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
@@ -545,9 +628,26 @@ async fn test_oauth2_openid_basic_flow_impl(
 ///
 /// The response should be returned as a query parameter.
 #[kanidmd_testkit::test]
-async fn test_oauth2_openid_basic_flow_mode_unset(rsclient: &KanidmClient) {
-    test_oauth2_openid_basic_flow_impl(rsclient, None, false, Some(TEST_INTEGRATION_STATE_VALUE))
-        .await;
+async fn test_oauth2_openid_basic_flow_mode_unset_bearer(rsclient: &KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(
+        rsclient,
+        None,
+        false,
+        Some(TEST_INTEGRATION_STATE_VALUE),
+        AuthMethod::Basic,
+    )
+    .await;
+}
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_mode_unset_post(rsclient: &KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(
+        rsclient,
+        None,
+        false,
+        Some(TEST_INTEGRATION_STATE_VALUE),
+        AuthMethod::ClientSecretPost,
+    )
+    .await;
 }
 
 /// Test an OAuth 2.0/OpenID confidential client Authorisation Code flow, with
@@ -555,12 +655,24 @@ async fn test_oauth2_openid_basic_flow_mode_unset(rsclient: &KanidmClient) {
 ///
 /// The response should be returned as a query parameter.
 #[kanidmd_testkit::test]
-async fn test_oauth2_openid_basic_flow_mode_query(rsclient: &KanidmClient) {
+async fn test_oauth2_openid_basic_flow_mode_query_bearer(rsclient: &KanidmClient) {
     test_oauth2_openid_basic_flow_impl(
         rsclient,
         Some("query"),
         false,
         Some(TEST_INTEGRATION_STATE_VALUE),
+        AuthMethod::Basic,
+    )
+    .await;
+}
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_mode_query_post(rsclient: &KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(
+        rsclient,
+        Some("query"),
+        false,
+        Some(TEST_INTEGRATION_STATE_VALUE),
+        AuthMethod::ClientSecretPost,
     )
     .await;
 }
@@ -570,12 +682,24 @@ async fn test_oauth2_openid_basic_flow_mode_query(rsclient: &KanidmClient) {
 ///
 /// The response should be returned in the URI's fragment.
 #[kanidmd_testkit::test]
-async fn test_oauth2_openid_basic_flow_mode_fragment(rsclient: &KanidmClient) {
+async fn test_oauth2_openid_basic_flow_mode_fragment_bearer(rsclient: &KanidmClient) {
     test_oauth2_openid_basic_flow_impl(
         rsclient,
         Some("fragment"),
         true,
         Some(TEST_INTEGRATION_STATE_VALUE),
+        AuthMethod::Basic,
+    )
+    .await;
+}
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_mode_fragment_post(rsclient: &KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(
+        rsclient,
+        Some("fragment"),
+        true,
+        Some(TEST_INTEGRATION_STATE_VALUE),
+        AuthMethod::ClientSecretPost,
     )
     .await;
 }
@@ -585,8 +709,21 @@ async fn test_oauth2_openid_basic_flow_mode_fragment(rsclient: &KanidmClient) {
 ///
 /// The response should be returned in the URI's fragment.
 #[kanidmd_testkit::test]
-async fn test_oauth2_openid_basic_flow_no_state(rsclient: &KanidmClient) {
-    test_oauth2_openid_basic_flow_impl(rsclient, Some("fragment"), true, None).await;
+async fn test_oauth2_openid_basic_flow_no_state_bearer(rsclient: &KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(rsclient, Some("fragment"), true, None, AuthMethod::Basic)
+        .await;
+}
+/// The response should be returned in the URI's fragment.
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_basic_flow_no_state_post(rsclient: &KanidmClient) {
+    test_oauth2_openid_basic_flow_impl(
+        rsclient,
+        Some("fragment"),
+        true,
+        None,
+        AuthMethod::ClientSecretPost,
+    )
+    .await;
 }
 
 /// Tests an OAuth 2.0 / OpenID public client Authorisation Client flow.
@@ -721,7 +858,9 @@ async fn test_oauth2_openid_public_flow_impl(
 
     // Step 0 - get the jwks public key.
     let response = client
-        .get(rsclient.make_url("/oauth2/openid/test_integration/public_key.jwk"))
+        .get(rsclient.make_url(&format!(
+            "/oauth2/openid/{TEST_INTEGRATION_RS_ID}/public_key.jwk",
+        )))
         .send()
         .await
         .expect("Failed to send request.");
@@ -770,7 +909,11 @@ async fn test_oauth2_openid_public_flow_impl(
         .await
         .expect("Failed to send request.");
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Failed to send initial authorize call"
+    );
     assert_no_cache!(response);
 
     let consent_req: AuthorisationResponse = response
@@ -785,7 +928,10 @@ async fn test_oauth2_openid_public_flow_impl(
     } = consent_req
     {
         // Note the supplemental scope here (admin)
-        assert!(scopes.contains(ADMIN_TEST_USER));
+        assert!(
+            scopes.contains(ADMIN_TEST_USER),
+            "Didn't find user {ADMIN_TEST_USER} in scope"
+        );
         consent_token
     } else {
         unreachable!();
@@ -799,10 +945,14 @@ async fn test_oauth2_openid_public_flow_impl(
         .query(&[("token", consent_token.as_str())])
         .send()
         .await
-        .expect("Failed to send request.");
+        .expect("Failed to send user consent request.");
 
     // This should yield a 302 redirect with some query params.
-    assert_eq!(response.status(), StatusCode::FOUND);
+    assert_eq!(
+        response.status(),
+        StatusCode::FOUND,
+        "Didn't get redirected"
+    );
     assert_no_cache!(response);
 
     // And we should have a URL in the location header.
@@ -810,14 +960,14 @@ async fn test_oauth2_openid_public_flow_impl(
         .headers()
         .get("Location")
         .and_then(|hv| hv.to_str().ok().map(str::to_string))
-        .expect("Invalid redirect url");
+        .expect("Invalid/missing redirect url in Location header");
 
     // Now check it's content
-    let redir_url = Url::parse(&redir_str).expect("Url parse failure");
+    let redir_url = Url::parse(&redir_str).expect("Redirect URL parse failure");
 
     let pairs: BTreeMap<_, _> = if response_in_fragment {
         assert!(redir_url.query().is_none());
-        let fragment = redir_url.fragment().expect("missing URL fragment");
+        let fragment = redir_url.fragment().expect("Missing URL fragment");
         query_parse(fragment.as_bytes()).collect()
     } else {
         // response_mode = query is default for response_type = code
@@ -826,10 +976,11 @@ async fn test_oauth2_openid_public_flow_impl(
     };
 
     // We should have state and code.
-    let code = pairs.get("code").expect("code not found!");
+    let code = pairs.get("code").expect("code not found in query params!");
     assert_eq!(
         pairs.get("state").map(|s| s.to_string()),
-        state.map(|s| s.to_string())
+        state.map(|s| s.to_string()),
+        "Didn't get state from query pairs {pairs:?}"
     );
 
     // Step 3 - the "resource server" then uses this state and code to directly contact
@@ -841,8 +992,7 @@ async fn test_oauth2_openid_public_flow_impl(
             redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
             code_verifier: Some(pkce_code_verifier.secret().clone()),
         },
-        client_id: Some(TEST_INTEGRATION_RS_ID.to_string()),
-        client_secret: None,
+        client_post_auth: (TEST_INTEGRATION_RS_ID, None).into(),
     };
 
     let response = client
@@ -875,7 +1025,7 @@ async fn test_oauth2_openid_public_flow_impl(
     // token and the userinfo endpoints.
     assert_eq!(
         oidc.iss,
-        rsclient.make_url("/oauth2/openid/test_integration")
+        rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}"))
     );
     eprintln!("{:?}", oidc.s_claims.email);
     assert_eq!(oidc.s_claims.email.as_deref(), Some(NOT_ADMIN_TEST_EMAIL));
@@ -891,7 +1041,7 @@ async fn test_oauth2_openid_public_flow_impl(
     let response = client
         .request(
             reqwest::Method::OPTIONS,
-            rsclient.make_url("/oauth2/openid/test_integration/userinfo"),
+            rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}/userinfo")),
         )
         .send()
         .await
@@ -907,7 +1057,7 @@ async fn test_oauth2_openid_public_flow_impl(
     assert!(cors_header.eq("*"));
 
     let response = client
-        .get(rsclient.make_url("/oauth2/openid/test_integration/userinfo"))
+        .get(rsclient.make_url(&format!("/oauth2/openid/{TEST_INTEGRATION_RS_ID}/userinfo")))
         .bearer_auth(atr.access_token.clone())
         .send()
         .await
@@ -1020,7 +1170,7 @@ async fn test_oauth2_token_post_bad_bodies(rsclient: &KanidmClient) {
 }
 
 #[kanidmd_testkit::test]
-async fn test_oauth2_token_revoke_post(rsclient: &KanidmClient) {
+async fn test_oauth2_token_revoke_post_bearer(rsclient: &KanidmClient) {
     let res = rsclient
         .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
         .await;
@@ -1077,4 +1227,38 @@ async fn test_oauth2_token_revoke_post(rsclient: &KanidmClient) {
         .expect("Failed to send token request.");
     println!("{response:?}");
     assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[kanidmd_testkit::test]
+async fn test_oauth2_token_revoke_post_postauth(rsclient: &KanidmClient) {
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .tls_built_in_native_certs(false)
+        .no_proxy()
+        .build()
+        .expect("Failed to create client.");
+
+    let form = TokenRevokeRequest {
+        token: "lolol".into(),
+        token_type_hint: None,
+        client_post_auth: ClientPostAuth {
+            client_id: Some("invalid".to_string()),
+            client_secret: Some("lolol".to_string()),
+        },
+    };
+
+    // test for bad auth
+    let response = client
+        .post(rsclient.make_url(OAUTH2_TOKEN_REVOKE_ENDPOINT))
+        .form(&form)
+        .send()
+        .await
+        .expect("Failed to send token request.");
+    println!("{response:?}");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -410,11 +410,8 @@ async fn test_oauth2_openid_basic_flow_impl(
         token_type_hint: None,
         client_post_auth: ClientPostAuth::default(),
     };
-    // TODO: make this work with POST auth
-    let mut  response = client
-        .post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT))
-        // .basic_auth(TEST_INTEGRATION_RS_ID, Some(client_secret.clone()))
-       ;
+
+    let mut response = client.post(rsclient.make_url(OAUTH2_TOKEN_INTROSPECT_ENDPOINT));
 
     match auth_method {
         AuthMethod::Basic => {

--- a/tools/cli/src/cli/synch.rs
+++ b/tools/cli/src/cli/synch.rs
@@ -1,7 +1,6 @@
 use crate::{handle_client_error, KanidmClientParser, SynchOpt};
 use dialoguer::Confirm;
 use kanidm_proto::cli::OpType;
-use kanidm_proto::cli::OpType;
 
 impl SynchOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {

--- a/tools/cli/src/cli/synch.rs
+++ b/tools/cli/src/cli/synch.rs
@@ -1,6 +1,7 @@
 use crate::{handle_client_error, KanidmClientParser, SynchOpt};
 use dialoguer::Confirm;
 use kanidm_proto::cli::OpType;
+use kanidm_proto::cli::OpType;
 
 impl SynchOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {


### PR DESCRIPTION
# Change summary

- client_secret_post auth for oauth2 endpoints
- updates the tests to use both basic and post auth

Fixes #3827 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
