### PR TITLE
Fix false positive permission warning for directories

### DIFF
--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -574,8 +574,8 @@ async fn start_daemon(opt: KanidmdParser, config: Configuration) -> ExitCode {
                 warn!("WARNING: DB folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", db_par_path_buf.to_str().unwrap_or("invalid file path"));
             }
             #[cfg(not(target_os = "windows"))]
-            if i_meta.mode() & 0o007 != 0 {
-                warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str().unwrap_or("invalid file path"));
+            if i_meta.mode() & 0o002 != 0 {
+                warn!("WARNING: DB folder {} has 'everyone' write permission in the mode. This could be a security risk ...", db_par_path_buf.to_str().unwrap_or("invalid file path"));
             }
         }
     } else {
@@ -844,8 +844,8 @@ async fn kanidm_main(config: Configuration, opt: KanidmdParser) -> ExitCode {
                         warn!("WARNING: TLS Client CA folder permissions on {} indicate it may not be RW. This could cause the server start up to fail!", ca_dir.display());
                     }
                     #[cfg(not(target_os = "windows"))]
-                    if i_meta.mode() & 0o007 != 0 {
-                        warn!("WARNING: TLS Client CA folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", ca_dir.display());
+                    if i_meta.mode() & 0o002 != 0 {
+                        warn!("WARNING: TLS Client CA folder {} has 'everyone' write permission in the mode. This could be a security risk ...", ca_dir.display());
                     }
                 }
             }

--- a/unix_integration/resolver_common/src/cli/resolver.rs
+++ b/unix_integration/resolver_common/src/cli/resolver.rs
@@ -702,8 +702,8 @@ async fn main_inner<F: SparkleFlavour>(clap_args: clap::ArgMatches, flavour: F) 
                         );
             }
 
-            if i_meta.mode() & 0o007 != 0 {
-                warn!("WARNING: DB folder {} has 'everyone' permission bits in the mode. This could be a security risk ...", db_par_path_buf.to_str()
+            if i_meta.mode() & 0o002 != 0 {
+                warn!("WARNING: DB folder {} has 'everyone' write permission in the mode. This could be a security risk ...", db_par_path_buf.to_str()
                         .unwrap_or("<db_par_path_buf invalid>")
                         );
             }


### PR DESCRIPTION
## Summary

- Fix overly broad permission bitmask `0o007` (any world bit) to `0o002` (world-writable only) in DB folder and TLS CA folder checks
- Directories with world-readable or world-executable bits (e.g. `0o755`, common default) no longer trigger a spurious security warning
- Updated warning message to specify "write permission" instead of the vague "permission bits"

Applies to `server/daemon/src/main.rs` and `unix_integration/resolver_common/src/cli/resolver.rs`.

Fixes #3910

## Test plan

- [ ] Start kanidmd with a DB directory at mode `0o755` and verify no warning is emitted
- [ ] Set DB directory to `0o777` (world-writable) and verify the warning fires
- [ ] Confirm `kanidm-unixd` resolver shows the same corrected behavior