### PR TITLE
added ExecReload statement to systemd service

### DIFF
--- a/platform/opensuse/kanidmd.service
+++ b/platform/opensuse/kanidmd.service
@@ -17,6 +17,7 @@ CacheDirectoryMode=0750
 RuntimeDirectory=kanidmd
 RuntimeDirectoryMode=0755
 ExecStart=/usr/sbin/kanidmd server -c /etc/kanidm/server.toml
+ExecReload=/bin/kill -HUP $MAINPID
 
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE

--- a/server/daemon/debian/kanidmd.service
+++ b/server/daemon/debian/kanidmd.service
@@ -19,6 +19,7 @@ CacheDirectoryMode=0750
 RuntimeDirectory=kanidmd
 RuntimeDirectoryMode=0755
 ExecStart=/usr/bin/kanidmd server
+ExecReload=/bin/kill -HUP $MAINPID
 
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
# Change summary

Even without the support of `notify-reload` in kanidmd (as it was never properly working and was removed in #3885), it could support systemd reload by just providing the `ExecReload` statement in the service configuration. I tried this fix at my instance and it seems to work perfectly fine.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
