### PR TITLE
Missing attributes in migration access

### DIFF
--- a/examples/migrations/00-basic.hjson
+++ b/examples/migrations/00-basic.hjson
@@ -48,6 +48,14 @@
       "name": "remove-all-members",
       // Setting a value to null will cause its content to be removed.
       "member": null
-    }
+    },
+    {
+      "state": "present",
+      "id": "ffc56e18-6d84-4997-b111-3f997ee158eb",
+      "class": [
+        "group"
+      ],
+      "name": "lion_admins"
+    },
   ]
 }

--- a/server/lib/src/server/access/migration.rs
+++ b/server/lib/src/server/access/migration.rs
@@ -64,7 +64,13 @@ pub fn migration_entry_attrs(
             EntryClass::AccountPolicy.as_ref(),
             EntryClass::PosixGroup.as_ref(),
         ]);
-        allow_attrs.extend([Attribute::Member, Attribute::Name, Attribute::Description])
+        allow_attrs.extend([
+            Attribute::Member,
+            Attribute::Name,
+            Attribute::Description,
+            Attribute::EntryManagedBy,
+            Attribute::GidNumber,
+        ])
     }
 
     if classes.contains(EntryClass::Person.into()) {
@@ -81,6 +87,8 @@ pub fn migration_entry_attrs(
             Attribute::Mail,
             Attribute::SshPublicKey,
             Attribute::Description,
+            Attribute::LoginShell,
+            Attribute::GidNumber,
         ])
     }
 
@@ -96,6 +104,7 @@ pub fn migration_entry_attrs(
             Attribute::Mail,
             Attribute::SshPublicKey,
             Attribute::Description,
+            Attribute::EntryManagedBy,
         ])
     }
 
@@ -132,6 +141,7 @@ pub fn migration_entry_attrs(
             Attribute::OAuth2RsOrigin,
             Attribute::OAuth2RsOriginLanding,
             Attribute::OAuth2ConsentPromptEnable,
+            Attribute::EntryManagedBy,
         ])
     }
 

--- a/server/lib/src/server/access/migration.rs
+++ b/server/lib/src/server/access/migration.rs
@@ -115,12 +115,14 @@ pub fn migration_entry_attrs(
     if classes.contains(EntryClass::OAuth2ResourceServer.into()) {
         allow_cls.clear();
         allow_cls.extend([
+            EntryClass::Account.as_ref(),
             EntryClass::OAuth2ResourceServer.as_ref(),
             EntryClass::OAuth2ResourceServerBasic.as_ref(),
             EntryClass::OAuth2ResourceServerPublic.as_ref(),
         ]);
         allow_attrs.extend([
             Attribute::Name,
+            Attribute::DisplayName,
             Attribute::Description,
             Attribute::OAuth2RsScopeMap,
             Attribute::OAuth2RsSupScopeMap,
@@ -128,6 +130,7 @@ pub fn migration_entry_attrs(
             Attribute::OAuth2PreferShortUsername,
             Attribute::OAuth2RsClaimMap,
             Attribute::OAuth2RsOrigin,
+            Attribute::OAuth2RsOriginLanding,
             Attribute::OAuth2ConsentPromptEnable,
         ])
     }

--- a/server/lib/src/server/access/migration.rs
+++ b/server/lib/src/server/access/migration.rs
@@ -76,6 +76,7 @@ pub fn migration_entry_attrs(
         ]);
         allow_attrs.extend([
             Attribute::Name,
+            Attribute::DisplayName,
             Attribute::LegalName,
             Attribute::Mail,
             Attribute::SshPublicKey,
@@ -91,6 +92,7 @@ pub fn migration_entry_attrs(
         ]);
         allow_attrs.extend([
             Attribute::Name,
+            Attribute::DisplayName,
             Attribute::Mail,
             Attribute::SshPublicKey,
             Attribute::Description,


### PR DESCRIPTION
# Change summary

- Missing DisplayName attribute in migrations access policy.

Fixes #4384 

Checklist

- [x] This PR contains no AI generated code
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
