### PR TITLE
Add note about building client tools locked

### DIFF
--- a/book/src/installing_client_tools.md
+++ b/book/src/installing_client_tools.md
@@ -153,5 +153,5 @@ re-run the install command. You will likely need to install additional developme
 [Developer Guide](developers/).
 
 ```bash
-cargo install kanidm_tools
+cargo install kanidm_tools --locked
 ```


### PR DESCRIPTION
Building the client tools from source fails. It looks like there was an API break in digest between the current resolution vs the included lockfile. From what i can tell it happened because the locked version uses a different version of digest.

# Change summary

The error I got was:

```
error[E0432]: unresolved import `digest::crypto_common`
 --> /home/adrian/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/kbkdf-0.0.1/src/lib.rs:8:5
  |
8 |     crypto_common::KeySizeUser,
  |     ^^^^^^^^^^^^^ could not find `crypto_common` in `digest`

error[E0220]: associated type `KeySize` not found for `K`
   --> /home/adrian/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/kbkdf-0.0.1/src/lib.rs:141:61
    |
141 |     fn derive(&self, params: Params) -> Result<Array<u8, K::KeySize>, Error> {
    |                                                             ^^^^^^^ there is an associated type `KeySize` in the trait `KeySizeUser`
    |
help: consider further restricting type parameter `K` with trait `KeySizeUser`
    |
134 |     K: KeySizeUser + KeySizeUser,
    |                    +++++++++++++
```

-

Fixes #

Currently the client tools don't build for me without the locked flag.

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
