### PR TITLE
Resolve infinite reauth loop

### DIFF
--- a/proto/src/cli.rs
+++ b/proto/src/cli.rs
@@ -1,46 +1,5 @@
-use std::str::FromStr;
-
-use clap::{builder::PossibleValue, Parser, ValueEnum};
-use serde::Deserialize;
-
 use crate::internal::FsType;
-
-#[derive(Debug, Copy, Clone, Deserialize)]
-pub enum OpType {
-    Read,
-    Write,
-}
-
-impl FromStr for OpType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "read" => Ok(OpType::Read),
-            "write" => Ok(OpType::Write),
-            _ => Err(format!("Invalid OpType: {}", s)),
-        }
-    }
-}
-
-impl ValueEnum for OpType {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Read, Self::Write]
-    }
-
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(PossibleValue::from(self.as_str()))
-    }
-}
-
-impl OpType {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            OpType::Read => "read",
-            OpType::Write => "write",
-        }
-    }
-}
+use clap::Parser;
 
 #[derive(Debug, Parser, Clone)]
 pub struct KanidmdCli {

--- a/tools/cli/src/cli/domain/mod.rs
+++ b/tools/cli/src/cli/domain/mod.rs
@@ -1,6 +1,7 @@
+use crate::OpType;
 use crate::{handle_client_error, DomainOpt, KanidmClientParser};
 use anyhow::{Context, Error};
-use kanidm_proto::{cli::OpType, internal::ImageValue};
+use kanidm_proto::internal::ImageValue;
 use std::fs::read;
 
 impl DomainOpt {

--- a/tools/cli/src/cli/graph.rs
+++ b/tools/cli/src/cli/graph.rs
@@ -1,7 +1,7 @@
+use crate::OpType;
 use crate::{
     handle_client_error, GraphCommonOpt, GraphType, KanidmClientParser, ObjectType, OutputMode,
 };
-use kanidm_proto::cli::OpType;
 use kanidm_proto::internal::Filter::{Eq, Or};
 
 impl GraphCommonOpt {

--- a/tools/cli/src/cli/group/account_policy.rs
+++ b/tools/cli/src/cli/group/account_policy.rs
@@ -1,8 +1,8 @@
+use crate::OpType;
 use crate::{
     handle_client_error, handle_group_account_policy_error, GroupAccountPolicyOpt,
     KanidmClientParser,
 };
-use kanidm_proto::cli::OpType;
 
 impl GroupAccountPolicyOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {

--- a/tools/cli/src/cli/group/mod.rs
+++ b/tools/cli/src/cli/group/mod.rs
@@ -1,5 +1,5 @@
+use crate::OpType;
 use crate::{handle_client_error, GroupOpt, GroupPosix, KanidmClientParser, OutputMode};
-use kanidm_proto::cli::OpType;
 use kanidm_proto::constants::ATTR_GIDNUMBER;
 
 mod account_policy;

--- a/tools/cli/src/cli/lib.rs
+++ b/tools/cli/src/cli/lib.rs
@@ -13,7 +13,7 @@
 #[macro_use]
 extern crate tracing;
 
-use kanidm_proto::cli::OpType;
+pub(crate) use crate::common::OpType;
 use std::path::PathBuf;
 
 use identify_user_no_tui::{run_identity_verification_no_tui, IdentifyUserState};
@@ -162,7 +162,7 @@ impl KanidmClientParser {
         match self.commands.clone() {
             KanidmClientOpt::Raw { commands } => commands.exec(self).await,
             KanidmClientOpt::Login(lopt) => lopt.exec(self).await,
-            KanidmClientOpt::Reauth { mode } => self.reauth(mode).await,
+            KanidmClientOpt::Reauth => self.reauth().await,
             KanidmClientOpt::Logout(lopt) => lopt.exec(self).await,
             KanidmClientOpt::Session { commands } => commands.exec(self).await,
             KanidmClientOpt::CSelf { commands } => commands.exec(self).await,

--- a/tools/cli/src/cli/oauth2.rs
+++ b/tools/cli/src/cli/oauth2.rs
@@ -1,7 +1,7 @@
+use crate::OpType;
 use crate::{handle_client_error, Oauth2Opt, OutputMode};
 use crate::{KanidmClientParser, Oauth2ClaimMapJoin};
 use anyhow::{Context, Error};
-use kanidm_proto::cli::OpType;
 use kanidm_proto::internal::{ImageValue, Oauth2ClaimMapJoin as ProtoOauth2ClaimMapJoin};
 use std::fs::read;
 use std::process::exit;

--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -2,12 +2,12 @@ use crate::common::try_expire_at_from_string;
 use std::fmt::{self, Debug};
 use std::str::FromStr;
 
+use crate::OpType;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input, Password, Select};
 use kanidm_client::ClientError::Http as ClientErrorHttp;
 use kanidm_client::KanidmClient;
 use kanidm_proto::attribute::Attribute;
-use kanidm_proto::cli::OpType;
 use kanidm_proto::constants::{ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM, ATTR_GIDNUMBER};
 use kanidm_proto::internal::OperationError::{
     DuplicateKey, DuplicateLabel, InvalidLabel, NoMatchingEntries, PasswordQuality,

--- a/tools/cli/src/cli/raw.rs
+++ b/tools/cli/src/cli/raw.rs
@@ -1,5 +1,5 @@
+use crate::OpType;
 use crate::{KanidmClientParser, OutputMode, RawOpt};
-use kanidm_proto::cli::OpType;
 use kanidm_proto::scim_v1::{
     client::{ScimEntryPostGeneric, ScimEntryPutGeneric},
     ScimEntryGetQuery,

--- a/tools/cli/src/cli/recycle.rs
+++ b/tools/cli/src/cli/recycle.rs
@@ -1,5 +1,5 @@
+use crate::OpType;
 use crate::{handle_client_error, KanidmClientParser, RecycleOpt};
-use kanidm_proto::cli::OpType;
 
 impl RecycleOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {

--- a/tools/cli/src/cli/serviceaccount.rs
+++ b/tools/cli/src/cli/serviceaccount.rs
@@ -1,5 +1,5 @@
 use crate::common::try_expire_at_from_string;
-use kanidm_proto::cli::OpType;
+use crate::OpType;
 use kanidm_proto::constants::{
     ATTR_ACCOUNT_EXPIRE, ATTR_ACCOUNT_VALID_FROM, ATTR_GIDNUMBER, ATTR_SSH_PUBLICKEY,
 };

--- a/tools/cli/src/cli/session.rs
+++ b/tools/cli/src/cli/session.rs
@@ -6,13 +6,13 @@ use std::io::{self, BufReader, BufWriter, ErrorKind, IsTerminal, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::OpType;
 use compact_jwt::{
     traits::JwsVerifiable, Jwk, JwsCompact, JwsEs256Verifier, JwsVerifier, JwtError,
 };
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
 use kanidm_client::{ClientError, KanidmClient};
-use kanidm_proto::cli::OpType;
 use kanidm_proto::internal::UserAuthToken;
 use kanidm_proto::v1::{AuthAllowed, AuthResponse, AuthState};
 #[cfg(target_family = "unix")]

--- a/tools/cli/src/cli/synch.rs
+++ b/tools/cli/src/cli/synch.rs
@@ -1,6 +1,6 @@
+use crate::OpType;
 use crate::{handle_client_error, KanidmClientParser, SynchOpt};
 use dialoguer::Confirm;
-use kanidm_proto::cli::OpType;
 
 impl SynchOpt {
     pub async fn exec(&self, opt: KanidmClientParser) {

--- a/tools/cli/src/cli/system_config/badlist.rs
+++ b/tools/cli/src/cli/system_config/badlist.rs
@@ -1,5 +1,5 @@
+use crate::OpType;
 use crate::{handle_client_error, KanidmClientParser, OutputMode, PwBadlistOpt};
-use kanidm_proto::cli::OpType;
 
 // use std::thread;
 use std::fs::File;

--- a/tools/cli/src/cli/system_config/denied_names.rs
+++ b/tools/cli/src/cli/system_config/denied_names.rs
@@ -1,4 +1,4 @@
-use kanidm_proto::cli::OpType;
+use crate::OpType;
 
 use crate::{handle_client_error, DeniedNamesOpt, KanidmClientParser, OutputMode};
 

--- a/tools/cli/src/cli/system_config/message.rs
+++ b/tools/cli/src/cli/system_config/message.rs
@@ -1,4 +1,4 @@
-use kanidm_proto::cli::OpType;
+use crate::OpType;
 
 use crate::{KanidmClientParser, MessageOpt, OutputMode};
 // use kanidm_proto::scim_v1::{ScimEntryGetQuery};

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -1397,10 +1397,7 @@ pub enum KanidmClientOpt {
     /// Login to an account to use with future cli operations
     Login(LoginOpt),
     /// Reauthenticate to access privileged functions of this account for a short period.
-    Reauth {
-        #[clap()]
-        mode: kanidm_proto::cli::OpType,
-    },
+    Reauth,
     /// Logout of an active cli session
     Logout(LogoutOpt),
     /// Manage active cli sessions


### PR DESCRIPTION
Reauthentication was incorrectly refactored to use the operation type in it's arguments. Since reauth is a read-only operation, if a write type was passed to it, it would incorrectly loop as reauth hadn't completed. Additionally, many options related to the optype which is an internal detail of the cli, were moved out of the cli. This returns them.


Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
