### PR TITLE
Fix inconsistent flag documentation: send-reset-token

### DIFF
--- a/book/src/accounts/authentication_and_credentials.md
+++ b/book/src/accounts/authentication_and_credentials.md
@@ -94,7 +94,7 @@ If you have [configured outbound email](/email_setup.md) you can send the reset 
 ```bash
 kanidm person credential send-reset-token [OPTIONS] <account_id> [ALTERNATE_EMAIL]
 kanidm person credential send-reset-token demo_user
-kanidm person credential send-reset-token --ttl 86400 demo_user secondary.address@example.com 
+kanidm person credential send-reset-token --ttl 86400 demo_user secondary.address@example.com
 ```
 
 Once the credential reset has been committed the token is immediately invalidated and can never be used again. By

--- a/book/src/accounts/authentication_and_credentials.md
+++ b/book/src/accounts/authentication_and_credentials.md
@@ -92,9 +92,9 @@ value.
 If you have [configured outbound email](/email_setup.md) you can send the reset link directly to the user's email with:
 
 ```bash
-kanidm person credential send-reset-token <account_id> [TTL] [ALTERNATE_EMAIL]
+kanidm person credential send-reset-token [OPTIONS] <account_id> [ALTERNATE_EMAIL]
 kanidm person credential send-reset-token demo_user
-kanidm person credential send-reset-token demo_user 86400 secondary.address@example.com
+kanidm person credential send-reset-token --ttl 86400 demo_user secondary.address@example.com 
 ```
 
 Once the credential reset has been committed the token is immediately invalidated and can never be used again. By


### PR DESCRIPTION
# Change summary
Fix inconsistency in documentation regarding new command: `kanidm person credential send-reset-token`
-

Fixes 
> If the TTL was adapted as an option rather as an argument, the ~dogs~ docs are missing the update 

 _Originally posted by @scaredmushroom in [#4259](https://github.com/kanidm/kanidm/pull/4259/changes/BASE..e671137511c94686f042f2c86c7917cb4bed55db#r3136483494)_

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
