### PR TITLE
Prevent migration double-deletes

### DIFF
--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -325,7 +325,8 @@ impl QueryServerWriteTransaction<'_> {
             .map(|uuid| f_eq(Attribute::Uuid, PartialValue::Uuid(uuid)))
             .collect();
 
-        let filter = filter_all!(f_or(filter));
+        // Don't attempt to delete already removed entries that are in the recycle bin.
+        let filter = filter!(f_or(filter));
 
         let result = self.internal_delete(&filter);
 


### PR DESCRIPTION
The query for internal migration deletes incorrectly attempted to delete entries that were already in the recyclebin awaiting purge. This can lead to a situation where updates in quick succession would cause the second delete event to trigger a replication protection feature.

Fixes #4343

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
