### PR TITLE
Radius support for SAN-DN

### DIFF
--- a/pykanidm/kanidm/radius/__init__.py
+++ b/pykanidm/kanidm/radius/__init__.py
@@ -100,9 +100,16 @@ def authorize(
     dargs = dict(args)
     logging.error("Authorise: %s", json.dumps(dargs))
     cn_uuid = dargs.get("TLS-Client-Cert-Common-Name", None)
+    # Relies on https://github.com/FreeRADIUS/freeradius-server/pull/5703 which is not yet merged upstream,
+    # however it is patched in OpenSUSE https://build.opensuse.org/requests/1325702
+    san_dn_cn = dargs.get("TLS-Client-Cert-Subject-Alt-Name-Directory-Name-Common-Name", None)
     username = dargs["User-Name"]
 
-    if cn_uuid is not None:
+
+    if san_dn_cn is not None:
+        logging.debug("Using TLS-Client-Cert-Subject-Alt-Name-Directory-Name-Common-Name")
+        user_id = san_dn_cn
+    elif cn_uuid is not None:
         logging.debug("Using TLS-Client-Cert-Common-Name")
         user_id = cn_uuid
     else:

--- a/rlm_python/sites-available/check-eap-tls
+++ b/rlm_python/sites-available/check-eap-tls
@@ -38,7 +38,7 @@ server check-eap-tls {
 authorize {
 
 	#
-	# By default, we just accept the request:
+	# By default, we just reject the request:
 	#
 	update config {
 		&Auth-Type := Accept

--- a/server/lib/src/value.rs
+++ b/server/lib/src/value.rs
@@ -2662,4 +2662,20 @@ mod tests {
         );
         assert!(SessionState::ExpiresAt(OffsetDateTime::UNIX_EPOCH) > SessionState::NeverExpires);
     }
+
+    #[test]
+    fn test_extract_val_dn_regexn() {
+        fn do_extract(name: &str) -> &str {
+            EXTRACT_VAL_DN
+                .captures(name)
+                .and_then(|caps| caps.name("val"))
+                .map(|v| v.as_str())
+                .unwrap()
+        }
+
+        assert_eq!(do_extract("william"), "william");
+        assert_eq!(do_extract("cn=william"), "william");
+        assert_eq!(do_extract("cn=william,o=blackhats"), "william");
+        assert_eq!(do_extract("cn=william@example.com"), "william@example.com");
+    }
 }


### PR DESCRIPTION
Adds support to extract the CN from subjectAltName DN strings in EAP-TLS certificates.

Add a test to extract-val-dn regex to assert it works as expected - initially I thought this was the problem, but it was actually an issue in my TLS cert, but the tests are always good.

Fixes #

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
