### PR TITLE
Correct RADIUS API token generation examples

### DIFF
--- a/book/src/integrations/radius.md
+++ b/book/src/integrations/radius.md
@@ -91,7 +91,7 @@ kanidm group add-members --name idm_admin idm_radius_servers radius_service_acco
 Now reset the account password, using the `admin` account:
 
 ```bash
-kanidm service-account api-token generate --name admin radius_service_account radius1
+kanidm service-account api-token generate --name idm_admin radius_service_account radius1
 ```
 
 ## Deploying a RADIUS Container


### PR DESCRIPTION
# Change summary

- Change "admin" to "idm_admin" in the step that creates RADIUS API token. Using `admin` account returns `Error generating service account api token -> Http(403, Some(AccessDenied)` and I have to use `idm_admin`.

I'd call it a follow-up of #3697.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
