### PR TITLE
fix: ensure CLI exits with non-zero code on HTTP client errors

### DIFF
--- a/tools/cli/src/cli/lib.rs
+++ b/tools/cli/src/cli/lib.rs
@@ -53,8 +53,10 @@ pub(crate) fn handle_client_error(response: ClientError, _output_mode: OutputMod
                 std::process::exit(1);
             } else if status == StatusCode::NOT_FOUND {
                 error!("Item not found: Check all names are correct.");
+                std::process::exit(1);
             } else {
                 error!("HTTP Error: {}{}", status, error_msg);
+                std::process::exit(1);
             }
         }
         ClientError::Transport(e) => {
@@ -67,6 +69,7 @@ pub(crate) fn handle_client_error(response: ClientError, _output_mode: OutputMod
         }
         _ => {
             eprintln!("{response:?}");
+            std::process::exit(1);
         }
     };
 }


### PR DESCRIPTION
Previously, only INTERNAL_SERVER_ERROR (500), Transport, and UntrustedCertificate errors would call `std::process::exit(1)` - while NOT_FOUND (404), other HTTP errors, and the default case would just log errors and return normally, causing the CLI to exit with code 0.

This continues the work started in commit 4b7563adc8e where the developer noted: "uh, so I started messing with handling exit codes...".

I encountered the issue with a command like:
```
kanidm system oauth2 update-scope-map foobar
```
would log "Item not found" but return exit code 0, making it hard(er) to write proper shell scripts.

### Alternative fix strategy

```
main()
  └─ rt.block_on(signal_handler(opt))
      └─ opt.exec()
          └─ [various command implementations]
              └─ handle_client_error()
                  └─ std::process::exit(1)  ← exits process here
```

In main.rs, I notice signal_handler returns `ExitCode::SUCCESS`, even when `opt.exec()` encounters errors. This could be refactored instead, but would involve bigger changes to the codebase which I wasn't sure if it's a good idea and just went with the existing pattern.
