### PR TITLE
Add max_age / improve prompt=login - now without grace periods! 

### DIFF
--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -18,7 +18,7 @@ use kanidmd_lib::{
     event::{OnlineBackupEvent, SearchEvent, SearchResult, WhoamiResult},
     filter::{Filter, FilterInvalid},
     idm::account::ListUserAuthTokenEvent,
-    idm::authentication::AuthStep,
+    idm::authentication::{AuthStep, ReauthRequest},
     idm::credupdatesession::CredentialUpdateSessionToken,
     idm::event::{
         AuthEvent, AuthResult, CredentialStatusEvent, RadiusAuthTokenEvent, UnixGroupTokenEvent,
@@ -152,6 +152,7 @@ impl QueryServerReadV1 {
         &self,
         client_auth_info: ClientAuthInfo,
         issue: AuthIssueSession,
+        reauth_req: ReauthRequest,
         eventid: Uuid,
     ) -> Result<AuthResult, OperationError> {
         let ct = duration_from_epoch_now();
@@ -173,7 +174,7 @@ impl QueryServerReadV1 {
         // Generally things like auth denied are in Ok() msgs
         // so true errors should always trigger a rollback.
         let res = idm_auth
-            .reauth_init(ident, issue, ct, client_auth_info)
+            .reauth_init(ident, issue, ct, client_auth_info, reauth_req)
             .await
             .and_then(|r| idm_auth.commit().map(|_| r));
 

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -27,8 +27,8 @@ use kanidmd_lib::{
     idm::ldap::{LdapBoundToken, LdapResponseState},
     idm::oauth2::{
         AccessTokenIntrospectRequest, AccessTokenIntrospectResponse, AuthorisationRequest,
-        AuthoriseReject, AuthoriseResponse, JwkKeySet, Oauth2Error, Oauth2Rfc8414MetadataResponse,
-        OidcDiscoveryResponse, OidcToken,
+        AuthorisationRequestContext, AuthoriseReject, AuthoriseResponse, JwkKeySet, Oauth2Error,
+        Oauth2Rfc8414MetadataResponse, OidcDiscoveryResponse, OidcToken,
     },
     idm::server::{DomainInfoRead, IdmServerTransaction},
     idm::serviceaccount::ListApiTokenEvent,
@@ -1351,6 +1351,7 @@ impl QueryServerReadV1 {
         &self,
         client_auth_info: ClientAuthInfo,
         auth_req: AuthorisationRequest,
+        auth_req_ctx: AuthorisationRequestContext,
         eventid: Uuid,
     ) -> Result<AuthoriseResponse, Oauth2Error> {
         let ct = duration_from_epoch_now();
@@ -1367,7 +1368,7 @@ impl QueryServerReadV1 {
             .ok();
 
         // Now we can send to the idm server for authorisation checking.
-        idms_prox_read.check_oauth2_authorisation(ident.as_ref(), &auth_req, ct)
+        idms_prox_read.check_oauth2_authorisation(ident.as_ref(), &auth_req, &auth_req_ctx, ct)
     }
 
     #[instrument(

--- a/server/core/src/https/oauth2.rs
+++ b/server/core/src/https/oauth2.rs
@@ -25,12 +25,9 @@ use kanidm_proto::constants::uri::{
 };
 use kanidm_proto::constants::APPLICATION_JSON;
 use kanidm_proto::oauth2::AuthorisationResponse;
-
-#[cfg(feature = "dev-oauth2-device-flow")]
-use kanidm_proto::oauth2::DeviceAuthorizationResponse;
 use kanidmd_lib::idm::oauth2::{
-    AccessTokenIntrospectRequest, AccessTokenRequest, AuthorisationRequest, AuthoriseResponse,
-    ErrorResponse, Oauth2Error, TokenRevokeRequest,
+    AccessTokenIntrospectRequest, AccessTokenRequest, AuthorisationRequest,
+    AuthorisationRequestContext, AuthoriseResponse, ErrorResponse, Oauth2Error, TokenRevokeRequest,
 };
 use kanidmd_lib::prelude::f_eq;
 use kanidmd_lib::prelude::*;
@@ -38,6 +35,9 @@ use kanidmd_lib::value::PartialValue;
 use serde::{Deserialize, Serialize};
 use serde_with::formats::CommaSeparator;
 use serde_with::{serde_as, StringWithSeparator};
+
+#[cfg(feature = "dev-oauth2-device-flow")]
+use kanidm_proto::oauth2::DeviceAuthorizationResponse;
 
 #[cfg(feature = "dev-oauth2-device-flow")]
 use uri::OAUTH2_AUTHORISE_DEVICE;
@@ -188,9 +188,11 @@ async fn oauth2_authorise(
     kopid: KOpId,
     client_auth_info: ClientAuthInfo,
 ) -> impl IntoResponse {
+    let auth_req_ctx = AuthorisationRequestContext::default();
+
     let res: Result<AuthoriseResponse, Oauth2Error> = state
         .qe_r_ref
-        .handle_oauth2_authorise(client_auth_info, auth_req, kopid.eventid)
+        .handle_oauth2_authorise(client_auth_info, auth_req, auth_req_ctx, kopid.eventid)
         .await;
 
     match res {
@@ -240,9 +242,10 @@ async fn oauth2_authorise(
                 .body(body)
                 .unwrap()
         }
-        Ok(AuthoriseResponse::AuthenticationRequired { .. })
-        | Err(Oauth2Error::AuthenticationRequired) => {
-            // This will trigger our ui to auth and retry.
+        Ok(AuthoriseResponse::ReauthenticationRequired { .. })
+        | Ok(AuthoriseResponse::AuthenticationRequired { .. })
+        | Err(Oauth2Error::AuthenticationRequired) =>
+        {
             #[allow(clippy::unwrap_used)]
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)

--- a/server/core/src/https/v1.rs
+++ b/server/core/src/https/v1.rs
@@ -26,7 +26,7 @@ use kanidm_proto::v1::{
     AuthState as ProtoAuthState, Entry as ProtoEntry, GroupUnixExtend, SingleStringRequest,
     UatStatus, UnixGroupToken, UnixUserToken, WhoamiResponse,
 };
-use kanidmd_lib::idm::authentication::{AuthState, AuthStep};
+use kanidmd_lib::idm::authentication::{AuthState, AuthStep, ReauthRequest};
 use kanidmd_lib::idm::event::AuthResult;
 use kanidmd_lib::prelude::*;
 use kanidmd_lib::value::PartialValue;
@@ -2858,7 +2858,12 @@ pub async fn reauth(
     // This may change in the future ...
     let inter = state
         .qe_r_ref
-        .handle_reauth(client_auth_info, obj, kopid.eventid)
+        .handle_reauth(
+            client_auth_info,
+            obj,
+            ReauthRequest::GrantReadWrite,
+            kopid.eventid,
+        )
         .await;
     debug!("ReAuth result: {:?}", inter);
     auth_session_state_management(&state, jar, inter)

--- a/server/core/src/https/views/login.rs
+++ b/server/core/src/https/views/login.rs
@@ -8,8 +8,6 @@ use crate::https::{
 };
 use askama::Template;
 use askama_web::WebTemplate;
-use base64::{engine::general_purpose, Engine as _};
-
 use axum::http::HeaderMap;
 use axum::{
     extract::{Query, State},
@@ -17,6 +15,7 @@ use axum::{
     Extension, Form, Json,
 };
 use axum_extra::extract::cookie::{CookieJar, SameSite};
+use base64::{engine::general_purpose, Engine as _};
 use hyper::Uri;
 use kanidm_proto::internal::{
     UserAuthToken, COOKIE_AUTH_SESSION_ID, COOKIE_BEARER_TOKEN, COOKIE_CU_SESSION_TOKEN,
@@ -26,7 +25,9 @@ use kanidm_proto::{
     oauth2::{AccessTokenRequest, AccessTokenResponse},
     v1::{AuthAllowed, AuthIssueSession, AuthMech},
 };
-use kanidmd_lib::idm::authentication::{AuthCredential, AuthExternal, AuthState, AuthStep};
+use kanidmd_lib::idm::authentication::{
+    AuthCredential, AuthExternal, AuthState, AuthStep, ReauthRequest,
+};
 use kanidmd_lib::idm::event::AuthResult;
 use kanidmd_lib::prelude::OperationError;
 use kanidmd_lib::prelude::*;
@@ -229,7 +230,16 @@ pub async fn view_reauth_to_referer_get(
         error: None,
     };
 
-    Ok(view_reauth_get(state, client_auth_info, kopid, jar, redirect, display_ctx).await)
+    Ok(view_reauth_get(
+        state,
+        client_auth_info,
+        kopid,
+        jar,
+        redirect,
+        display_ctx,
+        ReauthRequest::GrantReadWrite,
+    )
+    .await)
 }
 
 pub async fn view_reauth_get(
@@ -239,6 +249,7 @@ pub async fn view_reauth_get(
     jar: CookieJar,
     return_location: &str,
     display_ctx: LoginDisplayCtx,
+    reauth_req: ReauthRequest,
 ) -> Response {
     let session_valid_result = state
         .qe_r_ref
@@ -252,6 +263,7 @@ pub async fn view_reauth_get(
                 .handle_reauth(
                     client_auth_info.clone(),
                     AuthIssueSession::Cookie,
+                    reauth_req,
                     kopid.eventid,
                 )
                 .await;
@@ -367,6 +379,7 @@ pub async fn view_oauth2_reauth_get(
         jar,
         Urls::Oauth2Resume.as_ref(),
         display_ctx,
+        ReauthRequest::VerifyCredentials,
     )
     .await
 }

--- a/server/core/src/https/views/login.rs
+++ b/server/core/src/https/views/login.rs
@@ -57,12 +57,14 @@ struct SessionContext {
 #[derive(Clone)]
 pub enum ReauthPurpose {
     ProfileSettings,
+    OAuth2 { client_name: String },
 }
 
 impl fmt::Display for ReauthPurpose {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ProfileSettings => write!(f, "Profile and Settings"),
+            Self::OAuth2 { client_name } => write!(f, "OAuth2 - {}", client_name),
         }
     }
 }
@@ -238,10 +240,6 @@ pub async fn view_reauth_get(
     return_location: &str,
     display_ctx: LoginDisplayCtx,
 ) -> Response {
-    // No matter what, we always clear the stored oauth2 cookie to prevent
-    // ui loops
-    let jar = cookies::destroy(jar, COOKIE_OAUTH2_REQ, &state);
-
     let session_valid_result = state
         .qe_r_ref
         .handle_auth_valid(client_auth_info.clone(), kopid.eventid)
@@ -353,6 +351,24 @@ pub fn view_oauth2_get(
         },
     )
         .into_response()
+}
+
+pub async fn view_oauth2_reauth_get(
+    state: ServerState,
+    client_auth_info: ClientAuthInfo,
+    kopid: KOpId,
+    jar: CookieJar,
+    display_ctx: LoginDisplayCtx,
+) -> Response {
+    view_reauth_get(
+        state,
+        client_auth_info,
+        kopid,
+        jar,
+        Urls::Oauth2Resume.as_ref(),
+        display_ctx,
+    )
+    .await
 }
 
 pub async fn view_index_get(

--- a/server/core/src/https/views/mod.rs
+++ b/server/core/src/https/views/mod.rs
@@ -2,7 +2,6 @@ use crate::https::views::admin::{admin_api_router, admin_router};
 use crate::https::{middleware, ServerState};
 use askama::Template;
 use askama_web::WebTemplate;
-
 use axum::{
     middleware::from_fn_with_state,
     response::Redirect,

--- a/server/core/src/https/views/oauth2.rs
+++ b/server/core/src/https/views/oauth2.rs
@@ -1,20 +1,16 @@
+use super::login::{LoginDisplayCtx, Oauth2Ctx};
+use super::{cookies, UnrecoverableErrorView};
+use crate::https::views::{
+    errors::HtmxError,
+    login::{Reauth, ReauthPurpose},
+};
 use crate::https::{
     extractors::{DomainInfo, DomainInfoRead, VerifiedClientInformation},
     middleware::KOpId,
     ServerState,
 };
-use kanidmd_lib::idm::oauth2::{AuthorisationRequest, AuthoriseResponse, Oauth2Error};
-use kanidmd_lib::prelude::*;
-
-use kanidm_proto::internal::COOKIE_OAUTH2_REQ;
-
-use std::collections::BTreeSet;
-
 use askama::Template;
 use askama_web::WebTemplate;
-
-#[cfg(feature = "dev-oauth2-device-flow")]
-use axum::http::StatusCode;
 use axum::{
     extract::{Query, State},
     http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -23,10 +19,17 @@ use axum::{
 };
 use axum_extra::extract::cookie::{CookieJar, SameSite};
 use axum_htmx::HX_REDIRECT;
+use kanidm_proto::internal::UserAuthToken;
+use kanidm_proto::internal::COOKIE_OAUTH2_REQ;
+use kanidmd_lib::idm::oauth2::{
+    AuthorisationRequest, AuthorisationRequestContext, AuthoriseResponse, Oauth2Error,
+};
+use kanidmd_lib::prelude::*;
 use serde::Deserialize;
+use std::collections::BTreeSet;
 
-use super::login::{LoginDisplayCtx, Oauth2Ctx};
-use super::{cookies, UnrecoverableErrorView};
+#[cfg(feature = "dev-oauth2-device-flow")]
+use axum::http::StatusCode;
 
 #[derive(Template, WebTemplate)]
 #[template(path = "oauth2_consent_request.html")]
@@ -44,6 +47,14 @@ struct AccessDeniedView {
     operation_id: Uuid,
 }
 
+#[derive(Default)]
+enum AuthReqState {
+    #[default]
+    None,
+    Initial(AuthorisationRequest),
+    Resumed(AuthorisationRequest),
+}
+
 pub async fn view_index_get(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
@@ -58,7 +69,7 @@ pub async fn view_index_get(
         client_auth_info,
         domain_info,
         jar,
-        Some(auth_req),
+        AuthReqState::Initial(auth_req),
     )
     .await
 }
@@ -71,7 +82,9 @@ pub async fn view_resume_get(
     jar: CookieJar,
 ) -> Response {
     let maybe_auth_req =
-        cookies::get_signed::<AuthorisationRequest>(&state, &jar, COOKIE_OAUTH2_REQ);
+        cookies::get_signed::<AuthorisationRequest>(&state, &jar, COOKIE_OAUTH2_REQ)
+            .map(AuthReqState::Resumed)
+            .unwrap_or_default();
 
     oauth2_auth_req(
         state,
@@ -90,7 +103,8 @@ async fn oauth2_auth_req(
     client_auth_info: ClientAuthInfo,
     domain_info: DomainInfoRead,
     jar: CookieJar,
-    maybe_auth_req: Option<AuthorisationRequest>,
+    // maybe_auth_req: Option<AuthorisationRequest>,
+    auth_req: AuthReqState,
 ) -> Response {
     // No matter what, we always clear the stored oauth2 cookie to prevent
     // ui loops
@@ -98,28 +112,37 @@ async fn oauth2_auth_req(
 
     // If the auth_req was cross-signed, old, or just bad, error. But we have *cleared* it
     // from the cookie which means we won't see it again.
-    let Some(auth_req) = maybe_auth_req else {
-        error!("unable to resume session, no valid auth_req was found in the cookie. This cookie has been removed.");
-        return (
-            jar,
-            UnrecoverableErrorView {
-                err_code: OperationError::UI0003InvalidOauth2Resume,
-                operation_id: kopid.eventid,
-                domain_info,
-            },
-        )
-            .into_response();
+
+    let (auth_req, auth_req_ctx) = match auth_req {
+        AuthReqState::Initial(ar) => (ar, AuthorisationRequestContext::default()),
+        AuthReqState::Resumed(ar) => (ar, AuthorisationRequestContext::resumed_session()),
+        AuthReqState::None => {
+            error!("unable to resume session, no valid auth_req was found in the cookie. This cookie has been removed.");
+            return (
+                jar,
+                UnrecoverableErrorView {
+                    err_code: OperationError::UI0003InvalidOauth2Resume,
+                    operation_id: kopid.eventid,
+                    domain_info,
+                },
+            )
+                .into_response();
+        }
     };
 
     let res: Result<AuthoriseResponse, Oauth2Error> = state
         .qe_r_ref
-        .handle_oauth2_authorise(client_auth_info, auth_req.clone(), kopid.eventid)
+        .handle_oauth2_authorise(
+            client_auth_info.clone(),
+            auth_req.clone(),
+            auth_req_ctx,
+            kopid.eventid,
+        )
         .await;
 
     match res {
         Ok(AuthoriseResponse::Permitted(success)) => {
             let redirect_uri = success.build_redirect_uri();
-
             (
                 jar,
                 [
@@ -152,7 +175,61 @@ async fn oauth2_auth_req(
             )
                 .into_response()
         }
+        Ok(AuthoriseResponse::ReauthenticationRequired { client_name }) => {
+            // Sign the auth req and hide it in our cookie - we'll come back for
+            // you later.
+            let maybe_jar = cookies::make_signed(&state, COOKIE_OAUTH2_REQ, &auth_req)
+                .map(|mut cookie| {
+                    cookie.set_same_site(SameSite::Strict);
+                    // Expire at the end of the session.
+                    cookie.set_expires(None);
+                    // Could experiment with this to a shorter value, but session should be enough.
+                    cookie.set_max_age(time::Duration::minutes(15));
+                    jar.clone().add(cookie)
+                })
+                .ok_or(OperationError::InvalidSessionState);
 
+            let new_jar = match maybe_jar {
+                Ok(jar) => jar,
+                Err(err_code) => {
+                    return (
+                        jar,
+                        UnrecoverableErrorView {
+                            err_code,
+                            operation_id: kopid.eventid,
+                            domain_info,
+                        },
+                    )
+                        .into_response();
+                }
+            };
+
+            let uat: &UserAuthToken = match client_auth_info.pre_validated_uat() {
+                Ok(uat) => uat,
+                Err(op_err) => {
+                    return HtmxError::new(&kopid, op_err, domain_info.clone()).into_response()
+                }
+            };
+
+            let display_ctx = LoginDisplayCtx {
+                domain_info,
+                oauth2: None,
+                reauth: Some(Reauth {
+                    username: uat.spn.clone(),
+                    purpose: ReauthPurpose::OAuth2 { client_name },
+                }),
+                error: None,
+            };
+
+            super::login::view_oauth2_reauth_get(
+                state,
+                client_auth_info,
+                kopid,
+                new_jar,
+                display_ctx,
+            )
+            .await
+        }
         Ok(AuthoriseResponse::AuthenticationRequired {
             client_name,
             login_hint,

--- a/server/core/src/https/views/oauth2.rs
+++ b/server/core/src/https/views/oauth2.rs
@@ -103,7 +103,6 @@ async fn oauth2_auth_req(
     client_auth_info: ClientAuthInfo,
     domain_info: DomainInfoRead,
     jar: CookieJar,
-    // maybe_auth_req: Option<AuthorisationRequest>,
     auth_req: AuthReqState,
 ) -> Response {
     // No matter what, we always clear the stored oauth2 cookie to prevent

--- a/server/core/src/https/views/reauth.rs
+++ b/server/core/src/https/views/reauth.rs
@@ -9,6 +9,7 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use axum_extra::extract::cookie::CookieJar;
 use kanidm_proto::internal::{PrivilegesActive, UserAuthToken};
+use kanidmd_lib::idm::authentication::ReauthRequest;
 use kanidmd_lib::idm::server::DomainInfoRead;
 use kanidmd_lib::prelude::ClientAuthInfo;
 use uuid::Uuid;
@@ -99,6 +100,7 @@ pub(crate) async fn render_reauth(
         jar,
         return_to.as_ref(),
         display_ctx,
+        ReauthRequest::GrantReadWrite,
     )
     .await)
 }

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -191,9 +191,9 @@ pub const OAUTH_REFRESH_TOKEN_EXPIRY: u32 = 3600 * 16;
 /// of the refresh token, which is bound to the issuing session.
 pub const OAUTH2_ACCESS_TOKEN_EXPIRY: u32 = 15 * 60;
 
-/// The grace window for prompt=login. If the user has authenticated
-/// within this window, we assume their authentication is fresh enough.
-pub const OAUTH2_OIDC_PROMPT_LOGIN_GRACE: Duration = Duration::from_secs(300);
+
+/// The absolute maximum that can be requested for max-age requests in OIDC.
+pub const OAUTH2_OIDC_MAX_AGE_CLAMP: i64 = 86400;
 
 /// The amount of time a suppliers clock can be "ahead" before
 /// we warn about possible clock synchronisation issues.

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -191,7 +191,6 @@ pub const OAUTH_REFRESH_TOKEN_EXPIRY: u32 = 3600 * 16;
 /// of the refresh token, which is bound to the issuing session.
 pub const OAUTH2_ACCESS_TOKEN_EXPIRY: u32 = 15 * 60;
 
-
 /// The absolute maximum that can be requested for max-age requests in OIDC.
 pub const OAUTH2_OIDC_MAX_AGE_CLAMP: i64 = 86400;
 

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -191,6 +191,10 @@ pub const OAUTH_REFRESH_TOKEN_EXPIRY: u32 = 3600 * 16;
 /// of the refresh token, which is bound to the issuing session.
 pub const OAUTH2_ACCESS_TOKEN_EXPIRY: u32 = 15 * 60;
 
+/// The grace window for prompt=login. If the user has authenticated
+/// within this window, we assume their authentication is fresh enough.
+pub const OAUTH2_OIDC_PROMPT_LOGIN_GRACE: Duration = Duration::from_secs(300);
+
 /// The amount of time a suppliers clock can be "ahead" before
 /// we warn about possible clock synchronisation issues.
 pub const REPL_SUPPLIER_ADVANCE_WINDOW: Duration = Duration::from_secs(600);

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -423,6 +423,7 @@ impl Account {
         session_id: Uuid,
         session_expiry: Option<OffsetDateTime>,
         scope: SessionScope,
+        read_write: bool,
         ct: Duration,
         account_policy: &ResolvedAccountPolicy,
     ) -> Option<UserAuthToken> {
@@ -439,21 +440,21 @@ impl Account {
                 );
                 return None;
             }
-            SessionScope::PrivilegeCapable =>
-            // Return a ReadWrite session with an inner expiry for the privileges
-            {
+            SessionScope::PrivilegeCapable if read_write => {
+                // Return a ReadWrite session with an inner expiry for the privileges
                 let expiry = Some(
                     OffsetDateTime::UNIX_EPOCH
                         + ct
                         + Duration::from_secs(account_policy.privilege_expiry().into()),
                 );
-                (
-                    UatPurpose::ReadWrite { expiry },
-                    // Needs to come from the actual original session. If we don't do this we have
-                    // to re-update the expiry in the DB. We don't want a re-auth to extend a time
-                    // bound session.
-                    session_expiry,
-                )
+                // session_expiry needs to come from the actual original session. If we don't do this we have
+                // to re-update the expiry in the DB. We don't want a re-auth to extend a time
+                // bound session.
+                (UatPurpose::ReadWrite { expiry }, session_expiry)
+            }
+            SessionScope::PrivilegeCapable => {
+                // The user is not requesting privileges, just proof of presence. Reissue as priv capable.
+                (UatPurpose::ReadWrite { expiry: None }, session_expiry)
             }
         };
 

--- a/server/lib/src/idm/authentication.rs
+++ b/server/lib/src/idm/authentication.rs
@@ -141,6 +141,13 @@ impl fmt::Debug for AuthCredential {
     }
 }
 
+#[derive(Default)]
+pub enum ReauthRequest {
+    #[default]
+    VerifyCredentials,
+    GrantReadWrite,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) enum PreValidatedTokenStatus {
     #[default]

--- a/server/lib/src/idm/authsession/mod.rs
+++ b/server/lib/src/idm/authsession/mod.rs
@@ -8,7 +8,7 @@ use crate::credential::{BackupCodes, Credential, CredentialType, Password};
 use crate::idm::account::Account;
 use crate::idm::accountpolicy::ResolvedAccountPolicy;
 use crate::idm::audit::AuditEvent;
-use crate::idm::authentication::{AuthCredential, AuthExternal, AuthState};
+use crate::idm::authentication::{AuthCredential, AuthExternal, AuthState, ReauthRequest};
 use crate::idm::delayed::{
     AuthSessionRecord, BackupCodeRemoval, DelayedAction, PasswordUpgrade, WebauthnCounterIncrement,
 };
@@ -57,6 +57,7 @@ enum AuthIntent {
         privileged: bool,
     },
     Reauth {
+        read_write: bool,
         session_id: Uuid,
         session_expiry: Option<OffsetDateTime>,
     },
@@ -1274,6 +1275,7 @@ impl AuthSession {
         session: &Session,
         cred_id: Uuid,
         key_object: Arc<KeyObject>,
+        reauth_req: &ReauthRequest,
     ) -> (Option<Self>, AuthState) {
         #[allow(clippy::large_enum_variant)]
         /// An inner enum to allow us to more easily define state within this fn
@@ -1395,12 +1397,18 @@ impl AuthSession {
         match state {
             State::Proceed(handler) => {
                 let next_auth_state = handler.next_auth_state();
+                let read_write = match reauth_req {
+                    ReauthRequest::GrantReadWrite => true,
+                    ReauthRequest::VerifyCredentials => false,
+                };
+
                 let auth_session = AuthSession {
                     account: asd.account,
                     account_policy: asd.account_policy,
                     state: AuthSessionState::InProgress(handler),
                     issue: asd.issue,
                     intent: AuthIntent::Reauth {
+                        read_write,
                         session_id,
                         session_expiry,
                     },
@@ -1695,6 +1703,7 @@ impl AuthSession {
                 Ok(uat)
             }
             AuthIntent::Reauth {
+                read_write,
                 session_id,
                 session_expiry,
             } => {
@@ -1719,6 +1728,7 @@ impl AuthSession {
                         session_id,
                         session_expiry,
                         scope,
+                        read_write,
                         time,
                         &self.account_policy,
                     )

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2403,16 +2403,6 @@ impl IdmServerProxyReadTransaction<'_> {
         // Login on every request with this param.
         // We can always add a login timestamp later on.
 
-        // OIDC Core 1.0 §3.1.2.1
-        // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate
-        if auth_req.prompt.contains(&Prompt::Login) {
-            debug!("prompt=login was requested, forcing re-authentication");
-            return Ok(AuthoriseResponse::AuthenticationRequired {
-                client_name: o2rs.displayname.clone(),
-                login_hint: auth_req.oidc_ext.login_hint.clone(),
-            });
-        }
-
         // TODO: display = popup vs touch vs wap etc.
 
         // TODO: max_age, pass through with consent req. If 0, force login.
@@ -2438,6 +2428,31 @@ impl IdmServerProxyReadTransaction<'_> {
                 });
             }
         };
+
+        // OIDC Core 1.0 §3.1.2.1
+        // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate
+        if auth_req.prompt.contains(&Prompt::Login) {
+            // Was the session recently validated?
+            // This calculates current time minus grace. This way if the session was issued *after*
+            // this deadline, then it must be valid.
+            let odt_prompt_deadline =
+                (OffsetDateTime::UNIX_EPOCH + ct) - OAUTH2_OIDC_PROMPT_LOGIN_GRACE;
+
+            let session_recently_validated = ident
+                .get_session()
+                .map(|session| session.issued_at > odt_prompt_deadline)
+                .unwrap_or_default();
+
+            if session_recently_validated {
+                debug!("prompt=login was requested, session is fresh enough to proceed");
+            } else {
+                debug!("prompt=login was requested, forcing re-authentication");
+                return Ok(AuthoriseResponse::AuthenticationRequired {
+                    client_name: o2rs.displayname.clone(),
+                    login_hint: auth_req.oidc_ext.login_hint.clone(),
+                });
+            }
+        }
 
         let account_uuid = ident.get_uuid();
 
@@ -8576,7 +8591,20 @@ mod tests {
 
         let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::Login]));
 
-        // Even though the user is authenticated, prompt=login should force re-auth.
+        // We are within the grace time, no prompt forced.
+        let result = idms_prox_read
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .expect("prompt=login should not error");
+
+        assert!(
+            matches!(result, AuthoriseResponse::ConsentRequested { .. }),
+            "prompt=login should not have been forced"
+        );
+
+        // Even though the user is authenticated, prompt=login should force re-auth as the session
+        // is outside of the grace period.
+        let ct = ct + OAUTH2_OIDC_PROMPT_LOGIN_GRACE;
+
         let result = idms_prox_read
             .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("prompt=login should not error");

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -234,7 +234,7 @@ struct TokenExchangeCode {
 pub(crate) enum Oauth2TokenType {
     Refresh {
         scopes: BTreeSet<String>,
-        parent_session_id: Uuid,
+        parent_session_id: Option<Uuid>,
         session_id: Uuid,
         exp: i64,
         uuid: Uuid,
@@ -274,6 +274,10 @@ pub enum AuthoriseResponse {
         client_name: String,
         // A username hint, if any
         login_hint: Option<String>,
+    },
+    ReauthenticationRequired {
+        // A pretty-name of the client
+        client_name: String,
     },
     ConsentRequested {
         // A pretty-name of the client
@@ -1550,7 +1554,7 @@ impl IdmServerProxyWriteTransaction<'_> {
 
         // ==== We are now GOOD TO GO! ====
         // Grant the access token response.
-        let parent_session_id = code_xchg.session_id;
+        let parent_session_id = Some(code_xchg.session_id);
         let session_id = Uuid::new_v4();
 
         let scopes = code_xchg.scopes;
@@ -1623,7 +1627,7 @@ impl IdmServerProxyWriteTransaction<'_> {
                     .check_oauth2_account_uuid_valid(
                         uuid,
                         session_id,
-                        Some(parent_session_id),
+                        parent_session_id,
                         iat,
                         ct,
                     )
@@ -1814,7 +1818,7 @@ impl IdmServerProxyWriteTransaction<'_> {
             process_requested_scopes_for_identity(o2rs, &ident, req_scopes)?;
 
         let session_id = Uuid::new_v4();
-        let parent_session_id = apit.token_id;
+        let parent_session_id = None;
         let account_uuid = apit.account_id;
 
         self.generate_access_token_response(
@@ -1942,14 +1946,12 @@ impl IdmServerProxyWriteTransaction<'_> {
         //
         scopes: BTreeSet<String>,
         account_uuid: Uuid,
-        parent_session_id: Uuid,
+        parent_session_id: Option<Uuid>,
         session_id: Uuid,
         nonce: Option<String>,
     ) -> Result<AccessTokenResponse, Oauth2Error> {
         let odt_ct = OffsetDateTime::UNIX_EPOCH + ct;
         let iat = ct.as_secs() as i64;
-
-        // TODO: Configurable from the oauth2rs configuration?
 
         // Disclaimer: It may seem odd here that we are ignoring our session when it comes to expiry
         // times. However, this actually is valid because when we take the initial code exchange
@@ -1958,6 +1960,9 @@ impl IdmServerProxyWriteTransaction<'_> {
         // expiries are *purely* for the tokens we issue and are *not related* to the expiries of the
         // the session - these are enforced as above!
 
+        // Refresh tokens can be configured, but access token expiry can not. This is because
+        // OAuth2 has no *revocation* mechanism, so we need to be validating and re-issuing
+        // access tokens frequently.
         let expiry = odt_ct + Duration::from_secs(OAUTH2_ACCESS_TOKEN_EXPIRY as u64);
         let expires_in = OAUTH2_ACCESS_TOKEN_EXPIRY;
         let refresh_expiry = iat + o2rs.refresh_token_expiry as i64;
@@ -1974,6 +1979,28 @@ impl IdmServerProxyWriteTransaction<'_> {
 
         let client_id = o2rs.name.clone();
 
+        let entry = match self.qs_write.internal_search_uuid(account_uuid) {
+            Ok(entry) => entry,
+            Err(err) => return Err(Oauth2Error::ServerError(err)),
+        };
+
+        // TODO: Should probably pass from the ident OR the refresh token which will
+        // retain a copy!
+        let auth_time = if let Some(parent_session_id) = parent_session_id {
+            let parent_session = entry
+                .get_ava_as_session_map(Attribute::UserAuthTokenSession)
+                .and_then(|sessions| sessions.get(&parent_session_id))
+                .ok_or_else(|| {
+                    error!(?parent_session_id, id = %entry.get_display_id(), "Unable to locate parent session");
+                    Oauth2Error::ServerError(OperationError::InvalidState)
+                })?;
+
+            // Should be based on last-auth-time!!!
+            Some(parent_session.issued_at.unix_timestamp())
+        } else {
+            None
+        };
+
         let id_token = if scopes.contains(OAUTH2_SCOPE_OPENID) {
             // TODO: Scopes map to claims:
             //
@@ -1987,17 +2014,10 @@ impl IdmServerProxyWriteTransaction<'_> {
             // TODO: Can the user consent to which claims are released? Today as we don't support most
             // of them anyway, no, but in the future, we can stash these to the consent req.
 
-            // TODO: If max_age was requested in the request, we MUST provide auth_time.
-
             // amr == auth method
             // We removed this from uat, and I think that it's okay here. AMR is a bit useless anyway
             // since there is no standard for what it should look like wrt to cred strength.
             let amr = None;
-
-            let entry = match self.qs_write.internal_search_uuid(account_uuid) {
-                Ok(entry) => entry,
-                Err(err) => return Err(Oauth2Error::ServerError(err)),
-            };
 
             let account = match Account::try_from_entry_rw(&entry, &mut self.qs_write) {
                 Ok(account) => account,
@@ -2014,7 +2034,7 @@ impl IdmServerProxyWriteTransaction<'_> {
                 iat,
                 nbf: Some(iat),
                 exp,
-                auth_time: None,
+                auth_time,
                 nonce: nonce.clone(),
                 at_hash: None,
                 acr: None,
@@ -2059,13 +2079,13 @@ impl IdmServerProxyWriteTransaction<'_> {
             jti: session_id,
             client_id,
             extensions: OAuth2RFC9068TokenExtensions {
-                auth_time: None,
+                auth_time,
                 acr: None,
                 amr: None,
                 scope: scopes.clone(),
                 nonce: nonce.clone(),
                 session_id,
-                parent_session_id: Some(parent_session_id),
+                parent_session_id,
             },
         };
 
@@ -2117,7 +2137,7 @@ impl IdmServerProxyWriteTransaction<'_> {
         let session = Value::Oauth2Session(
             session_id,
             Oauth2Session {
-                parent: Some(parent_session_id),
+                parent: parent_session_id,
                 state: SessionState::ExpiresAt(odt_refresh_expiry),
                 issued_at: odt_ct,
                 rs_uuid: o2rs.uuid,
@@ -2397,16 +2417,8 @@ impl IdmServerProxyReadTransaction<'_> {
         // prompt - if set to login, we need to force a re-auth. But we don't want to
         // if the user "only just" logged in, that's annoying. So we need a time window for
         // this, to detect when we should force it to the consent req.
-        //
-        // Idk man, Sure its a little awkward but with how few apps actually use `prompt=login`
-        // I think it is unlikely we will cause a significant amount of user friction by forcing
-        // Login on every request with this param.
-        // We can always add a login timestamp later on.
 
         // TODO: display = popup vs touch vs wap etc.
-
-        // TODO: max_age, pass through with consent req. If 0, force login.
-        // Otherwise force a login re the uat timeout.
 
         // TODO: ui_locales / claims_locales for the ui. Only if we don't have a Uat that
         // would provide this.
@@ -2429,27 +2441,43 @@ impl IdmServerProxyReadTransaction<'_> {
             }
         };
 
-        // OIDC Core 1.0 §3.1.2.1
-        // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate
-        if auth_req.prompt.contains(&Prompt::Login) {
-            // Was the session recently validated?
-            // This calculates current time minus grace. This way if the session was issued *after*
-            // this deadline, then it must be valid.
-            let odt_prompt_deadline =
-                (OffsetDateTime::UNIX_EPOCH + ct) - OAUTH2_OIDC_PROMPT_LOGIN_GRACE;
 
-            let session_recently_validated = ident
-                .get_session()
-                .map(|session| session.issued_at > odt_prompt_deadline)
-                .unwrap_or_default();
+
+        // OIDC Core 1.0 §3.1.2.1
+        // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate.
+        // This is equivalent to max_age=0;
+        let max_age = if auth_req.prompt.contains(&Prompt::Login) {
+            Some(0)
+        } else {
+            auth_req.max_age
+                .map(|m| m.clamp(0, OAUTH2_OIDC_MAX_AGE_CLAMP))
+        };
+
+        if let Some(max_age) = max_age {
+            let session_recently_validated = if max_age <= 0 {
+                // Reauth will be forced.
+                false
+            } else {
+                let odt_prompt_deadline =
+                    (OffsetDateTime::UNIX_EPOCH + ct) - Duration::from_secs(max_age as u64);
+
+                // Was the session recently validated?
+                // This calculates current time minus grace. This way if the session was issued *after*
+                // this deadline, then it must be valid.
+                let session_recently_validated = ident
+                    .get_session()
+                    .map(|session| session.issued_at > odt_prompt_deadline)
+                    .unwrap_or_default();
+
+                session_recently_validated
+            };
 
             if session_recently_validated {
                 debug!("prompt=login was requested, session is fresh enough to proceed");
             } else {
                 debug!("prompt=login was requested, forcing re-authentication");
-                return Ok(AuthoriseResponse::AuthenticationRequired {
+                return Ok(AuthoriseResponse::ReauthenticationRequired {
                     client_name: o2rs.displayname.clone(),
-                    login_hint: auth_req.oidc_ext.login_hint.clone(),
                 });
             }
         }
@@ -2952,7 +2980,7 @@ impl IdmServerProxyReadTransaction<'_> {
             client_id: _,
             extensions:
                 OAuth2RFC9068TokenExtensions {
-                    auth_time: _,
+                    auth_time,
                     acr: _,
                     amr: _,
                     scope: scopes,
@@ -3001,7 +3029,7 @@ impl IdmServerProxyReadTransaction<'_> {
             iat,
             nbf: Some(nbf),
             exp,
-            auth_time: None,
+            auth_time,
             nonce,
             at_hash: None,
             acr: None,
@@ -5728,7 +5756,7 @@ mod tests {
         assert_eq!(oidc.nbf, Some(iat));
         // Previously this was the auth session but it's now inline with the access token expiry.
         assert_eq!(oidc.exp, iat + (OAUTH2_ACCESS_TOKEN_EXPIRY as i64));
-        assert!(oidc.auth_time.is_none());
+        assert!(oidc.auth_time.is_some());
         // Is nonce correctly passed through?
         assert_eq!(oidc.nonce, Some("abcdef".to_string()));
         assert!(oidc.at_hash.is_none());
@@ -5765,7 +5793,7 @@ mod tests {
         assert_eq!(oidc.iat, userinfo.iat);
         assert_eq!(oidc.nbf, userinfo.nbf);
         assert_eq!(oidc.exp, userinfo.exp);
-        assert!(userinfo.auth_time.is_none());
+        assert_eq!(oidc.auth_time, userinfo.auth_time);
         assert_eq!(userinfo.nonce, Some("abcdef".to_string()));
         assert!(userinfo.at_hash.is_none());
         assert!(userinfo.acr.is_none());
@@ -5813,7 +5841,7 @@ mod tests {
         assert_eq!(oidc.iat, userinfo.iat);
         assert_eq!(oidc.nbf, userinfo.nbf);
         assert_eq!(oidc.exp, userinfo.exp);
-        assert!(userinfo.auth_time.is_none());
+        assert_eq!(oidc.auth_time, userinfo.auth_time);
         assert_eq!(userinfo.nonce, Some("abcdef".to_string()));
         assert!(userinfo.at_hash.is_none());
         assert!(userinfo.acr.is_none());
@@ -7661,7 +7689,7 @@ mod tests {
         assert_eq!(oidc.nbf, Some(iat));
         // Previously this was the auth session but it's now inline with the access token expiry.
         assert_eq!(oidc.exp, iat + (OAUTH2_ACCESS_TOKEN_EXPIRY as i64));
-        assert!(oidc.auth_time.is_none());
+        assert!(oidc.auth_time.is_some());
         // Is nonce correctly passed through?
         assert_eq!(oidc.nonce, Some("abcdef".to_string()));
         assert!(oidc.at_hash.is_none());
@@ -7709,7 +7737,7 @@ mod tests {
         assert_eq!(oidc.iat, userinfo.iat);
         assert_eq!(oidc.nbf, userinfo.nbf);
         assert_eq!(oidc.exp, userinfo.exp);
-        assert!(userinfo.auth_time.is_none());
+        assert_eq!(oidc.auth_time, userinfo.auth_time);
         assert_eq!(userinfo.nonce, Some("abcdef".to_string()));
         assert!(userinfo.at_hash.is_none());
         assert!(userinfo.jti.is_some());
@@ -8572,6 +8600,7 @@ mod tests {
         );
     }
 
+
     /// OIDC Core 1.0 §3.1.2.1 prompt=login:
     ///
     /// > The Authorization Server SHOULD prompt the End-User for reauthentication.
@@ -8582,6 +8611,8 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
+        const OAUTH2_OIDC_PROMPT_LOGIN_GRACE: i64 = 300;
+
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
         let (_secret, _uat, ident, _) =
             setup_oauth2_resource_server_basic(idms, ct, true, false, false).await;
@@ -8589,7 +8620,8 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
-        let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::Login]));
+        let mut auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([]));
+        auth_req.max_age = Some(OAUTH2_OIDC_PROMPT_LOGIN_GRACE);
 
         // We are within the grace time, no prompt forced.
         let result = idms_prox_read
@@ -8601,16 +8633,28 @@ mod tests {
             "prompt=login should not have been forced"
         );
 
-        // Even though the user is authenticated, prompt=login should force re-auth as the session
-        // is outside of the grace period.
-        let ct = ct + OAUTH2_OIDC_PROMPT_LOGIN_GRACE;
+        // Even though the user is authenticated, max_age now will force re-auth as the session
+        // is outside of the max_age period.
+        let ct = ct + Duration::from_secs(OAUTH2_OIDC_PROMPT_LOGIN_GRACE as u64);
 
         let result = idms_prox_read
             .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
             .expect("prompt=login should not error");
 
         assert!(
-            matches!(result, AuthoriseResponse::AuthenticationRequired { .. }),
+            matches!(result, AuthoriseResponse::ReauthenticationRequired { .. }),
+            "max_age must force re-authentication even when user is already authenticated"
+        );
+
+        // Prompt login always forces reauth.
+        let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::Login]));
+
+        let result = idms_prox_read
+            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .expect("prompt=login should not error");
+
+        assert!(
+            matches!(result, AuthoriseResponse::ReauthenticationRequired { .. }),
             "prompt=login must force re-authentication even when user is already authenticated"
         );
     }

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2476,7 +2476,12 @@ impl IdmServerProxyReadTransaction<'_> {
 
                 // Was the session recently validated?
                 auth_time
-                    .map(|at| at > odt_prompt_deadline)
+                    .map(|at| {
+                        // We need to limit this to whole seconds.
+                        let at = at.truncate_to_second();
+                        let odt_prompt_deadline = odt_prompt_deadline.truncate_to_second();
+                        at > odt_prompt_deadline
+                    })
                     .unwrap_or_default()
             };
 

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -184,6 +184,12 @@ impl AuthorisationRequestContext {
     }
 }
 
+struct OAuth2SessionContext {
+    pub(crate) auth_time: Option<OffsetDateTime>,
+    pub(crate) nonce: Option<String>,
+    pub(crate) account_uuid: Uuid,
+}
+
 // == internal state formats that we encrypt and send.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 enum SupportedResponseMode {
@@ -239,6 +245,7 @@ struct TokenExchangeCode {
     pub scopes: BTreeSet<String>,
     // We stash some details here for oidc.
     pub nonce: Option<String>,
+    pub auth_time: Option<OffsetDateTime>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -254,6 +261,7 @@ pub(crate) enum Oauth2TokenType {
         nbf: i64,
         // We stash some details here for oidc.
         nonce: Option<String>,
+        auth_time: Option<OffsetDateTime>,
     },
     ClientAccess {
         scopes: BTreeSet<String>,
@@ -1427,6 +1435,7 @@ impl IdmServerProxyWriteTransaction<'_> {
             redirect_uri: consent_req.redirect_uri.clone(),
             scopes: consent_req.scopes.clone(),
             nonce: consent_req.nonce,
+            auth_time: ident.last_verified_at(),
         };
 
         // Encrypt the exchange token
@@ -1569,17 +1578,19 @@ impl IdmServerProxyWriteTransaction<'_> {
         let session_id = Uuid::new_v4();
 
         let scopes = code_xchg.scopes;
-        let account_uuid = code_xchg.account_uuid;
-        let nonce = code_xchg.nonce;
+        let session_ctx = OAuth2SessionContext {
+            auth_time: code_xchg.auth_time,
+            nonce: code_xchg.nonce,
+            account_uuid: code_xchg.account_uuid,
+        };
 
         self.generate_access_token_response(
             o2rs,
             ct,
             scopes,
-            account_uuid,
             parent_session_id,
             session_id,
-            nonce,
+            session_ctx,
         )
     }
 
@@ -1626,6 +1637,7 @@ impl IdmServerProxyWriteTransaction<'_> {
                 iat,
                 nbf: _,
                 nonce,
+                auth_time,
             } => {
                 if exp <= ct.as_secs() as i64 {
                     security_info!(?uuid, "refresh token has expired, ");
@@ -1706,17 +1718,16 @@ impl IdmServerProxyWriteTransaction<'_> {
 
                 // ----------
                 // good to go
-
                 let account_uuid = uuid;
+                let session_ctx = OAuth2SessionContext { auth_time, nonce, account_uuid };
 
                 self.generate_access_token_response(
                     o2rs,
                     ct,
                     update_scopes,
-                    account_uuid,
                     parent_session_id,
                     session_id,
-                    nonce,
+                    session_ctx,
                 )
             }
         }
@@ -1824,16 +1835,20 @@ impl IdmServerProxyWriteTransaction<'_> {
 
         let session_id = Uuid::new_v4();
         let parent_session_id = None;
-        let account_uuid = apit.account_id;
+        let session_ctx = OAuth2SessionContext {
+            // Service accounts don't have an auth time
+            auth_time: None,
+            account_uuid: apit.account_id,
+            nonce: None,
+        };
 
         self.generate_access_token_response(
             o2rs,
             ct,
             granted_scopes,
-            account_uuid,
             parent_session_id,
             session_id,
-            None,
+            session_ctx,
         )
     }
 
@@ -1948,12 +1963,10 @@ impl IdmServerProxyWriteTransaction<'_> {
         &mut self,
         o2rs: &Oauth2RS,
         ct: Duration,
-        //
         scopes: BTreeSet<String>,
-        account_uuid: Uuid,
         parent_session_id: Option<Uuid>,
         session_id: Uuid,
-        nonce: Option<String>,
+        session_ctx: OAuth2SessionContext,
     ) -> Result<AccessTokenResponse, Oauth2Error> {
         let odt_ct = OffsetDateTime::UNIX_EPOCH + ct;
         let iat = ct.as_secs() as i64;
@@ -1984,27 +1997,12 @@ impl IdmServerProxyWriteTransaction<'_> {
 
         let client_id = o2rs.name.clone();
 
-        let entry = match self.qs_write.internal_search_uuid(account_uuid) {
+        let entry = match self.qs_write.internal_search_uuid(session_ctx.account_uuid) {
             Ok(entry) => entry,
             Err(err) => return Err(Oauth2Error::ServerError(err)),
         };
 
-        // TODO: Should probably pass from the ident OR the refresh token which will
-        // retain a copy!
-        let auth_time = if let Some(parent_session_id) = parent_session_id {
-            let parent_session = entry
-                .get_ava_as_session_map(Attribute::UserAuthTokenSession)
-                .and_then(|sessions| sessions.get(&parent_session_id))
-                .ok_or_else(|| {
-                    error!(?parent_session_id, id = %entry.get_display_id(), "Unable to locate parent session");
-                    Oauth2Error::ServerError(OperationError::InvalidState)
-                })?;
-
-            // Should be based on last-auth-time!!!
-            Some(parent_session.issued_at.unix_timestamp())
-        } else {
-            None
-        };
+        let auth_time = session_ctx.auth_time;
 
         let id_token = if scopes.contains(OAUTH2_SCOPE_OPENID) {
             // TODO: Scopes map to claims:
@@ -2034,13 +2032,13 @@ impl IdmServerProxyWriteTransaction<'_> {
 
             let oidc = OidcToken {
                 iss: iss.clone(),
-                sub: OidcSubject::U(account_uuid),
+                sub: OidcSubject::U(session_ctx.account_uuid),
                 aud: aud.clone(),
                 iat,
                 nbf: Some(iat),
                 exp,
-                auth_time,
-                nonce: nonce.clone(),
+                auth_time: auth_time.map(|at| at.unix_timestamp()),
+                nonce: session_ctx.nonce.clone(),
                 at_hash: None,
                 acr: None,
                 amr,
@@ -2076,7 +2074,7 @@ impl IdmServerProxyWriteTransaction<'_> {
         // We need to record this into the record? Delayed action?
         let access_token_data = OAuth2RFC9068Token {
             iss: iss.to_string(),
-            sub: account_uuid,
+            sub: session_ctx.account_uuid,
             aud,
             exp,
             nbf: iat,
@@ -2084,11 +2082,11 @@ impl IdmServerProxyWriteTransaction<'_> {
             jti: session_id,
             client_id,
             extensions: OAuth2RFC9068TokenExtensions {
-                auth_time,
+                auth_time: auth_time.map(|at| at.unix_timestamp()),
                 acr: None,
                 amr: None,
                 scope: scopes.clone(),
-                nonce: nonce.clone(),
+                nonce: session_ctx.nonce.clone(),
                 session_id,
                 parent_session_id,
             },
@@ -2115,10 +2113,11 @@ impl IdmServerProxyWriteTransaction<'_> {
             parent_session_id,
             session_id,
             exp: refresh_expiry,
-            uuid: account_uuid,
+            uuid: session_ctx.account_uuid,
             iat,
             nbf: iat,
-            nonce,
+            nonce: session_ctx.nonce,
+            auth_time,
         };
 
         let refresh_token_data = JweBuilder::into_json(&refresh_token_raw)
@@ -2159,7 +2158,7 @@ impl IdmServerProxyWriteTransaction<'_> {
 
         self.qs_write
             .internal_modify(
-                &filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(account_uuid))),
+                &filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(session_ctx.account_uuid))),
                 &modlist,
             )
             .map_err(|e| {
@@ -2458,6 +2457,8 @@ impl IdmServerProxyReadTransaction<'_> {
                 .map(|m| m.clamp(0, OAUTH2_OIDC_MAX_AGE_CLAMP))
         };
 
+        let auth_time = ident.last_verified_at();
+
         if let Some(max_age) = max_age {
             let session_recently_validated = if max_age <= 0 {
                 // Reauth will be forced.
@@ -2467,14 +2468,9 @@ impl IdmServerProxyReadTransaction<'_> {
                     (OffsetDateTime::UNIX_EPOCH + ct) - Duration::from_secs(max_age as u64);
 
                 // Was the session recently validated?
-                // This calculates current time minus grace. This way if the session was issued *after*
-                // this deadline, then it must be valid.
-                let session_recently_validated = ident
-                    .get_session()
-                    .map(|session| session.issued_at > odt_prompt_deadline)
-                    .unwrap_or_default();
-
-                session_recently_validated
+                auth_time
+                    .map(|at| at > odt_prompt_deadline)
+                    .unwrap_or_default()
             };
 
             if auth_req_ctx.resumed {
@@ -2544,6 +2540,7 @@ impl IdmServerProxyReadTransaction<'_> {
                 redirect_uri: auth_req.redirect_uri.clone(),
                 scopes: granted_scopes.into_iter().collect(),
                 nonce: auth_req.nonce.clone(),
+                auth_time,
             };
 
             // Encrypt the exchange token with the key of the client

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -1719,7 +1719,11 @@ impl IdmServerProxyWriteTransaction<'_> {
                 // ----------
                 // good to go
                 let account_uuid = uuid;
-                let session_ctx = OAuth2SessionContext { auth_time, nonce, account_uuid };
+                let session_ctx = OAuth2SessionContext {
+                    auth_time,
+                    nonce,
+                    account_uuid,
+                };
 
                 self.generate_access_token_response(
                     o2rs,
@@ -2158,7 +2162,10 @@ impl IdmServerProxyWriteTransaction<'_> {
 
         self.qs_write
             .internal_modify(
-                &filter!(f_eq(Attribute::Uuid, PartialValue::Uuid(session_ctx.account_uuid))),
+                &filter!(f_eq(
+                    Attribute::Uuid,
+                    PartialValue::Uuid(session_ctx.account_uuid)
+                )),
                 &modlist,
             )
             .map_err(|e| {

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -173,6 +173,17 @@ impl PkceS256Secret {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct AuthorisationRequestContext {
+    resumed: bool,
+}
+
+impl AuthorisationRequestContext {
+    pub fn resumed_session() -> Self {
+        Self { resumed: true }
+    }
+}
+
 // == internal state formats that we encrypt and send.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 enum SupportedResponseMode {
@@ -1624,13 +1635,7 @@ impl IdmServerProxyWriteTransaction<'_> {
                 // Check the session is still valid. This call checks the parent session
                 // and the OAuth2 session.
                 let valid = self
-                    .check_oauth2_account_uuid_valid(
-                        uuid,
-                        session_id,
-                        parent_session_id,
-                        iat,
-                        ct,
-                    )
+                    .check_oauth2_account_uuid_valid(uuid, session_id, parent_session_id, iat, ct)
                     .map_err(|_| admin_error!("Account is not valid"));
 
                 let Ok(Some(entry)) = valid else {
@@ -2215,12 +2220,13 @@ impl IdmServerProxyReadTransaction<'_> {
         &self,
         maybe_ident: Option<&Identity>,
         auth_req: &AuthorisationRequest,
+        auth_req_ctx: &AuthorisationRequestContext,
         ct: Duration,
     ) -> Result<AuthoriseResponse, Oauth2Error> {
         // due to identity processing we already know that:
         // * the session must be authenticated, and valid
         // * is within it's valid time window.
-        trace!(?auth_req);
+        trace!(?auth_req, ?auth_req_ctx);
 
         if auth_req.response_type != ResponseType::Code {
             admin_warn!("Unsupported OAuth2 response_type (should be 'code')");
@@ -2441,15 +2447,14 @@ impl IdmServerProxyReadTransaction<'_> {
             }
         };
 
-
-
         // OIDC Core 1.0 §3.1.2.1
         // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate.
         // This is equivalent to max_age=0;
         let max_age = if auth_req.prompt.contains(&Prompt::Login) {
             Some(0)
         } else {
-            auth_req.max_age
+            auth_req
+                .max_age
                 .map(|m| m.clamp(0, OAUTH2_OIDC_MAX_AGE_CLAMP))
         };
 
@@ -2472,7 +2477,11 @@ impl IdmServerProxyReadTransaction<'_> {
                 session_recently_validated
             };
 
-            if session_recently_validated {
+            if auth_req_ctx.resumed {
+                // We must have just arrived here after an authentication or reauthentication - as
+                // a result the session is fresh, and we can continue.
+                debug!("auth_request_context indicates that the session was just authenticated - proceeding.");
+            } else if session_recently_validated {
                 debug!("prompt=login was requested, session is fresh enough to proceed");
             } else {
                 debug!("prompt=login was requested, forcing re-authentication");
@@ -3576,7 +3585,8 @@ fn check_is_loopback(redirect_uri: &Url) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        CtSecret, Oauth2TokenType, PkceS256Secret, TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE_ACCESS,
+        AuthorisationRequestContext, CtSecret, Oauth2TokenType, PkceS256Secret,
+        TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE_ACCESS,
     };
     use crate::credential::Credential;
     use crate::idm::accountpolicy::ResolvedAccountPolicy;
@@ -3638,8 +3648,10 @@ mod tests {
                 unknown_keys: Default::default(),
             };
 
+            let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
             $idms_prox_read
-                .check_oauth2_authorisation(Some($ident), &auth_req, $ct)
+                .check_oauth2_authorisation(Some($ident), &auth_req, &auth_req_ctx, $ct)
                 .expect("OAuth2 authorisation failed")
         }};
     }
@@ -4211,6 +4223,8 @@ mod tests {
 
         let pkce_request = pkce_secret.to_request();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         //  * response type != code.
         let auth_req = AuthorisationRequest {
             // We're unlikely to support Implicit Grant
@@ -4231,7 +4245,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::UnsupportedResponseType
         );
@@ -4255,7 +4269,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidRequest
         );
@@ -4279,7 +4293,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidClientId
         );
@@ -4303,7 +4317,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -4327,7 +4341,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -4351,7 +4365,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -4374,7 +4388,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -4397,7 +4411,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -4420,7 +4434,7 @@ mod tests {
         };
 
         let req = idms_prox_read
-            .check_oauth2_authorisation(None, &auth_req, ct)
+            .check_oauth2_authorisation(None, &auth_req, &auth_req_ctx, ct)
             .unwrap();
 
         assert!(matches!(
@@ -4447,7 +4461,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::AccessDenied
         );
@@ -4471,7 +4485,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&idm_admin_ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&idm_admin_ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::AccessDenied
         );
@@ -4495,7 +4509,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&anon_ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&anon_ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::AccessDenied
         );
@@ -4776,6 +4790,8 @@ mod tests {
 
         let redirect_uri = Url::parse("https://portal.example.com/?custom=foo").unwrap();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
             response_mode: None,
@@ -4793,7 +4809,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("OAuth2 authorisation failed");
 
         trace!(?consent_request);
@@ -4877,7 +4893,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("OAuth2 authorisation failed");
 
         trace!(?consent_request);
@@ -6219,6 +6235,8 @@ mod tests {
             OAUTH2_SCOPE_OPENID.to_string()
         );
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         // Check we allow none.
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
@@ -6237,7 +6255,7 @@ mod tests {
         };
 
         idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("Oauth2 authorisation failed");
     }
 
@@ -6467,6 +6485,8 @@ mod tests {
 
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
             response_mode: None,
@@ -6488,7 +6508,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("Oauth2 authorisation failed");
 
         // Should be in the consent phase;
@@ -6551,7 +6571,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("Oauth2 authorisation failed");
 
         // Should be present in the consent phase however!
@@ -6674,6 +6694,8 @@ mod tests {
         // We attempt pkce even though the rs is set to not support pkce.
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         // First, the user does not request pkce in their exchange.
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
@@ -6692,7 +6714,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("Failed to perform OAuth2 authorisation request.");
 
         // Should be in the consent phase;
@@ -6753,6 +6775,8 @@ mod tests {
         // We attempt pkce even though the rs is set to not support pkce.
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         // First, NOTE the lack of https on the redir uri.
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
@@ -6772,7 +6796,7 @@ mod tests {
 
         assert!(
             idms_prox_read
-                .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+                .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
                 .unwrap_err()
                 == Oauth2Error::InvalidOrigin
         );
@@ -7819,6 +7843,8 @@ mod tests {
         // == Setup the authorisation request
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
             response_mode: None,
@@ -7836,7 +7862,7 @@ mod tests {
         };
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("OAuth2 authorisation failed");
 
         // Should be in the consent phase;
@@ -8307,6 +8333,8 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = AuthorisationRequest {
             response_type: ResponseType::Code,
             response_mode: None,
@@ -8325,7 +8353,7 @@ mod tests {
         println!("{auth_req:?}");
 
         let consent_request = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("OAuth2 authorisation failed");
 
         // Should be in the consent phase;
@@ -8450,6 +8478,8 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = auth_req_with_prompt(
             pkce_secret.to_request(),
             Vec::from([
@@ -8463,7 +8493,8 @@ mod tests {
         );
 
         // Too many prompt values should cause the request to be rejected with InvalidRequest
-        let result = idms_prox_read.check_oauth2_authorisation(Some(&ident), &auth_req, ct);
+        let result =
+            idms_prox_read.check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct);
 
         assert_eq!(
             result.unwrap_err(),
@@ -8491,12 +8522,15 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = auth_req_with_prompt(
             pkce_secret.to_request(),
             Vec::from([Prompt::Invalid(invalid_value)]),
         );
 
-        let result = idms_prox_read.check_oauth2_authorisation(Some(&ident), &auth_req, ct);
+        let result =
+            idms_prox_read.check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct);
 
         assert_eq!(
             result.unwrap_err(),
@@ -8524,10 +8558,12 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::None]));
 
         // No identity provided (None) - user is not authenticated.
-        let result = idms_prox_read.check_oauth2_authorisation(None, &auth_req, ct);
+        let result = idms_prox_read.check_oauth2_authorisation(None, &auth_req, &auth_req_ctx, ct);
 
         assert!(
             result.unwrap_err() == Oauth2Error::LoginRequired,
@@ -8554,10 +8590,13 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::None]));
 
         // Ident is authenticated but has never granted consent.
-        let result = idms_prox_read.check_oauth2_authorisation(Some(&ident), &auth_req, ct);
+        let result =
+            idms_prox_read.check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct);
 
         assert!(
             result.unwrap_err() == Oauth2Error::InteractionRequired,
@@ -8588,10 +8627,12 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::None]));
 
         let result = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("prompt=none with prior consent should succeed");
 
         assert!(
@@ -8599,7 +8640,6 @@ mod tests {
             "prompt=none with authenticated user and prior consent must return Permitted"
         );
     }
-
 
     /// OIDC Core 1.0 §3.1.2.1 prompt=login:
     ///
@@ -8620,12 +8660,14 @@ mod tests {
         let idms_prox_read = idms.proxy_read().await.unwrap();
         let pkce_secret = PkceS256Secret::default();
 
+        let auth_req_ctx = AuthorisationRequestContext { resumed: false };
+
         let mut auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([]));
         auth_req.max_age = Some(OAUTH2_OIDC_PROMPT_LOGIN_GRACE);
 
         // We are within the grace time, no prompt forced.
         let result = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("prompt=login should not error");
 
         assert!(
@@ -8638,7 +8680,7 @@ mod tests {
         let ct = ct + Duration::from_secs(OAUTH2_OIDC_PROMPT_LOGIN_GRACE as u64);
 
         let result = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("prompt=login should not error");
 
         assert!(
@@ -8650,12 +8692,25 @@ mod tests {
         let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::Login]));
 
         let result = idms_prox_read
-            .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
             .expect("prompt=login should not error");
 
         assert!(
             matches!(result, AuthoriseResponse::ReauthenticationRequired { .. }),
             "prompt=login must force re-authentication even when user is already authenticated"
+        );
+
+        // However, if the server indicates that our context is directly after a session resumption
+        // aka we just logged in - we can proceed.
+        let auth_req_ctx = AuthorisationRequestContext { resumed: true };
+
+        let result = idms_prox_read
+            .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
+            .expect("prompt=login should not error");
+
+        assert!(
+            matches!(result, AuthoriseResponse::ConsentRequested { .. }),
+            "prompt=login should not have been forced"
         );
     }
 
@@ -8687,7 +8742,7 @@ mod tests {
     //     let auth_req = auth_req_with_prompt(pkce_secret.to_request(), Vec::from([Prompt::Consent]));
 
     //     let result = idms_prox_read
-    //         .check_oauth2_authorisation(Some(&ident), &auth_req, ct)
+    //         .check_oauth2_authorisation(Some(&ident), &auth_req, &auth_req_ctx, ct)
     //         .expect("prompt=consent should not error");
 
     //     assert!(

--- a/server/lib/src/idm/reauth.rs
+++ b/server/lib/src/idm/reauth.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use crate::credential::softlock::CredSoftLock;
 use crate::idm::account::Account;
-use crate::idm::authentication::AuthState;
+use crate::idm::authentication::{AuthState, ReauthRequest};
 use crate::idm::authsession::{AuthSession, AuthSessionData};
 use crate::idm::event::AuthResult;
 use crate::idm::server::IdmServerAuthTransaction;
@@ -24,6 +24,7 @@ impl IdmServerAuthTransaction<'_> {
         issue: AuthIssueSession,
         ct: Duration,
         client_auth_info: ClientAuthInfo,
+        reauth_req: ReauthRequest,
     ) -> Result<AuthResult, OperationError> {
         // re-auth only works on users, so lets get the user account.
         // hint - it's in the ident!
@@ -141,8 +142,14 @@ impl IdmServerAuthTransaction<'_> {
 
         let domain_keys = self.qs_read.get_domain_key_object_handle()?;
 
-        let (auth_session, state) =
-            AuthSession::new_reauth(asd, ident.session_id, session, session_cred_id, domain_keys);
+        let (auth_session, state) = AuthSession::new_reauth(
+            asd,
+            ident.session_id,
+            session,
+            session_cred_id,
+            domain_keys,
+            &reauth_req,
+        );
 
         // Push the re-auth session to the session maps.
         match auth_session {
@@ -173,18 +180,15 @@ impl IdmServerAuthTransaction<'_> {
 mod tests {
     use crate::credential::totp::Totp;
     use crate::idm::audit::AuditEvent;
-    use crate::idm::authentication::AuthState;
+    use crate::idm::authentication::{AuthState, ReauthRequest};
     use crate::idm::credupdatesession::{InitCredentialUpdateEvent, MfaRegStateStatus};
     use crate::idm::delayed::DelayedAction;
     use crate::idm::event::{AuthEvent, AuthResult};
     use crate::idm::server::IdmServerTransaction;
     use crate::prelude::*;
-
-    use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech};
-
     use compact_jwt::JwsCompact;
+    use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech};
     use uuid::uuid;
-
     use webauthn_authenticator_rs::softpasskey::SoftPasskey;
     use webauthn_authenticator_rs::WebauthnAuthenticator;
 
@@ -489,6 +493,7 @@ mod tests {
         ident: &Identity,
         wa: &mut SoftPasskey,
         idms_delayed: &mut IdmServerDelayed,
+        reauth_req: ReauthRequest,
     ) -> Option<JwsCompact> {
         let mut idms_auth = idms.auth().await.unwrap();
         let origin = idms_auth.get_origin().clone();
@@ -499,6 +504,7 @@ mod tests {
                 AuthIssueSession::Token,
                 ct,
                 Source::Internal.into(),
+                reauth_req,
             )
             .await
             .expect("Failed to start reauth.");
@@ -565,6 +571,7 @@ mod tests {
                 AuthIssueSession::Token,
                 ct,
                 Source::Internal.into(),
+                ReauthRequest::GrantReadWrite,
             )
             .await
             .expect("Failed to start reauth.");
@@ -647,9 +654,16 @@ mod tests {
         assert!(matches!(session.scope, SessionScope::PrivilegeCapable));
 
         // Start the re-auth
-        let token = reauth_passkey(idms, ct, &ident, &mut passkey, idms_delayed)
-            .await
-            .expect("Failed to get new session token");
+        let token = reauth_passkey(
+            idms,
+            ct,
+            &ident,
+            &mut passkey,
+            idms_delayed,
+            ReauthRequest::GrantReadWrite,
+        )
+        .await
+        .expect("Failed to get new session token");
 
         // Token_str to uat
         let ident = token_to_ident(idms, ct, token.clone().into()).await;
@@ -657,6 +671,25 @@ mod tests {
         // They now have the entitlement.
         debug!(?ident);
         assert!(matches!(ident.access_scope(), AccessScope::ReadWrite));
+
+        // If you re-auth asking for verify only, you don't get the entitlement.
+        let token = reauth_passkey(
+            idms,
+            ct,
+            &ident,
+            &mut passkey,
+            idms_delayed,
+            ReauthRequest::VerifyCredentials,
+        )
+        .await
+        .expect("Failed to get new session token");
+
+        // Token_str to uat
+        let ident = token_to_ident(idms, ct, token.clone().into()).await;
+
+        // They now have the entitlement.
+        debug!(?ident);
+        assert!(matches!(ident.access_scope(), AccessScope::ReadOnly));
     }
 
     #[idm_test(audit = 1)]

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -822,6 +822,9 @@ pub trait IdmServerTransaction<'a> {
             uat.session_id,
             scope,
             limits,
+            // This strictly is the "last_verified_at" time but due to the current
+            // design of uat, issued_at is the same as last verification.
+            Some(uat.issued_at),
         ))
     }
 
@@ -841,14 +844,19 @@ pub trait IdmServerTransaction<'a> {
         }
 
         let scope = (&apit.purpose).into();
+        // While we did just verify the token, that's different to an interactive
+        // proof of presence like a human would provide.
+        let last_verified_at = None;
 
         let limits = Limits::api_token();
+
         Ok(Identity::new(
             IdentType::User(IdentUser { entry }),
             source,
             apit.token_id,
             scope,
             limits,
+            last_verified_at,
         ))
     }
 
@@ -934,6 +942,11 @@ pub trait IdmServerTransaction<'a> {
         }
 
         let certificate_uuid = cert_entry.get_uuid();
+        // The certificate is still valid, so we mark the session as always
+        // valid/issued at now. Because of how mTLS works, this means the
+        // certificate MUST have been JUST verified for the ongoing connection.
+        let odt_ct = OffsetDateTime::UNIX_EPOCH + ct;
+        let last_verified_at = Some(odt_ct);
 
         Ok(Identity::new(
             IdentType::User(IdentUser { entry }),
@@ -942,6 +955,7 @@ pub trait IdmServerTransaction<'a> {
             certificate_uuid,
             scope,
             limits,
+            last_verified_at,
         ))
     }
 
@@ -1031,6 +1045,9 @@ pub trait IdmServerTransaction<'a> {
             limits.search_max_filter_test = max_filter as usize;
         }
 
+        // Ldap sessions don't provide strong proof of presence.
+        let last_verified_at = None;
+
         // Users via LDAP are always only granted anonymous rights unless
         // they auth with an api-token
         Ok(Identity::new(
@@ -1039,6 +1056,7 @@ pub trait IdmServerTransaction<'a> {
             session_id,
             AccessScope::ReadOnly,
             limits,
+            last_verified_at,
         ))
     }
 
@@ -1121,6 +1139,7 @@ pub trait IdmServerTransaction<'a> {
 
         // If scope is not Synchronise, then fail.
         let scope = (&sync_token.purpose).into();
+        let last_verified_at = None;
 
         let limits = Limits::unlimited();
         Ok(Identity::new(
@@ -1129,6 +1148,7 @@ pub trait IdmServerTransaction<'a> {
             sync_token.token_id,
             scope,
             limits,
+            last_verified_at,
         ))
     }
 }

--- a/server/lib/src/server/identity.rs
+++ b/server/lib/src/server/identity.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeSet;
 use std::hash::Hash;
 use std::net::IpAddr;
 use std::sync::Arc;
+use time::OffsetDateTime;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Source {
@@ -149,6 +150,7 @@ pub struct Identity {
     pub(crate) session_id: Uuid,
     pub(crate) scope: AccessScope,
     limits: Limits,
+    last_verified_at: Option<OffsetDateTime>,
 }
 
 impl std::fmt::Display for Identity {
@@ -178,6 +180,7 @@ impl Identity {
         session_id: Uuid,
         scope: AccessScope,
         limits: Limits,
+        last_verified_at: Option<OffsetDateTime>,
     ) -> Self {
         Self {
             origin,
@@ -185,6 +188,7 @@ impl Identity {
             session_id,
             scope,
             limits,
+            last_verified_at,
         }
     }
 
@@ -202,6 +206,12 @@ impl Identity {
         &mut self.limits
     }
 
+    /// This is the time at which the session associated with this identity last
+    /// had it's credentials postively verified at.
+    pub(crate) fn last_verified_at(&self) -> Option<OffsetDateTime> {
+        self.last_verified_at
+    }
+
     pub(crate) fn migration() -> Self {
         Identity {
             origin: IdentType::Internal(InternalRole::Migration),
@@ -209,6 +219,7 @@ impl Identity {
             session_id: UUID_INTERNAL_SESSION_ID,
             scope: AccessScope::ReadWrite,
             limits: Limits::unlimited(),
+            last_verified_at: None,
         }
     }
 
@@ -219,6 +230,7 @@ impl Identity {
             session_id: UUID_INTERNAL_SESSION_ID,
             scope: AccessScope::ReadOnly,
             limits: Limits::unlimited(),
+            last_verified_at: None,
         }
     }
 
@@ -229,6 +241,7 @@ impl Identity {
             session_id: UUID_INTERNAL_SESSION_ID,
             scope: AccessScope::ReadWrite,
             limits: Limits::unlimited(),
+            last_verified_at: None,
         }
     }
 
@@ -239,6 +252,7 @@ impl Identity {
             session_id: UUID_INTERNAL_SESSION_ID,
             scope: AccessScope::ReadWrite,
             limits: Limits::unlimited(),
+            last_verified_at: None,
         }
     }
 
@@ -252,6 +266,7 @@ impl Identity {
             session_id: UUID_INTERNAL_SESSION_ID,
             scope: AccessScope::ReadOnly,
             limits: Limits::unlimited(),
+            last_verified_at: None,
         }
     }
 
@@ -264,6 +279,7 @@ impl Identity {
             session_id: UUID_INTERNAL_SESSION_ID,
             scope: AccessScope::ReadWrite,
             limits: Limits::unlimited(),
+            last_verified_at: None,
         }
     }
 

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -276,7 +276,7 @@ async fn test_oauth2_openid_basic_flow_impl(
         ("code_challenge_method", "S256"),
         ("redirect_uri", TEST_INTEGRATION_RS_REDIRECT_URL),
         ("scope", "email read openid"),
-        ("max_age", "1"),
+        ("max_age", "15"),
     ];
 
     if let Some(response_mode) = response_mode {


### PR DESCRIPTION
This improves prompt=login, importantly cycle breaking when the login is performed from the session resumption.

Fixes #4321

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
