### PR TITLE
Allow SMTP urls in mail-sender

### DIFF
--- a/examples/mail_sender.toml
+++ b/examples/mail_sender.toml
@@ -29,9 +29,11 @@ mail_reply_to_address = "tobias@example.com"
 
 # The hostname/address of the outgoing SMTP relay. This must support TLS.
 # You can specify the port as well if it is not the default (465). For example:
-# mail_relay = "smtp.example.com:12345"
+# mail_relay = "smtps://smtp.example.com" // SMTPS relay
+# mail_relay = "smtp://smtp.example.com" // SMTP with StartTLS
+# mail_relay = "smtps://smtp.example.com:12345" // SMTPS with alternate port
 
-mail_relay = "smtp.example.com"
+mail_relay = "smtps://smtp.example.com"
 
 # The username to authenticate to the SMTP relay as.
 mail_username = "kanidm@example.com"

--- a/tools/mail_sender/src/config.rs
+++ b/tools/mail_sender/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
 
     pub mail_from_address: Address,
     pub mail_reply_to_address: Address,
-    pub mail_relay: String,
+    pub mail_relay: Url,
     pub mail_username: String,
     pub mail_password: String,
     /// Defaults to 15 seconds if not specified

--- a/tools/mail_sender/src/main.rs
+++ b/tools/mail_sender/src/main.rs
@@ -363,16 +363,14 @@ fn config_security_checks(cfg_path: &Path) -> bool {
 
 /// Build the mailer object, tests to ensure that the server doesn't include a scheme
 fn build_mailer(
-    mail_relay: &str,
+    mail_relay: &Url,
     creds: Credentials,
     timeout: u64,
 ) -> Result<AsyncSmtpTransport<Tokio1Executor>, ()> {
-    if mail_relay.contains("://") {
-        error!("Mail relay should not contain a scheme (e.g. 'smtp://'), just the hostname or hostname:port");
-        return Err(());
-    }
+    let mut url_secure = mail_relay.clone();
+    url_secure.set_query(Some("tls=required"));
 
-    match AsyncSmtpTransport::<Tokio1Executor>::relay(mail_relay) {
+    match AsyncSmtpTransport::<Tokio1Executor>::from_url(url_secure.as_str()) {
         Ok(mailer_builder) => Ok(mailer_builder
             .timeout(Some(Duration::from_secs(timeout)))
             .credentials(creds)
@@ -458,7 +456,7 @@ async fn driver_main(opt: Opt) -> Result<(), ()> {
     );
 
     let mailer = build_mailer(
-        mail_config.mail_relay.as_str(),
+        &mail_config.mail_relay,
         creds,
         mail_config.mail_connect_timeout_seconds,
     )?;
@@ -659,14 +657,25 @@ fn main() {
     };
 }
 
-#[tokio::test]
-async fn test_build_mailer() {
-    let creds = Credentials::new("username".to_owned(), "password".to_owned());
+#[cfg(test)]
+mod tests {
+    use super::build_mailer;
+    use lettre::transport::smtp::authentication::Credentials;
+    use url::Url;
 
-    build_mailer("example.com", creds.clone(), 1).expect("Failed to build mailer");
-    build_mailer("example.com:12345", creds.clone(), 1).expect("Failed to build mailer with port");
-    build_mailer("examplehost", creds.clone(), 1).expect("Failed to build mailer with short name");
+    #[tokio::test]
+    async fn test_build_mailer() {
+        let creds = Credentials::new("username".to_owned(), "password".to_owned());
 
-    // no scheme allowed
-    build_mailer("smtp://example.com", creds, 1).expect_err("Should fail with invalid host format");
+        build_mailer(&Url::parse("smtp://example.com").unwrap(), creds.clone(), 1)
+            .expect("Failed to build mailer");
+        build_mailer(
+            &Url::parse("smtp://example.com:12345").unwrap(),
+            creds.clone(),
+            1,
+        )
+        .expect("Failed to build mailer with port");
+        build_mailer(&Url::parse("smtp://examplehost").unwrap(), creds.clone(), 1)
+            .expect("Failed to build mailer with short name");
+    }
 }


### PR DESCRIPTION
In the original addition of the mail sender, we used the wrong connection function that didn't accept urls. This changes the setup to accept smtp urls, allowing the port to be changed.

Fixes #4322

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
