### PR TITLE
Change AttributeUniqueness to yield BAD_REQUEST

### DIFF
--- a/server/core/src/https/errors.rs
+++ b/server/core/src/https/errors.rs
@@ -100,6 +100,7 @@ impl IntoResponse for WebError {
                     OperationError::PasswordQuality(_)
                     | OperationError::EmptyRequest
                     | OperationError::InvalidAttribute(_)
+                    | OperationError::AttributeUniqueness(_)
                     | OperationError::InvalidAttributeName(_)
                     | OperationError::SchemaViolation(_)
                     | OperationError::CU0003WebauthnUserNotVerified
@@ -109,6 +110,7 @@ impl IntoResponse for WebError {
                     _ => (StatusCode::INTERNAL_SERVER_ERROR, None),
                 };
                 let body = serde_json::to_string(&inner).unwrap_or(inner.to_string());
+                debug!(?body);
 
                 match headers {
                     Some(headers) => (code, headers, body).into_response(),


### PR DESCRIPTION
# Change summary

- This makes attribute unique errors handle better by changing their type to badrequest
- Really, this is showing the cracks in our error handling story and something we should address more concretely in future. 

Fixes #3951

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
