### PR TITLE
kanidm 1.8.3 does not recognize gzip as a compression algorithm

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -139,4 +139,4 @@ schedule = "00 22 * * *"
 # versions = 7
 
 # Compression can either be "gzip" or "nocompression", will compress the backups on disk if specified.
-compression = "gzip"
+compression = "Gzip"


### PR DESCRIPTION
The example server.toml specifies `gzip` while kanidm is expecting `Gzip`.

```
Nov 28 10:20:52 nixie docker[1172080]: kanidm        | ERROR: Configuration Parse Failure: Custom { kind: InvalidData, error: Error { message: "unknown variant `gzip`, expected `NoCompression` or `Gzip`", input: ... keys: ["online_backup", "compression"], span: Some(5516..5522) } }
```

# Change summary

- Change example to specify Gzip

Fixes #

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
