### PR TITLE
Disable prompt=login

### DIFF
--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -2377,11 +2377,7 @@ impl IdmServerProxyReadTransaction<'_> {
         // OIDC Core 1.0 §3.1.2.1
         // prompt=login - The Authorization Server MUST prompt the End-User to re-authenticate
         if auth_req.prompt.contains(&Prompt::Login) {
-            debug!("prompt=login was requested, forcing re-authentication");
-            return Ok(AuthoriseResponse::AuthenticationRequired {
-                client_name: o2rs.displayname.clone(),
-                login_hint: auth_req.oidc_ext.login_hint.clone(),
-            });
+            debug!("prompt=login is currently disabled.");
         }
 
         // TODO: display = popup vs touch vs wap etc.
@@ -8528,6 +8524,7 @@ mod tests {
         );
     }
 
+    /*
     /// OIDC Core 1.0 §3.1.2.1 prompt=login:
     ///
     /// > The Authorization Server SHOULD prompt the End-User for reauthentication.
@@ -8557,6 +8554,7 @@ mod tests {
             "prompt=login must force re-authentication even when user is already authenticated"
         );
     }
+    */
 
     //TODO: Implement prompt=consent. Requires supporting prompt=login%20consent which will require extra thinking
 


### PR DESCRIPTION
# Change summary

Prompt=login was added to the OIDC/OAuth2 flow in the server, however it is apparent that it was released too soon.

* It contains an infinite auth loop
* It incorrectly prompts for the user's identity during reauthentication
* It does not provide the auth_time claim that an RP needs to validate the legitimacy of the authorisation.

For this reason I am proposing that we disable this in 1.10 so that we can rework it in 1.11. 

Relates #4321

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
