### PR TITLE
Fixes #3668 by adding CSS to support forced-colors on the toggle switch

### DIFF
--- a/server/core/static/style.css
+++ b/server/core/static/style.css
@@ -1,8 +1,9 @@
 :root {
   --totp-width-and-height: 30px;
   --totp-stroke-width: 60px;
-  --navbar-colors-transition: color 0.15s ease-in-out,
-    background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+  --navbar-colors-transition:
+    color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -203,4 +204,29 @@ nav a.navbar-brand {
 
 .cursor-pointer:hover {
   cursor: pointer;
+}
+
+@media (forced-colors: active) and (prefers-color-scheme: light) {
+  .form-check-input:checked {
+    background-color: ButtonText !important;
+  }
+  .form-switch .form-check-input:checked {
+    forced-color-adjust: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .form-check-input:focus {
+    outline: 1px solid Highlight;
+  }
+  .form-check-input:disabled ~ .form-check-label,
+  .form-check-input[disabled] ~ .form-check-label {
+    color: GrayText;
+  }
+  .form-select:focus {
+    outline: 1px solid transparent;
+  }
+  .form-switch .form-check-input {
+    border: 1px solid;
+  }
 }


### PR DESCRIPTION
# Change summary

- I was able to reproduce the issue on Chrome and Firefox on Windows. The issue mainly arises due to the white fill color of the SVG used for the toggle switch knob. The white color doesn't contrast with the light theme, so it's hard to see.

- To mitigate this, I have added CSS using the `forced-colors` media query that ensures the toggle switch background uses system colors that contrast with the white knob in high contrast themes.

- I have Verified on Windows High Contrast mode (both light and dark themes). Screenshots of the fix are below.

Toggle switch off (High contrast light theme) :
<img width="1920" height="913" alt="light-mode-off" src="https://github.com/user-attachments/assets/e8001e22-dc1c-4749-8ff0-2f2ae19a007a" />

Toggle switch on (High contrast light theme) :
<img width="1920" height="913" alt="light-mode-on" src="https://github.com/user-attachments/assets/f416a837-8c34-400a-897f-d671f3330a50" />


Toggle switch off (High contrast dark theme):
<img width="1920" height="913" alt="dark-mode-off" src="https://github.com/user-attachments/assets/9df1ca14-1dec-4cd1-98e3-ea2543245c1d" />
 
 Toggle switch on (High contrast dark theme):
<img width="1920" height="913" alt="dark-mode-on" src="https://github.com/user-attachments/assets/c7827f4c-4ee9-4373-8657-a4c6db80f9c7" />


Fixes #3668 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
