### PR TITLE
tools/cli: Rename `u2fhid` feature to `mozilla`

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -69,7 +69,7 @@ features = ["win10"]
 
 [target."cfg(any(target_os = \"linux\",target_os = \"macos\"))".dependencies.webauthn-authenticator-rs]
 workspace = true
-features = ["u2fhid"]
+features = ["mozilla"]
 
 
 [dev-dependencies]

--- a/tools/cli/src/cli/webauthn/mod.rs
+++ b/tools/cli/src/cli/webauthn/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-mod u2fhid;
+mod mozilla;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-use u2fhid::get_authenticator_backend;
+use mozilla::get_authenticator_backend;
 
 #[cfg(target_os = "windows")]
 mod win10;

--- a/tools/cli/src/cli/webauthn/mozilla.rs
+++ b/tools/cli/src/cli/webauthn/mozilla.rs
@@ -1,0 +1,5 @@
+use webauthn_authenticator_rs::mozilla::MozillaAuthenticator;
+
+pub fn get_authenticator_backend() -> MozillaAuthenticator {
+    MozillaAuthenticator::new()
+}

--- a/tools/cli/src/cli/webauthn/u2fhid.rs
+++ b/tools/cli/src/cli/webauthn/u2fhid.rs
@@ -1,5 +1,0 @@
-use webauthn_authenticator_rs::u2fhid::U2FHid;
-
-pub fn get_authenticator_backend() -> U2FHid {
-    U2FHid::new()
-}


### PR DESCRIPTION
# Change summary

`webauthn-authenticator-rs`' `u2fhid` feature was renamed to `mozilla` in https://github.com/kanidm/webauthn-rs/pull/317

The `u2fhid` alias will be removed in https://github.com/kanidm/webauthn-rs/pull/569, which will break `kanidm`.

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
