### PR TITLE
Avoid LSE instructions in arm64 Linux builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,7 +8,23 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes"]
+rustflags = [
+    "-C",
+    "link-arg=-fuse-ld=lld",
+    "-C",
+    "force-frame-pointers=yes",
+    "-C",
+    "target-cpu=generic",
+    "-C",
+    "target-feature=-lse",
+]
+
+[env]
+# Keep Linux arm64 release builds compatible with ARMv8.0-A systems such as
+# Raspberry Pi 4. libmimalloc-sys otherwise requests -march=armv8.1-a, which
+# can emit LSE atomics that SIGILL on older arm64 hardware.
+CFLAGS_aarch64_unknown_linux_gnu = { value = "-march=armv8-a", force = false }
+CXXFLAGS_aarch64_unknown_linux_gnu = { value = "-march=armv8-a", force = false }
 
 [target.powerpc64le-unknown-linux-gnu]
 linker = "clang"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,16 +8,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
-rustflags = [
-    "-C",
-    "link-arg=-fuse-ld=lld",
-    "-C",
-    "force-frame-pointers=yes",
-    "-C",
-    "target-cpu=generic",
-    "-C",
-    "target-feature=-lse",
-]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes"]
 
 [env]
 # Keep Linux arm64 release builds compatible with ARMv8.0-A systems such as

--- a/libs/profiles/src/lib.rs
+++ b/libs/profiles/src/lib.rs
@@ -11,6 +11,7 @@ use std::env;
 #[allow(non_camel_case_types)]
 enum CpuOptLevel {
     apple_m1,
+    armv8_a,
     none,
     native,
     neon_v8,
@@ -25,6 +26,10 @@ impl Default for CpuOptLevel {
             CpuOptLevel::x86_64_v2
         } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
             CpuOptLevel::apple_m1
+        } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "linux") {
+            // Keep native arm64 Linux release builds on the ARMv8.0-A baseline.
+            // Dependency C/C++ flags for cross builds are enforced in .cargo/config.toml.
+            CpuOptLevel::armv8_a
         /*
         } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "linux") {
             // Disable neon_v8 on linux - this has issues on non-apple hardware and on
@@ -41,6 +46,7 @@ impl std::fmt::Display for CpuOptLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             CpuOptLevel::apple_m1 => write!(f, "apple_m1"),
+            CpuOptLevel::armv8_a => write!(f, "armv8_a"),
             CpuOptLevel::none => write!(f, "none"),
             CpuOptLevel::native => write!(f, "native"),
             CpuOptLevel::neon_v8 => write!(f, "neon_v8"),
@@ -116,6 +122,9 @@ pub fn apply_profile() {
 
     match profile_cfg.cpu_flags {
         CpuOptLevel::apple_m1 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=apple_m1"),
+        CpuOptLevel::armv8_a => {
+            println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=generic -Ctarget-feature=-lse")
+        }
         CpuOptLevel::none => {}
         CpuOptLevel::native => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=native"),
         CpuOptLevel::neon_v8 => {

--- a/libs/profiles/src/lib.rs
+++ b/libs/profiles/src/lib.rs
@@ -123,7 +123,7 @@ pub fn apply_profile() {
     match profile_cfg.cpu_flags {
         CpuOptLevel::apple_m1 => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=apple_m1"),
         CpuOptLevel::armv8_a => {
-            println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=generic -Ctarget-feature=-lse")
+            println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-feature=-lse")
         }
         CpuOptLevel::none => {}
         CpuOptLevel::native => println!("cargo:rustc-env=RUSTFLAGS=-Ctarget-cpu=native"),

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,6 @@ RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
 # ======================
 FROM repos AS builder
-ARG TARGETARCH
 ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE="container_generic"
 ARG KANIDM_BUILD_OPTIONS=""
@@ -44,18 +43,12 @@ COPY . /usr/src/kanidm
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
 # Exports don't persist through RUN statements.
-# Keep arm64 container builds compatible with ARMv8.0-A systems such as Raspberry Pi 4.
 RUN --mount=type=cache,id=cargo,target=/cargo \
     --mount=type=cache,id=sccache,target=/sccache \
     export CARGO_HOME=/cargo && \
     export SCCACHE_DIR=/sccache && \
     export RUSTC_WRAPPER=/usr/bin/sccache && \
     export CC="/usr/bin/clang" && \
-    if [ "${TARGETARCH}" = "arm64" ]; then \
-        export RUSTFLAGS="${RUSTFLAGS} -Ctarget-cpu=generic -Ctarget-feature=-lse"; \
-        export CFLAGS="${CFLAGS:+$CFLAGS }-march=armv8-a"; \
-        export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }-march=armv8-a"; \
-    fi && \
     cargo auditable build --locked -p daemon ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,7 @@ RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
 # ======================
 FROM repos AS builder
+ARG TARGETARCH
 ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE="container_generic"
 ARG KANIDM_BUILD_OPTIONS=""
@@ -43,12 +44,18 @@ COPY . /usr/src/kanidm
 WORKDIR /usr/src/kanidm/kanidmd/daemon
 
 # Exports don't persist through RUN statements.
+# Keep arm64 container builds compatible with ARMv8.0-A systems such as Raspberry Pi 4.
 RUN --mount=type=cache,id=cargo,target=/cargo \
     --mount=type=cache,id=sccache,target=/sccache \
     export CARGO_HOME=/cargo && \
     export SCCACHE_DIR=/sccache && \
     export RUSTC_WRAPPER=/usr/bin/sccache && \
     export CC="/usr/bin/clang" && \
+    if [ "${TARGETARCH}" = "arm64" ]; then \
+        export RUSTFLAGS="${RUSTFLAGS} -Ctarget-cpu=generic -Ctarget-feature=-lse"; \
+        export CFLAGS="${CFLAGS:+$CFLAGS }-march=armv8-a"; \
+        export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }-march=armv8-a"; \
+    fi && \
     cargo auditable build --locked -p daemon ${KANIDM_BUILD_OPTIONS} \
         --target-dir="/usr/src/kanidm/target/" \
         --features="${KANIDM_FEATURES}" \


### PR DESCRIPTION
## Summary

Linux `aarch64` builds now apply conservative ARMv8.0-A flags through the shared Cargo/build-profile path rather than only inside the server container Dockerfile. This keeps release outputs compatible with Raspberry Pi 4 / Cortex-A72 class systems that do not support ARMv8.1-A LSE atomics.

Concretely, the aarch64 Linux target adds:

- a profile-side `armv8_a` default for native aarch64 Linux builds
- `-Ctarget-feature=-lse` from that profile
- `CFLAGS_aarch64_unknown_linux_gnu=-march=armv8-a`
- `CXXFLAGS_aarch64_unknown_linux_gnu=-march=armv8-a`

The C/C++ flags are required because the observed illegal instruction comes from `libmimalloc-sys`, whose build script requests `-march=armv8.1-a` and can emit LSE instructions such as `casal`/`ldaddal` on arm64 builders with newer CPUs.

Closes #4371.

## Validation

- `nix shell nixpkgs#cargo -c cargo metadata --no-deps --format-version 1`
- `nix shell nixpkgs#cargo nixpkgs#rustfmt -c cargo fmt --check`
- `git diff --check`
- `nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#pkg-config nixpkgs#clang nixpkgs#lld -c cargo check -p kanidm_build_profiles`
- Earlier container-only version: `docker build --target repos -f server/Dockerfile -t kanidm-dockerfile-syntax-check .`
- Separately smoke-tested an equivalent 1.10.3 rebuild on an RK3399 ARMv8.0-A host: `kanidmd version` prints `kanidmd 1.10.3` instead of exiting with SIGILL.
