### PR TITLE
Correctly encode ssh tag values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,6 +3923,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
  "webauthn-rs-proto",
 ]

--- a/libs/client/Cargo.toml
+++ b/libs/client/Cargo.toml
@@ -38,4 +38,5 @@ tokio = { workspace = true, features = [
 toml = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 url = { workspace = true, features = ["serde"] }
+urlencoding = { workspace = true }
 webauthn-rs-proto = { workspace = true }

--- a/libs/client/src/person.rs
+++ b/libs/client/src/person.rs
@@ -1,11 +1,9 @@
-use std::collections::BTreeMap;
-
+use crate::{ClientError, KanidmClient};
 use kanidm_proto::constants::*;
 use kanidm_proto::internal::{CredentialStatus, IdentifyUserRequest, IdentifyUserResponse};
 use kanidm_proto::v1::{AccountUnixExtend, Entry, SingleStringRequest, UatStatus};
+use std::collections::BTreeMap;
 use uuid::Uuid;
-
-use crate::{ClientError, KanidmClient};
 
 impl KanidmClient {
     pub async fn idm_person_account_list(&self) -> Result<Vec<Entry>, ClientError> {
@@ -167,7 +165,8 @@ impl KanidmClient {
         tag: &str,
         pubkey: &str,
     ) -> Result<(), ClientError> {
-        let sk = (tag.to_string(), pubkey.to_string());
+        let tag = urlencoding::encode(tag);
+        let sk = (tag, pubkey.to_string());
         self.perform_post_request(format!("/v1/person/{id}/_ssh_pubkeys").as_str(), sk)
             .await
     }
@@ -177,6 +176,7 @@ impl KanidmClient {
         id: &str,
         tag: &str,
     ) -> Result<(), ClientError> {
+        let tag = urlencoding::encode(tag);
         self.perform_delete_request(format!("/v1/person/{id}/_ssh_pubkeys/{tag}").as_str())
             .await
     }

--- a/server/lib/src/valueset/ssh.rs
+++ b/server/lib/src/valueset/ssh.rs
@@ -35,7 +35,15 @@ impl ValueSetSshKey {
                     .map_err(|err| {
                         warn!(%tag, ?err, "discarding corrupted ssh public key");
                     })
-                    .map(|pk| (tag, pk))
+                    .map(|pk| {
+                        if tag.is_empty() {
+                            // No tag was known - use the hash of the key to guarantee it's unique.
+                            // New keys can't be created with empty strs
+                            (pk.fingerprint().hash, pk)
+                        } else {
+                            (tag, pk)
+                        }
+                    })
                     .ok()
             })
             .collect();
@@ -145,6 +153,7 @@ impl ValueSetT for ValueSetSshKey {
 
     fn validate(&self, _schema_attr: &SchemaAttribute) -> bool {
         self.map.iter().all(|(s, _key)| {
+            !s.is_empty() &&
             Value::validate_str_escapes(s)
                 // && Value::validate_iname(s)
                 && Value::validate_singleline(s)


### PR DESCRIPTION
# Change summary

- If an ssh key has no tag, derive a tag from the fingerprint hash
- correctly encode the tag value so that tags with special chars are routed properly.
- deny new keys from being created with an empty tag.

Fixes #4270

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
