### PR TITLE
fix(debian): Use correct bin path for kanidmd reload

### DIFF
--- a/server/daemon/debian/kanidmd.service
+++ b/server/daemon/debian/kanidmd.service
@@ -19,7 +19,7 @@ CacheDirectoryMode=0750
 RuntimeDirectory=kanidmd
 RuntimeDirectoryMode=0755
 ExecStart=/usr/bin/kanidmd server
-ExecReload=/usr/sbin/kanidmd scripting reload
+ExecReload=/usr/bin/kanidmd scripting reload
 
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE


### PR DESCRIPTION

# Change summary
- The reload exec introduced with 652bd9a9348949b6671b620bd12ae623a426cab8 mistakenly assumed kanidmd would be placed in sbin, but unlike with SuSE on Debian I chose to place in in /bin given that it's not run with elevated privileges.
- There's probably a style guide somewhere that I haven't read that says which bin is correct, but I'm not going to go find it and read it, so fixing instead the ExecReload to refer to where the bin is at.

Preferably this would also be backported to 1.9 if there's still another 1.9.x release.

Fixes https://github.com/kanidm/kanidm_ppa_automation/issues/42

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
