### PR TITLE
docs: Don't enable unixd Kanidm provider in safe default config

### DIFF
--- a/book/src/integrations/pam_and_nsswitch.md
+++ b/book/src/integrations/pam_and_nsswitch.md
@@ -59,7 +59,7 @@ You can also configure unixd with the file /etc/kanidm/unixd:
 ```
 
 If you are using the Kanidm provider features, you also need to configure `/etc/kanidm/config`. This is the covered in
-[client_tools](../client_tools.md#kanidm-configuration).
+[client_tools](../client_tools.md#kanidm-configuration). At a minimum the `uri` option must be set.
 
 You can start, and then check the status of the daemon with the following commands:
 
@@ -71,7 +71,8 @@ kanidm-unix status
 If the daemon is working, you should see:
 
 ```text
-working!
+system: online
+Kanidm: online
 ```
 
 If it is not working, you will see an error message:
@@ -79,6 +80,11 @@ If it is not working, you will see an error message:
 ```text
 [2020-02-14T05:58:10Z ERROR kanidm-unix] Error ->
    Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }
+```
+
+If the unixd daemon is running but not configured to use the Kanidm provider, only system status is reported:
+```text
+system: online
 ```
 
 For more information, see the [Troubleshooting](pam_and_nsswitch/troubleshooting.md) section.

--- a/book/src/integrations/pam_and_nsswitch/troubleshooting.md
+++ b/book/src/integrations/pam_and_nsswitch/troubleshooting.md
@@ -2,9 +2,19 @@
 
 ## Check POSIX-status of Group and Configuration
 
-If authentication is failing via PAM, make sure that a list of groups is configured in `/etc/kanidm/unixd`:
+If authentication is failing via PAM, make sure that you enabled the Kanidm provider and that
+a list of valid groups is configured in `/etc/kanidm/unixd`. The `[kanidm]` line is important!
 
+You can check the provider status, the second line is only shown if enabled:
+```bash
+> kanidm-unix status
+system: online
+Kanidm: online
+```
+
+Example of a minimum `/etc/kanidm/unixd` config:
 ```toml
+[kanidm]
 pam_allowed_login_groups = ["example_group"]
 ```
 

--- a/book/src/integrations/ssh_key_distribution.md
+++ b/book/src/integrations/ssh_key_distribution.md
@@ -43,8 +43,9 @@ Enter password:
 
 ### Public Key Caching Configuration
 
-If you have `kanidm_unixd` running, you can use it to locally cache SSH public keys. This means you can still SSH into
-your machines, even if your network is down, you move away from Kanidm, or some other interruption occurs.
+If you have `kanidm_unixd` running and have enabled the Kanidm provider, you can use it to locally cache SSH public keys.
+This means you can still SSH into your machines, even if your network is down, you move away from Kanidm,
+or some other interruption occurs.
 
 The `kanidm_ssh_authorizedkeys` command is part of the `kanidm-unix-clients` package, so should be installed on the
 servers. It communicates to `kanidm_unixd`, so you should have a configured PAM/nsswitch setup as well.

--- a/examples/unixd
+++ b/examples/unixd
@@ -141,6 +141,7 @@ version = '2'
 
 # ========================================
 # This section enables the Kanidm provider
+# If enabled, /etc/kanidm/config MUST have a valid `uri` setting for the daemon to start.
 [kanidm]
 
 # Defines a set of POSIX groups where membership of any of these groups

--- a/examples/unixd-safe-default
+++ b/examples/unixd-safe-default
@@ -4,16 +4,14 @@
 
 version = '2'
 
-[kanidm]
+# Steps to enable the Kanidm auth provider:
+# 1. Uncomment the `[kanidm]` line below to enable the provider.
+# 2. Set the `pam_allowed_login_groups` option to a valid group.
+# 3. Also update /etc/kanidm/config and set the `idm_uri` option.
+
+# [kanidm]
+# pam_allowed_login_groups = ["your_posix_login_group"]
 # default_shell = "/bin/sh"
 # home_attr = "uuid"
 # home_alias = "spn"
 # use_etc_skel = false
-
-# Defines a set of POSIX groups where membership of any of these groups
-# will be allowed to login via PAM
-#
-# WITHOUT THIS SET, NOBODY WILL BE ABLE TO LOG IN VIA PAM
-#
-# Replace your group below and uncomment this line
-# pam_allowed_login_groups = ["your_posix_login_group"]


### PR DESCRIPTION
# Change summary

When enabled without further configuration, unixd will fail to start which can cause speedlooping and other confusing issues. While this is just an example config, it's also used as the default config of Debian based unixd installs so this is a partial solution to #3838.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
