### PR TITLE
Correctly handle deleted accounts during page visits

### DIFF
--- a/server/core/src/https/views/login.rs
+++ b/server/core/src/https/views/login.rs
@@ -68,12 +68,14 @@ impl fmt::Display for ReauthPurpose {
 #[derive(Clone)]
 pub enum LoginError {
     InvalidUsername,
+    SessionExpired,
 }
 
 impl fmt::Display for LoginError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidUsername => write!(f, "Invalid username"),
+            Self::SessionExpired => write!(f, "Session Expired"),
         }
     }
 }
@@ -383,11 +385,17 @@ pub async fn view_index_get(
 
             let remember_me = !username.is_empty();
 
+            let error = if session_valid_result == Err(OperationError::SessionExpired) {
+                Some(LoginError::SessionExpired)
+            } else {
+                None
+            };
+
             let display_ctx = LoginDisplayCtx {
                 domain_info,
                 oauth2: None,
                 reauth: None,
-                error: None,
+                error,
             };
 
             (

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -423,14 +423,25 @@ pub trait IdmServerTransaction<'a> {
             client_cert,
             bearer_token,
             basic_authz: _,
-            pre_validated_token: _,
+            pre_validated_token,
         } = client_auth_info;
 
-        // Future - if there is a pre-validated UAT, use that. For now I want to review
-        // all the auth and validation flows to ensure that the UAT path is security
-        // wise equivalent to the other paths. This pre-validation is an "optimisation"
+        // If there is a pre-validated UAT, use that. This pre-validation is an "optimisation"
         // for the web-ui where operations will make a number of api calls, and we don't
         // want to do redundant work.
+        match pre_validated_token {
+            PreValidatedTokenStatus::Valid(uat) => {
+                return self.process_uat_to_identity(&uat, ct, source)
+            }
+            PreValidatedTokenStatus::SessionExpired => return Err(OperationError::SessionExpired),
+            PreValidatedTokenStatus::NotAuthenticated | PreValidatedTokenStatus::None => {
+                // Fall through and verify the credential details.
+                //
+                // NOTE: Currently pre-validation only applies to UAT, not certificate
+                // or api token flows. These will incorrectly set the pre-validation
+                // to NotAuthenticated. It's a larger refactor to correct that.
+            }
+        }
 
         match (client_cert, bearer_token) {
             (Some(client_cert_info), _) => {
@@ -747,9 +758,15 @@ pub trait IdmServerTransaction<'a> {
         let entry = self
             .get_qs_txn()
             .internal_search_uuid(uat.uuid)
-            .map_err(|e| {
-                admin_error!(?e, "from_ro_uat failed");
-                e
+            .map_err(|err| {
+                error!(?err, "from_ro_uat failed");
+                // If the account was deleted, or has not yet been replicated to this instance,
+                // we need to inform the user that the session they are using isn't valid. So
+                // we pass up SessionExpired here.
+                match err {
+                    OperationError::NoMatchingEntries => OperationError::SessionExpired,
+                    err => err,
+                }
             })?;
 
         let valid = Account::check_user_auth_token_valid(ct, uat, &entry);

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -437,7 +437,7 @@ pub trait IdmServerTransaction<'a> {
             PreValidatedTokenStatus::NotAuthenticated | PreValidatedTokenStatus::None => {
                 // Fall through and verify the credential details.
                 //
-                // NOTE: Currently pre-validation only applies to UAT, not certificate
+                // TODO: Currently pre-validation only applies to UAT, not certificate
                 // or api token flows. These will incorrectly set the pre-validation
                 // to NotAuthenticated. It's a larger refactor to correct that.
             }


### PR DESCRIPTION
# Change summary

- When an account is deleted it would show a "no matching entries" error rather than redirect to the login screen
- When an account is deleted we now return "session expired" so that the login flow is triggered.

Fixes #4266

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
