### PR TITLE
add nsswitch config check to unixd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,6 +3711,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sketching",
+ "tempfile",
  "time",
  "tokio",
  "tokio-util",

--- a/unix_integration/resolver/Cargo.toml
+++ b/unix_integration/resolver/Cargo.toml
@@ -102,6 +102,7 @@ kanidm_utils_users = { workspace = true }
 [dev-dependencies]
 kanidmd_core = { workspace = true }
 kanidmd_testkit = { workspace = true }
+tempfile = { workspace = true }
 
 [build-dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/unix_integration/resolver/src/bin/kanidm-unix.rs
+++ b/unix_integration/resolver/src/bin/kanidm-unix.rs
@@ -22,6 +22,7 @@ use kanidm_unix_common::unix_config::PamNssConfig;
 use kanidm_unix_common::unix_proto::{
     ClientRequest, ClientResponse, PamAuthRequest, PamAuthResponse, PamServiceInfo,
 };
+use kanidm_unix_resolver::check_nsswitch_has_kanidm;
 use std::path::PathBuf;
 
 include!("../opt/tool.rs");
@@ -252,6 +253,8 @@ async fn main() -> ExitCode {
 
             let mut daemon_client = setup_client!();
             let req = ClientRequest::Status;
+
+            check_nsswitch_has_kanidm(None);
 
             match daemon_client.call(req, None).await {
                 Ok(r) => match r {

--- a/unix_integration/resolver/src/bin/kanidm_unixd.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd.rs
@@ -17,6 +17,7 @@ use kanidm_hsm_crypto::{
     provider::{BoxedDynTpm, SoftTpm, Tpm},
     AuthValue,
 };
+use kanidm_lib_file_permissions::diagnose_path;
 use kanidm_proto::constants::DEFAULT_CLIENT_CONFIG_PATH;
 use kanidm_proto::internal::OperationError;
 use kanidm_unix_common::constants::DEFAULT_CONFIG_PATH;
@@ -26,11 +27,14 @@ use kanidm_unix_common::unix_passwd::EtcDb;
 use kanidm_unix_common::unix_proto::{
     ClientRequest, ClientResponse, TaskRequest, TaskRequestFrame, TaskResponse,
 };
-use kanidm_unix_resolver::db::{Cache, Db};
 use kanidm_unix_resolver::idprovider::interface::IdProvider;
 use kanidm_unix_resolver::idprovider::kanidm::KanidmProvider;
 use kanidm_unix_resolver::idprovider::system::SystemProvider;
 use kanidm_unix_resolver::resolver::{AuthSession, Resolver};
+use kanidm_unix_resolver::{
+    check_nsswitch_has_kanidm,
+    db::{Cache, Db},
+};
 use kanidm_utils_users::{get_current_gid, get_current_uid, get_effective_gid, get_effective_uid};
 use libc::umask;
 use lru::LruCache;
@@ -130,9 +134,16 @@ async fn handle_task_client(
                     // Other things ....
                     // Some(Ok(TaskResponse::ReloadSystemIds))
 
+                    None => {
+                        // The stream has ended, we should stop operation.
+                        info!("Task client disconnected, stopping task handler.");
+                        return Ok(())
+                    }
+
                     other => {
-                        error!("Error -> {:?}", other);
-                        return Err(Box::new(IoError::other("oh no!")));
+                        let errmsg = format!("Received unexpected message from kanidm-unixd-tasks: {:?}", other);
+                        error!("{}", errmsg);
+                        return Err(Box::new(IoError::other(errmsg)));
                     }
                 }
             }
@@ -543,7 +554,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
             "Client config missing from {} - cannot start up. Quitting.",
             cfg_path_str
         );
-        let diag = kanidm_lib_file_permissions::diagnose_path(cfg_path.as_ref());
+        let diag = diagnose_path(cfg_path.as_ref());
         info!(%diag);
         return ExitCode::FAILURE;
     } else {
@@ -551,7 +562,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
             Ok(v) => v,
             Err(e) => {
                 error!("Unable to read metadata for {} - {:?}", cfg_path_str, e);
-                let diag = kanidm_lib_file_permissions::diagnose_path(cfg_path.as_ref());
+                let diag = diagnose_path(cfg_path.as_ref());
                 info!(%diag);
                 return ExitCode::FAILURE;
             }
@@ -581,7 +592,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
             "unixd config missing from {} - cannot start up. Quitting.",
             unixd_path_str
         );
-        let diag = kanidm_lib_file_permissions::diagnose_path(unixd_path.as_ref());
+        let diag = diagnose_path(unixd_path.as_ref());
         info!(%diag);
         return ExitCode::FAILURE;
     } else {
@@ -589,7 +600,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
             Ok(v) => v,
             Err(e) => {
                 error!("Unable to read metadata for {} - {:?}", unixd_path_str, e);
-                let diag = kanidm_lib_file_permissions::diagnose_path(unixd_path.as_ref());
+                let diag = diagnose_path(unixd_path.as_ref());
                 info!(%diag);
                 return ExitCode::FAILURE;
             }
@@ -633,6 +644,8 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
         None
     };
 
+    check_nsswitch_has_kanidm(None);
+
     if clap_args.get_flag("configtest") {
         eprintln!("###################################");
         eprintln!("Dumping configs:\n###################################");
@@ -664,7 +677,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
                         .to_str()
                         .unwrap_or("<db_parent_path invalid>")
                 );
-                let diag = kanidm_lib_file_permissions::diagnose_path(cache_db_path.as_ref());
+                let diag = diagnose_path(cache_db_path.as_ref());
                 info!(%diag);
                 return ExitCode::FAILURE;
             }
@@ -714,7 +727,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
                     "Refusing to run - DB path {} already exists and is not a file.",
                     cache_db_path.to_str().unwrap_or("<cache_db_path invalid>")
                 );
-                let diag = kanidm_lib_file_permissions::diagnose_path(cache_db_path.as_ref());
+                let diag = diagnose_path(cache_db_path.as_ref());
                 info!(%diag);
                 return ExitCode::FAILURE;
             };
@@ -727,7 +740,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
                         cache_db_path.to_str().unwrap_or("<cache_db_path invalid>"),
                         e
                     );
-                    let diag = kanidm_lib_file_permissions::diagnose_path(cache_db_path.as_ref());
+                    let diag = diagnose_path(cache_db_path.as_ref());
                     info!(%diag);
                     return ExitCode::FAILURE;
                 }
@@ -753,7 +766,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
 
     // Check for and create the hsm pin if required.
     if let Err(err) = write_hsm_pin(cfg.hsm_pin_path.as_str()).await {
-        let diag = kanidm_lib_file_permissions::diagnose_path(cfg.hsm_pin_path.as_ref());
+        let diag = diagnose_path(cfg.hsm_pin_path.as_ref());
         info!(%diag);
         error!(
             ?err,
@@ -767,7 +780,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
     let hsm_pin = match read_hsm_pin(cfg.hsm_pin_path.as_str()).await {
         Ok(hp) => hp,
         Err(err) => {
-            let diag = kanidm_lib_file_permissions::diagnose_path(cfg.hsm_pin_path.as_ref());
+            let diag = diagnose_path(cfg.hsm_pin_path.as_ref());
             info!(%diag);
             error!(
                 ?err,
@@ -930,7 +943,7 @@ async fn main_inner(clap_args: clap::ArgMatches) -> ExitCode {
     let task_listener = match UnixListener::bind(cfg.task_sock_path.as_str()) {
         Ok(l) => l,
         Err(_e) => {
-            let diag = kanidm_lib_file_permissions::diagnose_path(cfg.task_sock_path.as_ref());
+            let diag = diagnose_path(cfg.task_sock_path.as_ref());
             info!(%diag);
             error!("Failed to bind UNIX socket {}", cfg.task_sock_path.as_str());
             return ExitCode::FAILURE;

--- a/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
+++ b/unix_integration/resolver/src/bin/kanidm_unixd_tasks.rs
@@ -56,6 +56,8 @@ use std::fs::{create_dir, remove_file};
 #[cfg(all(target_family = "unix", feature = "selinux"))]
 use kanidm_unix_common::selinux_util;
 
+static KANIDM_UNIX_RETRY_SECS: u64 = 5;
+
 fn chown(path: &Path, gid: u32) -> Result<(), String> {
     let path_os = CString::new(path.as_os_str().as_bytes())
         .map_err(|_| "Unable to create c-string".to_string())?;
@@ -493,7 +495,7 @@ async fn handle_tasks(
             biased; // tell tokio to poll these in order
             _ = ctl_broadcast_rx.recv() => {
                 // We received a shutdown signal.
-                debug!("Received shutdown signal, breaking task handler loop ...");
+                info!("Received shutdown signal, breaking task handler loop ...");
                 return
             }
             // We bias to *sending* messages in tasks.
@@ -734,15 +736,15 @@ async fn main() -> ExitCode {
                                     info!("Found kanidm_unixd, waiting for tasks ...");
 
                                     // Yep! Now let the main handler do its job.
-                                    // If it returns (dc, etc, then we loop and try again).
+                                    // If it returns (disconnected, etc, then we loop and try again).
                                     handle_tasks(stream, &mut d_broadcast_rx, &mut shadow_data_watch_rx, &cfg).await;
                                     continue;
                                 }
                                 Err(e) => {
                                     debug!("\\---> {:?}", e);
-                                    error!("Unable to find kanidm_unixd, sleeping ...");
+                                    error!("Unable to find kanidm_unixd, sleeping for {} seconds ...", KANIDM_UNIX_RETRY_SECS);
                                     // Back off.
-                                    time::sleep(Duration::from_millis(5000)).await;
+                                    time::sleep(Duration::from_secs(KANIDM_UNIX_RETRY_SECS)).await;
                                 }
                             }
                         }

--- a/unix_integration/resolver/src/lib.rs
+++ b/unix_integration/resolver/src/lib.rs
@@ -10,6 +10,8 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
+use std::{fs, path::PathBuf};
+
 #[cfg(target_family = "unix")]
 #[macro_use]
 extern crate tracing;
@@ -23,3 +25,75 @@ pub mod db;
 pub mod idprovider;
 #[cfg(target_family = "unix")]
 pub mod resolver;
+
+/// Check for passwd and groups lines and return them if they're missing, this allows us to test parsing
+pub fn parse_nsswitch_contents_return_missing(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            for tag in ["passwd:", "group:"] {
+                if line.starts_with(tag) {
+                    debug!(
+                        "Found {} line in nsswitch.conf: {}",
+                        tag.trim_end_matches(':'),
+                        line
+                    );
+                    if !line.contains("kanidm") {
+                        warn!(
+                            "nsswitch.conf {} line does not contain string 'kanidm': {}",
+                            tag.trim_end_matches(':'),
+                            line
+                        );
+                        return Some(line.to_string());
+                    } else {
+                        debug!(
+                            "nsswitch.conf {} line contains string 'kanidm': {}",
+                            tag.trim_end_matches(':'),
+                            line
+                        );
+                        return None;
+                    }
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+/// Warn the admin that user/group resolution may fail if Kanidm is not configured in nsswitch.conf. This is a common misconfiguration that can lead to confusion, and is worth proactively warning about.
+pub fn check_nsswitch_has_kanidm(path: Option<PathBuf>) -> bool {
+    // returns true if kanidm is configured in nsswitch.conf, false otherwise.
+    let nsswitch_conf = path.unwrap_or_else(|| PathBuf::from("/etc/nsswitch.conf"));
+    if nsswitch_conf.exists() {
+        match fs::read_to_string(&nsswitch_conf) {
+            Ok(contents) => {
+                let missing_lines = parse_nsswitch_contents_return_missing(&contents);
+                if missing_lines.is_empty() {
+                    debug!(
+                        "{} appears to have Kanidm configured OK for passwd/group resolution",
+                        nsswitch_conf.display()
+                    );
+                    true
+                } else {
+                    warn!("Kanidm does not appear to be configured in {} for passwd/group resolution. Lines of interest: {:?}", nsswitch_conf.display(), missing_lines);
+                    false
+                }
+            }
+            Err(err) => {
+                debug!(
+                    ?err,
+                    "Couldn't read {} to check for Kanidm presence",
+                    nsswitch_conf.display()
+                );
+                false
+            }
+        }
+    } else {
+        debug!(
+            "Couldn't read {} to check for Kanidm presence - file does not exist",
+            nsswitch_conf.display()
+        );
+        false
+    }
+}

--- a/unix_integration/resolver/tests/lib_tests.rs
+++ b/unix_integration/resolver/tests/lib_tests.rs
@@ -1,0 +1,22 @@
+use kanidm_unix_resolver::{check_nsswitch_has_kanidm, parse_nsswitch_contents_return_missing};
+
+#[test]
+fn parse_nsswitch_contents() {
+    let contents = r#"
+        passwd: files
+        group: files
+    "#;
+    let missing = parse_nsswitch_contents_return_missing(contents);
+    assert_eq!(missing.len(), 2);
+    assert!(missing.contains(&"passwd: files".to_string()));
+    assert!(missing.contains(&"group: files".to_string()));
+
+    let contents = r#"
+    # this is a comment
+        passwd: files kanidm
+        group: files kanidm
+    "#;
+    let tempfile = tempfile::NamedTempFile::new().expect("failed to create temp file");
+    std::fs::write(tempfile.path(), contents).expect("failed to write to temp file");
+    assert!(check_nsswitch_has_kanidm(Some(tempfile.path().into())));
+}


### PR DESCRIPTION
# Change summary

- on startup, check that /etc/nsswitch.conf has kanidm entries and warn the admin if not
- also when the stream disconnects from unixd-tasks and it gets a None response, stop throwing "oh no!" errors


Checklist

- [x] This PR contains no AI generated code
