### PR TITLE
maint: pin the rust version to allow the docs to build

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -33,7 +33,9 @@ jobs:
             pkg-config \
             tpm-udev
       - name: "Run clippy"
-        run: cargo clippy --lib --bins --examples --all-features
+        run: |
+          rustup component add clippy
+          cargo clippy --lib --bins --examples --all-features
   fmt:
     runs-on: ubuntu-latest
     steps:
@@ -41,4 +43,6 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: "Run cargo fmt"
-        run: cargo fmt --check
+        run: |
+          rustup component add rustfmt
+          cargo fmt --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.89"


### PR DESCRIPTION
# Change summary

- the `rust-toolchain.toml` file is set to stable which is causing older builds to fail, pinning this to a working version

Fixes #something

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
