### PR TITLE
20260516 oauth2 tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ altnames.cnf
 .backup*_test.json
 .backup_test.db
 **/target/**
+tools/oauth2-tester/Cargo.lock
 /insecure
 **/*.rs.bk
 test.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ dependencies = [
  "kanidm_utils_users",
  "kanidmd_core",
  "prctl",
- "reqwest 0.13.4",
+ "reqwest",
  "sd-notify",
  "serde",
  "serde_json",
@@ -3464,7 +3464,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -3591,7 +3591,7 @@ dependencies = [
  "hyper",
  "kanidm_lib_file_permissions",
  "kanidm_proto",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3603,19 +3603,6 @@ dependencies = [
  "urlencoding",
  "uuid",
  "webauthn-rs-proto",
-]
-
-[[package]]
-name = "kanidm_device_flow"
-version = "1.11.0-dev"
-dependencies = [
- "anyhow",
- "kanidm_proto",
- "oauth2",
- "reqwest 0.13.4",
- "sketching",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3765,7 +3752,7 @@ dependencies = [
  "opentelemetry",
  "qrcode",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "serde",
  "serde-hjson",
@@ -3860,6 +3847,7 @@ dependencies = [
 name = "kanidmd_testkit"
 version = "1.11.0-dev"
 dependencies = [
+ "base64 0.22.1",
  "cidr",
  "compact_jwt",
  "escargot",
@@ -3876,8 +3864,7 @@ dependencies = [
  "kanidmd_core",
  "kanidmd_lib",
  "ldap3_client",
- "oauth2",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sketching",
@@ -4636,26 +4623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "getrandom 0.2.17",
- "http",
- "rand 0.8.7",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -5612,38 +5579,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ resolver = "2"
 members = [
     "proto",
     "tools/cli",
-    "tools/device_flow",
     "tools/iam_migrations/freeipa",
     "tools/iam_migrations/ldap",
+    "tools/mail_sender",
     "tools/orca",
     "unix_integration/common",
     "unix_integration/nss_sparkle_common",
@@ -44,7 +44,11 @@ members = [
     "libs/scim_proto",
     "libs/sketching",
     "libs/users",
-    "tools/mail_sender",
+]
+
+exclude = [
+    "tools/device_flow",
+    "tools/oauth2-tester",
 ]
 
 # Below follows some guides/estimates to system resources consumed during a build.
@@ -223,7 +227,6 @@ nix = { version = "0.31.3", features = ["mount"] }
 nonempty = "0.12.0"
 notify-debouncer-full = { version = "0.7" }
 num_enum = "0.7.6"
-oauth2_ext = { version = "^5.0.0", package = "oauth2", default-features = false }
 opentelemetry = { version = "0.32.0" }
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
     "serde",

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -23,7 +23,7 @@ use compact_jwt::{
     JweCompact, JwsCompact, OidcClaims, OidcSubject,
 };
 use concread::cowcell::*;
-use crypto_glue::{s256::Sha256, traits::Digest};
+use crypto_glue::{s256::{Sha256, Sha256Output}, traits::Digest};
 use hashbrown::HashMap;
 use hashbrown::HashSet;
 use kanidm_proto::constants::*;
@@ -145,10 +145,14 @@ impl From<String> for PkceS256Secret {
 }
 
 impl PkceS256Secret {
-    pub fn to_request(&self) -> PkceRequest {
+    pub fn to_challenge(&self) -> Sha256Output {
         let mut hasher = Sha256::new();
         hasher.update(self.secret.as_bytes());
-        let code_challenge = hasher.finalize();
+        hasher.finalize()
+    }
+
+    pub fn to_request(&self) -> PkceRequest {
+        let code_challenge = self.to_challenge();
 
         PkceRequest {
             code_challenge: code_challenge.to_vec(),
@@ -165,10 +169,7 @@ impl PkceS256Secret {
     }
 
     pub fn verify<V: AsRef<[u8]>>(&self, challenge: V) -> bool {
-        let mut hasher = Sha256::new();
-        hasher.update(self.secret.as_bytes());
-        let code_challenge = hasher.finalize();
-
+        let code_challenge = self.to_challenge();
         challenge.as_ref() == code_challenge.as_slice()
     }
 }

--- a/server/lib/src/idm/oauth2.rs
+++ b/server/lib/src/idm/oauth2.rs
@@ -23,7 +23,10 @@ use compact_jwt::{
     JweCompact, JwsCompact, OidcClaims, OidcSubject,
 };
 use concread::cowcell::*;
-use crypto_glue::{s256::{Sha256, Sha256Output}, traits::Digest};
+use crypto_glue::{
+    s256::{Sha256, Sha256Output},
+    traits::Digest,
+};
 use hashbrown::HashMap;
 use hashbrown::HashSet;
 use kanidm_proto::constants::*;

--- a/server/testkit/Cargo.toml
+++ b/server/testkit/Cargo.toml
@@ -50,6 +50,7 @@ url = { workspace = true, features = ["serde"] }
 kanidm_build_profiles = { workspace = true }
 
 [dev-dependencies]
+base64 = { workspace = true }
 cidr = { workspace = true }
 compact_jwt = { workspace = true, features = ["unsafe_release_without_verify"] }
 escargot = "0.5.15"
@@ -59,9 +60,6 @@ hyper = { workspace = true }
 http-body-util = { workspace = true }
 hyper-util = { workspace = true }
 ldap3_client = { workspace = true }
-oauth2_ext = { workspace = true, default-features = false, features = [
-    "reqwest",
-] }
 serde_json = { workspace = true }
 time = { workspace = true }
 kanidm_lib_crypto = { workspace = true }

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+use base64::{engine::general_purpose, Engine as _};
 use compact_jwt::{JwkKeySet, JwsEs256Verifier, JwsVerifier, OidcToken, OidcUnverified};
 use kanidm_client::ClientError;
 use kanidm_client::{http::header, KanidmClient, StatusCode};
@@ -12,13 +13,13 @@ use kanidm_proto::oauth2::{
 };
 use kanidmd_lib::constants::NAME_IDM_ALL_ACCOUNTS;
 use kanidmd_lib::prelude::Attribute;
+use kanidmd_lib::idm::oauth2::PkceS256Secret;
 use kanidmd_testkit::{
     assert_no_cache, ADMIN_TEST_PASSWORD, ADMIN_TEST_USER, NOT_ADMIN_TEST_EMAIL,
     NOT_ADMIN_TEST_PASSWORD, NOT_ADMIN_TEST_USERNAME, TEST_INTEGRATION_RS_DISPLAY,
     TEST_INTEGRATION_RS_GROUP_ALL, TEST_INTEGRATION_RS_ID, TEST_INTEGRATION_RS_REDIRECT_URL,
     TEST_INTEGRATION_RS_URL, TEST_INTEGRATION_STATE_VALUE,
 };
-use oauth2_ext::PkceCodeChallenge;
 use reqwest::header::{HeaderValue, CONTENT_TYPE};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
@@ -267,7 +268,9 @@ async fn test_oauth2_openid_basic_flow_impl(
     // Since we are a client, we can just "pretend" we got the redirect, and issue the
     // get call directly. This should be a 200. (?)
 
-    let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
+    let pkce_secret = PkceS256Secret::default();
+    let pkce_code_challenge = general_purpose::URL_SAFE_NO_PAD.encode(&pkce_secret.to_challenge());
+    let pkce_code_verifier = pkce_secret.to_verifier();
 
     let mut query = vec![
         ("response_type", "code"),
@@ -364,7 +367,7 @@ async fn test_oauth2_openid_basic_flow_impl(
     let mut form_req: AccessTokenRequest = GrantTypeReq::AuthorizationCode {
         code: code.to_string(),
         redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
-        code_verifier: Some(pkce_code_verifier.secret().clone()),
+        code_verifier: Some(pkce_code_verifier),
     }
     .into();
 
@@ -881,7 +884,9 @@ async fn test_oauth2_openid_public_flow_impl(
     //
     // Since we are a client, we can just "pretend" we got the redirect, and issue the
     // get call directly. This should be a 200. (?)
-    let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
+    let pkce_secret = PkceS256Secret::default();
+    let pkce_code_challenge = general_purpose::URL_SAFE_NO_PAD.encode(&pkce_secret.to_challenge());
+    let pkce_code_verifier = pkce_secret.to_verifier();
 
     let mut query = vec![
         ("response_type", "code"),
@@ -989,7 +994,7 @@ async fn test_oauth2_openid_public_flow_impl(
         grant_type: GrantTypeReq::AuthorizationCode {
             code: code.to_string(),
             redirect_uri: Url::parse(TEST_INTEGRATION_RS_REDIRECT_URL).expect("Invalid URL"),
-            code_verifier: Some(pkce_code_verifier.secret().clone()),
+            code_verifier: Some(pkce_code_verifier),
         },
         client_post_auth: (TEST_INTEGRATION_RS_ID, None).into(),
     };

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -12,8 +12,8 @@ use kanidm_proto::oauth2::{
     OidcDiscoveryResponse, TokenRevokeRequest,
 };
 use kanidmd_lib::constants::NAME_IDM_ALL_ACCOUNTS;
-use kanidmd_lib::prelude::Attribute;
 use kanidmd_lib::idm::oauth2::PkceS256Secret;
+use kanidmd_lib::prelude::Attribute;
 use kanidmd_testkit::{
     assert_no_cache, ADMIN_TEST_PASSWORD, ADMIN_TEST_USER, NOT_ADMIN_TEST_EMAIL,
     NOT_ADMIN_TEST_PASSWORD, NOT_ADMIN_TEST_USERNAME, TEST_INTEGRATION_RS_DISPLAY,

--- a/tools/device_flow/Cargo.toml
+++ b/tools/device_flow/Cargo.toml
@@ -25,3 +25,5 @@ reqwest = { workspace = true }
 sketching = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["rt", "macros", "time"] }
 tracing = { workspace = true }
+
+

--- a/tools/oauth2-tester/Cargo.toml
+++ b/tools/oauth2-tester/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "kanidm_oauth2_tester"
+description = "Kanidm OAuth2 Client Tester"
+version = "0.0.1"
+rust-version = "1.93"
+edition = "2021"
+
+
+[features]
+
+[dependencies]
+askama = { version = "0.16.0" }
+askama_web = { version = "0.16.0", features = ["axum-0.8"] }
+axum = { version = "0.8.8", features = [
+    "form",
+    "json",
+    "macros",
+    "query",
+    "tokio",
+    "tracing",
+] }
+clap = { version = "4.6.0", features = ["derive", "env"] }
+chrono = "^0.4.44"
+
+axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+tower-sessions = { version = "0.14.0", features = ["signed"] }
+tower-http = { version = "0.6.2", default-features = false, features = ["fs"] }
+
+openidconnect = { version = "4.0.1", default-features = false, features = ["reqwest", "rustls-tls"] }
+
+rustls = "*"
+serde = "1"
+tokio = { version = "1.51.1", default-features = false, features = ["rt", "macros", "time"] }
+time = { version = "^0.3.47", features = ["formatting", "local-offset"] }
+url = "^2.5.8"
+
+
+tracing = "^0.1.44"
+tracing-subscriber = { version = "^0.3.23", features = ["env-filter"] }

--- a/tools/oauth2-tester/src/auth_oidc.rs
+++ b/tools/oauth2-tester/src/auth_oidc.rs
@@ -1,0 +1,380 @@
+use crate::AppState;
+use askama::Template;
+use askama_web::WebTemplate;
+use axum::body::Body;
+use axum::{
+    extract::{Query, State},
+    http::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Redirect, Response},
+    Form, Json,
+};
+use chrono::{DateTime, Utc};
+use openidconnect::{
+    core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata},
+    reqwest, AccessToken, AuthorizationCode, Client, ClientId, ClientSecret, CsrfToken,
+    EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce, OAuth2TokenResponse,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, TokenResponse,
+};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use std::sync::Arc;
+use tower_sessions::Session;
+use tracing::{debug, error, info, trace};
+use url::Url;
+
+// This is disgusting. Thanks openidconnect.
+pub type ConfiguredClient = CoreClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
+pub(crate) async fn middleware(
+    State(state): State<Arc<AppState>>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    let session = (&request).extensions().get::<Session>().unwrap();
+    let maybe_user_token: Option<User> = { session.get("token").await.unwrap() };
+
+    let uwu_senpai_redir_me_pls = request
+        .uri()
+        .path_and_query()
+        .map(|path| path.as_str().to_string());
+
+    if let Some(uwu_senpai_redir_me_pls) = uwu_senpai_redir_me_pls {
+        if let Err(e) = session.insert("uwu_senpai", uwu_senpai_redir_me_pls).await {
+            error!(?e, "Failed to setup uri return path");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        };
+    }
+
+    let current_user = if let Some(current_user) = maybe_user_token {
+        current_user
+    } else {
+        return Redirect::to("/oidc/login").into_response();
+    };
+
+    let now = chrono::offset::Utc::now();
+    if current_user.exp > now {
+        info!(
+            "authenticated session found remaining {}",
+            current_user.exp - now
+        );
+        request.extensions_mut().insert(current_user);
+        next.run(request).await
+    } else if let Some(refresh_token) = current_user.refresh_token.as_ref() {
+        info!("expired session, attempting refresh");
+
+        if let Err(err) = session.remove_value("token").await {
+            error!(?err, "oauth2 token request failure");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+
+        let nonce: Nonce = if let Some(n) = session.get("nonce").await.unwrap() {
+            n
+        } else {
+            error!("nonce");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        };
+
+        let r_token = state
+            .oidc
+            .exchange_refresh_token(&refresh_token)
+            .expect("Unable to proceed with exchange")
+            .request_async(&state.async_http_client)
+            .await;
+
+        let token = match r_token {
+            Ok(tr) => tr,
+            Err(e) => {
+                error!("oauth2 token request failure - {:?}", e);
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+
+        let id_tok = match token.id_token() {
+            Some(id_tok) => id_tok,
+            None => {
+                error!("oidc id_token not provided");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+
+        let claims = match id_tok.claims(&state.oidc.id_token_verifier(), &nonce) {
+            Ok(c) => c,
+            Err(e) => {
+                error!(
+                    ?e,
+                    "Failed to access id_token claims - token verification failed"
+                );
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
+
+        // Do I care about ATH? It's meant to check if an access token was swapped out, but nothing
+        // checks if the refresh token was?
+
+        let user = User {
+            sub: claims.subject().as_str().to_owned(),
+            /*
+            // I'm not actually sure it's possible to access this claim .... :(
+            displayname: claims.name()
+                .unwrap()
+                ,
+            */
+            // email: claims.email().unwrap().as_str().to_owned(),
+            username: claims.preferred_username().unwrap().as_str().to_owned(),
+            exp: claims.expiration(),
+            access_token: token.access_token().to_owned(),
+            refresh_token: token.refresh_token().cloned(),
+        };
+
+        if let Err(e) = session.insert("token", user).await {
+            error!(?e, "Failed to setup request session");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        } else {
+            // New token valid, run the request.
+            next.run(request).await
+        }
+    } else {
+        info!("no refresh token, reauthenticate pls");
+        Redirect::to("/oidc/login").into_response()
+    }
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "oidc.html")]
+struct LoginView {}
+
+pub async fn login_view(State(state): State<Arc<AppState>>, session: Session) -> Response {
+    LoginView {}.into_response()
+}
+
+#[derive(Deserialize, Debug)]
+pub struct FormLoginOptions {
+    scopes: String,
+    max_age: String,
+}
+
+#[axum::debug_handler]
+pub(crate) async fn login_post(
+    State(state): State<Arc<AppState>>,
+    session: Session,
+    Form(form_data): Form<FormLoginOptions>,
+) -> Result<Response, StatusCode> {
+    let (pkce_code_challenge, pkce_code_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    trace!(?session);
+    debug!(?form_data);
+    debug!("challenge -> {:?}", pkce_code_challenge.as_str());
+    debug!("secret -> {:?}", pkce_code_verifier.secret());
+
+    let oidc = state.oidc.authorize_url(
+        CoreAuthenticationFlow::AuthorizationCode,
+        CsrfToken::new_random,
+        Nonce::new_random,
+    );
+
+    let max_age = u64::from_str(&form_data.max_age).ok();
+
+    let oidc = max_age.into_iter().fold(oidc, |oidc, max_age| {
+        oidc.set_max_age(std::time::Duration::from_secs(max_age))
+    });
+
+    let oidc = form_data
+        .scopes
+        .split_ascii_whitespace()
+        .fold(oidc, |oidc, scope| {
+            oidc.add_scope(Scope::new(scope.to_string()))
+        });
+
+    let (auth_url, csrf_token, nonce) = oidc.set_pkce_challenge(pkce_code_challenge).url();
+
+    // We can stash the verifier in the session.
+    session
+        .insert("pkce_code_verifier", &pkce_code_verifier)
+        .await
+        .unwrap();
+    session.insert("csrf_token", &csrf_token).await.unwrap();
+    session.insert("nonce", &nonce).await.unwrap();
+
+    info!("starting oauth");
+
+    Ok(Redirect::to(auth_url.as_str()).into_response())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct OauthResp {
+    state: CsrfToken,
+    code: AuthorizationCode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct User {
+    sub: String,
+    // displayname: String,
+    // email: String,
+    username: String,
+    exp: DateTime<Utc>,
+    access_token: AccessToken,
+    refresh_token: Option<RefreshToken>,
+}
+
+#[axum::debug_handler]
+pub(crate) async fn response_view(
+    State(state): State<Arc<AppState>>,
+    session: Session,
+    Query(params): Query<OauthResp>,
+) -> Result<Response, StatusCode> {
+    trace!(?session);
+    debug!("params -> {:?}", params);
+
+    // get the verifier and csrf token
+    let pkce_code_verifier: PkceCodeVerifier = session
+        .get("pkce_code_verifier")
+        .await
+        .unwrap()
+        .ok_or_else(|| {
+            error!("pkce code verifier was not found");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    debug!("secret -> {:?}", pkce_code_verifier.secret());
+
+    let csrf_token: CsrfToken = session.get("csrf_token").await.unwrap().ok_or_else(|| {
+        error!("csrf");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let nonce: Nonce = session.get("nonce").await.unwrap().ok_or_else(|| {
+        error!("nonce");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Compare state to csrf token.
+    if csrf_token.secret() != params.state.secret() {
+        error!("csrf validation");
+        return Err(StatusCode::CONFLICT);
+    }
+
+    let r_token = state
+        .oidc
+        .exchange_code(params.code)
+        .expect("Unable to proceed with exchange")
+        .set_pkce_verifier(pkce_code_verifier)
+        .request_async(&state.async_http_client)
+        .await;
+
+    let token = match r_token {
+        Ok(tr) => tr,
+        Err(e) => {
+            error!("oauth2 token request failure - {:?}", e);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    let id_tok = match token.id_token() {
+        Some(id_tok) => id_tok,
+        None => {
+            error!("oidc id_token not provided");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    let claims = match id_tok.claims(&state.oidc.id_token_verifier(), &nonce) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                ?e,
+                "Failed to access id_token claims - token verification failed"
+            );
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    // Do I care about ATH? It's meant to check if an access token was swapped out, but nothing
+    // checks if the refresh token was?
+
+    let user = User {
+        sub: claims.subject().as_str().to_owned(),
+        /*
+        // I'm not actually sure it's possible to access this claim .... :(
+        displayname: claims.name()
+            .unwrap()
+            ,
+        */
+        // email: claims.email().unwrap().as_str().to_owned(),
+        username: claims.preferred_username().unwrap().as_str().to_owned(),
+        exp: claims.expiration(),
+        access_token: token.access_token().to_owned(),
+        refresh_token: token.refresh_token().cloned(),
+    };
+
+    if let Err(e) = session.insert("token", user).await {
+        error!(?e, "Failed to setup request session");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    let maybe_uwu_senpai: Option<String> = { session.get("uwu_senpai").await.unwrap() };
+
+    if let Some(uwu_senpai) = maybe_uwu_senpai {
+        Ok(Redirect::to(&uwu_senpai).into_response())
+    } else {
+        Ok(Redirect::to("/oidc/whoami").into_response())
+    }
+}
+
+pub(crate) async fn whoami_view(
+    session: Session,
+    // State(state): State<Arc<AppState>>,
+) -> Response {
+    let maybe_user_token: Option<User> = session.get("token").await.unwrap();
+
+    let current_user = if let Some(current_user) = maybe_user_token {
+        current_user
+    } else {
+        return Redirect::to("/oidc/login").into_response();
+    };
+
+    Json(current_user.username).into_response()
+}
+
+pub async fn configure(
+    client_id: &str,
+    client_secret: Option<&str>,
+    client_url: &str,
+    kanidm_url: &Url,
+    async_http_client: &reqwest::Client,
+) -> ConfiguredClient {
+    let mut discovery_url = kanidm_url.clone();
+    discovery_url
+        .path_segments_mut()
+        .unwrap()
+        .extend(["oauth2", "openid", client_id]);
+
+    let issuer = IssuerUrl::new(discovery_url.to_string()).expect("Unable to parse issuer url");
+
+    let redir_url = RedirectUrl::new(format!("{}/oidc/response", client_url))
+        .expect("Unable to parse client url");
+
+    debug!(discover_url = ?issuer);
+
+    let provider_metadata = CoreProviderMetadata::discover_async(issuer, async_http_client)
+        .await
+        .expect("Unable to discover oidc provider");
+
+    debug!(?provider_metadata);
+
+    CoreClient::from_provider_metadata(
+        provider_metadata,
+        ClientId::new(client_id.to_string()),
+        client_secret.map(|s| ClientSecret::new(s.to_string())),
+    )
+    // Set the URL the user will be redirected to after the authorization process.
+    .set_redirect_uri(redir_url)
+}

--- a/tools/oauth2-tester/src/main.rs
+++ b/tools/oauth2-tester/src/main.rs
@@ -1,0 +1,171 @@
+use askama::Template;
+use askama_web::WebTemplate;
+use axum::middleware;
+use axum::response::Html;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use clap::Parser;
+use openidconnect::reqwest;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tower_http::services::{ServeDir, ServeFile};
+use tower_sessions::cookie::{Key, SameSite};
+use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
+use tracing::{debug, error, info};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{fmt, EnvFilter};
+use url::Url;
+
+mod auth_oidc;
+
+#[derive(Template, WebTemplate)]
+#[template(path = "index.html")]
+struct IndexView {}
+
+async fn index_view() -> Response {
+    IndexView {}.into_response()
+}
+
+async fn status_view() -> Html<&'static str> {
+    Html(r#"Ok"#)
+}
+
+struct AppState {
+    oidc: auth_oidc::ConfiguredClient,
+    async_http_client: reqwest::Client,
+}
+
+#[derive(Debug, clap::Parser)]
+#[clap(about = "OAuth2 Testing Tool")]
+struct EnvConfig {
+    #[arg(env = "CLIENT_SECRET")]
+    client_secret: Option<String>,
+
+    #[arg(default_value = "oauth2_test", env = "CLIENT_ID")]
+    client_id: String,
+
+    #[arg(default_value = "https://localhost:8443/", env = "KANIDM_URL")]
+    kanidm_url: Url,
+
+    #[structopt(
+        default_value = "127.0.0.1:8843",
+        env = "TLS_BIND_ADDRESS",
+        long = "tlsaddr"
+    )]
+    /// Address to listen to for https
+    tls_bind_addr: SocketAddr,
+
+    #[structopt(
+        env = "TLS_PEM_KEY",
+        long = "tlskey",
+        default_value = "/tmp/kanidm/key.pem"
+    )]
+    /// Path to the TLS Key file in PEM format.
+    tls_pem_key: String,
+    #[structopt(
+        env = "TLS_PEM_CHAIN",
+        long = "tlschain",
+        default_value = "/tmp/kanidm/chain.pem"
+    )]
+    /// Path to the TLS Chain file in PEM format.
+    tls_pem_chain: String,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let fmt_layer = fmt::layer().with_writer(std::io::stderr);
+
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .init();
+
+    //
+    let env_config = EnvConfig::parse();
+
+    debug!(?env_config);
+
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .unwrap();
+
+    let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(
+        env_config.tls_pem_chain,
+        env_config.tls_pem_key,
+    )
+    .await
+    .expect("Failed to process pem files");
+
+    // TODO: In future the oauth2/openidconnect crates will detach their
+    // reqwest versions, but until then we have to use what they bundle.
+    //
+    // See: https://github.com/ramosbugs/oauth2-rs/tree/main/oauth2-reqwest
+
+    let async_http_client = {
+        let builder = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .redirect(reqwest::redirect::Policy::none());
+
+        builder.build().unwrap()
+    };
+
+    let oidc = auth_oidc::configure(
+        &env_config.client_id,
+        env_config.client_secret.as_deref(),
+        &format!("https://{}", env_config.tls_bind_addr),
+        &env_config.kanidm_url,
+        &async_http_client,
+    )
+    .await;
+
+    let app_state = Arc::new(AppState {
+        oidc,
+        async_http_client,
+    });
+
+    let key = Key::generate();
+
+    let session_store = MemoryStore::default();
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_same_site(SameSite::Lax)
+        .with_expiry(Expiry::OnInactivity(time::Duration::seconds(300)))
+        .with_signed(key);
+
+    let with_oidc_auth = Router::new()
+        .route("/oidc/whoami", get(auth_oidc::whoami_view))
+        .layer(middleware::from_fn_with_state(
+            app_state.clone(),
+            auth_oidc::middleware,
+        ));
+
+    let with_oidc_unauth = Router::new()
+        .route(
+            "/oidc/login",
+            get(auth_oidc::login_view).post(auth_oidc::login_post),
+        )
+        .route("/oidc/response", get(auth_oidc::response_view));
+
+    let with_unauth = Router::new()
+        .route("/", get(index_view))
+        .route("/_status", get(status_view));
+
+    let app = Router::new()
+        .merge(with_oidc_auth)
+        .merge(with_oidc_unauth)
+        .merge(with_unauth)
+        .with_state(app_state.clone())
+        .layer(session_layer);
+
+    println!("listening on https://{}", env_config.tls_bind_addr);
+    axum_server::bind_rustls(env_config.tls_bind_addr, tls_config)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/tools/oauth2-tester/templates/base.html
+++ b/tools/oauth2-tester/templates/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+<meta charset="utf-8" />
+<title>OAuth2 Tester</title>
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OAuth2 Tester</title>
+    {% block head %}{% endblock %}
+</head>
+
+<body>
+    <div id="content">
+	  <div class="container-fluid">
+		<div class="row">
+		  <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+			{% block content %}<p>Uh oh~</p>{% endblock %}
+		  </main>
+		</div>
+	  </div>
+    </div>
+</body>
+
+</html>

--- a/tools/oauth2-tester/templates/index.html
+++ b/tools/oauth2-tester/templates/index.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<a href="/oidc/login">OIDC</a>
+
+{% endblock %}

--- a/tools/oauth2-tester/templates/oidc.html
+++ b/tools/oauth2-tester/templates/oidc.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<form action="#" method="post">
+
+    <label for="scopes">Scopes</label>
+    <input type="text" id="scopes" name="scopes">
+
+    <label for="max_age">Max Age</label>
+    <input type="number" id="max_age" name="max_age">
+
+    <button>Login</button>
+</form>
+
+{% endblock %}
+


### PR DESCRIPTION
# Change summary

Adds an OAuth2 tester with some configurable form parameters. I plan to merge in an OAuth2 version, and move the device flow code into the this tester too. 

It looks like the oauth2/openidconnect crate are a bit problematic, they have ancient versions of a bunch of deps. We were using them in one place for a test case to do pkce - something that we have already.

So I have moved this tester out of the workspace to avoid polluting our workspace with the deps such as axum-server, tower, oauth2, etc. 

I wonder if it would make more sense for this to go as a separate repo rather than here? 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
