### PR TITLE
fix(oauth2): prevent re-authentication loop in prompt=login flows after successful auth

### DIFF
--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1353,6 +1353,37 @@ impl QueryServerReadV1 {
         auth_req: AuthorisationRequest,
         eventid: Uuid,
     ) -> Result<AuthoriseResponse, Oauth2Error> {
+        self.handle_oauth2_authorise_inner(client_auth_info, auth_req, eventid, false)
+            .await
+    }
+
+    #[instrument(
+        level = "info",
+        skip_all,
+        fields(uuid = ?eventid)
+    )]
+    pub async fn handle_oauth2_authorise_resume(
+        &self,
+        client_auth_info: ClientAuthInfo,
+        auth_req: AuthorisationRequest,
+        eventid: Uuid,
+    ) -> Result<AuthoriseResponse, Oauth2Error> {
+        self.handle_oauth2_authorise_inner(client_auth_info, auth_req, eventid, true)
+            .await
+    }
+
+    #[instrument(
+        level = "info",
+        skip_all,
+        fields(uuid = ?eventid)
+    )]
+    async fn handle_oauth2_authorise_inner(
+        &self,
+        client_auth_info: ClientAuthInfo,
+        auth_req: AuthorisationRequest,
+        eventid: Uuid,
+        resume_after_auth: bool,
+    ) -> Result<AuthoriseResponse, Oauth2Error> {
         let ct = duration_from_epoch_now();
         let mut idms_prox_read = self
             .idms
@@ -1367,7 +1398,11 @@ impl QueryServerReadV1 {
             .ok();
 
         // Now we can send to the idm server for authorisation checking.
-        idms_prox_read.check_oauth2_authorisation(ident.as_ref(), &auth_req, ct)
+        if resume_after_auth {
+            idms_prox_read.check_oauth2_authorisation_resume(ident.as_ref(), &auth_req, ct)
+        } else {
+            idms_prox_read.check_oauth2_authorisation(ident.as_ref(), &auth_req, ct)
+        }
     }
 
     #[instrument(

--- a/server/core/src/https/views/oauth2.rs
+++ b/server/core/src/https/views/oauth2.rs
@@ -73,7 +73,7 @@ pub async fn view_resume_get(
     let maybe_auth_req =
         cookies::get_signed::<AuthorisationRequest>(&state, &jar, COOKIE_OAUTH2_REQ);
 
-    oauth2_auth_req(
+    oauth2_auth_req_resume(
         state,
         kopid,
         client_auth_info,
@@ -91,6 +91,47 @@ async fn oauth2_auth_req(
     domain_info: DomainInfoRead,
     jar: CookieJar,
     maybe_auth_req: Option<AuthorisationRequest>,
+) -> Response {
+    oauth2_auth_req_inner(
+        state,
+        kopid,
+        client_auth_info,
+        domain_info,
+        jar,
+        maybe_auth_req,
+        false,
+    )
+    .await
+}
+
+async fn oauth2_auth_req_resume(
+    state: ServerState,
+    kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
+    domain_info: DomainInfoRead,
+    jar: CookieJar,
+    maybe_auth_req: Option<AuthorisationRequest>,
+) -> Response {
+    oauth2_auth_req_inner(
+        state,
+        kopid,
+        client_auth_info,
+        domain_info,
+        jar,
+        maybe_auth_req,
+        true,
+    )
+    .await
+}
+
+async fn oauth2_auth_req_inner(
+    state: ServerState,
+    kopid: KOpId,
+    client_auth_info: ClientAuthInfo,
+    domain_info: DomainInfoRead,
+    jar: CookieJar,
+    maybe_auth_req: Option<AuthorisationRequest>,
+    resume_after_auth: bool,
 ) -> Response {
     // No matter what, we always clear the stored oauth2 cookie to prevent
     // ui loops
@@ -111,10 +152,17 @@ async fn oauth2_auth_req(
             .into_response();
     };
 
-    let res: Result<AuthoriseResponse, Oauth2Error> = state
-        .qe_r_ref
-        .handle_oauth2_authorise(client_auth_info, auth_req.clone(), kopid.eventid)
-        .await;
+    let res = if resume_after_auth {
+        state
+            .qe_r_ref
+            .handle_oauth2_authorise_resume(client_auth_info, auth_req.clone(), kopid.eventid)
+            .await
+    } else {
+        state
+            .qe_r_ref
+            .handle_oauth2_authorise(client_auth_info, auth_req.clone(), kopid.eventid)
+            .await
+    };
 
     match res {
         Ok(AuthoriseResponse::Permitted(success)) => {

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2168,6 +2168,27 @@ impl IdmServerProxyReadTransaction<'_> {
         auth_req: &AuthorisationRequest,
         ct: Duration,
     ) -> Result<AuthoriseResponse, Oauth2Error> {
+        self.check_oauth2_authorisation_inner(maybe_ident, auth_req, ct, false)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    pub fn check_oauth2_authorisation_resume(
+        &self,
+        maybe_ident: Option<&Identity>,
+        auth_req: &AuthorisationRequest,
+        ct: Duration,
+    ) -> Result<AuthoriseResponse, Oauth2Error> {
+        self.check_oauth2_authorisation_inner(maybe_ident, auth_req, ct, true)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    fn check_oauth2_authorisation_inner(
+        &self,
+        maybe_ident: Option<&Identity>,
+        auth_req: &AuthorisationRequest,
+        ct: Duration,
+        resume_after_auth: bool,
+    ) -> Result<AuthoriseResponse, Oauth2Error> {
         // due to identity processing we already know that:
         // * the session must be authenticated, and valid
         // * is within it's valid time window.
@@ -2376,7 +2397,7 @@ impl IdmServerProxyReadTransaction<'_> {
 
         // OIDC Core 1.0 §3.1.2.1
         // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate
-        if auth_req.prompt.contains(&Prompt::Login) {
+        if auth_req.prompt.contains(&Prompt::Login) && !resume_after_auth {
             debug!("prompt=login was requested, forcing re-authentication");
             return Ok(AuthoriseResponse::AuthenticationRequired {
                 client_name: o2rs.displayname.clone(),


### PR DESCRIPTION
I hit the same re-authentication loop from #4329 with Stalwart as the client.
The important constraint for this patch was to avoid mutating request parameters or cookies. I did not want to remove `prompt=login` from the original request or rewrite the stored OAuth2 request cookie. Instead, the fix makes `/ui/oauth2/resume` continue via internal server-side resume context, so the original request remains unchanged while the flow can complete successfully after login.