### PR TITLE
When no upgrade checks are performed, issue a status: PASS

### DIFF
--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -131,6 +131,13 @@ async fn submit_admin_req(path: &str, req: AdminTaskRequest, output_mode: Consol
                     info!("domain_current_level   : {}", current_level);
                     info!("domain_upgrade_level   : {}", upgrade_level);
 
+                    if report_items.is_empty() {
+                        // Nothing to report, so this implies a pass.
+                        info!("------------------------");
+                        info!("status                 : PASS");
+                        return;
+                    }
+
                     for item in report_items {
                         info!("------------------------");
                         match item.status {
@@ -188,7 +195,7 @@ async fn submit_admin_req(path: &str, req: AdminTaskRequest, output_mode: Consol
                                 }
                             }
                         }
-                    }
+                    } // end for report items
                 }
             }
         }


### PR DESCRIPTION
# Change summary

- Domain upgrade check would only give a status if a check is performed. Not every domain version needs these checks, so sometimes they would issue an empty result. In these cases, return status: PASS to the user to make it clear they are "good to go". 

Fixes #3872

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
