### PR TITLE
20260327 token auth metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,8 @@ dependencies = [
 [[package]]
 name = "compact_jwt"
 version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edc5af3006c35170ccbc0ecd24ead895bf19cdc1f1a2805c636bc5d53576954"
 dependencies = [
  "base64 0.22.1",
  "base64urlsafedata 0.5.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -209,7 +209,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
  "syn 2.0.117",
@@ -230,11 +230,11 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
  "unicode-ident",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -370,7 +370,7 @@ dependencies = [
  "log",
  "memoffset",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "runloop",
  "serde",
@@ -389,9 +389,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef252edff26ddba56bbcdf2ee3307b8129acb86f5749b68990c168a6fcc9c76"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
 dependencies = [
  "axum",
  "axum-core",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -597,7 +597,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -620,7 +620,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -629,7 +629,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -678,9 +678,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -836,7 +836,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -918,18 +918,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -954,18 +954,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "color_quant"
@@ -992,8 +992,6 @@ dependencies = [
 [[package]]
 name = "compact_jwt"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edc5af3006c35170ccbc0ecd24ead895bf19cdc1f1a2805c636bc5d53576954"
 dependencies = [
  "base64 0.22.1",
  "base64urlsafedata 0.5.4",
@@ -1252,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1287,7 +1285,7 @@ dependencies = [
  "p521",
  "pbkdf2 0.12.2",
  "pkcs8",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "sec1",
  "serde",
@@ -1334,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -1850,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1947,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -2126,7 +2124,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2143,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2343,7 +2341,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-path",
  "libc",
@@ -2489,7 +2487,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2537,7 +2535,7 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "filetime",
  "fnv",
@@ -2602,7 +2600,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2700,7 +2698,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -2783,7 +2781,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -2817,7 +2815,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -2915,7 +2913,7 @@ version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -3041,7 +3039,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3274,9 +3272,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "serde",
  "typenum",
@@ -3307,15 +3305,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3383,12 +3380,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3396,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3409,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3423,15 +3421,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3443,15 +3441,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3565,12 +3563,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3581,7 +3579,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -3632,9 +3630,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -3767,19 +3765,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonschema"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
 dependencies = [
  "ahash",
  "bytecount",
@@ -4170,7 +4170,7 @@ version = "1.10.0-dev"
 dependencies = [
  "base64 0.22.1",
  "base64urlsafedata 0.6.0-dev",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_jwt",
  "concread",
  "crypto-glue",
@@ -4409,9 +4409,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -4431,12 +4431,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -4452,14 +4451,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4516,9 +4515,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4555,9 +4554,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4597,7 +4596,7 @@ checksum = "ec030dc8fd1b7e687766d33899a5541bcf21630165a06c8a0e55573e7e713387"
 dependencies = [
  "lambert_w",
  "matrixmultiply",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -4684,9 +4683,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -4774,7 +4773,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4814,7 +4813,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4845,7 +4844,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4902,7 +4901,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -4924,9 +4923,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -5042,7 +5041,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5058,7 +5057,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5195,7 +5194,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5324,9 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbd25f71dd5249dba9ed843d52500c8757a25511560d01a94f4abf56b52a1d5"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
  "getrandom 0.4.2",
  "phc",
@@ -5440,7 +5439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5596,18 +5595,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -5680,7 +5679,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "chrono",
  "flate2",
  "procfs-core",
@@ -5693,7 +5692,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "chrono",
  "hex",
 ]
@@ -5748,9 +5747,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qrcode"
@@ -5778,7 +5777,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -5797,9 +5796,9 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5852,9 +5851,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5863,9 +5862,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5879,7 +5878,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5909,7 +5908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5932,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rawpointer"
@@ -5948,16 +5947,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5993,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -6199,7 +6198,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6256,9 +6255,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rusticata-macros"
@@ -6275,7 +6274,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6288,7 +6287,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6297,9 +6296,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6361,9 +6360,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6394,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06522a356e94a02a1f83d699a1d84dd2ba613fbb20b211153bd5a75de9ccdc92"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
  "cipher 0.5.1",
@@ -6507,7 +6506,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6530,7 +6529,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fee6a6e1169aaaedef3a34850d69fd01e80500bc9cf6c0681c4df5968f5822"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "once_cell",
@@ -6553,9 +6552,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -6637,7 +6636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde_core",
@@ -6669,9 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -6698,7 +6697,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6726,7 +6725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88e79009728d8311d42d754f2f319a975f9e38f156fd5e422d2451486c78b286"
 dependencies = [
  "base64ct",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "subtle",
 ]
@@ -6826,9 +6825,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -6925,9 +6924,9 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -7164,9 +7163,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7210,9 +7209,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -7272,54 +7271,54 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -7366,7 +7365,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7384,7 +7383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7555,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -7657,7 +7656,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7703,9 +7702,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7783,11 +7782,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -7796,7 +7795,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -7810,9 +7809,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7823,23 +7822,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7847,9 +7842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7860,9 +7855,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -7884,7 +7879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7895,17 +7890,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7996,7 +7991,7 @@ dependencies = [
  "der-parser",
  "hex",
  "nom 7.1.3",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",
@@ -8025,9 +8020,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8452,9 +8447,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -8467,6 +8462,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -8487,7 +8488,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -8517,8 +8518,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8537,7 +8538,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8549,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-cert"
@@ -8592,18 +8593,18 @@ checksum = "6ca0dab8c05f373dd32654b714999ccaea9ed936d5281e6820f07b146176f648"
 dependencies = [
  "hmac 0.13.0-rc.5",
  "mcf",
- "password-hash 0.6.0",
+ "password-hash 0.6.1",
  "pbkdf2 0.13.0-rc.9",
- "salsa20 0.11.0-rc.2",
+ "salsa20 0.11.0",
  "sha2 0.11.0-rc.5",
  "subtle",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -8612,9 +8613,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8624,18 +8625,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8644,18 +8645,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8686,9 +8687,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -8697,9 +8698,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8708,9 +8709,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8726,7 +8727,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]
@@ -8763,9 +8764,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ codegen-units = 256
 ## As Kanidm maintains a number of libraries, sometimes during development we need to override them
 ## with local or git versions. This patch table allows quick uncommenting to achieve that.
 
-# compact_jwt = { path = "../compact-jwt" }
+compact_jwt = { path = "../compact-jwt" }
 # crypto-glue = { path = "../crypto-glue" }
 # concread = { path = "../concread" }
 # idlset = { path = "../idlset" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ codegen-units = 256
 ## As Kanidm maintains a number of libraries, sometimes during development we need to override them
 ## with local or git versions. This patch table allows quick uncommenting to achieve that.
 
-compact_jwt = { path = "../compact-jwt" }
+# compact_jwt = { path = "../compact-jwt" }
 # crypto-glue = { path = "../crypto-glue" }
 # concread = { path = "../concread" }
 # idlset = { path = "../idlset" }

--- a/proto/src/oauth2.rs
+++ b/proto/src/oauth2.rs
@@ -533,15 +533,16 @@ pub enum IdTokenSignAlg {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum TokenEndpointAuthMethod {
+pub enum EndpointAuthMethod {
+    None,
     ClientSecretPost,
     ClientSecretBasic,
     ClientSecretJwt,
     PrivateKeyJwt,
 }
 
-fn token_endpoint_auth_methods_supported_default() -> Vec<TokenEndpointAuthMethod> {
-    vec![TokenEndpointAuthMethod::ClientSecretBasic]
+fn token_endpoint_auth_methods_supported_default() -> Vec<EndpointAuthMethod> {
+    vec![EndpointAuthMethod::ClientSecretBasic]
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -631,7 +632,7 @@ pub struct OidcDiscoveryResponse {
     pub request_object_encryption_enc_values_supported: Option<Vec<String>>,
     // Defaults to client_secret_basic
     #[serde(default = "token_endpoint_auth_methods_supported_default")]
-    pub token_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub token_endpoint_auth_methods_supported: Vec<EndpointAuthMethod>,
     pub token_endpoint_auth_signing_alg_values_supported: Option<Vec<String>>,
     // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
     pub display_values_supported: Option<Vec<DisplayValue>>,
@@ -667,11 +668,11 @@ pub struct OidcDiscoveryResponse {
 
     // rfc7009
     pub revocation_endpoint: Option<Url>,
-    pub revocation_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub revocation_endpoint_auth_methods_supported: Vec<EndpointAuthMethod>,
 
     // rfc7662
     pub introspection_endpoint: Option<Url>,
-    pub introspection_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub introspection_endpoint_auth_methods_supported: Vec<EndpointAuthMethod>,
     pub introspection_endpoint_auth_signing_alg_values_supported: Option<Vec<IdTokenSignAlg>>,
 
     /// Ref <https://www.rfc-editor.org/rfc/rfc8628#section-4>
@@ -701,7 +702,7 @@ pub struct Oauth2Rfc8414MetadataResponse {
     pub grant_types_supported: Vec<GrantType>,
 
     #[serde(default = "token_endpoint_auth_methods_supported_default")]
-    pub token_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub token_endpoint_auth_methods_supported: Vec<EndpointAuthMethod>,
 
     pub token_endpoint_auth_signing_alg_values_supported: Option<Vec<IdTokenSignAlg>>,
 
@@ -713,11 +714,11 @@ pub struct Oauth2Rfc8414MetadataResponse {
 
     // rfc7009
     pub revocation_endpoint: Option<Url>,
-    pub revocation_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub revocation_endpoint_auth_methods_supported: Vec<EndpointAuthMethod>,
 
     // rfc7662
     pub introspection_endpoint: Option<Url>,
-    pub introspection_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
+    pub introspection_endpoint_auth_methods_supported: Vec<EndpointAuthMethod>,
     pub introspection_endpoint_auth_signing_alg_values_supported: Option<Vec<IdTokenSignAlg>>,
 
     // RFC7636

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1400,7 +1400,6 @@ impl QueryServerReadV1 {
     )]
     pub async fn handle_oauth2_token_introspect(
         &self,
-        client_auth_info: ClientAuthInfo,
         intr_req: AccessTokenIntrospectRequest,
         eventid: Uuid,
     ) -> Result<AccessTokenIntrospectResponse, Oauth2Error> {
@@ -1411,7 +1410,7 @@ impl QueryServerReadV1 {
             .await
             .map_err(Oauth2Error::ServerError)?;
         // Now we can send to the idm server for introspection checking.
-        idms_prox_read.check_oauth2_token_introspect(&client_auth_info, &intr_req, ct)
+        idms_prox_read.check_oauth2_token_introspect(&intr_req, ct)
     }
 
     #[instrument(

--- a/server/core/src/actors/v1_write.rs
+++ b/server/core/src/actors/v1_write.rs
@@ -1762,7 +1762,6 @@ impl QueryServerWriteV1 {
     )]
     pub async fn handle_oauth2_token_revoke(
         &self,
-        client_auth_info: ClientAuthInfo,
         intr_req: TokenRevokeRequest,
         eventid: Uuid,
     ) -> Result<(), Oauth2Error> {
@@ -1773,7 +1772,7 @@ impl QueryServerWriteV1 {
             .await
             .map_err(Oauth2Error::ServerError)?;
         idms_prox_write
-            .oauth2_token_revoke(&client_auth_info, &intr_req, ct)
+            .oauth2_token_revoke(&intr_req, ct)
             .and_then(|()| idms_prox_write.commit().map_err(Oauth2Error::ServerError))
     }
 

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -614,13 +614,12 @@ pub async fn oauth2_openid_publickey_get(
 pub async fn oauth2_token_introspect_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
-    AuthorisationHeaders(client_auth_info): AuthorisationHeaders,
     Form(intr_req): Form<AccessTokenIntrospectRequest>,
 ) -> impl IntoResponse {
     request_trace!("Introspect Request - {:?}", intr_req);
     let res = state
         .qe_r_ref
-        .handle_oauth2_token_introspect(client_auth_info, intr_req, kopid.eventid)
+        .handle_oauth2_token_introspect(intr_req, kopid.eventid)
         .await;
 
     match res {
@@ -676,14 +675,13 @@ pub async fn oauth2_token_introspect_post(
 pub async fn oauth2_token_revoke_post(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
-    AuthorisationHeaders(client_auth_info): AuthorisationHeaders,
     Form(intr_req): Form<TokenRevokeRequest>,
 ) -> impl IntoResponse {
     request_trace!("Revoke Request - {:?}", intr_req);
 
     let res = state
         .qe_w_ref
-        .handle_oauth2_token_revoke(client_auth_info, intr_req, kopid.eventid)
+        .handle_oauth2_token_revoke(intr_req, kopid.eventid)
         .await;
 
     match res {

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2647,9 +2647,9 @@ impl IdmServerProxyReadTransaction<'_> {
         // by a scanning attack.
 
         if let Ok(jwsc) = JwsCompact::from_str(&intr_req.token) {
-            self.oauth2_token_introspect_jwt(jwsc, ct)
+            self.oauth2_token_introspect_jwt(&jwsc, ct)
         } else if let Ok(jwec) = JweCompact::from_str(&intr_req.token) {
-            self.oauth2_token_introspect_jwe(jwec, ct)
+            self.oauth2_token_introspect_jwe(&jwec, ct)
         } else {
             error!("Failed to deserialise a valid JWE");
             Err(Oauth2Error::AuthenticationRequired)
@@ -2659,7 +2659,7 @@ impl IdmServerProxyReadTransaction<'_> {
     #[instrument(level = "trace", skip_all)]
     pub fn oauth2_token_introspect_jwt(
         &mut self,
-        jwsc: JwsCompact,
+        jwsc: &JwsCompact,
         ct: Duration,
     ) -> Result<AccessTokenIntrospectResponse, Oauth2Error> {
         let unverified_client_id = jwsc.header().client_id.as_ref().ok_or_else(|| {
@@ -2678,7 +2678,7 @@ impl IdmServerProxyReadTransaction<'_> {
 
         let access_token = o2rs
             .key_object
-            .jws_verify(&jwsc)
+            .jws_verify(jwsc)
             .map_err(|err| {
                 error!(?err, "Unable to verify access token");
                 Oauth2Error::AuthenticationRequired
@@ -2768,7 +2768,7 @@ impl IdmServerProxyReadTransaction<'_> {
     #[instrument(level = "trace", skip_all)]
     pub fn oauth2_token_introspect_jwe(
         &mut self,
-        jwec: JweCompact,
+        jwec: &JweCompact,
         ct: Duration,
     ) -> Result<AccessTokenIntrospectResponse, Oauth2Error> {
         let unverified_client_id = jwec.header().client_id.as_ref().ok_or_else(|| {
@@ -2787,7 +2787,7 @@ impl IdmServerProxyReadTransaction<'_> {
 
         let token: Oauth2TokenType = o2rs
             .key_object
-            .jwe_decrypt(&jwec)
+            .jwe_decrypt(jwec)
             .map_err(|_| {
                 admin_error!("Failed to decrypt token introspection request");
                 Oauth2Error::AuthenticationRequired

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -16,7 +16,7 @@ use base64::{engine::general_purpose, Engine as _};
 pub use compact_jwt::{compact::JwkKeySet, OidcToken};
 use compact_jwt::{
     crypto::{JweA128GCMEncipher, JweA128KWEncipher},
-    jwe::Jwe,
+    jwe::JweBuilder,
     jws::JwsBuilder,
     JweCompact, JwsCompact, OidcClaims, OidcSubject,
 };
@@ -28,11 +28,11 @@ use kanidm_proto::constants::*;
 pub use kanidm_proto::oauth2::{
     AccessTokenIntrospectRequest, AccessTokenIntrospectResponse, AccessTokenRequest,
     AccessTokenResponse, AccessTokenType, AuthorisationRequest, ClaimType, ClientAuth,
-    ClientPostAuth, CodeChallengeMethod, DeviceAuthorizationResponse, DisplayValue, ErrorResponse,
-    GrantType, GrantTypeReq, IdTokenSignAlg, OAuth2RFC9068Token, OAuth2RFC9068TokenExtensions,
-    Oauth2Rfc8414MetadataResponse, OidcDiscoveryResponse, OidcWebfingerRel, OidcWebfingerResponse,
-    PkceAlg, PkceRequest, ResponseMode, ResponseType, SubjectType, TokenEndpointAuthMethod,
-    TokenRevokeRequest, OAUTH2_TOKEN_TYPE_ACCESS_TOKEN,
+    ClientPostAuth, CodeChallengeMethod, DeviceAuthorizationResponse, DisplayValue,
+    EndpointAuthMethod, ErrorResponse, GrantType, GrantTypeReq, IdTokenSignAlg, OAuth2RFC9068Token,
+    OAuth2RFC9068TokenExtensions, Oauth2Rfc8414MetadataResponse, OidcDiscoveryResponse,
+    OidcWebfingerRel, OidcWebfingerResponse, PkceAlg, PkceRequest, ResponseMode, ResponseType,
+    SubjectType, TokenRevokeRequest, OAUTH2_TOKEN_TYPE_ACCESS_TOKEN,
 };
 use kanidm_proto::oauth2::{IssuedTokenType, Prompt};
 use serde::{Deserialize, Serialize};
@@ -627,7 +627,6 @@ fn get_client_auth(
             client_secret: client_post_auth.client_secret.clone(),
         })
     } else {
-        admin_warn!("OAuth2 client authentication not provided");
         Err(Oauth2Error::AuthenticationRequired)
     }
 }
@@ -968,46 +967,38 @@ impl IdmServerProxyWriteTransaction<'_> {
     #[instrument(level = "debug", skip_all)]
     pub fn oauth2_token_revoke(
         &mut self,
-        client_auth_info: &ClientAuthInfo,
         revoke_req: &TokenRevokeRequest,
         ct: Duration,
     ) -> Result<(), Oauth2Error> {
-        let client_auth = get_client_auth(client_auth_info, &revoke_req.client_post_auth)?;
-
-        // Get the o2rs for the handle.
-        let o2rs = self
-            .oauth2rs
-            .inner
-            .rs_set_get(client_auth.client_id.as_str())
-            .ok_or_else(|| {
-                warn!("Invalid OAuth2 client_id");
-                Oauth2Error::AuthenticationRequired
-            })?;
-
-        // check the secret.
-        match &o2rs.type_ {
-            OauthRSType::Basic { authz_secret, .. } => {
-                if Some(authz_secret) != client_auth.client_secret.as_ref() {
-                    info!("Invalid OAuth2 client_id secret, this can happen if your RS is public but you configured a 'basic' type.");
-                    return Err(Oauth2Error::AuthenticationRequired);
-                }
-            }
-            // Relies on the token to be valid.
-            OauthRSType::Public { .. } => {}
-        };
-
-        // We are authenticated! Yay! Now we can actually check things ...
+        // We don't need to authenticate, since possession of the access token is already enough
+        // to prove identity, and we enforce it is cryptographically valid so it can't be bruteforced
+        // by a scanning attack.
 
         // Because this is the only path that deals with the tokens that
         // are either signed *or* encrypted, we need to check both options.
 
         let (session_id, expiry, uuid) = if let Ok(jwsc) = JwsCompact::from_str(&revoke_req.token) {
+            let unverified_client_id = jwsc.header().client_id.as_ref().ok_or_else(|| {
+                error!("Token does not contain the OAuth2 client id");
+                Oauth2Error::AuthenticationRequired
+            })?;
+
+            // Get the o2rs for the handle.
+            let o2rs = self
+                .oauth2rs
+                .inner
+                .rs_set_get(unverified_client_id)
+                .ok_or_else(|| {
+                    warn!("Invalid OAuth2 client_id");
+                    Oauth2Error::AuthenticationRequired
+                })?;
+
             let access_token = o2rs
                 .key_object
                 .jws_verify(&jwsc)
                 .map_err(|err| {
                     admin_error!(?err, "Unable to verify access token");
-                    Oauth2Error::InvalidRequest
+                    Oauth2Error::AuthenticationRequired
                 })
                 .and_then(|jws| {
                     jws.from_json().map_err(|err| {
@@ -1024,19 +1015,29 @@ impl IdmServerProxyWriteTransaction<'_> {
             } = access_token;
 
             (session_id, exp, uuid)
-        } else {
+        } else if let Ok(jwec) = JweCompact::from_str(&revoke_req.token) {
             // Assume it's encrypted.
-            let jwe_compact = JweCompact::from_str(&revoke_req.token).map_err(|_| {
-                error!("Failed to deserialise a valid JWE");
-                Oauth2Error::InvalidRequest
+            let unverified_client_id = jwec.header().client_id.as_ref().ok_or_else(|| {
+                error!("Token does not contain the OAuth2 client id");
+                Oauth2Error::AuthenticationRequired
             })?;
+
+            // Get the o2rs for the handle.
+            let o2rs = self
+                .oauth2rs
+                .inner
+                .rs_set_get(unverified_client_id)
+                .ok_or_else(|| {
+                    warn!("Invalid OAuth2 client_id");
+                    Oauth2Error::AuthenticationRequired
+                })?;
 
             let token: Oauth2TokenType = o2rs
                 .key_object
-                .jwe_decrypt(&jwe_compact)
+                .jwe_decrypt(&jwec)
                 .map_err(|_| {
                     error!("Failed to decrypt token revoke request");
-                    Oauth2Error::InvalidRequest
+                    Oauth2Error::AuthenticationRequired
                 })
                 .and_then(|jwe| {
                     jwe.from_json().map_err(|err| {
@@ -1059,6 +1060,9 @@ impl IdmServerProxyWriteTransaction<'_> {
                     ..
                 } => (session_id, exp, uuid),
             }
+        } else {
+            error!("Failed to deserialise a valid JWE or JWS");
+            return Err(Oauth2Error::AuthenticationRequired);
         };
 
         // Only submit a revocation if the token is not yet expired.
@@ -1099,7 +1103,10 @@ impl IdmServerProxyWriteTransaction<'_> {
         ct: Duration,
     ) -> Result<AccessTokenResponse, Oauth2Error> {
         // Public clients will send the client_id via the ATR, so we need to handle this case.
-        let client_auth = get_client_auth(client_auth_info, &token_req.client_post_auth)?;
+        let client_auth = get_client_auth(client_auth_info, &token_req.client_post_auth)
+            .inspect_err(|_| {
+                warn!("OAuth2 Client Authentcation Required");
+            })?;
 
         let o2rs = self.get_client(&client_auth.client_id)?;
         let is_token_exchange = matches!(token_req.grant_type, GrantTypeReq::TokenExchange { .. });
@@ -1351,10 +1358,12 @@ impl IdmServerProxyWriteTransaction<'_> {
         };
 
         // Encrypt the exchange token
-        let code_data_jwe = Jwe::into_json(&xchg_code).map_err(|err| {
-            error!(?err, "Unable to encode xchg_code data");
-            OperationError::SerdeJsonError
-        })?;
+        let code_data_jwe = JweBuilder::into_json(&xchg_code)
+            .map(|builder| builder.set_client_id(Some(&o2rs.name)).build())
+            .map_err(|err| {
+                error!(?err, "Unable to encode xchg_code data");
+                OperationError::SerdeJsonError
+            })?;
 
         let code = o2rs
             .key_object
@@ -1817,10 +1826,12 @@ impl IdmServerProxyWriteTransaction<'_> {
             nbf: iat,
         };
 
-        let access_token_data = Jwe::into_json(&access_token_raw).map_err(|err| {
-            error!(?err, "Unable to encode token data");
-            Oauth2Error::ServerError(OperationError::SerdeJsonError)
-        })?;
+        let access_token_data = JweBuilder::into_json(&access_token_raw)
+            .map(|builder| builder.set_client_id(Some(&o2rs.name)).build())
+            .map_err(|err| {
+                error!(?err, "Unable to encode token data");
+                Oauth2Error::ServerError(OperationError::SerdeJsonError)
+            })?;
 
         let access_token = o2rs
             .key_object
@@ -1959,7 +1970,7 @@ impl IdmServerProxyWriteTransaction<'_> {
 
             trace!(?oidc);
             let oidc = JwsBuilder::into_json(&oidc)
-                .map(|builder| builder.build())
+                .map(|builder| builder.set_client_id(Some(&o2rs.name)).build())
                 .map_err(|err| {
                     admin_error!(?err, "Unable to encode access token data");
                     Oauth2Error::ServerError(OperationError::InvalidState)
@@ -2002,7 +2013,12 @@ impl IdmServerProxyWriteTransaction<'_> {
         };
 
         let access_token_data = JwsBuilder::into_json(&access_token_data)
-            .map(|builder| builder.set_typ(Some("at+jwt")).build())
+            .map(|builder| {
+                builder
+                    .set_typ(Some("at+jwt"))
+                    .set_client_id(Some(&o2rs.name))
+                    .build()
+            })
             .map_err(|err| {
                 error!(?err, "Unable to encode access token data");
                 Oauth2Error::ServerError(OperationError::InvalidState)
@@ -2028,10 +2044,12 @@ impl IdmServerProxyWriteTransaction<'_> {
             nonce,
         };
 
-        let refresh_token_data = Jwe::into_json(&refresh_token_raw).map_err(|err| {
-            error!(?err, "Unable to encode token data");
-            Oauth2Error::ServerError(OperationError::SerdeJsonError)
-        })?;
+        let refresh_token_data = JweBuilder::into_json(&refresh_token_raw)
+            .map(|builder| builder.set_client_id(Some(&o2rs.name)).build())
+            .map_err(|err| {
+                error!(?err, "Unable to encode token data");
+                Oauth2Error::ServerError(OperationError::SerdeJsonError)
+            })?;
 
         let refresh_token = o2rs
             .key_object
@@ -2449,10 +2467,12 @@ impl IdmServerProxyReadTransaction<'_> {
             };
 
             // Encrypt the exchange token with the key of the client
-            let code_data_jwe = Jwe::into_json(&xchg_code).map_err(|err| {
-                error!(?err, "Unable to encode xchg_code data");
-                Oauth2Error::ServerError(OperationError::SerdeJsonError)
-            })?;
+            let code_data_jwe = JweBuilder::into_json(&xchg_code)
+                .map(|builder| builder.set_client_id(Some(&o2rs.name)).build())
+                .map_err(|err| {
+                    error!(?err, "Unable to encode xchg_code data");
+                    Oauth2Error::ServerError(OperationError::SerdeJsonError)
+                })?;
 
             let code = o2rs
                 .key_object
@@ -2525,10 +2545,12 @@ impl IdmServerProxyReadTransaction<'_> {
                 response_mode,
             };
 
-            let consent_jwe = Jwe::into_json(&consent_req).map_err(|err| {
-                error!(?err, "Unable to encode consent data");
-                Oauth2Error::ServerError(OperationError::SerdeJsonError)
-            })?;
+            let consent_jwe = JweBuilder::into_json(&consent_req)
+                .map(|builder| builder.set_client_id(Some(&o2rs.name)).build())
+                .map_err(|err| {
+                    error!(?err, "Unable to encode consent data");
+                    Oauth2Error::ServerError(OperationError::SerdeJsonError)
+                })?;
 
             let consent_token = self
                 .oauth2rs
@@ -2617,190 +2639,226 @@ impl IdmServerProxyReadTransaction<'_> {
     #[instrument(level = "debug", skip_all)]
     pub fn check_oauth2_token_introspect(
         &mut self,
-        client_auth_info: &ClientAuthInfo,
         intr_req: &AccessTokenIntrospectRequest,
         ct: Duration,
     ) -> Result<AccessTokenIntrospectResponse, Oauth2Error> {
-        let client_auth = get_client_auth(client_auth_info, &intr_req.client_post_auth)?;
+        // We don't need to authenticate, since possession of the access token is already enough
+        // to prove identity, and we enforce it is cryptographically valid so it can't be bruteforced
+        // by a scanning attack.
 
-        // Get the o2rs for the handle.
+        if let Ok(jwsc) = JwsCompact::from_str(&intr_req.token) {
+            self.oauth2_token_introspect_jwt(jwsc, ct)
+        } else if let Ok(jwec) = JweCompact::from_str(&intr_req.token) {
+            self.oauth2_token_introspect_jwe(jwec, ct)
+        } else {
+            error!("Failed to deserialise a valid JWE");
+            Err(Oauth2Error::AuthenticationRequired)
+        }
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub fn oauth2_token_introspect_jwt(
+        &mut self,
+        jwsc: JwsCompact,
+        ct: Duration,
+    ) -> Result<AccessTokenIntrospectResponse, Oauth2Error> {
+        let unverified_client_id = jwsc.header().client_id.as_ref().ok_or_else(|| {
+            error!("Token does not contain the OAuth2 client id");
+            Oauth2Error::AuthenticationRequired
+        })?;
+
         let o2rs = self
             .oauth2rs
             .inner
-            .rs_set_get(&client_auth.client_id)
+            .rs_set_get(unverified_client_id)
             .ok_or_else(|| {
                 warn!("Invalid OAuth2 client_id");
                 Oauth2Error::AuthenticationRequired
             })?;
 
-        // We don't need to authenticate, since possession of the access token is already enough
-        // to prove identity, and we enforce it is cryptographically valid so it can't be bruteforced
-        // by a scanning attack.
-        let prefer_short_username = o2rs.prefer_short_username;
-
-        if let Ok(jwsc) = JwsCompact::from_str(&intr_req.token) {
-            let access_token = o2rs
-                .key_object
-                .jws_verify(&jwsc)
-                .map_err(|err| {
-                    error!(?err, "Unable to verify access token");
+        let access_token = o2rs
+            .key_object
+            .jws_verify(&jwsc)
+            .map_err(|err| {
+                error!(?err, "Unable to verify access token");
+                Oauth2Error::AuthenticationRequired
+            })
+            .and_then(|jws| {
+                jws.from_json().map_err(|err| {
+                    error!(?err, "Unable to deserialise access token");
                     Oauth2Error::InvalidRequest
                 })
-                .and_then(|jws| {
-                    jws.from_json().map_err(|err| {
-                        error!(?err, "Unable to deserialise access token");
-                        Oauth2Error::InvalidRequest
-                    })
-                })?;
-
-            let OAuth2RFC9068Token::<_> {
-                iss: _,
-                sub,
-                aud: _,
-                exp,
-                nbf,
-                iat,
-                jti,
-                client_id: _,
-                extensions:
-                    OAuth2RFC9068TokenExtensions {
-                        auth_time: _,
-                        acr: _,
-                        amr: _,
-                        scope: scopes,
-                        nonce: _,
-                        session_id,
-                        parent_session_id,
-                    },
-            } = access_token;
-
-            // Has this token expired?
-            if exp <= ct.as_secs() as i64 {
-                security_info!(?sub, "access token has expired, returning inactive");
-                return Ok(AccessTokenIntrospectResponse::inactive(jti));
-            }
-
-            // Is the user expired, or the OAuth2 session invalid?
-            let valid = self
-                .check_oauth2_account_uuid_valid(sub, session_id, parent_session_id, iat, ct)
-                .map_err(|_| admin_error!("Account is not valid"));
-
-            let Ok(Some(entry)) = valid else {
-                security_info!(
-                    ?sub,
-                    "access token account is not valid, returning inactive"
-                );
-                return Ok(AccessTokenIntrospectResponse::inactive(jti));
-            };
-
-            let account = match Account::try_from_entry_ro(&entry, &mut self.qs_read) {
-                Ok(account) => account,
-                Err(err) => return Err(Oauth2Error::ServerError(err)),
-            };
-
-            // ==== good to generate response ====
-
-            let scope = scopes.clone();
-
-            let preferred_username = if prefer_short_username {
-                Some(account.name().into())
-            } else {
-                Some(account.spn().into())
-            };
-
-            let token_type = Some(AccessTokenType::Bearer);
-            Ok(AccessTokenIntrospectResponse {
-                active: true,
-                scope,
-                client_id: Some(client_auth.client_id.clone()),
-                username: preferred_username,
-                token_type,
-                iat: Some(iat),
-                exp: Some(exp),
-                nbf: Some(nbf),
-                sub: Some(sub.to_string()),
-                aud: Some(client_auth.client_id),
-                iss: None,
-                jti,
-            })
-        } else {
-            let jwe_compact = JweCompact::from_str(&intr_req.token).map_err(|_| {
-                error!("Failed to deserialise a valid JWE");
-                Oauth2Error::InvalidRequest
             })?;
 
-            let token: Oauth2TokenType = o2rs
-                .key_object
-                .jwe_decrypt(&jwe_compact)
-                .map_err(|_| {
-                    admin_error!("Failed to decrypt token introspection request");
+        let OAuth2RFC9068Token::<_> {
+            iss: _,
+            sub,
+            aud: _,
+            exp,
+            nbf,
+            iat,
+            jti,
+            client_id: _,
+            extensions:
+                OAuth2RFC9068TokenExtensions {
+                    auth_time: _,
+                    acr: _,
+                    amr: _,
+                    scope: scopes,
+                    nonce: _,
+                    session_id,
+                    parent_session_id,
+                },
+        } = access_token;
+
+        // Has this token expired?
+        if exp <= ct.as_secs() as i64 {
+            security_info!(?sub, "access token has expired, returning inactive");
+            return Ok(AccessTokenIntrospectResponse::inactive(jti));
+        }
+
+        let prefer_short_username = o2rs.prefer_short_username;
+        let client_id = o2rs.name.clone();
+
+        // Is the user expired, or the OAuth2 session invalid?
+        let valid = self
+            .check_oauth2_account_uuid_valid(sub, session_id, parent_session_id, iat, ct)
+            .map_err(|_| admin_error!("Account is not valid"));
+
+        let Ok(Some(entry)) = valid else {
+            security_info!(
+                ?sub,
+                "access token account is not valid, returning inactive"
+            );
+            return Ok(AccessTokenIntrospectResponse::inactive(jti));
+        };
+
+        let account = match Account::try_from_entry_ro(&entry, &mut self.qs_read) {
+            Ok(account) => account,
+            Err(err) => return Err(Oauth2Error::ServerError(err)),
+        };
+
+        // ==== good to generate response ====
+
+        let scope = scopes.clone();
+
+        let preferred_username = if prefer_short_username {
+            Some(account.name().into())
+        } else {
+            Some(account.spn().into())
+        };
+
+        let token_type = Some(AccessTokenType::Bearer);
+        Ok(AccessTokenIntrospectResponse {
+            active: true,
+            scope,
+            client_id: Some(client_id.clone()),
+            username: preferred_username,
+            token_type,
+            iat: Some(iat),
+            exp: Some(exp),
+            nbf: Some(nbf),
+            sub: Some(sub.to_string()),
+            aud: Some(client_id),
+            iss: None,
+            jti,
+        })
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub fn oauth2_token_introspect_jwe(
+        &mut self,
+        jwec: JweCompact,
+        ct: Duration,
+    ) -> Result<AccessTokenIntrospectResponse, Oauth2Error> {
+        let unverified_client_id = jwec.header().client_id.as_ref().ok_or_else(|| {
+            error!("Token does not contain the OAuth2 client id");
+            Oauth2Error::AuthenticationRequired
+        })?;
+
+        let o2rs = self
+            .oauth2rs
+            .inner
+            .rs_set_get(unverified_client_id)
+            .ok_or_else(|| {
+                warn!("Invalid OAuth2 client_id");
+                Oauth2Error::AuthenticationRequired
+            })?;
+
+        let token: Oauth2TokenType = o2rs
+            .key_object
+            .jwe_decrypt(&jwec)
+            .map_err(|_| {
+                admin_error!("Failed to decrypt token introspection request");
+                Oauth2Error::AuthenticationRequired
+            })
+            .and_then(|jwe| {
+                jwe.from_json().map_err(|err| {
+                    error!(?err, "Failed to deserialise token");
                     Oauth2Error::InvalidRequest
                 })
-                .and_then(|jwe| {
-                    jwe.from_json().map_err(|err| {
-                        error!(?err, "Failed to deserialise token");
-                        Oauth2Error::InvalidRequest
-                    })
-                })?;
+            })?;
 
-            match token {
-                Oauth2TokenType::ClientAccess {
-                    scopes,
-                    session_id,
-                    uuid,
-                    exp,
-                    iat,
-                    nbf,
-                } => {
-                    // Has this token expired?
-                    if exp <= ct.as_secs() as i64 {
-                        security_info!(?uuid, "access token has expired, returning inactive");
-                        return Ok(AccessTokenIntrospectResponse::inactive(session_id));
-                    }
-
-                    // We can't do the same validity check for the client as we do with an account
-                    let valid = self
-                        .check_oauth2_account_uuid_valid(uuid, session_id, None, iat, ct)
-                        .map_err(|_| admin_error!("Account is not valid"));
-
-                    let Ok(Some(entry)) = valid else {
-                        security_info!(
-                            ?uuid,
-                            "access token account is not valid, returning inactive"
-                        );
-                        return Ok(AccessTokenIntrospectResponse::inactive(session_id));
-                    };
-
-                    let scope = scopes.clone();
-
-                    let token_type = Some(AccessTokenType::Bearer);
-
-                    let username = if prefer_short_username {
-                        entry
-                            .get_ava_single_iname(Attribute::Name)
-                            .map(|s| s.to_string())
-                    } else {
-                        entry.get_ava_single_proto_string(Attribute::Spn)
-                    };
-
-                    Ok(AccessTokenIntrospectResponse {
-                        active: true,
-                        scope,
-                        client_id: Some(client_auth.client_id.clone()),
-                        username,
-                        token_type,
-                        iat: Some(iat),
-                        exp: Some(exp),
-                        nbf: Some(nbf),
-                        sub: Some(uuid.to_string()),
-                        aud: Some(client_auth.client_id),
-                        iss: None,
-                        jti: session_id,
-                    })
+        match token {
+            Oauth2TokenType::ClientAccess {
+                scopes,
+                session_id,
+                uuid,
+                exp,
+                iat,
+                nbf,
+            } => {
+                // Has this token expired?
+                if exp <= ct.as_secs() as i64 {
+                    security_info!(?uuid, "access token has expired, returning inactive");
+                    return Ok(AccessTokenIntrospectResponse::inactive(session_id));
                 }
-                Oauth2TokenType::Refresh { session_id, .. } => {
-                    Ok(AccessTokenIntrospectResponse::inactive(session_id))
-                }
+
+                let prefer_short_username = o2rs.prefer_short_username;
+                let client_id = o2rs.name.clone();
+
+                // We can't do the same validity check for the client as we do with an account
+                let valid = self
+                    .check_oauth2_account_uuid_valid(uuid, session_id, None, iat, ct)
+                    .map_err(|_| admin_error!("Account is not valid"));
+
+                let Ok(Some(entry)) = valid else {
+                    security_info!(
+                        ?uuid,
+                        "access token account is not valid, returning inactive"
+                    );
+                    return Ok(AccessTokenIntrospectResponse::inactive(session_id));
+                };
+
+                let scope = scopes.clone();
+
+                let token_type = Some(AccessTokenType::Bearer);
+
+                let username = if prefer_short_username {
+                    entry
+                        .get_ava_single_iname(Attribute::Name)
+                        .map(|s| s.to_string())
+                } else {
+                    entry.get_ava_single_proto_string(Attribute::Spn)
+                };
+
+                Ok(AccessTokenIntrospectResponse {
+                    active: true,
+                    scope,
+                    client_id: Some(client_id.clone()),
+                    username,
+                    token_type,
+                    iat: Some(iat),
+                    exp: Some(exp),
+                    nbf: Some(nbf),
+                    sub: Some(uuid.to_string()),
+                    aud: Some(client_id),
+                    iss: None,
+                    jti: session_id,
+                })
+            }
+            Oauth2TokenType::Refresh { session_id, .. } => {
+                Ok(AccessTokenIntrospectResponse::inactive(session_id))
             }
         }
     }
@@ -2934,19 +2992,13 @@ impl IdmServerProxyReadTransaction<'_> {
         let grant_types_supported = vec![GrantType::AuthorisationCode, GrantType::TokenExchange];
 
         let token_endpoint_auth_methods_supported = vec![
-            TokenEndpointAuthMethod::ClientSecretBasic,
-            TokenEndpointAuthMethod::ClientSecretPost,
+            EndpointAuthMethod::ClientSecretBasic,
+            EndpointAuthMethod::ClientSecretPost,
         ];
 
-        let revocation_endpoint_auth_methods_supported = vec![
-            TokenEndpointAuthMethod::ClientSecretBasic,
-            TokenEndpointAuthMethod::ClientSecretPost,
-        ];
+        let revocation_endpoint_auth_methods_supported = vec![EndpointAuthMethod::None];
 
-        let introspection_endpoint_auth_methods_supported = vec![
-            TokenEndpointAuthMethod::ClientSecretBasic,
-            TokenEndpointAuthMethod::ClientSecretPost,
-        ];
+        let introspection_endpoint_auth_methods_supported = vec![EndpointAuthMethod::None];
 
         let service_documentation = Some(URL_SERVICE_DOCUMENTATION.clone());
 
@@ -3014,8 +3066,8 @@ impl IdmServerProxyReadTransaction<'_> {
 
         let userinfo_signing_alg_values_supported = None;
         let token_endpoint_auth_methods_supported = vec![
-            TokenEndpointAuthMethod::ClientSecretBasic,
-            TokenEndpointAuthMethod::ClientSecretPost,
+            EndpointAuthMethod::ClientSecretBasic,
+            EndpointAuthMethod::ClientSecretPost,
         ];
         let display_values_supported = Some(vec![DisplayValue::Page]);
         let claim_types_supported = vec![ClaimType::Normal];
@@ -3032,16 +3084,10 @@ impl IdmServerProxyReadTransaction<'_> {
         // The following are extensions allowed by the oidc specification.
 
         let revocation_endpoint = Some(o2rs.revocation_endpoint.clone());
-        let revocation_endpoint_auth_methods_supported = vec![
-            TokenEndpointAuthMethod::ClientSecretBasic,
-            TokenEndpointAuthMethod::ClientSecretPost,
-        ];
+        let revocation_endpoint_auth_methods_supported = vec![EndpointAuthMethod::None];
 
         let introspection_endpoint = Some(o2rs.introspection_endpoint.clone());
-        let introspection_endpoint_auth_methods_supported = vec![
-            TokenEndpointAuthMethod::ClientSecretBasic,
-            TokenEndpointAuthMethod::ClientSecretPost,
-        ];
+        let introspection_endpoint_auth_methods_supported = vec![EndpointAuthMethod::None];
 
         Ok(OidcDiscoveryResponse {
             issuer,
@@ -4852,7 +4898,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
 
         eprintln!("👉  {intr_response:?}");
@@ -4891,7 +4937,7 @@ mod tests {
         // check again.
         let mut idms_prox_read = idms.proxy_read().await.unwrap();
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
 
         assert!(!intr_response.active);
@@ -4953,29 +4999,14 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
         eprintln!("👉  {intr_response:?}");
         assert!(intr_response.active);
         drop(idms_prox_read);
 
-        // First, the revoke needs basic auth. Provide incorrect auth, and we fail.
-        let mut idms_prox_write = idms.proxy_write(ct).await.unwrap();
-
-        let bad_client_authz = ClientAuthInfo::encode_basic("test_resource_server", "12345");
-
-        let revoke_request = TokenRevokeRequest {
-            token: oauth2_token.access_token.clone(),
-            token_type_hint: None,
-            client_post_auth: ClientPostAuth::default(),
-        };
-        let e = idms_prox_write
-            .oauth2_token_revoke(&bad_client_authz, &revoke_request, ct)
-            .unwrap_err();
-        assert!(matches!(e, Oauth2Error::AuthenticationRequired));
-        assert!(idms_prox_write.commit().is_ok());
-
-        // Now submit a non-existent/invalid token. Does not affect our tokens validity.
+        // Now submit a non-existent/invalid token. Considered a failure to authenticate
+        // as the token wasn't valid.
         let mut idms_prox_write = idms.proxy_write(ct).await.unwrap();
         let revoke_request = TokenRevokeRequest {
             token: "this is an invalid token, nothing will happen!".to_string(),
@@ -4983,15 +5014,15 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         let e = idms_prox_write
-            .oauth2_token_revoke(&client_authz, &revoke_request, ct)
+            .oauth2_token_revoke(&revoke_request, ct)
             .unwrap_err();
-        assert!(matches!(e, Oauth2Error::InvalidRequest));
+        assert!(matches!(e, Oauth2Error::AuthenticationRequired));
         assert!(idms_prox_write.commit().is_ok());
 
         // Check our token is still valid.
         let mut idms_prox_read = idms.proxy_read().await.unwrap();
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
         assert!(intr_response.active);
         drop(idms_prox_read);
@@ -5004,14 +5035,14 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         assert!(idms_prox_write
-            .oauth2_token_revoke(&client_authz, &revoke_request, ct,)
+            .oauth2_token_revoke(&revoke_request, ct,)
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
 
         // Assert it is now invalid.
         let mut idms_prox_read = idms.proxy_read().await.unwrap();
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
 
         assert!(!intr_response.active);
@@ -5040,14 +5071,14 @@ mod tests {
         let mut idms_prox_read = idms.proxy_read().await.unwrap();
         // Grace window in effect.
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
         assert!(intr_response.active);
 
         // Grace window passed, it will now be invalid.
         let ct = ct + AUTH_TOKEN_GRACE_WINDOW;
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
         assert!(!intr_response.active);
 
@@ -5061,7 +5092,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         assert!(idms_prox_write
-            .oauth2_token_revoke(&client_authz, &revoke_request, ct,)
+            .oauth2_token_revoke(&revoke_request, ct,)
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
     }
@@ -5324,8 +5355,8 @@ mod tests {
         assert!(
             discovery.token_endpoint_auth_methods_supported
                 == vec![
-                    TokenEndpointAuthMethod::ClientSecretBasic,
-                    TokenEndpointAuthMethod::ClientSecretPost
+                    EndpointAuthMethod::ClientSecretBasic,
+                    EndpointAuthMethod::ClientSecretPost
                 ]
         );
         assert!(discovery.service_documentation.is_some());
@@ -5344,11 +5375,7 @@ mod tests {
                 )
         );
         assert!(
-            discovery.revocation_endpoint_auth_methods_supported
-                == vec![
-                    TokenEndpointAuthMethod::ClientSecretBasic,
-                    TokenEndpointAuthMethod::ClientSecretPost
-                ]
+            discovery.revocation_endpoint_auth_methods_supported == vec![EndpointAuthMethod::None,]
         );
 
         assert!(
@@ -5363,10 +5390,7 @@ mod tests {
         );
         assert!(
             discovery.introspection_endpoint_auth_methods_supported
-                == vec![
-                    TokenEndpointAuthMethod::ClientSecretBasic,
-                    TokenEndpointAuthMethod::ClientSecretPost
-                ]
+                == vec![EndpointAuthMethod::None,]
         );
         assert!(discovery
             .introspection_endpoint_auth_signing_alg_values_supported
@@ -5490,8 +5514,8 @@ mod tests {
         assert!(
             discovery.token_endpoint_auth_methods_supported
                 == vec![
-                    TokenEndpointAuthMethod::ClientSecretBasic,
-                    TokenEndpointAuthMethod::ClientSecretPost
+                    EndpointAuthMethod::ClientSecretBasic,
+                    EndpointAuthMethod::ClientSecretPost
                 ]
         );
         assert_eq!(
@@ -5544,11 +5568,7 @@ mod tests {
                 )
         );
         assert!(
-            discovery.revocation_endpoint_auth_methods_supported
-                == vec![
-                    TokenEndpointAuthMethod::ClientSecretBasic,
-                    TokenEndpointAuthMethod::ClientSecretPost
-                ]
+            discovery.revocation_endpoint_auth_methods_supported == vec![EndpointAuthMethod::None,]
         );
 
         assert!(
@@ -5562,10 +5582,7 @@ mod tests {
         );
         assert!(
             discovery.introspection_endpoint_auth_methods_supported
-                == vec![
-                    TokenEndpointAuthMethod::ClientSecretBasic,
-                    TokenEndpointAuthMethod::ClientSecretPost
-                ]
+                == vec![EndpointAuthMethod::None,]
         );
         assert!(discovery
             .introspection_endpoint_auth_signing_alg_values_supported
@@ -6947,7 +6964,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         assert!(idms_prox_write
-            .oauth2_token_revoke(&client_authz, &revoke_request, ct,)
+            .oauth2_token_revoke(&revoke_request, ct,)
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
 
@@ -7608,7 +7625,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
 
         eprintln!("👉  {intr_response:?}");
@@ -7841,7 +7858,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to introspect service account token");
 
         assert!(intr_response.active);
@@ -7863,7 +7880,6 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
         let (secret, _uat, _ident, _) =
             setup_oauth2_resource_server_basic(idms, ct, true, false, false).await;
-        let client_authz = ClientAuthInfo::encode_basic("test_resource_server", secret.as_str());
 
         // scope: Some(btreeset!["invalid_scope".to_string()]),
         let mut idms_prox_write = idms.proxy_write(ct).await.unwrap();
@@ -7895,7 +7911,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
 
         eprintln!("👉  {intr_response:?}");
@@ -7923,7 +7939,7 @@ mod tests {
             client_post_auth: ClientPostAuth::default(),
         };
         assert!(idms_prox_write
-            .oauth2_token_revoke(&client_authz, &revoke_request, ct,)
+            .oauth2_token_revoke(&revoke_request, ct,)
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
 
@@ -7938,7 +7954,7 @@ mod tests {
         };
 
         let intr_response = idms_prox_read
-            .check_oauth2_token_introspect(&client_authz, &intr_request, ct)
+            .check_oauth2_token_introspect(&intr_request, ct)
             .expect("Failed to inspect token");
         assert!(!intr_response.active);
 


### PR DESCRIPTION
# Change summary

- In a previous pr, we allowed oauth2 token introspection/revocation without client authentication. The PR was incomplete, where we still required auth to be partially presented. Additionally, we didn't update the metadata to reflect our capabilities. This PR resolves both issues, ensuring that we only need a VALID token for introspect and revoke, while also reflecting the correct details in metadata.

Depends on https://github.com/kanidm/compact-jwt/pull/50

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
