### PR TITLE
Example of ipv4 to ipv6 addr mapping.

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -89,11 +89,22 @@ origin = "https://idm.example.com"
 #   and which format the information is provided in.
 #   Defaults to "none" (no trusted sources)
 #   Only one option can be used at a time.
+#
+#   NOTE: Linux can sometimes used ipv4 to ipv6 mapped
+#         addresses. You may need to use the "::ffff:"
+#         prefixed ips instead of ipv4 addresses.
+#
 # [http_client_address_info]
 # proxy-v2 = ["127.0.0.1", "127.0.0.0/8"]
 #   # OR
 # [http_client_address_info]
+# proxy-v2 = ["::ffff:127.0.0.1", "::ffff:127.0.0.0/120"]
+#   # OR
+# [http_client_address_info]
 # x-forward-for = ["127.0.0.1", "127.0.0.0/8"]
+#   # OR
+# [http_client_address_info]
+# x-forward-for = ["::ffff:127.0.0.1", "::ffff:127.0.0.0/120"]
 
 #   LDAPS requests can be reverse proxied by a loadbalancer.
 #   To preserve the original IP of the caller, these systems

--- a/examples/server_container.toml
+++ b/examples/server_container.toml
@@ -88,11 +88,22 @@ origin = "https://idm.example.com"
 #   and which format the information is provided in.
 #   Defaults to "none" (no trusted sources)
 #   Only one option can be used at a time.
+#
+#   NOTE: Linux can sometimes used ipv4 to ipv6 mapped
+#         addresses. You may need to use the "::ffff:"
+#         prefixed ips instead of ipv4 addresses.
+#
 # [http_client_address_info]
 # proxy-v2 = ["127.0.0.1", "127.0.0.0/8"]
 #   # OR
 # [http_client_address_info]
+# proxy-v2 = ["::ffff:127.0.0.1", "::ffff:127.0.0.0/120"]
+#   # OR
+# [http_client_address_info]
 # x-forward-for = ["127.0.0.1", "127.0.0.0/8"]
+#   # OR
+# [http_client_address_info]
+# x-forward-for = ["::ffff:127.0.0.1", "::ffff:127.0.0.0/120"]
 
 #   LDAPS requests can be reverse proxied by a loadbalancer.
 #   To preserve the original IP of the caller, these systems


### PR DESCRIPTION
# Change summary

- Document examples of linux ipv4 to ipv6 mapping. 

Fixes #3837

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
