### PR TITLE
Add password check api

### DIFF
--- a/proto/src/internal/credupdate.rs
+++ b/proto/src/internal/credupdate.rs
@@ -76,6 +76,7 @@ pub struct CUSessionToken {
 #[serde(rename_all = "lowercase")]
 pub enum CURequest {
     PrimaryRemove,
+    PasswordQualityCheck(String),
     Password(String),
     CancelMFAReg,
     TotpGenerate,
@@ -100,6 +101,7 @@ impl fmt::Debug for CURequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let t = match self {
             CURequest::PrimaryRemove => "CURequest::PrimaryRemove",
+            CURequest::PasswordQualityCheck(_) => "CURequest::PasswordQualityCheck",
             CURequest::Password(_) => "CURequest::Password",
             CURequest::CancelMFAReg => "CURequest::CancelMFAReg",
             CURequest::TotpGenerate => "CURequest::TotpGenerate",

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1171,147 +1171,86 @@ impl QueryServerReadV1 {
         match scr {
             CURequest::PrimaryRemove => idms_cred_update
                 .credential_primary_delete(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_delete",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_delete",);
                 }),
             CURequest::PasswordQualityCheck(pw) => idms_cred_update
                 .credential_check_password_quality(&session_token, ct, &pw)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_check_password_quality",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_check_password_quality",);
                 }),
             CURequest::Password(pw) => idms_cred_update
                 .credential_primary_set_password(&session_token, ct, &pw)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_set_password",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_set_password",);
                 }),
             CURequest::CancelMFAReg => idms_cred_update
                 .credential_update_cancel_mfareg(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_update_cancel_mfareg",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_update_cancel_mfareg",);
                 }),
             CURequest::TotpGenerate => idms_cred_update
                 .credential_primary_init_totp(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_init_totp",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_init_totp",);
                 }),
             CURequest::TotpVerify(totp_chal, label) => idms_cred_update
                 .credential_primary_check_totp(&session_token, ct, totp_chal, &label)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_check_totp",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_check_totp",);
                 }),
             CURequest::TotpAcceptSha1 => idms_cred_update
                 .credential_primary_accept_sha1_totp(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_accept_sha1_totp",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_accept_sha1_totp",);
                 }),
             CURequest::TotpRemove(label) => idms_cred_update
                 .credential_primary_remove_totp(&session_token, ct, &label)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_remove_totp",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_remove_totp",);
                 }),
             CURequest::BackupCodeGenerate => idms_cred_update
                 .credential_primary_init_backup_codes(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_primary_init_backup_codes",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_primary_init_backup_codes",);
                 }),
             CURequest::BackupCodeRemove => idms_cred_update
                 .credential_primary_remove_backup_codes(&session_token, ct)
-                .map_err(|e| {
+                .inspect_err(|err| {
                     error!(
-                        err = ?e,
+                        ?err,
                         "Failed to begin credential_primary_remove_backup_codes",
                     );
-                    e
                 }),
             CURequest::PasskeyInit => idms_cred_update
                 .credential_passkey_init(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_passkey_init",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_passkey_init",);
                 }),
             CURequest::PasskeyFinish(label, rpkc) => idms_cred_update
                 .credential_passkey_finish(&session_token, ct, label, &rpkc)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_passkey_finish",
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_passkey_finish",);
                 }),
             CURequest::PasskeyRemove(uuid) => idms_cred_update
                 .credential_passkey_remove(&session_token, ct, uuid)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_passkey_remove"
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_passkey_remove",);
                 }),
             CURequest::AttestedPasskeyInit => idms_cred_update
                 .credential_attested_passkey_init(&session_token, ct)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_attested_passkey_init"
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_attested_passkey_init",);
                 }),
             CURequest::AttestedPasskeyFinish(label, rpkc) => idms_cred_update
                 .credential_attested_passkey_finish(&session_token, ct, label, &rpkc)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_attested_passkey_finish"
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_attested_passkey_finish",);
                 }),
             CURequest::AttestedPasskeyRemove(uuid) => idms_cred_update
                 .credential_attested_passkey_remove(&session_token, ct, uuid)
-                .map_err(|e| {
-                    error!(
-                        err = ?e,
-                        "Failed to begin credential_attested_passkey_remove"
-                    );
-                    e
+                .inspect_err(|err| {
+                    error!(?err, "Failed to begin credential_attested_passkey_remove",);
                 }),
             CURequest::UnixPasswordRemove => idms_cred_update
                 .credential_unix_delete(&session_token, ct)
@@ -1323,13 +1262,11 @@ impl QueryServerReadV1 {
                 .inspect_err(|err| {
                     error!(?err, "Failed to begin credential_unix_set_password");
                 }),
-
             CURequest::SshPublicKey(label, pubkey) => idms_cred_update
                 .credential_sshkey_add(&session_token, ct, label, pubkey)
                 .inspect_err(|err| {
                     error!(?err, "Failed to begin credential_sshkey_remove");
                 }),
-
             CURequest::SshPublicKeyRemove(label) => idms_cred_update
                 .credential_sshkey_remove(&session_token, ct, &label)
                 .inspect_err(|err| {

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1178,6 +1178,15 @@ impl QueryServerReadV1 {
                     );
                     e
                 }),
+            CURequest::PasswordQualityCheck(pw) => idms_cred_update
+                .credential_check_password_quality(&session_token, ct, &pw)
+                .map_err(|e| {
+                    error!(
+                        err = ?e,
+                        "Failed to begin credential_check_password_quality",
+                    );
+                    e
+                }),
             CURequest::Password(pw) => idms_cred_update
                 .credential_primary_set_password(&session_token, ct, &pw)
                 .map_err(|e| {

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -1797,6 +1797,42 @@ impl IdmServerCredUpdateTransaction<'_> {
     }
 
     #[instrument(level = "trace", skip(cust, self))]
+    pub fn credential_check_password_quality(
+        &self,
+        cust: &CredentialUpdateSessionToken,
+        ct: Duration,
+        pw: &str,
+    ) -> Result<CredentialUpdateSessionStatus, OperationError> {
+        let session_handle = self.get_current_session(cust, ct)?;
+        let session = session_handle.try_lock().map_err(|_| {
+            admin_error!("Session already locked, unable to proceed.");
+            OperationError::InvalidState
+        })?;
+        trace!(?session);
+
+        self.check_password_quality(
+            pw,
+            &session.resolved_account_policy,
+            session.account.related_inputs().as_slice(),
+            session.account.radius_secret.as_deref(),
+        )
+        .map_err(|e| match e {
+            PasswordQuality::TooShort(sz) => {
+                OperationError::PasswordQuality(vec![PasswordFeedback::TooShort(sz)])
+            }
+            PasswordQuality::BadListed => {
+                OperationError::PasswordQuality(vec![PasswordFeedback::BadListed])
+            }
+            PasswordQuality::DontReusePasswords => {
+                OperationError::PasswordQuality(vec![PasswordFeedback::DontReusePasswords])
+            }
+            PasswordQuality::Feedback(feedback) => OperationError::PasswordQuality(feedback),
+        })?;
+
+        Ok(session.deref().into())
+    }
+
+    #[instrument(level = "trace", skip(cust, self))]
     pub fn credential_primary_set_password(
         &self,
         cust: &CredentialUpdateSessionToken,


### PR DESCRIPTION
# Change summary

- Adds the server side parts for a CURequest::PasswordQualityCheck. 
- @tennox What is remaining is a handler similar to https://github.com/kanidm/kanidm/blob/master/server/core/src/https/views/reset.rs#L688 which issues a CURequest::PasswordQuality check, and then can render the html or whatever. Not 100% sure what you want this to look like or how to do it nicely within the htmx space, but I think you are better in this area than I am.   

Relates #3650

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
