### PR TITLE
Show clear error for public OAuth2 consent prompt

### DIFF
--- a/libs/client/src/oauth.rs
+++ b/libs/client/src/oauth.rs
@@ -1,11 +1,12 @@
 use crate::{ClientError, KanidmClient};
 use kanidm_proto::attribute::Attribute;
 use kanidm_proto::constants::{
-    ATTR_DISPLAYNAME, ATTR_KEY_ACTION_REVOKE, ATTR_KEY_ACTION_ROTATE, ATTR_NAME,
+    ATTR_CLASS, ATTR_DISPLAYNAME, ATTR_KEY_ACTION_REVOKE, ATTR_KEY_ACTION_ROTATE, ATTR_NAME,
     ATTR_OAUTH2_ALLOW_INSECURE_CLIENT_DISABLE_PKCE, ATTR_OAUTH2_ALLOW_LOCALHOST_REDIRECT,
     ATTR_OAUTH2_CONSENT_PROMPT_ENABLE, ATTR_OAUTH2_JWT_LEGACY_CRYPTO_ENABLE,
     ATTR_OAUTH2_PREFER_SHORT_USERNAME, ATTR_OAUTH2_RS_BASIC_SECRET, ATTR_OAUTH2_RS_ORIGIN,
     ATTR_OAUTH2_RS_ORIGIN_LANDING, ATTR_OAUTH2_STRICT_REDIRECT_URI,
+    OAUTH2_RESOURCE_SERVER_PUBLIC,
 };
 use kanidm_proto::internal::{ImageValue, Oauth2ClaimMapJoin};
 use kanidm_proto::v1::Entry;
@@ -14,6 +15,9 @@ use std::collections::BTreeMap;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use url::Url;
+
+const OAUTH2_PUBLIC_CLIENT_CONSENT_PROMPT_ERROR: &str =
+    "OAuth2 public clients must always prompt for consent; disable-consent-prompt can only be used with basic clients.";
 
 impl KanidmClient {
     // ==== Oauth2 resource server configuration
@@ -530,6 +534,9 @@ impl KanidmClient {
     }
 
     pub async fn idm_oauth2_rs_disable_consent_prompt(&self, id: &str) -> Result<(), ClientError> {
+        self.idm_oauth2_rs_assert_consent_prompt_configurable(id)
+            .await?;
+
         let mut update_oauth2_rs = Entry {
             attrs: BTreeMap::new(),
         };
@@ -539,5 +546,28 @@ impl KanidmClient {
         );
         self.perform_patch_request(format!("/v1/oauth2/{}", id).as_str(), update_oauth2_rs)
             .await
+    }
+
+    async fn idm_oauth2_rs_assert_consent_prompt_configurable(
+        &self,
+        id: &str,
+    ) -> Result<(), ClientError> {
+        let entry = self.idm_oauth2_rs_get(id).await?;
+
+        if entry
+            .as_ref()
+            .and_then(|entry| entry.attrs.get(ATTR_CLASS))
+            .is_some_and(|classes| {
+                classes
+                    .iter()
+                    .any(|class| class == OAUTH2_RESOURCE_SERVER_PUBLIC)
+            })
+        {
+            Err(ClientError::InvalidRequest(
+                OAUTH2_PUBLIC_CLIENT_CONSENT_PROMPT_ERROR.to_string(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/libs/client/src/oauth.rs
+++ b/libs/client/src/oauth.rs
@@ -10,7 +10,7 @@ use kanidm_proto::constants::{
 };
 use kanidm_proto::internal::{ImageValue, Oauth2ClaimMapJoin};
 use kanidm_proto::v1::Entry;
-use reqwest::multipart;
+use reqwest::{multipart, StatusCode};
 use std::collections::BTreeMap;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
@@ -534,9 +534,6 @@ impl KanidmClient {
     }
 
     pub async fn idm_oauth2_rs_disable_consent_prompt(&self, id: &str) -> Result<(), ClientError> {
-        self.idm_oauth2_rs_assert_consent_prompt_configurable(id)
-            .await?;
-
         let mut update_oauth2_rs = Entry {
             attrs: BTreeMap::new(),
         };
@@ -544,30 +541,34 @@ impl KanidmClient {
             ATTR_OAUTH2_CONSENT_PROMPT_ENABLE.to_string(),
             vec!["false".to_string()],
         );
-        self.perform_patch_request(format!("/v1/oauth2/{}", id).as_str(), update_oauth2_rs)
+
+        match self
+            .perform_patch_request(format!("/v1/oauth2/{}", id).as_str(), update_oauth2_rs)
             .await
+        {
+            Err(err @ ClientError::Http(StatusCode::FORBIDDEN, _, _)) => {
+                if self.idm_oauth2_rs_is_public_client(id).await? {
+                    Err(ClientError::InvalidRequest(
+                        OAUTH2_PUBLIC_CLIENT_CONSENT_PROMPT_ERROR.to_string(),
+                    ))
+                } else {
+                    Err(err)
+                }
+            }
+            result => result,
+        }
     }
 
-    async fn idm_oauth2_rs_assert_consent_prompt_configurable(
-        &self,
-        id: &str,
-    ) -> Result<(), ClientError> {
+    async fn idm_oauth2_rs_is_public_client(&self, id: &str) -> Result<bool, ClientError> {
         let entry = self.idm_oauth2_rs_get(id).await?;
 
-        if entry
+        Ok(entry
             .as_ref()
             .and_then(|entry| entry.attrs.get(ATTR_CLASS))
             .is_some_and(|classes| {
                 classes
                     .iter()
                     .any(|class| class == OAUTH2_RESOURCE_SERVER_PUBLIC)
-            })
-        {
-            Err(ClientError::InvalidRequest(
-                OAUTH2_PUBLIC_CLIENT_CONSENT_PROMPT_ERROR.to_string(),
-            ))
-        } else {
-            Ok(())
-        }
+            }))
     }
 }

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -1293,8 +1293,8 @@ async fn test_oauth2_openid_public_consent_cant_be_disabled(rsclient: &KanidmCli
         .await
         .expect_err("Disabled consent prompt on a public RS!");
 
-    assert!(matches!(
-        error,
-        ClientError::Http(StatusCode::FORBIDDEN, _, _)
-    ));
+    assert!(
+        matches!(error, ClientError::InvalidRequest(message) if message
+            .contains("public clients must always prompt for consent"))
+    );
 }

--- a/server/testkit/tests/testkit/oauth2_test.rs
+++ b/server/testkit/tests/testkit/oauth2_test.rs
@@ -1298,3 +1298,39 @@ async fn test_oauth2_openid_public_consent_cant_be_disabled(rsclient: &KanidmCli
             .contains("public clients must always prompt for consent"))
     );
 }
+
+#[kanidmd_testkit::test]
+async fn test_oauth2_openid_public_consent_raw_patch_is_rejected(rsclient: &KanidmClient) {
+    let res = rsclient
+        .auth_simple_password(ADMIN_TEST_USER, ADMIN_TEST_PASSWORD)
+        .await;
+    assert!(res.is_ok());
+
+    rsclient
+        .idm_oauth2_rs_public_create(
+            TEST_INTEGRATION_RS_ID,
+            TEST_INTEGRATION_RS_DISPLAY,
+            TEST_INTEGRATION_RS_URL,
+        )
+        .await
+        .expect("Failed to create oauth2 config");
+
+    let patch_body =
+        serde_json::json!({"attrs": { ATTR_OAUTH2_CONSENT_PROMPT_ENABLE : ["false"]}});
+
+    let error: ClientError = match rsclient
+        .perform_patch_request::<serde_json::Value, String>(
+            format!("/v1/oauth2/{TEST_INTEGRATION_RS_ID}").as_str(),
+            patch_body,
+        )
+        .await
+    {
+        Ok(val) => panic!("Expected failure to patch public OAuth2 consent prompt: {val:?}"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        error,
+        ClientError::Http(StatusCode::FORBIDDEN, _, _)
+    ));
+}


### PR DESCRIPTION
# Change summary

- Add a client-side check before disabling the OAuth2 consent prompt.
- Return a clearer `InvalidRequest` when the target OAuth2 client is public, since public clients must always prompt for consent.
- Update the existing testkit public-client consent prompt test to cover the clearer error path.

Fixes #4161

Checklist

- [ ] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
