### PR TITLE
cli: allow clearing person's legalname attribute

### DIFF
--- a/libs/client/src/person.rs
+++ b/libs/client/src/person.rs
@@ -63,9 +63,14 @@ impl KanidmClient {
             );
         }
         if let Some(newlegalname) = legalname {
-            update_entry
-                .attrs
-                .insert(ATTR_LEGALNAME.to_string(), vec![newlegalname.to_string()]);
+            // An empty string means we should purge the attribute, which
+            // is done by inserting an empty vec as the entry value
+            let val = if newlegalname.is_empty() {
+                vec![]
+            } else {
+                vec![newlegalname.to_string()]
+            };
+            update_entry.attrs.insert(ATTR_LEGALNAME.to_string(), val);
         }
         if let Some(mail) = mail {
             update_entry

--- a/tools/cli/src/opt/kanidm.rs
+++ b/tools/cli/src/opt/kanidm.rs
@@ -479,8 +479,8 @@ pub enum ServiceAccountPosix {
 pub struct PersonUpdateOpt {
     #[clap(flatten)]
     aopts: AccountCommonOpt,
-    #[clap(long, short, help = "Set the legal name for the person.",
-    value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    #[clap(long, short, help = "Set the legal name for the person. Giving an empty string clears the attribute.",
+    value_parser = clap::builder::StringValueParser::new())]
     legalname: Option<String>,
     #[clap(long, short, help = "Set the account name for the person.",
     value_parser = clap::builder::NonEmptyStringValueParser::new())]


### PR DESCRIPTION
# Change summary
The `--legalname` option for `kanidm person update` now accepts an empty string, which signals a desire to clear the legalname attribute.

The corresponding function in the client library now recognizes the empty string's meaning and modifies the patch request accordingly.

Fixes #3573

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
