### PR TITLE
Resolve base64 encoding of webauthn fields

### DIFF
--- a/server/core/src/https/views/login.rs
+++ b/server/core/src/https/views/login.rs
@@ -8,6 +8,7 @@ use crate::https::{
 };
 use askama::Template;
 use askama_web::WebTemplate;
+use base64::{engine::general_purpose, Engine as _};
 
 use axum::http::HeaderMap;
 use axum::{
@@ -951,7 +952,8 @@ async fn view_login_step(
                                 LoginBackupCodeView { display_ctx }.into_response()
                             }
                             AuthAllowed::SecurityKey(chal) => {
-                                let chal_json = serde_json::to_string(&chal)
+                                let chal_json = serde_json::to_vec(&chal)
+                                    .map(|data| general_purpose::STANDARD.encode(data))
                                     .map_err(|_| OperationError::SerdeJsonError)?;
                                 LoginWebauthnView {
                                     display_ctx,
@@ -961,7 +963,8 @@ async fn view_login_step(
                                 .into_response()
                             }
                             AuthAllowed::Passkey(chal) => {
-                                let chal_json = serde_json::to_string(&chal)
+                                let chal_json = serde_json::to_vec(&chal)
+                                    .map(|data| general_purpose::STANDARD.encode(data))
                                     .map_err(|_| OperationError::SerdeJsonError)?;
                                 LoginWebauthnView {
                                     display_ctx,

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -24,6 +24,7 @@ use axum_htmx::{
     HxEvent, HxLocation, HxPushUrl, HxRequest, HxReselect, HxResponseTrigger, HxReswap, HxRetarget,
     SwapOption,
 };
+use base64::{engine::general_purpose, Engine as _};
 use futures_util::TryFutureExt;
 use kanidm_proto::internal::{
     CUCredState, CUExtPortal, CURegState, CURegWarning, CURequest, CUSessionToken, CUStatus,
@@ -505,7 +506,9 @@ pub(crate) async fn view_new_passkey(
 
     let response = match cu_status.mfaregstate {
         CURegState::Passkey(chal) | CURegState::AttestedPasskey(chal) => {
-            if let Ok(challenge) = serde_json::to_string(&chal) {
+            if let Ok(challenge) =
+                serde_json::to_vec(&chal).map(|data| general_purpose::STANDARD.encode(data))
+            {
                 AddPasskeyPartial {
                     challenge,
                     class: init_form.class,

--- a/server/core/static/modules/cred_update.mjs
+++ b/server/core/static/modules/cred_update.mjs
@@ -57,12 +57,13 @@ function onPasskeyCreated(assertion) {
         let creationData = {};
 
         creationData.id = assertion.id;
-        creationData.rawId = Base64.fromUint8Array(new Uint8Array(assertion.rawId));
+        creationData.rawId = Base64.fromUint8Array(new Uint8Array(assertion.rawId), true);
         creationData.response = {};
         creationData.response.attestationObject = Base64.fromUint8Array(
             new Uint8Array(assertion.response.attestationObject),
+            true
         );
-        creationData.response.clientDataJSON = Base64.fromUint8Array(new Uint8Array(assertion.response.clientDataJSON));
+        creationData.response.clientDataJSON = Base64.fromUint8Array(new Uint8Array(assertion.response.clientDataJSON), true);
         creationData.type = assertion.type;
         creationData.extensions = assertion.getClientExtensionResults();
         creationData.extensions.uvm = undefined;
@@ -89,7 +90,7 @@ function onPasskeyCreated(assertion) {
 function startPasskeyEnrollment() {
     try {
         const form = document.getElementById("passkeyNamingForm");
-        const credentialRequestOptions = JSON.parse(decodeURIComponent(form.dataset.challenge));
+        const credentialRequestOptions = JSON.parse(atob(form.dataset.challenge));
         credentialRequestOptions.publicKey.challenge = Base64.toUint8Array(
             credentialRequestOptions.publicKey.challenge,
         );

--- a/server/core/static/pkhtml.js
+++ b/server/core/static/pkhtml.js
@@ -12,7 +12,7 @@
 
 function passkey_login() {
     let form = document.getElementById("cred-form");
-    let credentialRequestOptions = JSON.parse(decodeURIComponent(form.dataset.challenge));
+    let credentialRequestOptions = JSON.parse(atob(form.dataset.challenge));
     credentialRequestOptions.publicKey.challenge = Base64.toUint8Array(credentialRequestOptions.publicKey.challenge);
     credentialRequestOptions.publicKey.allowCredentials?.forEach(function (listItem) {
         listItem.id = Base64.toUint8Array(listItem.id);


### PR DESCRIPTION
Webauthn 6.1-dev enforces stricter rules about base64 encoding. The JS on the credential creation page was encoding with standard/padded rather than url safe unpadded. This caused webauthn to refuse to create credentials.

- Initially I thought it was due to uri encoding, but it wasn't. I did change the forms to use base64 instead, which I'm happy to revert, I think the uri encoding worked fine. 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
