### PR TITLE
Missing constraint on skip upgrade process

### DIFF
--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -85,12 +85,19 @@ pub const DOMAIN_TGT_LEVEL: DomainVersion = DOMAIN_LEVEL_13;
 // The current patch level if any out of band fixes are required.
 pub const DOMAIN_TGT_PATCH_LEVEL: u32 = PATCH_LEVEL_2;
 
-// The maximum supported domain functional level
+// The maximum supported domain functional level. This generally
+// represents a *future* version of the server which doesn't exist
+// yet.
 pub const DOMAIN_MAX_LEVEL: DomainVersion = DOMAIN_LEVEL_14;
 
-// The minimum level that we can re-migrate from.
-// This should be DOMAIN_TGT_LEVEL minus 2
-pub const DOMAIN_MIN_REMIGRATION_LEVEL: DomainVersion = DOMAIN_LEVEL_10;
+// The minimum level that we can re-migrate from. Remember, this
+// means we should be able to move from min level to the next level
+// and generally represents the absolute oldest level we can create
+// in a test case.
+pub const DOMAIN_MIN_REMIGRATION_LEVEL: DomainVersion = DOMAIN_LEVEL_9;
+
+// How many domain levels we can upgrade through in a single operation.
+pub const DOMAIN_MIGRATION_SKIPS: DomainVersion = 1;
 
 // The minimum supported domain functional level (for replication)
 pub const DOMAIN_MIN_LEVEL: DomainVersion = DOMAIN_TGT_LEVEL;

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -68,39 +68,51 @@ impl QueryServer {
                     return Err(OperationError::MG0009InvalidTargetLevelForBootstrap);
                 }
             }
-        } else {
-            // Domain info was present, so we need to reflect that in our server
-            // domain structures. If we don't do this, the in memory domain level
-            // is stuck at 0 which can confuse init domain info below.
-            //
-            // This also is where the former domain taint flag will be loaded to
-            // d_info so that if the *previous* execution of the database was
-            // a devel version, we'll still trigger the forced remigration in
-            // in the case that we are moving from dev -> stable.
-            write_txn.force_domain_reload();
 
-            write_txn.reload()?;
-
-            // Indicate the schema is now ready, which allows dyngroups to work when they
-            // are created in the next phase of migrations.
-            write_txn.set_phase(ServerPhase::SchemaReady);
-
-            // #2756 - if we *aren't* creating the base IDM entries, then we
-            // need to force dyn groups to reload since we're now at schema
-            // ready. This is done indirectly by ... reloading the schema again.
-            //
-            // This is because dyngroups don't load until server phase >= schemaready
-            // and the reload path for these is either a change in the dyngroup entry
-            // itself or a change to schema reloading. Since we aren't changing the
-            // dyngroup here, we have to go via the schema reload path.
-            write_txn.force_schema_reload();
-
-            // Reload as init idm affects access controls.
-            write_txn.reload()?;
-
-            // Domain info is now ready and reloaded, we can proceed.
-            write_txn.set_phase(ServerPhase::DomainInfoReady);
+            write_txn
+                .internal_apply_domain_migration(domain_target_level)
+                .map(|()| {
+                    warn!(
+                        "Domain level has been bootstrapped to {}",
+                        domain_target_level
+                    );
+                })?;
         }
+
+        // These steps apply both to bootstrapping and normal startup, since we now have
+        // a DB with data populated in either path.
+
+        // Domain info is now present, so we need to reflect that in our server
+        // domain structures. If we don't do this, the in memory domain level
+        // is stuck at 0 which can confuse init domain info below.
+        //
+        // This also is where the former domain taint flag will be loaded to
+        // d_info so that if the *previous* execution of the database was
+        // a devel version, we'll still trigger the forced remigration in
+        // in the case that we are moving from dev -> stable.
+        write_txn.force_domain_reload();
+
+        write_txn.reload()?;
+
+        // Indicate the schema is now ready, which allows dyngroups to work when they
+        // are created in the next phase of migrations.
+        write_txn.set_phase(ServerPhase::SchemaReady);
+
+        // #2756 - if we *aren't* creating the base IDM entries, then we
+        // need to force dyn groups to reload since we're now at schema
+        // ready. This is done indirectly by ... reloading the schema again.
+        //
+        // This is because dyngroups don't load until server phase >= schemaready
+        // and the reload path for these is either a change in the dyngroup entry
+        // itself or a change to schema reloading. Since we aren't changing the
+        // dyngroup here, we have to go via the schema reload path.
+        write_txn.force_schema_reload();
+
+        // Reload as init idm affects access controls.
+        write_txn.reload()?;
+
+        // Domain info is now ready and reloaded, we can proceed.
+        write_txn.set_phase(ServerPhase::DomainInfoReady);
 
         // This is the start of domain info related migrations which we will need in future
         // to handle replication. Due to the access control rework, and the addition of "managed by"
@@ -122,6 +134,15 @@ impl QueryServer {
 
         // If the database domain info is a lower version than our target level, we reload.
         if domain_info_version < domain_target_level {
+            if (domain_target_level - domain_info_version) > DOMAIN_MIGRATION_SKIPS {
+                error!(
+                    "UNABLE TO PROCEED. You are attempting a skip update which is NOT SUPPORTED."
+                );
+                error!("For more see: https://kanidm.github.io/kanidm/stable/support.html#upgrade-policy and https://kanidm.github.io/kanidm/stable/server_updates.html");
+                error!(domain_previous_version = ?domain_info_version, domain_target_version = ?domain_target_level, domain_migration_steps_limit = ?DOMAIN_MIGRATION_SKIPS);
+                return Err(OperationError::MG0008SkipUpgradeAttempted);
+            }
+
             write_txn
                 .internal_apply_domain_migration(domain_target_level)
                 .map(|()| {

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -2155,15 +2155,16 @@ impl<'a> QueryServerWriteTransaction<'a> {
     pub fn domain_remigrate(&mut self, level: u32) -> Result<(), OperationError> {
         let mut_d_info = self.d_info.get_mut();
 
+        // NOTE: See reload_domain_info_version which asserts that we are not attempting
+        // an unsupported remigration. This check is just a smoke check to no-op if we
+        // are not requesting any meaningful action.
         if level > mut_d_info.d_vers {
             // Nothing to do.
             return Ok(());
-        } else if level < DOMAIN_MIN_REMIGRATION_LEVEL {
-            return Err(OperationError::MG0001InvalidReMigrationLevel);
         };
 
         info!(
-            "Prepare to re-migrate from {} -> {}",
+            "Preparing to re-migrate from {} -> {}",
             level, mut_d_info.d_vers
         );
         mut_d_info.d_vers = level;
@@ -2480,12 +2481,16 @@ impl<'a> QueryServerWriteTransaction<'a> {
         // will now see it's been increased. This also prevents recursion during reloads
         // inside of a domain migration.
         let mut_d_info = self.d_info.get_mut();
+        debug!(?mut_d_info);
+        // This is the value that is set as part of re-migrate.
         let previous_version = mut_d_info.d_vers;
         let previous_patch_level = mut_d_info.d_patch_level;
         mut_d_info.d_vers = domain_info_version;
         mut_d_info.d_patch_level = domain_info_patch_level;
         mut_d_info.d_devel_taint = domain_info_devel_taint;
         mut_d_info.d_allow_easter_eggs = domain_allow_easter_eggs;
+
+        debug!(?mut_d_info);
 
         // We must both be at the correct domain version *and* the correct patch level. If we are
         // not, then we only proceed to migrate *if* our server boot phase is correct.
@@ -2509,12 +2514,18 @@ impl<'a> QueryServerWriteTransaction<'a> {
             return Ok(());
         }
 
+        debug_assert!(DOMAIN_MIN_REMIGRATION_LEVEL < DOMAIN_PREVIOUS_TGT_LEVEL);
+
         if previous_version < DOMAIN_MIN_REMIGRATION_LEVEL {
-            error!("UNABLE TO PROCEED. You are attempting a Skip update which is NOT SUPPORTED. You must upgrade one-version of Kanidm at a time.");
+            let valid_levels: Vec<_> =
+                (DOMAIN_MIN_REMIGRATION_LEVEL..DOMAIN_PREVIOUS_TGT_LEVEL).collect();
+            error!("UNABLE TO PROCEED. You have requested an initial migration level which is lower than supported.");
             error!("For more see: https://kanidm.github.io/kanidm/stable/support.html#upgrade-policy and https://kanidm.github.io/kanidm/stable/server_updates.html");
             error!(domain_previous_version = ?previous_version, domain_target_version = ?domain_info_version);
             error!(domain_previous_patch_level = ?previous_patch_level, domain_target_patch_level = ?domain_info_patch_level);
-            return Err(OperationError::MG0008SkipUpgradeAttempted);
+            error!(?valid_levels);
+
+            return Err(OperationError::MG0001InvalidReMigrationLevel);
         }
 
         // Commented as an example of patch application
@@ -2526,6 +2537,10 @@ impl<'a> QueryServerWriteTransaction<'a> {
             self.migrate_domain_patch_level_2()?;
         }
         */
+
+        // This is to catch during development if we incorrectly move MIN_REMIGRATION but
+        // without actually updating these values correctly.
+        debug_assert!(DOMAIN_MIN_REMIGRATION_LEVEL == DOMAIN_LEVEL_9);
 
         if previous_version <= DOMAIN_LEVEL_9 && domain_info_version >= DOMAIN_LEVEL_10 {
             // 1.5 -> 1.6


### PR DESCRIPTION
When the migration process was changed from differentials to the now full template application process, the process for checking skip upgrades was changed. Due to the way this process changed, it caused an issue where the skip check was performed in the wrong part of the server, which then DID allow skip upgrades to be attempted.

This moves the skip upgrade check to an earlier phase of the server startup process, and also resolves a potential similar issue that may have occured during remigrations.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
