### PR TITLE
fix: Return unique LDAP attributes

### DIFF
--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2527,51 +2527,57 @@ impl Entry<EntryReduced, EntryCommitted> {
                 .collect()
         };
 
+        // Doing this to avoid duplicate attribute values per the LDAP spec
+        let mut attributes: BTreeMap<_, _> = BTreeMap::new();
         // Stage 3 - given our map, generate the final result.
-        let attributes: Vec<_> = attr_names
-            .into_iter()
-            .filter_map(|(ldap_a, kani_a)| {
-                // In some special cases, we may need to transform or rewrite the values.
-                match ldap_a {
-                    LDAP_ATTR_DN => Some(LdapPartialAttribute {
-                        atype: LDAP_ATTR_DN.to_string(),
-                        vals: vec![dn.as_bytes().to_vec()],
-                    }),
-                    LDAP_ATTR_ENTRYDN => Some(LdapPartialAttribute {
-                        atype: LDAP_ATTR_ENTRYDN.to_string(),
-                        vals: vec![dn.as_bytes().to_vec()],
-                    }),
-                    LDAP_ATTR_MAIL_PRIMARY | LDAP_ATTR_EMAIL_PRIMARY => {
-                        attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
-                            atype: ldap_a.to_string(),
-                            vals: pvs
-                                .first()
-                                .map(|first| vec![first.clone()])
-                                .unwrap_or_default(),
-                        })
-                    }
-                    LDAP_ATTR_MAIL_ALTERNATIVE | LDAP_ATTR_EMAIL_ALTERNATIVE => {
-                        attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
-                            atype: ldap_a.to_string(),
-                            vals: pvs
-                                .split_first()
-                                .map(|(_, rest)| rest.to_vec())
-                                .unwrap_or_default(),
-                        })
-                    }
-                    ATTR_HOME_DIRECTORY => Some(LdapPartialAttribute {
-                        atype: ATTR_HOME_DIRECTORY.to_string(),
-                        vals: vec![format!("/home/{}", self.get_uuid()).into_bytes()],
-                    }),
-                    _ => attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
+        attr_names.into_iter().for_each(|(ldap_a, kani_a)| {
+            // In some special cases, we may need to transform or rewrite the values.
+            if let Some(attr) = match ldap_a {
+                LDAP_ATTR_DN => Some(LdapPartialAttribute {
+                    atype: LDAP_ATTR_DN.to_string(),
+                    vals: vec![dn.as_bytes().to_vec()],
+                }),
+                LDAP_ATTR_ENTRYDN => Some(LdapPartialAttribute {
+                    atype: LDAP_ATTR_ENTRYDN.to_string(),
+                    vals: vec![dn.as_bytes().to_vec()],
+                }),
+                LDAP_ATTR_MAIL_PRIMARY | LDAP_ATTR_EMAIL_PRIMARY => {
+                    attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
                         atype: ldap_a.to_string(),
-                        vals: pvs.clone(),
-                    }),
+                        vals: pvs
+                            .first()
+                            .map(|first| vec![first.clone()])
+                            .unwrap_or_default(),
+                    })
                 }
-            })
-            .collect();
-
-        Ok(LdapSearchResultEntry { dn, attributes })
+                LDAP_ATTR_MAIL_ALTERNATIVE | LDAP_ATTR_EMAIL_ALTERNATIVE => {
+                    attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
+                        atype: ldap_a.to_string(),
+                        vals: pvs
+                            .split_first()
+                            .map(|(_, rest)| rest.to_vec())
+                            .unwrap_or_default(),
+                    })
+                }
+                ATTR_HOME_DIRECTORY => Some(LdapPartialAttribute {
+                    atype: ATTR_HOME_DIRECTORY.to_string(),
+                    vals: vec![format!("/home/{}", self.get_uuid()).into_bytes()],
+                }),
+                _ => attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
+                    atype: ldap_a.to_string(),
+                    vals: pvs.clone(),
+                }),
+            } {
+                // add it to the response
+                if let Some(replaced) = attributes.insert(ldap_a, attr) {
+                    debug!("Duplicate attribute {ldap_a}, original value: {replaced:?}");
+                };
+            }
+        });
+        Ok(LdapSearchResultEntry {
+            dn,
+            attributes: attributes.into_iter().map(|(_, attr)| attr).collect(),
+        })
     }
 }
 

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2576,7 +2576,7 @@ impl Entry<EntryReduced, EntryCommitted> {
         });
         Ok(LdapSearchResultEntry {
             dn,
-            attributes: attributes.into_iter().map(|(_, attr)| attr).collect(),
+            attributes: attributes.into_values().collect(),
         })
     }
 }

--- a/server/lib/src/entry.rs
+++ b/server/lib/src/entry.rs
@@ -2528,56 +2528,50 @@ impl Entry<EntryReduced, EntryCommitted> {
         };
 
         // Doing this to avoid duplicate attribute values per the LDAP spec
-        let mut attributes: BTreeMap<_, _> = BTreeMap::new();
-        // Stage 3 - given our map, generate the final result.
-        attr_names.into_iter().for_each(|(ldap_a, kani_a)| {
-            // In some special cases, we may need to transform or rewrite the values.
-            if let Some(attr) = match ldap_a {
-                LDAP_ATTR_DN => Some(LdapPartialAttribute {
-                    atype: LDAP_ATTR_DN.to_string(),
-                    vals: vec![dn.as_bytes().to_vec()],
-                }),
-                LDAP_ATTR_ENTRYDN => Some(LdapPartialAttribute {
-                    atype: LDAP_ATTR_ENTRYDN.to_string(),
-                    vals: vec![dn.as_bytes().to_vec()],
-                }),
-                LDAP_ATTR_MAIL_PRIMARY | LDAP_ATTR_EMAIL_PRIMARY => {
-                    attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
+        let attributes: Vec<_> = attr_names
+            .into_iter()
+            .filter_map(|(ldap_a, kani_a)| {
+                // In some special cases, we may need to transform or rewrite the values.
+                match ldap_a {
+                    LDAP_ATTR_DN => Some(LdapPartialAttribute {
+                        atype: LDAP_ATTR_DN.to_string(),
+                        vals: vec![dn.as_bytes().to_vec()],
+                    }),
+                    LDAP_ATTR_ENTRYDN => Some(LdapPartialAttribute {
+                        atype: LDAP_ATTR_ENTRYDN.to_string(),
+                        vals: vec![dn.as_bytes().to_vec()],
+                    }),
+                    LDAP_ATTR_MAIL_PRIMARY | LDAP_ATTR_EMAIL_PRIMARY => {
+                        attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
+                            atype: ldap_a.to_string(),
+                            vals: pvs
+                                .first()
+                                .map(|first| vec![first.clone()])
+                                .unwrap_or_default(),
+                        })
+                    }
+                    LDAP_ATTR_MAIL_ALTERNATIVE | LDAP_ATTR_EMAIL_ALTERNATIVE => {
+                        attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
+                            atype: ldap_a.to_string(),
+                            vals: pvs
+                                .split_first()
+                                .map(|(_, rest)| rest.to_vec())
+                                .unwrap_or_default(),
+                        })
+                    }
+                    ATTR_HOME_DIRECTORY => Some(LdapPartialAttribute {
+                        atype: ATTR_HOME_DIRECTORY.to_string(),
+                        vals: vec![format!("/home/{}", self.get_uuid()).into_bytes()],
+                    }),
+                    _ => attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
                         atype: ldap_a.to_string(),
-                        vals: pvs
-                            .first()
-                            .map(|first| vec![first.clone()])
-                            .unwrap_or_default(),
-                    })
+                        vals: pvs.clone(),
+                    }),
                 }
-                LDAP_ATTR_MAIL_ALTERNATIVE | LDAP_ATTR_EMAIL_ALTERNATIVE => {
-                    attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
-                        atype: ldap_a.to_string(),
-                        vals: pvs
-                            .split_first()
-                            .map(|(_, rest)| rest.to_vec())
-                            .unwrap_or_default(),
-                    })
-                }
-                ATTR_HOME_DIRECTORY => Some(LdapPartialAttribute {
-                    atype: ATTR_HOME_DIRECTORY.to_string(),
-                    vals: vec![format!("/home/{}", self.get_uuid()).into_bytes()],
-                }),
-                _ => attr_map.get(kani_a).map(|pvs| LdapPartialAttribute {
-                    atype: ldap_a.to_string(),
-                    vals: pvs.clone(),
-                }),
-            } {
-                // add it to the response
-                if let Some(replaced) = attributes.insert(ldap_a, attr) {
-                    debug!("Duplicate attribute {ldap_a}, original value: {replaced:?}");
-                };
-            }
-        });
-        Ok(LdapSearchResultEntry {
-            dn,
-            attributes: attributes.into_values().collect(),
-        })
+            })
+            .collect();
+
+        Ok(LdapSearchResultEntry { dn, attributes })
     }
 }
 

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -6,6 +6,7 @@ use std::iter;
 use std::str::FromStr;
 
 use compact_jwt::JwsCompact;
+use itertools::Itertools;
 use kanidm_proto::constants::*;
 use kanidm_proto::internal::{ApiToken, UserAuthToken};
 use ldap3_proto::simple::*;
@@ -330,6 +331,9 @@ impl LdapServer {
 
                 (Some(mapped_attrs), req_attrs)
             };
+            //
+            let k_attrs = k_attrs.map(|ka| ka.into_iter().sorted().dedup().collect());
+            let l_attrs = l_attrs.into_iter().sorted().dedup().collect::<Vec<_>>();
 
             debug!(attr = ?l_attrs, "LDAP Search Request LDAP Attrs");
             debug!(attr = ?k_attrs, "LDAP Search Request Mapped Attrs");

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -2835,4 +2835,43 @@ mod tests {
         assert_eq!(invalid_res, Err(OperationError::ResourceLimit));
         assert!(valid_res.is_ok());
     }
+
+    #[idm_test]
+    /// Ensures that we only get a single attribute back even if we request it multiple times
+    async fn test_ldap_distinct_attributes(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
+        let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
+
+        // Setup the anonymous login
+        let anon_t = ldaps
+            .do_bind(idms, "", "")
+            .await
+            .expect("failed to connect to ldap")
+            .expect("Failed to get token");
+        assert_eq!(
+            anon_t.effective_session,
+            LdapSession::UnixBind(UUID_ANONYMOUS)
+        );
+
+        let valid_search = SearchRequest {
+            msgid: 1,
+            base: "dc=example,dc=com".to_string(),
+            scope: LdapSearchScope::Subtree,
+            filter: LdapFilter::Present(Attribute::ObjectClass.to_string()),
+            attrs: vec![
+                "objectClass: person".to_string(),
+                "uuid".to_string(),
+                "uuid".to_string(),
+            ],
+        };
+
+        let valid_res = ldaps
+            .do_search(idms, &valid_search, &anon_t, Source::Internal)
+            .await
+            .expect("Search failed");
+        let response_zero = valid_res.into_iter().next().expect("No results");
+        let LdapOp::SearchResultEntry(searchresult) = response_zero.op else {
+            panic!("invalid result!");
+        };
+        assert!(searchresult.attributes.len() == 1)
+    }
 }

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -331,8 +331,8 @@ impl LdapServer {
                 (Some(mapped_attrs), req_attrs)
             };
 
-            admin_info!(attr = ?l_attrs, "LDAP Search Request LDAP Attrs");
-            admin_info!(attr = ?k_attrs, "LDAP Search Request Mapped Attrs");
+            debug!(attr = ?l_attrs, "LDAP Search Request LDAP Attrs");
+            debug!(attr = ?k_attrs, "LDAP Search Request Mapped Attrs");
 
             let ct = duration_from_epoch_now();
             let mut idm_read = idms.proxy_read().await?;
@@ -371,7 +371,7 @@ impl LdapServer {
                 ]),
             };
 
-            admin_info!(filter = ?lfilter, "LDAP Search Filter");
+            debug!(filter = ?lfilter, "LDAP Search Filter");
 
             // Build the event, with the permissions from effective_session
             //


### PR DESCRIPTION
# Change summary

- dedupes attribute responses in LDAP queries

Fixes #4361 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
