### PR TITLE
Invert incorrect thread count logic

### DIFF
--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -959,7 +959,7 @@ impl ConfigurationBuilder {
 
     // We always set threads to 1 unless it's the main server.
     pub fn is_server_mode(mut self, is_server: bool) -> Self {
-        if is_server {
+        if !is_server {
             self.threads = 1;
         }
         self


### PR DESCRIPTION
# Change summary

- The is_server check for thread count assignment was incorrect, and incorrectly limited the server to a single thread. 

Fixes #4293

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
