### PR TITLE
fix: correcting parsing of backup compression input

### DIFF
--- a/examples/server.toml
+++ b/examples/server.toml
@@ -138,5 +138,6 @@ schedule = "00 22 * * *"
 #   Number of backups to keep (default 7)
 # versions = 7
 
-# Compression can either be "gzip" or "nocompression", will compress the backups on disk if specified.
+# Compression can either be "gzip" or "nocompression".
+# Defaults to "gzip" if unspecified.
 compression = "gzip"

--- a/server/daemon/insecure_server.toml
+++ b/server/daemon/insecure_server.toml
@@ -28,6 +28,10 @@ origin = "https://localhost:8443"
 schedule = "@hourly"
 # enabled = true # default enabled
 
+# default is gzip, but can also be "nocompression"
+compression = "gzip"
+
+
 [replication]
 origin = "repl://127.0.0.1:8444"
 bindaddress = "0.0.0.0:8444"


### PR DESCRIPTION
# Change summary

- fixes parsing of the backup compression option, was previously stricter on capitalisation

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
