### PR TITLE
add dependency data to released containers

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,6 +21,7 @@ RUN \
     zypper install -y --no-recommends \
         sccache \
         cargo \
+        cargo-auditable \
         clang \
         gcc \
         cmake \
@@ -48,7 +49,7 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
     export SCCACHE_DIR=/sccache && \
     export RUSTC_WRAPPER=/usr/bin/sccache && \
     export CC="/usr/bin/clang" && \
-    cargo build --locked -p daemon ${KANIDM_BUILD_OPTIONS} \
+    cargo auditable build --locked -p daemon ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release; \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     zypper install -y --no-recommends \
         sccache \
         cargo \
+        cargo-auditable \
         clang \
         gcc \
         make \
@@ -42,23 +43,23 @@ RUN \
     export SCCACHE_DIR=/sccache; \
     export RUSTC_WRAPPER=/usr/bin/sccache; \
     export CC="/usr/bin/clang"; \
-    cargo build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
+    cargo auditable build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \
-    cargo build --locked -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
+    cargo auditable build --locked -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \
-    cargo build --locked -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
+    cargo auditable build --locked -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \
-    cargo build --locked -p kanidm-mail-sender ${KANIDM_BUILD_OPTIONS} \
+    cargo auditable build --locked -p kanidm-mail-sender ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release && \
-    cargo install \
+    cargo auditable install \
         --git https://github.com/kanidm/webauthn-rs.git \
         --rev 2ac5ff0e20f323cd904856a38a15899adf13fa5b \
         --force fido-mds-tool \


### PR DESCRIPTION
# Change summary

The tool and server containers now use cargo-auditable to build rust binaries in a way that exposes dependency data to vulnerability scanners.

Fixes #2432

## Testing
- Extracted built binaries from both containers, ran `cargo audit bin <path to binary>` on each binary, and saw output indicating `cargo auditable` data  was found in each binary.
- Ran `trivy image <local docker tag>` on both images and saw that the tool included our built binaries in its report summary.

## Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)