### PR TITLE
fix: kanidm_build_profiles has unwrap which can cause builds to fail

### DIFF
--- a/libs/profiles/build.rs
+++ b/libs/profiles/build.rs
@@ -59,7 +59,7 @@ fn main() {
         println!("cargo:rustc-env=KANIDM_PKG_COMMIT_REV={commit_rev}");
     }
 
-    println!("cargo:rerun-if-changed={}", profile_path.to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", profile_path.to_string_lossy());
 
     println!("cargo:rustc-env=KANIDM_BUILD_PROFILE={profile}");
     println!("cargo:rustc-env=KANIDM_BUILD_PROFILE_TOML={contents}");


### PR DESCRIPTION
# Change summary

- remove the unwraps and fail cleaner

Fixes #3971 

Checklist

- [x] This PR contains no AI generated code