### PR TITLE
Remove debug symbols in release builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
 # Single Largest Binary Maximum: 5GB
 # Time: ~6 minutes
 [profile.release]
-debug = true
+debug = "limited"
 strip = "none"
 lto = "thin"
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ debug = "limited"
 strip = "none"
 lto = "thin"
 opt-level = 3
-codegen-units = 32
+codegen-units = 1
 
 [profile.release.build-override]
 debug = false

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=cache,id=cargo,target=/cargo \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \
         --release; \
+    ls -alh /usr/src/kanidm/target/release; \
     sccache -s
 
 # Find and copy dynamically linked libraries using ldd


### PR DESCRIPTION
For a long time we've shipped with full debug symbols in our release profile. While in theory this is helpful, in reality it blew up the size of our containers for information we rarely if ever used.

This changes the default to "limited" so that rustc backtraces are still accurate, but without the full debuginfo set.

Fixes #4317

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
