### PR TITLE
Bump askama, askama_web to v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,11 +193,11 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "bb7125972258312e79827b60c9eb93938334100245081cf701a2dee981b17427"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "8ba5e7259a1580c61571e3116ebaaa01e3c001b2132b17c4cc5c70780ca3e994"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -222,22 +222,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "236ce20b77cb13506eaf5024899f4af6e12e8825f390bd943c4c37fd8f322e46"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c63392767bb2df6aa65a6e1e3b80fd89bb7af6d58359b924c0695620f1512e"
+dependencies = [
+ "rustc-hash 2.1.1",
  "serde",
  "serde_derive",
+ "unicode-ident",
  "winnow 0.7.14",
 ]
 
 [[package]]
 name = "askama_web"
-version = "0.14.7"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1acadd534892f9ef8c3809b47997e3cd857fad735edceff77a88be1c8236920"
+checksum = "c0d6576f8e59513752a3e2673ca602fb403be7d0d0aacba5cd8b219838ab58fe"
 dependencies = [
  "askama",
  "askama_web_derive",
@@ -248,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "askama_web_derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34921de3d57974069bad483fdfe0ec65d88c4ff892edd1ab4d8b03be0dda1b9b"
+checksum = "9767c17d33a63daf6da5872ffaf2ab0c289cd73ce7ed4f41d5ddf9149c004873"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ kanidm-hsm-crypto = { version = "^0.3.5" }
 
 anyhow = { version = "1.0.100" }
 argon2 = { version = "0.5.3", features = ["alloc"] }
-askama = { version = "0.14.0" }
-askama_web = { version = "0.14.7", features = ["axum-0.8"] }
+askama = { version = "0.15.1" }
+askama_web = { version = "0.15.0", features = ["axum-0.8"] }
 async-trait = "^0.1.89"
 axum = { version = "0.8.8", features = [
     "form",

--- a/server/core/templates/admin/admin_group_view_partial.html
+++ b/server/core/templates/admin/admin_group_view_partial.html
@@ -54,10 +54,10 @@ let can_modify_any_attr = scim_effective_access.modify_present.check_any(
         (% endif -%)
     (% endif -%)
 
-    (% call string_attr("UUID", "uuid", group.uuid, can_modify_any_attr, Attribute::Uuid) -%)
-    (% call string_attr("Name", "name", group.name.clone(), can_modify_any_attr, Attribute::Name) -%)
+    (% call string_attr("UUID", "uuid", group.uuid, can_modify_any_attr, Attribute::Uuid) -%)(% endcall %)
+    (% call string_attr("Name", "name", group.name.clone(), can_modify_any_attr, Attribute::Name) -%)(% endcall %)
     (% let description = group.description.clone().unwrap_or(String::new()) %)
-    (% call string_attr("Description", "description", description, can_modify_any_attr, Attribute::Description) -%)
+    (% call string_attr("Description", "description", description, can_modify_any_attr, Attribute::Description) -%)(% endcall %)
 </form>
     (% if scim_effective_access.search.check(&Attribute::Member) %)
         (% let can_edit_member = can_rw && scim_effective_access.modify_present.check(&Attribute::Member) %)

--- a/server/core/templates/admin/admin_person_details_partial.html
+++ b/server/core/templates/admin/admin_person_details_partial.html
@@ -10,20 +10,20 @@
 (% endmacro %)
 
 <form hx-validate="true" hx-ext="bs-validation">
-    (% call string_attr("UUID", "uuid", person.uuid, false, Attribute::Uuid) %)
-    (% call string_attr("SPN", "spn", person.spn, false, Attribute::Spn) %)
-    (% call string_attr("Name", "name", person.name, true, Attribute::Name) %)
-    (% call string_attr("Displayname", "displayname", person.displayname, true, Attribute::DisplayName) %)
+    (% call string_attr("UUID", "uuid", person.uuid, false, Attribute::Uuid) %)(% endcall %)
+    (% call string_attr("SPN", "spn", person.spn, false, Attribute::Spn) %)(% endcall %)
+    (% call string_attr("Name", "name", person.name, true, Attribute::Name) %)(% endcall %)
+    (% call string_attr("Displayname", "displayname", person.displayname, true, Attribute::DisplayName) %)(% endcall %)
 
     (% if let Some(description) = person.description %)
-        (% call string_attr("Description", "description", description, true, Attribute::Description) %)
+        (% call string_attr("Description", "description", description, true, Attribute::Description) %)(% endcall %)
     (% else %)
-        (% call string_attr("Description", "description", "none", true, Attribute::Description) %)
+        (% call string_attr("Description", "description", "none", true, Attribute::Description) %)(% endcall %)
     (% endif %)
 
     (% if let Some(entry_managed_by) = person.managed_by %)
-        (% call string_attr("Managed By", "managed_by", entry_managed_by.value, true, Attribute::EntryManagedBy) %)
+        (% call string_attr("Managed By", "managed_by", entry_managed_by.value, true, Attribute::EntryManagedBy) %)(% endcall %)
     (% else %)
-        (% call string_attr("Managed By", "managed_by", "none", true, Attribute::EntryManagedBy) %)
+        (% call string_attr("Managed By", "managed_by", "none", true, Attribute::EntryManagedBy) %)(% endcall %)
     (% endif %)
 </form>

--- a/server/core/templates/user_settings_partial_base.html
+++ b/server/core/templates/user_settings_partial_base.html
@@ -19,13 +19,13 @@
             class="side-menu list-unstyled flex-shrink-0 row-gap-1 d-flex flex-column"
         >
             (% call side_menu_item("Profile", (Urls::Profile),
-            ProfileMenuItems::UserProfile, "person") %) (% call
-            side_menu_item("Credentials", (Urls::UpdateCredentials),
-            ProfileMenuItems::Credentials, "shield-lock") %) (% call
-            side_menu_item("Enrol Device", (Urls::EnrolDevice),
-            ProfileMenuItems::EnrolDevice, "phone-flip") %) (% call
-            side_menu_item("RADIUS", (Urls::Radius), ProfileMenuItems::Radius,
-            "wifi") %)
+                ProfileMenuItems::UserProfile, "person") %)(% endcall %)
+            (% call side_menu_item("Credentials", (Urls::UpdateCredentials),
+                ProfileMenuItems::Credentials, "shield-lock") %)(% endcall %)
+            (% call side_menu_item("Enrol Device", (Urls::EnrolDevice),
+                ProfileMenuItems::EnrolDevice, "phone-flip") %)(% endcall %)
+            (% call side_menu_item("RADIUS", (Urls::Radius),
+                ProfileMenuItems::Radius, "wifi") %)(% endcall %)
         </ul>
         <div id="settings-window" class="flex-grow-1 ps-sm-4 ps-md-5 pt-sm-0 pt-4">
             <div>

--- a/server/core/templates/user_settings_profile_partial.html
+++ b/server/core/templates/user_settings_profile_partial.html
@@ -28,9 +28,9 @@ Profile
       hx-validate="true"
       hx-ext="bs-validation"
       novalidate>
-    (% call string_attr("Name", "name", person.name, true, Attribute::Name) %)
+    (% call string_attr("Name", "name", person.name, true, Attribute::Name) %)(% endcall %)
 
-    (% call string_attr("Displayname", "displayname", person.displayname, true, Attribute::DisplayName) %)
+    (% call string_attr("Displayname", "displayname", person.displayname, true, Attribute::DisplayName) %)(% endcall %)
 
     (% let can_edit_email = can_rw && scim_effective_access.modify_present.check(&Attribute::Mail) %)
     <div class="mb-2">


### PR DESCRIPTION
# Change summary

- `askama`: 0.14.0 -> 0.15.1
- `askama_web`: 0.14.7 -> 0.15.0
- Askama v0.15 has a breaking change to require a closing `(% endcall %)` for every macro invoked with a `(% call %)` block. All such callsites have been given a matching end statement. (askama-rs/askama#282, askama-rs/askama#422)

I've tested this change by manually inspecting the affected `/ui/admin/persons` and `/ui/profile` paths. The side menus and attribute lists on those pages still render properly.

## Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
