### PR TITLE
Fix bug where DEBUG is always true in RADIUS entrypoint.

### DIFF
--- a/rlm_python/radius_entrypoint.py
+++ b/rlm_python/radius_entrypoint.py
@@ -15,7 +15,7 @@ from kanidm.radius import CONFIG_PATHS
 from kanidm.types import KanidmClientConfig
 from kanidm.utils import load_config
 
-DEBUG = True
+DEBUG = False
 if os.environ.get("DEBUG", False):
     DEBUG = True
 


### PR DESCRIPTION
# Change summary

Howdy, KanIDM maintainers. I recently set up a new KanIDM instance and went to set up a RADIUS server today.

I noticed that the RADIUS server logs always had the debug output, even though I hadn't supplied the `DEBUG` environment variable like the docs suggested.

Upon looking at the entrypoint script for the RADIUS container, it became apparent that there was no way to set the `DEBUG` variable to false, since it defaults to true on both branches of that `if` statement.

This PR just changes the initial value of `DEBUG` to `False`, which matches what the current KanIDM book suggests the behavior should be, fixing this small bug.

Fixes #4168

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
