### PR TITLE
Logging improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6606,8 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "sshkeys"
-version = "0.3.3"
-source = "git+https://github.com/dnaeon/rust-sshkeys.git?rev=d736693769b9c4abebad8050fba92271f3c50226#d736693769b9c4abebad8050fba92271f3c50226"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dd24cd9c70e02c48882a32b74e784d8f2aaddba2a3a30c403d5a6e416fa117"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -7176,9 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-forest"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3298fe855716711a00474eceb89cc7dc254bbe67f6bc4afafdeec5f0c538771c"
+checksum = "92bdb3c949c9e81b71f78ba782f956b896019d82cc2f31025d21e04adab4d695"
 dependencies = [
  "smallvec",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,6 @@ codegen-units = 256
 # webauthn-rs-proto = { path = "../webauthn-rs/webauthn-rs-proto" }
 # sshkey-attest = { path = "../webauthn-rs/sshkey-attest" }
 
-# Allow ssh keys to have comments with spaces.
-sshkeys = { git = "https://github.com/dnaeon/rust-sshkeys.git", rev = "d736693769b9c4abebad8050fba92271f3c50226" }
-
 [workspace.dependencies]
 kanidmd_core = { path = "./server/core", version = "=1.8.0-dev" }
 kanidmd_lib = { path = "./server/lib", version = "=1.8.0-dev" }
@@ -266,7 +263,7 @@ shellexpand = "3.1.1"
 smartstring = "^1.0.1"
 smolset = "^1.3.1"
 sshkey-attest = "^0.5.3"
-sshkeys = "0.3.3"
+sshkeys = "0.3.4"
 svg = "0.18.0"
 syn = { version = "2.0.107", features = ["full"] }
 tempfile = "3.23.0"
@@ -282,7 +279,7 @@ tracing = { version = "^0.1.41", features = [
     "release_max_level_debug",
 ] }
 tracing-subscriber = { version = "^0.3.20", features = ["env-filter"] }
-tracing-forest = { version = "^0.2.0", features = ["defer"] }
+tracing-forest = { version = "^0.3.0", features = ["defer"] }
 url = "^2.5.2"
 urlencoding = "2.1.3"
 utoipa = { version = "5.4.0", features = ["url", "uuid"] }

--- a/server/core/src/https/middleware/mod.rs
+++ b/server/core/src/https/middleware/mod.rs
@@ -92,8 +92,7 @@ pub async fn ip_address_middleware(
 ) -> Response {
     match ip_address_middleware_inner(&state, &mut request).await {
         Ok(trusted_client_ip) => {
-            // By this point, proxy-v2 AND x-forward-for have resolved, so we can finally display this information.
-            info!(connection_addr = %trusted_client_ip.connection_addr, client_ip_addr = %trusted_client_ip.client_ip_addr);
+            // By this point, proxy-v2 AND x-forward-for have resolved, so we can finally insert this information.
             request.extensions_mut().insert(trusted_client_ip);
             next.run(request).await
         }

--- a/server/core/src/https/trace.rs
+++ b/server/core/src/https/trace.rs
@@ -1,28 +1,14 @@
 //! Reimplementation of tower-http's DefaultMakeSpan that only runs at "INFO" level for our own needs.
 
-use axum::http::{Request, StatusCode};
+use axum::http::Request;
 use kanidm_proto::constants::KOPID;
-use sketching::event_dynamic_lvl;
-use tower_http::LatencyUnit;
+use tower_http::trace::OnRequest;
 use tracing::{Level, Span};
 
 /// The default way Spans will be created for Trace.
 ///
 #[derive(Debug, Clone)]
 pub struct DefaultMakeSpanKanidmd {}
-
-impl DefaultMakeSpanKanidmd {
-    /// Create a new `DefaultMakeSpanKanidmd`.
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for DefaultMakeSpanKanidmd {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl<B> tower_http::trace::MakeSpan<B> for DefaultMakeSpanKanidmd {
     fn make_span(&mut self, request: &Request<B>) -> Span {
@@ -34,73 +20,56 @@ impl<B> tower_http::trace::MakeSpan<B> for DefaultMakeSpanKanidmd {
             method = %request.method(),
             uri = %request.uri(),
             version = ?request.version(),
-            // Defer logging this span until there is child information attached.
-            defer = true,
+            kopid = tracing::field::Empty, // filled in later
+            client_address = tracing::field::Empty, // filled in later
+            status_code = tracing::field::Empty, // filled in later
+            latency = tracing::field::Empty, // filled in later
         )
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct DefaultOnResponseKanidmd {
-    #[allow(dead_code)]
-    level: Level,
-    #[allow(dead_code)]
-    latency_unit: LatencyUnit,
-    #[allow(dead_code)]
-    include_headers: bool,
-}
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DefaultOnRequestKanidmd {}
 
-impl DefaultOnResponseKanidmd {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Self::default()
+impl<B> OnRequest<B> for DefaultOnRequestKanidmd {
+    fn on_request(&mut self, request: &axum::http::Request<B>, span: &Span) {
+        if let Some(client_conn_info) = request.extensions().get::<crate::https::ClientConnInfo>() {
+            span.record(
+                "client_address",
+                client_conn_info.connection_addr.to_string(),
+            );
+        };
     }
 }
 
-impl Default for DefaultOnResponseKanidmd {
-    fn default() -> Self {
-        Self {
-            level: Level::INFO,
-            latency_unit: LatencyUnit::Millis,
-            include_headers: false,
-        }
-    }
-}
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DefaultOnResponseKanidmd {}
 
 impl<B> tower_http::trace::OnResponse<B> for DefaultOnResponseKanidmd {
     fn on_response(
         self,
         response: &axum::response::Response<B>,
         latency: std::time::Duration,
-        _span: &Span,
+        span: &Span,
     ) {
+        if let Some(client_conn_info) = response.extensions().get::<crate::https::ClientConnInfo>()
+        {
+            span.record(
+                "connection_addr",
+                client_conn_info.connection_addr.to_string(),
+            );
+            span.record(
+                "client_ip_addr",
+                client_conn_info.client_ip_addr.to_string(),
+            );
+        };
         let kopid = match response.headers().get(KOPID) {
             Some(val) => val.to_str().unwrap_or("<invalid kopid>"),
             None => "<unknown>",
         };
-        let (level, msg) =
-            match response.status().is_success() || response.status().is_informational() {
-                true => (Level::DEBUG, "response sent"),
-                false => {
-                    if response.status().is_redirection() {
-                        (Level::INFO, "client redirection sent")
-                    } else if response.status().is_client_error() {
-                        if response.status() == StatusCode::NOT_FOUND {
-                            (Level::INFO, "client error")
-                        } else {
-                            (Level::WARN, "client error") // it worked, but there was an input error
-                        }
-                    } else {
-                        (Level::ERROR, "error handling request") // oh no the server failed
-                    }
-                }
-            };
-        event_dynamic_lvl!(
-            level,
-            ?latency,
-            status_code = response.status().as_u16(),
-            kopid = kopid,
-            msg
-        );
+
+        span.record("latency", latency.as_millis());
+        span.record("kopid", kopid);
+        span.record("status_code", response.status().as_u16());
     }
 }


### PR DESCRIPTION
# Change summary

- uses span.record properly to lessen the data logged about http requests

>[!NOTE]
> we can't release this version until https://github.com/QnnOkabayashi/tracing-forest/pull/42 is merged because `tracing-forest` doesn't implement `on_record` for spans.

Refers #3904

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
