### PR TITLE
Alert on unsaved changes

### DIFF
--- a/server/core/static/modules/cred_update.mjs
+++ b/server/core/static/modules/cred_update.mjs
@@ -130,6 +130,19 @@ function updateSubmitButtonVisibility(event) {
     submitButton.disabled = event.value === "";
 }
 
+function beforeUnloadHandler (event) {
+    console.debug("credupdate: beforeUnloadHandler");
+    var confirmationMessage = 'Unsaved changes will be lost.';
+
+    (event || window.event).returnValue = confirmationMessage;
+    return confirmationMessage;
+}
+
+window.removeBeforeUnloadHandler = function () {
+    console.debug("credupdate: removeBeforeUnloadHandler");
+    window.removeEventListener("beforeunload", beforeUnloadHandler);
+};
+
 (function () {
     console.debug("credupdate: init");
     document.body.addEventListener("addPasswordSwapped", () => {
@@ -140,4 +153,7 @@ function updateSubmitButtonVisibility(event) {
         startPasskeyEnrollment();
         setupSubmitBtnVisibility();
     });
+    window.addEventListener("beforeunload", beforeUnloadHandler);
 })();
+
+

--- a/server/core/templates/admin/admin_group_member_entry_partial.html
+++ b/server/core/templates/admin/admin_group_member_entry_partial.html
@@ -1,6 +1,5 @@
 <li class="list-group-item d-flex flex-row justify-content-between" hx-target="this">
-    <form hx-boost="true"
-          hx-post="/ui/api/admin/group/(( group_uuid ))/remove_member"
+    <form hx-post="/ui/api/admin/group/(( group_uuid ))/remove_member"
           hx-swap="delete"
           class="d-flex align-items-center flex-grow-1">
         <div class="flex-grow-1"><input readonly type="text" name="member" value="(( member_name ))" class="form-control-plaintext py-0"></div>

--- a/server/core/templates/admin/admin_group_view_partial.html
+++ b/server/core/templates/admin/admin_group_view_partial.html
@@ -48,7 +48,7 @@ let can_modify_any_attr = scim_effective_access.modify_present.check_any(
         (% if can_rw -%)
             <button type="submit" class="btn btn-primary">Save</button>
         (% else -%)
-            <a hx-boost="false" href="/ui/unlock">
+            <a href="/ui/unlock">
                 <button type="button" class="btn btn-secondary">Unlock Edit 🔒</button>
             </a>
         (% endif -%)

--- a/server/core/templates/base_htmx.html
+++ b/server/core/templates/base_htmx.html
@@ -29,7 +29,7 @@
 
 		(% block head %)(% endblock %)
 	</head>
-	<body hx-boost="true" class="flex-column d-flex h-100">
+	<body hx-boost="false" class="flex-column d-flex h-100">
 		(% block nav %)(% endblock %)
 		(% block body %)(% endblock %)
 		<footer class="footer mt-auto py-3 bg-body-tertiary text-end">

--- a/server/core/templates/credentials_update_partial.html
+++ b/server/core/templates/credentials_update_partial.html
@@ -205,7 +205,7 @@
                     <div class="mt-3 d-flex column-gap-2">
                         <button class="btn btn-danger"
                             hx-post="/ui/api/cu_cancel"
-                            hx-boost="false"
+                            hx-on:htmx:before-request="removeBeforeUnloadHandler()"
                         >Discard Changes</button>
                         <span class="d-inline-block" tabindex="0"
                             data-bs-toggle="tooltip"
@@ -214,7 +214,7 @@
                                 class="btn btn-success"
                                 type="submit"
                                 hx-post="/ui/api/cu_commit"
-                                hx-boost="false"
+                                hx-on:htmx:before-request="removeBeforeUnloadHandler()"
                                 (% if !can_commit %)disabled(% endif
                                 %)>Save Changes</button>
                         </span>

--- a/server/core/templates/recoverable_error_partial.html
+++ b/server/core/templates/recoverable_error_partial.html
@@ -13,7 +13,7 @@
                 <p>Operation ID: (( operation_id ))</p>
             </div>
             <div class="modal-footer">
-                <a href="(( recovery_path ))" hx-boost="(( recovery_boosted ))">
+                <a href="(( recovery_path ))">
                     <button type="button" class="btn btn-secondary"
                         data-bs-dismiss="modal">Continue</button>
                 </a>

--- a/server/core/templates/user_settings/profile_changes_partial.html
+++ b/server/core/templates/user_settings/profile_changes_partial.html
@@ -95,7 +95,7 @@ Profile Difference
                 hx-swap="outerHTML">Confirm Changes
         </button>
         (% else %)
-        <a href="/ui/unlock" hx-boost="false">
+        <a href="/ui/unlock">
             <!-- TODO: at the moment, session expiring here means progress is lost. Do we just show an error screen ? We can't pass the update state through the reauth session, and we don't have profile update sessions like cred update. -->
             <button class="btn btn-primary" type="button">Unlock Confirm 🔓</button>
         </a>

--- a/server/core/templates/user_settings_posix_partial.html
+++ b/server/core/templates/user_settings_posix_partial.html
@@ -13,7 +13,7 @@ Unix/Posix Settings
     (% if can_rw %)
         <button class="btn btn-primary" type="button" hx-post="/ui/api/user_settings/edit_posix">Edit</button>
     (% else %)
-        <a href=(Urls::ProfileUnlock) hx-boost="false">
+        <a href=(Urls::ProfileUnlock)>
             <button class="btn btn-primary" type="button">((UiMessage::UnlockEdit))</button>
         </a>
     (% endif %)

--- a/server/core/templates/user_settings_profile_partial.html
+++ b/server/core/templates/user_settings_profile_partial.html
@@ -38,7 +38,6 @@ Profile
             <label for="profileEmail" class="fw-bold">Email addresses (% if can_edit_email %)(select primary)(% endif %)</label>
             (% if can_edit_email %)
             <a class="cursor-pointer float-end"
-               hx-boost="true"
                hx-get="/ui/api/user_settings/add_email"
                hx-target="#emailAddresses"
                hx-include="#emailAddresses :last-child .email-index-state"
@@ -72,7 +71,7 @@ Profile
         (% if rw_active %)
         <button class="btn btn-primary" type="submit">Save</button>
         (% else %)
-        <a href="/ui/unlock" hx-boost="false"
+        <a href="/ui/unlock"
               (% if !rw_possible %)disabled(% endif %)
           >
             <button


### PR DESCRIPTION
A long term issue has been people not saving changes to their credentials. This adds the most basic javascript handler to catch the beforeunload event and warn about unsaved changes.


Fixes #3441 #3646 

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [ ] design document included (if relevant)
