### PR TITLE
Add missing kanidm-mail-sender binary to kanidm/tools container

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -80,10 +80,12 @@ RUN \
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ldap-sync /sbin/
+COPY --from=builder /usr/src/kanidm/target/release/kanidm-mail-sender /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/fido-mds-tool /sbin/
 RUN chmod +x /sbin/kanidm
 RUN chmod +x /sbin/kanidm-ipa-sync
 RUN chmod +x /sbin/kanidm-ldap-sync
+RUN chmod +x /sbin/kanidm-mail-sender
 RUN chmod +x /sbin/fido-mds-tool
 
 RUN mkdir /etc/kanidm && \


### PR DESCRIPTION
# Change summary

While reviewing the Kanidm documentation for sending password reset emails, I noticed that the required commands could not be executed because the corresponding binary was not present in the container. Although the binary is built during the builder stage, it is never copied into the final image.

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
