### PR TITLE
feat: add live server password feedback

### DIFF
--- a/proto/src/internal/credupdate.rs
+++ b/proto/src/internal/credupdate.rs
@@ -302,7 +302,7 @@ pub struct BackupCodesView {
     pub backup_codes: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum PasswordFeedback {
     // https://docs.rs/zxcvbn/latest/zxcvbn/feedback/enum.Suggestion.html

--- a/server/core/src/https/views/mod.rs
+++ b/server/core/src/https/views/mod.rs
@@ -139,6 +139,10 @@ pub fn view_router(state: ServerState) -> Router<ServerState> {
             post(reset::view_add_ssh_publickey),
         )
         .route("/radius/generate", post(radius::view_radius_post))
+        .route(
+            "/api/check_password_strength",
+            post(reset::check_pwd_strength),
+        )
         .route("/api/delete_alt_creds", post(reset::remove_alt_creds))
         .route("/api/delete_unixcred", post(reset::remove_unixcred))
         .route("/api/add_totp", post(reset::add_totp))

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -152,6 +152,11 @@ pub(crate) struct NewPassword {
 }
 
 #[derive(Deserialize, Debug)]
+pub(crate) struct PasswordStrengthCheck {
+    new_password: String,
+}
+
+#[derive(Deserialize, Debug)]
 pub(crate) struct NewPublicKey {
     title: String,
     key: String,
@@ -744,6 +749,76 @@ pub(crate) async fn view_new_pwd(
 
     let check_res = PwdCheckResult::Failure {
         pwd_equal,
+        warnings,
+    };
+
+    Ok((
+        status,
+        swapped_handler_trigger,
+        HxPushUrl("/ui/reset/change_password".to_string()),
+        AddPasswordPartial { check_res },
+    )
+        .into_response())
+}
+
+#[axum::debug_handler]
+pub(crate) async fn check_pwd_strength(
+    State(state): State<ServerState>,
+    Extension(kopid): Extension<KOpId>,
+    HxRequest(_hx_request): HxRequest,
+    VerifiedClientInformation(_client_auth_info): VerifiedClientInformation,
+    DomainInfo(domain_info): DomainInfo,
+    jar: CookieJar,
+    RawForm(raw_form_bytes): RawForm,
+) -> axum::response::Result<Response> {
+    let opt_form: Option<PasswordStrengthCheck> = raw_form_opt(&raw_form_bytes)?;
+
+    let cu_session_token: CUSessionToken = get_cu_session(&jar).await?;
+    let swapped_handler_trigger =
+        HxResponseTrigger::after_swap([HxEvent::from(KanidmHxEventName::AddPasswordSwapped)]);
+
+    let password_to_check = match opt_form {
+        None => {
+            return Ok((
+                swapped_handler_trigger,
+                AddPasswordPartial {
+                    check_res: PwdCheckResult::Init,
+                },
+            )
+                .into_response());
+        }
+        Some(new_passwords) => new_passwords,
+    };
+
+    let (warnings, status) = match state
+        .qe_r_ref
+        .handle_idmcredentialupdate(
+            cu_session_token,
+            CURequest::PasswordQualityCheck(password_to_check.new_password),
+            kopid.eventid,
+        )
+        .await
+    {
+        Ok(_) => (vec![], StatusCode::OK),
+        Err(OperationError::PasswordQuality(password_feedback)) => {
+            (password_feedback, StatusCode::UNPROCESSABLE_ENTITY)
+        }
+        Err(operr) => {
+            return Err(ErrorResponse::from(HtmxError::new(
+                &kopid,
+                operr,
+                domain_info,
+            )))
+        }
+    };
+
+    let check_res = PwdCheckResult::Failure {
+        // I don't believe users are interested in knowing their password fields differ from the server.
+        // These live password checks are ran on the first password field so the second one is likely empty.
+        //
+        // A live "passwords differing" feedback is already provided via js when they are typing in the password confirmation field.
+        // But the template requires this field so I set it to true.
+        pwd_equal: true,
         warnings,
     };
 

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -117,13 +117,39 @@ pub(crate) struct ResetTokenParam {
 #[derive(Template, WebTemplate)]
 #[template(path = "credential_update_add_password_partial.html")]
 struct AddPasswordPartial {
-    check_res: PwdCheckResult,
+    warnings: Vec<PasswordFeedback>,
+    pwd_equal: bool,
+}
+
+impl From<PwdCheckResult> for AddPasswordPartial {
+    fn from(value: PwdCheckResult) -> Self {
+        let warnings = value.warnings().to_vec();
+        let pwd_equal = value.pwd_equal();
+
+        AddPasswordPartial {
+            warnings,
+            pwd_equal,
+        }
+    }
 }
 
 #[derive(Template, WebTemplate)]
 #[template(path = "credential_update_set_unixcred_partial.html")]
 struct SetUnixCredPartial {
-    check_res: PwdCheckResult,
+    warnings: Vec<PasswordFeedback>,
+    pwd_equal: bool,
+}
+
+impl From<PwdCheckResult> for SetUnixCredPartial {
+    fn from(value: PwdCheckResult) -> Self {
+        let warnings = value.warnings().to_vec();
+        let pwd_equal = value.pwd_equal();
+
+        SetUnixCredPartial {
+            warnings,
+            pwd_equal,
+        }
+    }
 }
 
 #[derive(Template, WebTemplate)]
@@ -137,12 +163,35 @@ struct AddSshPublicKeyPartial {
 
 #[derive(Serialize, Deserialize, Debug)]
 enum PwdCheckResult {
-    Success,
-    Init,
+    // Init or success state
+    Ok,
+    // Used on password creation.
     Failure {
         pwd_equal: bool,
         warnings: Vec<PasswordFeedback>,
     },
+    // Used for live password strength checks.
+    Warnings {
+        warnings: Vec<PasswordFeedback>,
+    },
+}
+
+impl PwdCheckResult {
+    fn pwd_equal(&self) -> bool {
+        match self {
+            PwdCheckResult::Ok => true,
+            PwdCheckResult::Failure { pwd_equal, .. } => *pwd_equal,
+            PwdCheckResult::Warnings { .. } => true,
+        }
+    }
+
+    fn warnings(&self) -> &[PasswordFeedback] {
+        match self {
+            PwdCheckResult::Ok => &[],
+            PwdCheckResult::Failure { warnings, .. } => &warnings,
+            PwdCheckResult::Warnings { warnings } => &warnings,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -711,9 +760,7 @@ pub(crate) async fn view_new_pwd(
         None => {
             return Ok((
                 swapped_handler_trigger,
-                AddPasswordPartial {
-                    check_res: PwdCheckResult::Init,
-                },
+                AddPasswordPartial::from(PwdCheckResult::Ok),
             )
                 .into_response());
         }
@@ -756,12 +803,11 @@ pub(crate) async fn view_new_pwd(
         status,
         swapped_handler_trigger,
         HxPushUrl("/ui/reset/change_password".to_string()),
-        AddPasswordPartial { check_res },
+        AddPasswordPartial::from(check_res),
     )
         .into_response())
 }
 
-#[axum::debug_handler]
 pub(crate) async fn check_pwd_strength(
     State(state): State<ServerState>,
     Extension(kopid): Extension<KOpId>,
@@ -781,9 +827,7 @@ pub(crate) async fn check_pwd_strength(
         None => {
             return Ok((
                 swapped_handler_trigger,
-                AddPasswordPartial {
-                    check_res: PwdCheckResult::Init,
-                },
+                AddPasswordPartial::from(PwdCheckResult::Ok),
             )
                 .into_response());
         }
@@ -812,21 +856,13 @@ pub(crate) async fn check_pwd_strength(
         }
     };
 
-    let check_res = PwdCheckResult::Failure {
-        // I don't believe users are interested in knowing their password fields differ from the server.
-        // These live password checks are ran on the first password field so the second one is likely empty.
-        //
-        // A live "passwords differing" feedback is already provided via js when they are typing in the password confirmation field.
-        // But the template requires this field so I set it to true.
-        pwd_equal: true,
-        warnings,
-    };
+    let check_res = PwdCheckResult::Warnings { warnings };
 
     Ok((
         status,
         swapped_handler_trigger,
         HxPushUrl("/ui/reset/change_password".to_string()),
-        AddPasswordPartial { check_res },
+        AddPasswordPartial::from(check_res),
     )
         .into_response())
 }
@@ -908,9 +944,7 @@ pub(crate) async fn view_set_unixcred(
         None => {
             return Ok((
                 swapped_handler_trigger,
-                SetUnixCredPartial {
-                    check_res: PwdCheckResult::Init,
-                },
+                SetUnixCredPartial::from(PwdCheckResult::Ok),
             )
                 .into_response());
         }
@@ -953,7 +987,7 @@ pub(crate) async fn view_set_unixcred(
         status,
         swapped_handler_trigger,
         HxPushUrl("/ui/reset/set_unixcred".to_string()),
-        SetUnixCredPartial { check_res },
+        SetUnixCredPartial::from(check_res),
     )
         .into_response())
 }

--- a/server/core/src/https/views/reset.rs
+++ b/server/core/src/https/views/reset.rs
@@ -188,8 +188,9 @@ impl PwdCheckResult {
     fn warnings(&self) -> &[PasswordFeedback] {
         match self {
             PwdCheckResult::Ok => &[],
-            PwdCheckResult::Failure { warnings, .. } => &warnings,
-            PwdCheckResult::Warnings { warnings } => &warnings,
+            PwdCheckResult::Failure { warnings, .. } | PwdCheckResult::Warnings { warnings } => {
+                warnings
+            }
         }
     }
 }

--- a/server/core/templates/credential_update_add_password_partial.html
+++ b/server/core/templates/credential_update_add_password_partial.html
@@ -1,53 +1,68 @@
 <div>
     <form class="row g-2 pb-3 needs-validation" id="newPasswordForm" novalidate>
         <input hidden type="text" autocomplete="username" />
-        (% let potentially_invalid_input_class = "" %)
-        (% let potentially_invalid_reinput_class = "" %)
-        (% let pwd_equal = true %)
+        (% decl potentially_invalid_input_class -%)
+        (% decl potentially_invalid_reinput_class -%)
+        (% decl pwd_equal -%)
 
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res %)
-            (% let pwd_equal = pwd_equal.clone() %)
-            (% if !warnings.is_empty() %)
-                (% let potentially_invalid_input_class = "is-invalid" %)
-            (% endif %)
-            (% if pwd_equal %)
-                (% let potentially_invalid_reinput_class = "is-invalid" %)
-            (% endif %)
-        (% endif %)
+        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
+            (% set pwd_equal = pwd_equal.clone() -%)
+            (% if !warnings.is_empty() -%)
+                (% set potentially_invalid_input_class = "is-invalid" -%)
+            (% else -%)
+                (% set potentially_invalid_input_class = "" -%)
+            (% endif -%)
+            (% if !pwd_equal -%)
+                (% set potentially_invalid_reinput_class = "is-invalid" -%)
+            (% else -%)
+                (% set potentially_invalid_reinput_class = "" -%)
+            (% endif -%)
+        (% else -%)
+            (% set potentially_invalid_input_class = "" -%)
+            (% set potentially_invalid_reinput_class = "" -%)
+            (% set pwd_equal = true -%)
+        (% endif -%)
 
         <label for="new-password" class="form-label">Enter New Password</label>
         <input
-                aria-describedby="password-validation-feedback"
-                autocomplete="new-password"
-                class="form-control ((potentially_invalid_input_class))"
-                name="new_password"
-                id="new-password"
-                placeholder=""
-                type="password"
-                required
-                autofocus
+            hx-post="/ui/api/check_password_strength"
+            hx-trigger="keyup changed delay:500ms"
+            hx-target="#password-validation-feedback"
+            hx-select="#password-validation-feedback"
+            aria-describedby="password-validation-feedback"
+            autocomplete="new-password"
+            class="form-control ((potentially_invalid_input_class))"
+            name="new_password"
+            id="new-password"
+            placeholder=""
+            type="password"
+            required
+            autofocus
         />
         <!-- bootstrap hides the feedback if we remove is-invalid from the input above -->
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res %)
+        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
         <div id="password-validation-feedback" class="invalid-feedback d-block">
             <ul>
-                (% for warn in warnings %)
+                (% for warn in warnings -%)
                     <li>(( warn ))</li>
-                (% endfor %)
+                (% endfor -%)
             </ul>
         </div>
-        (% endif %)
-
+        (% else %)
+        <div id="password-validation-feedback" class="invalid-feedback d-block">
+        </div>
+        (% endif -%)
+    
         <label for="new-password-check" class="form-label">Repeat Password</label>
         <input
-                aria-describedby="neq-password-validation-feedback"
-                autocomplete="new-password"
-                class="form-control ((potentially_invalid_reinput_class))"
-                name="new_password_check"
-                id="new-password-check"
-                placeholder=""
-                type="password"
-                required
+            aria-describedby="neq-password-validation-feedback"
+            autocomplete="new-password"
+            class="form-control ((potentially_invalid_reinput_class))"
+            name="new_password_check"
+            id="new-password-check"
+            placeholder=""
+            type="password"
+            required
         />
         <div id="neq-password-validation-feedback" class="invalid-feedback">
             <ul><li>Passwords don't match</li></ul>
@@ -61,4 +76,3 @@
         >Submit</button>
     </div>
 </div>
-

--- a/server/core/templates/credential_update_add_password_partial.html
+++ b/server/core/templates/credential_update_add_password_partial.html
@@ -1,27 +1,6 @@
 <div>
     <form class="row g-2 pb-3 needs-validation" id="newPasswordForm" novalidate>
         <input hidden type="text" autocomplete="username" />
-        (% decl potentially_invalid_input_class -%)
-        (% decl potentially_invalid_reinput_class -%)
-        (% decl pwd_equal -%)
-
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
-            (% set pwd_equal = pwd_equal.clone() -%)
-            (% if !warnings.is_empty() -%)
-                (% set potentially_invalid_input_class = "is-invalid" -%)
-            (% else -%)
-                (% set potentially_invalid_input_class = "" -%)
-            (% endif -%)
-            (% if !pwd_equal -%)
-                (% set potentially_invalid_reinput_class = "is-invalid" -%)
-            (% else -%)
-                (% set potentially_invalid_reinput_class = "" -%)
-            (% endif -%)
-        (% else -%)
-            (% set potentially_invalid_input_class = "" -%)
-            (% set potentially_invalid_reinput_class = "" -%)
-            (% set pwd_equal = true -%)
-        (% endif -%)
 
         <label for="new-password" class="form-label">Enter New Password</label>
         <input
@@ -31,7 +10,7 @@
             hx-select="#password-validation-feedback"
             aria-describedby="password-validation-feedback"
             autocomplete="new-password"
-            class="form-control ((potentially_invalid_input_class))"
+            class="form-control (% if !warnings.is_empty() %)is-invalid(% endif %)"
             name="new_password"
             id="new-password"
             placeholder=""
@@ -40,7 +19,6 @@
             autofocus
         />
         <!-- bootstrap hides the feedback if we remove is-invalid from the input above -->
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
         <div id="password-validation-feedback" class="invalid-feedback d-block">
             <ul>
                 (% for warn in warnings -%)
@@ -48,16 +26,12 @@
                 (% endfor -%)
             </ul>
         </div>
-        (% else %)
-        <div id="password-validation-feedback" class="invalid-feedback d-block">
-        </div>
-        (% endif -%)
     
         <label for="new-password-check" class="form-label">Repeat Password</label>
         <input
             aria-describedby="neq-password-validation-feedback"
             autocomplete="new-password"
-            class="form-control ((potentially_invalid_reinput_class))"
+            class="form-control (% if !pwd_equal %)is-invalid(% endif %)"
             name="new_password_check"
             id="new-password-check"
             placeholder=""

--- a/server/core/templates/credential_update_set_unixcred_partial.html
+++ b/server/core/templates/credential_update_set_unixcred_partial.html
@@ -1,27 +1,6 @@
 <div>
     <form class="row g-2 pb-3 needs-validation" id="newPasswordForm" novalidate>
         <input hidden type="text" autocomplete="username" />
-        (% decl potentially_invalid_input_class -%)
-        (% decl potentially_invalid_reinput_class -%)
-        (% decl pwd_equal -%)
-
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
-            (% set pwd_equal = pwd_equal.clone() -%)
-            (% if !warnings.is_empty() -%)
-                (% set potentially_invalid_input_class = "is-invalid" -%)
-            (% else -%)
-                (% set potentially_invalid_input_class = "" -%)
-            (% endif -%)
-            (% if !pwd_equal -%)
-                (% set potentially_invalid_reinput_class = "is-invalid" -%)
-            (% else -%)
-                (% set potentially_invalid_reinput_class = "" -%)
-            (% endif -%)
-        (% else -%)
-            (% set potentially_invalid_input_class = "" -%)
-            (% set potentially_invalid_reinput_class = "" -%)
-            (% set pwd_equal = true -%)
-        (% endif -%)
 
         <label for="new-password" class="form-label">Enter New Password</label>
         <input
@@ -31,7 +10,7 @@
             hx-select="#password-validation-feedback"
             aria-describedby="password-validation-feedback"
             autocomplete="new-password"
-            class="form-control ((potentially_invalid_input_class))"
+            class="form-control (% if !warnings.is_empty() %)is-invalid(% endif %)"
             name="new_password"
             id="new-password"
             placeholder=""
@@ -40,7 +19,6 @@
             autofocus
         />
         <!-- bootstrap hides the feedback if we remove is-invalid from the input above -->
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
         <div id="password-validation-feedback" class="invalid-feedback d-block">
             <ul>
                 (% for warn in warnings -%)
@@ -48,16 +26,12 @@
                 (% endfor -%)
             </ul>
         </div>
-        (% else -%)
-        <div id="password-validation-feedback" class="invalid-feedback d-block">
-        </div>
-        (% endif -%)
 
         <label for="new-password-check" class="form-label">Repeat Password</label>
         <input
             aria-describedby="neq-password-validation-feedback"
             autocomplete="new-password"
-            class="form-control ((potentially_invalid_reinput_class))"
+            class="form-control (% if !pwd_equal %)is-invalid(% endif %)"
             name="new_password_check"
             id="new-password-check"
             placeholder=""

--- a/server/core/templates/credential_update_set_unixcred_partial.html
+++ b/server/core/templates/credential_update_set_unixcred_partial.html
@@ -1,53 +1,68 @@
 <div>
     <form class="row g-2 pb-3 needs-validation" id="newPasswordForm" novalidate>
         <input hidden type="text" autocomplete="username" />
-        (% let potentially_invalid_input_class = "" %)
-        (% let potentially_invalid_reinput_class = "" %)
-        (% let pwd_equal = true %)
+        (% decl potentially_invalid_input_class -%)
+        (% decl potentially_invalid_reinput_class -%)
+        (% decl pwd_equal -%)
 
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res %)
-            (% let pwd_equal = pwd_equal.clone() %)
-            (% if !warnings.is_empty() %)
-                (% let potentially_invalid_input_class = "is-invalid" %)
-            (% endif %)
-            (% if pwd_equal %)
-                (% let potentially_invalid_reinput_class = "is-invalid" %)
-            (% endif %)
-        (% endif %)
+        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
+            (% set pwd_equal = pwd_equal.clone() -%)
+            (% if !warnings.is_empty() -%)
+                (% set potentially_invalid_input_class = "is-invalid" -%)
+            (% else -%)
+                (% set potentially_invalid_input_class = "" -%)
+            (% endif -%)
+            (% if !pwd_equal -%)
+                (% set potentially_invalid_reinput_class = "is-invalid" -%)
+            (% else -%)
+                (% set potentially_invalid_reinput_class = "" -%)
+            (% endif -%)
+        (% else -%)
+            (% set potentially_invalid_input_class = "" -%)
+            (% set potentially_invalid_reinput_class = "" -%)
+            (% set pwd_equal = true -%)
+        (% endif -%)
 
         <label for="new-password" class="form-label">Enter New Password</label>
         <input
-                aria-describedby="password-validation-feedback"
-                autocomplete="new-password"
-                class="form-control ((potentially_invalid_input_class))"
-                name="new_password"
-                id="new-password"
-                placeholder=""
-                type="password"
-                required
-                autofocus
+            hx-post="/ui/api/check_password_strength"
+            hx-trigger="keyup changed delay:500ms"
+            hx-target="#password-validation-feedback"
+            hx-select="#password-validation-feedback"
+            aria-describedby="password-validation-feedback"
+            autocomplete="new-password"
+            class="form-control ((potentially_invalid_input_class))"
+            name="new_password"
+            id="new-password"
+            placeholder=""
+            type="password"
+            required
+            autofocus
         />
         <!-- bootstrap hides the feedback if we remove is-invalid from the input above -->
-        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res %)
+        (% if let PwdCheckResult::Failure with { pwd_equal, warnings } = check_res -%)
         <div id="password-validation-feedback" class="invalid-feedback d-block">
             <ul>
-                (% for warn in warnings %)
+                (% for warn in warnings -%)
                     <li>(( warn ))</li>
-                (% endfor %)
+                (% endfor -%)
             </ul>
         </div>
-        (% endif %)
+        (% else -%)
+        <div id="password-validation-feedback" class="invalid-feedback d-block">
+        </div>
+        (% endif -%)
 
         <label for="new-password-check" class="form-label">Repeat Password</label>
         <input
-                aria-describedby="neq-password-validation-feedback"
-                autocomplete="new-password"
-                class="form-control ((potentially_invalid_reinput_class))"
-                name="new_password_check"
-                id="new-password-check"
-                placeholder=""
-                type="password"
-                required
+            aria-describedby="neq-password-validation-feedback"
+            autocomplete="new-password"
+            class="form-control ((potentially_invalid_reinput_class))"
+            name="new_password_check"
+            id="new-password-check"
+            placeholder=""
+            type="password"
+            required
         />
         <div id="neq-password-validation-feedback" class="invalid-feedback">
             <ul><li>Passwords don't match</li></ul>


### PR DESCRIPTION
# Change summary

- Adds live password feedback after a 500ms of keyboard silence.
- Added for the password and unix password forms.
 
Supersedes #3650 

Checklist

- [x] This PR contains no AI generated code
- [x] book chapter included (if relevant)
- [x] design document included (if relevant)
