### PR TITLE
fix: log IDs for OpenTelemetry LDAP requests

### DIFF
--- a/libs/sketching/src/lib.rs
+++ b/libs/sketching/src/lib.rs
@@ -18,6 +18,21 @@ pub mod pipeline;
 
 pub use {tracing, tracing_forest, tracing_subscriber};
 
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum LoggerType {
+    TracingForest,
+    OpenTelemetry,
+}
+
+impl LoggerType {
+    pub fn status_code_field(self) -> &'static str {
+        match self {
+            LoggerType::TracingForest => "status_code",
+            LoggerType::OpenTelemetry => "http.response.status_code",
+        }
+    }
+}
+
 /// Start up the logging for test mode.
 pub fn test_init() {
     let filter = EnvFilter::builder()

--- a/libs/sketching/src/pipeline.rs
+++ b/libs/sketching/src/pipeline.rs
@@ -1,7 +1,5 @@
 use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
-use opentelemetry_otlp::{
-    tonic_types::metadata::MetadataMap, Protocol, WithExportConfig, WithTonicConfig,
-};
+use opentelemetry_otlp::{tonic_types::metadata::MetadataMap, WithExportConfig, WithTonicConfig};
 use opentelemetry_sdk::{
     trace::{Sampler, SdkTracerProvider},
     Resource,
@@ -14,6 +12,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use tracing::Subscriber;
 use tracing_core::Level;
+use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{filter::Directive, prelude::*, EnvFilter, Registry};
 
 const MAX_EVENTS_PER_SPAN: u32 = 64 * 1024;
@@ -70,7 +69,10 @@ pub fn start_logging_pipeline(
 
     // TODO: work out how to do metrics things
     if let Some(endpoint) = otlp_endpoint {
-        eprintln!("Starting OTLP logging pipeline endpoint={}", endpoint);
+        eprintln!(
+            "Attempting to start OTLP logging pipeline endpoint={}",
+            endpoint
+        );
 
         // setup metadata so we can auth to third-party services
         let mut tonic_metadata = MetadataMap::new();
@@ -95,7 +97,6 @@ pub fn start_logging_pipeline(
             .with_tonic()
             .with_endpoint(endpoint)
             .with_metadata(tonic_metadata)
-            .with_protocol(Protocol::HttpBinary)
             .with_timeout(Duration::from_secs(5))
             .build()
             .map_err(|err| err.to_string())?;
@@ -139,7 +140,6 @@ pub fn start_logging_pipeline(
 
         global::set_tracer_provider(provider.clone());
         provider.tracer("tracing-otel-subscriber");
-        use tracing_opentelemetry::OpenTelemetryLayer;
 
         let registry = tracing_subscriber::registry()
             .with(

--- a/proto/src/cli.rs
+++ b/proto/src/cli.rs
@@ -11,11 +11,11 @@ pub struct KanidmdCli {
     pub log_level: Option<sketching::LogLevel>,
 
     #[clap(
-        env = "KANIDM_OTEL_GRPC_URL",
+        env = "KANIDM_OTEL_GRPC_ENDPOINT",
         global = true,
-        help = "Specify the OpenTelemetry gRPC URL"
+        help = "Specify the OpenTelemetry gRPC endpoint (ip/hostname:port)"
     )]
-    pub otel_grpc_url: Option<String>,
+    pub otel_grpc_endpoint: Option<String>,
 
     #[clap(env = "KANIDM_DOMAIN", global = true, help = "Specify the domain")]
     pub domain: Option<String>,

--- a/server/core/src/config.rs
+++ b/server/core/src/config.rs
@@ -345,8 +345,8 @@ pub struct ServerConfig {
     #[serde(rename = "replication")]
     /// Replication configuration, this is a development feature and not yet ready for production use.
     repl_config: Option<ReplicationConfiguration>,
-    /// An optional OpenTelemetry collector (GRPC) url to send trace and log data to, eg `http://localhost:4317`. If not set, disables the feature.
-    otel_grpc_url: Option<String>,
+    /// An optional OpenTelemetry collector (GRPC) url to send trace and log data to, eg `localhost:4317`. If not set, disables the feature.
+    otel_grpc_endpoint: Option<String>,
 }
 
 impl ServerConfigUntagged {
@@ -433,7 +433,7 @@ pub struct ServerConfigV2 {
     #[serde(default)]
     #[serde(rename = "replication")]
     repl_config: Option<ReplicationConfiguration>,
-    otel_grpc_url: Option<String>,
+    otel_grpc_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -482,7 +482,7 @@ pub struct Configuration {
     pub repl_config: Option<ReplicationConfiguration>,
     /// This allows internally setting some unsafe options for replication.
     pub integration_repl_config: Option<Box<IntegrationReplConfig>>,
-    pub otel_grpc_url: Option<String>,
+    pub otel_grpc_endpoint: Option<String>,
 }
 
 impl Configuration {
@@ -514,7 +514,7 @@ impl Configuration {
             log_level: None,
             role: None,
             repl_config: None,
-            otel_grpc_url: None,
+            otel_grpc_endpoint: None,
         }
     }
 
@@ -542,7 +542,7 @@ impl Configuration {
             role: ServerRole::WriteReplicaNoUI,
             repl_config: None,
             integration_repl_config: None,
-            otel_grpc_url: None,
+            otel_grpc_endpoint: None,
         }
     }
 }
@@ -625,7 +625,7 @@ impl fmt::Display for Configuration {
                 write!(f, "replication: disabled, ")?;
             }
         }
-        write!(f, "otel_grpc_url: {:?}", self.otel_grpc_url)?;
+        write!(f, "otel_grpc_endpoint: {:?}", self.otel_grpc_endpoint)?;
         Ok(())
     }
 }
@@ -653,7 +653,7 @@ pub struct ConfigurationBuilder {
     role: Option<ServerRole>,
     log_level: Option<LogLevel>,
     repl_config: Option<ReplicationConfiguration>,
-    otel_grpc_url: Option<String>,
+    otel_grpc_endpoint: Option<String>,
 }
 
 impl ConfigurationBuilder {
@@ -664,8 +664,8 @@ impl ConfigurationBuilder {
             self.log_level = Some(*log_level);
         }
 
-        if let Some(otel_grpc_url) = &cli_config.otel_grpc_url {
-            self.otel_grpc_url = Some(otel_grpc_url.clone());
+        if let Some(otel_grpc_endpoint) = &cli_config.otel_grpc_endpoint {
+            self.otel_grpc_endpoint = Some(otel_grpc_endpoint.clone());
         }
 
         // core domainy things
@@ -888,8 +888,8 @@ impl ConfigurationBuilder {
             self.repl_config = config.repl_config;
         }
 
-        if config.otel_grpc_url.is_some() {
-            self.otel_grpc_url = config.otel_grpc_url;
+        if config.otel_grpc_endpoint.is_some() {
+            self.otel_grpc_endpoint = config.otel_grpc_endpoint;
         }
 
         self
@@ -976,8 +976,8 @@ impl ConfigurationBuilder {
             self.repl_config = config.repl_config;
         }
 
-        if config.otel_grpc_url.is_some() {
-            self.otel_grpc_url = config.otel_grpc_url;
+        if config.otel_grpc_endpoint.is_some() {
+            self.otel_grpc_endpoint = config.otel_grpc_endpoint;
         }
 
         self
@@ -1013,7 +1013,7 @@ impl ConfigurationBuilder {
             role,
             log_level,
             repl_config,
-            otel_grpc_url,
+            otel_grpc_endpoint,
         } = self;
 
         let tls_config = match (tls_key, tls_chain, tls_client_ca) {
@@ -1078,7 +1078,7 @@ impl ConfigurationBuilder {
             role,
             log_level,
             repl_config,
-            otel_grpc_url,
+            otel_grpc_endpoint,
             integration_repl_config: None,
             integration_test_config: None,
         })

--- a/server/core/src/https/mod.rs
+++ b/server/core/src/https/mod.rs
@@ -65,22 +65,6 @@ mod v1_oauth2;
 mod v1_scim;
 mod views;
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub(crate) enum LoggerType {
-    TracingForest,
-    OpenTelemetry,
-}
-
-impl LoggerType {
-    #[inline]
-    pub(crate) fn status_code_field(self) -> &'static str {
-        match self {
-            LoggerType::TracingForest => "status_code",
-            LoggerType::OpenTelemetry => "http.response.status_code",
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct ServerState {
     pub(crate) status_ref: &'static StatusActor,
@@ -283,7 +267,7 @@ pub async fn create_https_server(
 
     let trusted_tcp_info_ips = config.http_client_address_info.trusted_tcp_info();
 
-    let logging_pipeline = if config.otel_grpc_url.is_some() {
+    let logging_pipeline = if config.otel_grpc_endpoint.is_some() {
         LoggerType::OpenTelemetry
     } else {
         LoggerType::TracingForest

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -8,6 +8,7 @@ use kanidmd_lib::idm::ldap::{LdapBoundToken, LdapResponseState};
 use kanidmd_lib::prelude::*;
 use ldap3_proto::proto::LdapMsg;
 use ldap3_proto::LdapCodec;
+use sketching::LoggerType;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -40,8 +41,18 @@ async fn client_process_msg(
     client_address: SocketAddr,
     protomsg: LdapMsg,
     qe_r_ref: &'static QueryServerReadV1,
+    logging_pipeline: LoggerType,
 ) -> Option<LdapResponseState> {
-    let eventid = sketching::tracing_forest::id();
+    let eventid = match logging_pipeline {
+        LoggerType::TracingForest => sketching::tracing_forest::id(),
+        LoggerType::OpenTelemetry => {
+            // try to the current span ID and fail back to generating a Uuid
+            tracing::Span::current()
+                .id()
+                .map(|id| Uuid::from_u64_pair(0, id.into_u64()))
+                .unwrap_or(Uuid::new_v4())
+        }
+    };
     security_info!(
         client_ip = %client_address.ip(),
         client_port = %client_address.port(),
@@ -57,6 +68,7 @@ async fn client_process<STREAM>(
     client_address: SocketAddr,
     connection_address: SocketAddr,
     qe_r_ref: &'static QueryServerReadV1,
+    logging_pipeline: LoggerType,
 ) where
     STREAM: AsyncRead + AsyncWrite + AsyncWriteExt + Unpin,
 {
@@ -90,7 +102,7 @@ async fn client_process<STREAM>(
 
         debug!(?client_address, ?connection_address);
 
-        match client_process_msg(uat, caddr, protomsg, qe_r_ref).await {
+        match client_process_msg(uat, caddr, protomsg, qe_r_ref, logging_pipeline).await {
             // I'd really have liked to have put this near the [LdapResponseState::Bind] but due
             // to the handing of `audit` it isn't possible due to borrows, etc.
             Some(LdapResponseState::Unbind) => break,
@@ -153,6 +165,7 @@ async fn client_tls_accept(
     connection_addr: SocketAddr,
     qe_r_ref: &'static QueryServerReadV1,
     trusted_tcp_info_ips: Arc<TcpAddressInfo>,
+    logging_pipeline: LoggerType,
 ) {
     let Ok((stream, client_addr)) = process_client_addr(
         stream,
@@ -196,6 +209,7 @@ async fn client_tls_accept(
         client_addr,
         connection_addr,
         qe_r_ref,
+        logging_pipeline,
     ));
 }
 
@@ -207,6 +221,7 @@ async fn ldap_tls_acceptor(
     mut rx: broadcast::Receiver<CoreAction>,
     mut tls_acceptor_reload_rx: broadcast::Receiver<TlsAcceptor>,
     trusted_tcp_info_ips: Arc<TcpAddressInfo>,
+    logging_pipeline: LoggerType,
 ) {
     loop {
         tokio::select! {
@@ -220,7 +235,7 @@ async fn ldap_tls_acceptor(
                 match accept_result {
                     Ok((tcpstream, client_socket_addr)) => {
                         let clone_tls_acceptor = tls_acceptor.clone();
-                        tokio::spawn(client_tls_accept(tcpstream, clone_tls_acceptor, client_socket_addr, qe_r_ref, trusted_tcp_info_ips.clone()));
+                        tokio::spawn(client_tls_accept(tcpstream, clone_tls_acceptor, client_socket_addr, qe_r_ref, trusted_tcp_info_ips.clone(), logging_pipeline));
                     }
                     Err(err) => {
                         warn!(?err, "LDAP acceptor error, continuing");
@@ -241,6 +256,7 @@ async fn ldap_plaintext_acceptor(
     listener: TcpListener,
     qe_r_ref: &'static QueryServerReadV1,
     mut rx: broadcast::Receiver<CoreAction>,
+    logging_pipeline: LoggerType,
 ) {
     loop {
         tokio::select! {
@@ -253,7 +269,7 @@ async fn ldap_plaintext_acceptor(
             accept_result = listener.accept() => {
                 match accept_result {
                     Ok((tcpstream, client_socket_addr)) => {
-                        tokio::spawn(client_process(tcpstream, client_socket_addr, client_socket_addr, qe_r_ref));
+                        tokio::spawn(client_process(tcpstream, client_socket_addr, client_socket_addr, qe_r_ref, logging_pipeline));
                     }
                     Err(e) => {
                         error!("LDAP acceptor error, continuing -> {:?}", e);
@@ -272,6 +288,7 @@ pub(crate) async fn create_ldap_server(
     server_message_tx: &broadcast::Sender<CoreAction>,
     tls_acceptor_reload_tx: &broadcast::Sender<TlsAcceptor>,
     trusted_tcp_info_ips: Arc<TcpAddressInfo>,
+    logging_pipeline: LoggerType,
 ) -> Result<Vec<tokio::task::JoinHandle<()>>, ()> {
     let mut ldap_acceptor_handles = Vec::with_capacity(addresses.len());
 
@@ -310,9 +327,15 @@ pub(crate) async fn create_ldap_server(
                     rx,
                     tls_acceptor_reload_rx,
                     trusted_tcp_info_ips,
+                    logging_pipeline,
                 ))
             }
-            None => tokio::spawn(ldap_plaintext_acceptor(listener, qe_r_ref, rx)),
+            None => tokio::spawn(ldap_plaintext_acceptor(
+                listener,
+                qe_r_ref,
+                rx,
+                logging_pipeline,
+            )),
         };
 
         info!("Created LDAP interface");

--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -58,6 +58,7 @@ use kanidmd_lib::schema::Schema;
 use kanidmd_lib::status::StatusActor;
 use kanidmd_lib::value::CredentialType;
 use regex::Regex;
+use sketching::LoggerType;
 use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
 use std::path::Path;
@@ -1311,6 +1312,10 @@ pub async fn create_server_core(
     // If we have been requested to init LDAP, configure it now.
     let maybe_ldap_acceptor_handles = match &config.ldapbindaddress {
         Some(la) => {
+            let logging_pipeline = match config.otel_grpc_endpoint {
+                Some(_) => LoggerType::OpenTelemetry,
+                None => LoggerType::TracingForest,
+            };
             let opt_ldap_ssl_acceptor = maybe_tls_acceptor.clone();
 
             let h = ldaps::create_ldap_server(
@@ -1320,6 +1325,7 @@ pub async fn create_server_core(
                 &broadcast_tx,
                 &tls_acceptor_reload_tx,
                 config.ldap_client_address_info.trusted_tcp_info(),
+                logging_pipeline,
             )
             .await?;
             Some(h)

--- a/server/daemon/src/main.rs
+++ b/server/daemon/src/main.rs
@@ -504,7 +504,7 @@ async fn start_daemon(opt: KanidmdParser, config: Configuration) -> ExitCode {
 
     // TODO: only send to stderr when we're not in a TTY
     let (provider, logging_subscriber) = match sketching::pipeline::start_logging_pipeline(
-        &config.otel_grpc_url,
+        &config.otel_grpc_endpoint,
         config.log_level,
     ) {
         Err(err) => {


### PR DESCRIPTION
# Change summary

- the LDAP pipelines were calling just tracing_forest id which ... doesn't make it happy 😄 
- breaking change - "url" wasn't accurate or ... making things happy either - standard is to specify endpoint (ip/hostname:port) - changes config from `otel_grpc_url` to `otel_grpc_endpoint` (and associated environment variables)

Fixes #4365

Checklist

- [X] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
