### PR TITLE
Disable multithreading on RADIUS when DEBUG is False.

### DIFF
--- a/rlm_python/radius_entrypoint.py
+++ b/rlm_python/radius_entrypoint.py
@@ -147,7 +147,9 @@ def run_radiusd() -> None:
     if DEBUG:
         cmd_args = ["-X"]
     else:
-        cmd_args = ["-f", "-l", "stdout"]
+        # NOTE: the python3 module for radiusd does not seem to work correctly
+        # when multithreading is enabled, hence -t. See #4168 for details.
+        cmd_args = ["-f", "-t", "-l", "stdout"]
     freeradius_bin = find_freeradius_bin()
     if freeradius_bin is None:
         print("Failed to find FreeRADIUS binary, quitting!", file=sys.stderr)


### PR DESCRIPTION
# Change summary

I submitted the previous PR #4169 to address issue #4168, which addressed the issue that the RADIUS server always had `DEBUG` set to `True`. 

After further experimentation and testing, I think I discovered why it was that way to begin with. There appears to be an issue with the RADIUS server when multithreading is enabled, where the python3 module fails at the authorize step with `RLM_MODULE_FAIL` before even calling the Kanidm library function. Thus, the server completely breaks unless `DEBUG` is `True`.

This PR adds the `-t` flag when `DEBUG` is `False`, disabling multithreading (which is the case when passing `-X`).

This time, I have more thoroughly tested the change. See more info in [#4168, comment 3970196312](https://github.com/kanidm/kanidm/issues/4168#issuecomment-3970196312).

Fixes #4168 (again)

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
