### PR TITLE
docs: fix incorrect year in 1.9.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ We value your feedback! First, please see our [code of conduct]. If you have que
 
 ## Release Notes
 
-### 2025-02-11 - Kanidm 1.9.0
+### 2026-02-11 - Kanidm 1.9.0
 
 This is the latest stable release of the Kanidm Identity Management project. Every release is the combined effort of our
 community and we appreciate their invaluable contributions, comments, questions, feedback and support.


### PR DESCRIPTION
# Change summary

- Observed that all the 1.9.0 releases have incorrect year(2025) mostly a typo when creating 1.9.0 release (#4213 )

Fixes #
- Changed the year from 2025 to 2026 in the RELEASE_NOTES.md for the 1.9.0 release.

Note: The maintainers might need to update the release notes manually for patches 1.9.1 and 1.9.2

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
