### PR TITLE
Prevent server crashing on requests with low log level

### DIFF
--- a/server/core/src/https/trace.rs
+++ b/server/core/src/https/trace.rs
@@ -14,6 +14,11 @@ impl<B> tower_http::trace::MakeSpan<B> for DefaultMakeSpanKanidmd {
     fn make_span(&mut self, request: &Request<B>) -> Span {
         // Needs to be at info to ensure that there is always a span for each
         // tracing event to hook into.
+        //
+        // NOTE: There is a directive in the logging pipeline setup to force this
+        // span to always be at the info level. If this is not done, then there
+        // will not be an event uuid available which causes TONS of problems. Like
+        // crashing.
         tracing::span!(
             Level::INFO,
             "request",


### PR DESCRIPTION
This forces log_level info to always be set on the span generator so that an event uuid is always present.

Fixes #3952

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
