### PR TITLE
20260602 pam env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,11 +2812,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4077,9 +4077,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5828,9 +5828,9 @@ checksum = "5d79b4b604167921892e84afbbaad9d5ad74e091bf6c511d9dbfb0593f09fabd"
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ reqwest = { version = "0.13.4", default-features = false, features = [
     "query",
     "socks",
 ] }
-rusqlite = { version = "0.39.0", features = ["array", "bundled"] }
+rusqlite = { version = "=0.39.0", features = ["array", "bundled"] }
 rustls = { version = "0.23.37", default-features = false, features = [
     "std",
     "aws_lc_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ reqwest = { version = "0.13.4", default-features = false, features = [
     "query",
     "socks",
 ] }
-rusqlite = { version = "0.40.1", features = ["array", "bundled"] }
+rusqlite = { version = "0.39.0", features = ["array", "bundled"] }
 rustls = { version = "0.23.37", default-features = false, features = [
     "std",
     "aws_lc_rs",

--- a/unix_integration/common/src/unix_proto.rs
+++ b/unix_integration/common/src/unix_proto.rs
@@ -103,13 +103,23 @@ pub enum PamAuthRequest {
     Pin { cred: String },
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PamServiceInfo {
     pub service: String,
     // Somehow SDDM doesn't set this ...
     pub tty: Option<String>,
     // Only set if it really is a remote host?
     pub rhost: Option<String>,
+}
+
+impl Default for PamServiceInfo {
+    fn default() -> Self {
+        PamServiceInfo {
+            service: "kanidm:default".into(),
+            tty: None,
+            rhost: None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -129,8 +139,14 @@ pub enum ClientRequest {
         request: PamAuthRequest,
         session_id: u64,
     },
-    PamAccountAllowed(String),
-    PamAccountBeginSession(String),
+    PamAccountAllowed {
+        account_id: String,
+        info: PamServiceInfo,
+    },
+    PamAccountBeginSession {
+        account_id: String,
+        info: PamServiceInfo,
+    },
     InvalidateCache,
     ClearCache,
     Status,
@@ -155,10 +171,22 @@ impl ClientRequest {
                 info.rhost.as_deref().unwrap_or("")
             ),
             ClientRequest::PamAuthenticateStep { .. } => "PamAuthenticateStep".to_string(),
-            ClientRequest::PamAccountAllowed(id) => {
-                format!("PamAccountAllowed({id})")
-            }
-            ClientRequest::PamAccountBeginSession(_) => "PamAccountBeginSession".to_string(),
+
+            ClientRequest::PamAccountAllowed { account_id, info } => format!(
+                "PamAccountAllowed{{ account_id={} tty={} pam_secvice{} rhost={} }}",
+                account_id,
+                info.service,
+                info.tty.as_deref().unwrap_or(""),
+                info.rhost.as_deref().unwrap_or("")
+            ),
+            ClientRequest::PamAccountBeginSession { account_id, info } => format!(
+                "PamAccountBeginSession{{ account_id={} tty={} pam_secvice{} rhost={} }}",
+                account_id,
+                info.service,
+                info.tty.as_deref().unwrap_or(""),
+                info.rhost.as_deref().unwrap_or("")
+            ),
+
             ClientRequest::InvalidateCache => "InvalidateCache".to_string(),
             ClientRequest::ClearCache => "ClearCache".to_string(),
             ClientRequest::Status => "Status".to_string(),

--- a/unix_integration/nss_sparkle/build.rs
+++ b/unix_integration/nss_sparkle/build.rs
@@ -5,7 +5,8 @@ fn main() {
 
         cc::Build::new()
             .file("src/freebsd_nss.c")
-            .static_flag(true)
+            // No longer required
+            // .static_flag(true)
             .link_lib_modifier("+whole-archive")
             .compile("freebsd_nss");
     }

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -105,6 +105,7 @@ pub trait PamHandler {
 
     fn envlist(&self) -> PamResult<Vec<String>>;
 
+    #[allow(dead_code)]
     fn set_env(&self, value: &str) -> PamResult<()>;
 
     fn authtok(&self) -> PamResult<Option<String>>;

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -485,10 +485,13 @@ pub fn acct_mgmt<P: PamHandler>(
     req_opt: RequestOptions,
     current_time: OffsetDateTime,
 ) -> PamResultCode {
-    let info = pamh.service_info().inspect_err(|e| {
+    let info = match pamh.service_info() {
+        Ok(info) => info,
+        Err(e) => {
             error!(err = ?e, "get_pam_info");
+            return e;
         }
-    })?;
+    };
 
     /*
     // We can access values here within the calling context

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -485,13 +485,10 @@ pub fn acct_mgmt<P: PamHandler>(
     req_opt: RequestOptions,
     current_time: OffsetDateTime,
 ) -> PamResultCode {
-    let info = match pamh.service_info() {
-        Ok(info) => info,
-        Err(e) => {
+    let info = pamh.service_info().inspect_err(|e| {
             error!(err = ?e, "get_pam_info");
-            return e;
         }
-    };
+    })?;
 
     /*
     // We can access values here within the calling context

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -628,9 +628,11 @@ pub fn sm_chauthtok<P: PamHandler>(_pamh: &P, _opts: &ModuleOptions) -> PamResul
 
 pub fn sm_setcred<P: PamHandler>(pamh: &P, _opts: &ModuleOptions) -> PamResultCode {
     // We can set values here into the users session.
+    /*
     if let Err(err) = pamh.set_env("KANIDM_TEST_VAR=test") {
         error!(?err, "set_env");
     };
+    */
 
     match pamh.envlist() {
         Ok(envlist) => debug!(?envlist),

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -103,6 +103,10 @@ pub trait PamHandler {
 
     fn service_info(&self) -> PamResult<PamServiceInfo>;
 
+    fn envlist(&self) -> PamResult<Vec<String>>;
+
+    fn set_env(&self, value: &str) -> PamResult<()>;
+
     fn authtok(&self) -> PamResult<Option<String>>;
 
     /// Display a message to the user.
@@ -132,6 +136,11 @@ pub fn sm_authenticate_connected<P: PamHandler>(
             return e;
         }
     };
+
+    // We can use the env vars here to direct our authentication.
+    for (key, value) in std::env::vars() {
+        debug!("{key}: {value}");
+    }
 
     let account_id = match pamh.account_id() {
         Ok(acc) => acc,
@@ -475,6 +484,21 @@ pub fn acct_mgmt<P: PamHandler>(
     req_opt: RequestOptions,
     current_time: OffsetDateTime,
 ) -> PamResultCode {
+    let info = match pamh.service_info() {
+        Ok(info) => info,
+        Err(e) => {
+            error!(err = ?e, "get_pam_info");
+            return e;
+        }
+    };
+
+    /*
+    // We can access values here within the calling context
+    for (key, value) in std::env::vars() {
+        debug!("{key}: {value}");
+    }
+    */
+
     let account_id = match pamh.account_id() {
         Ok(acc) => acc,
         Err(err) => return err,
@@ -482,7 +506,7 @@ pub fn acct_mgmt<P: PamHandler>(
 
     match req_opt.connect_to_daemon() {
         Source::Daemon(daemon_client) => {
-            let req = ClientRequest::PamAccountAllowed(account_id);
+            let req = ClientRequest::PamAccountAllowed { account_id, info };
             match daemon_client.call_and_wait(req, None) {
                 Ok(r) => match r {
                     ClientResponse::PamStatus(Some(true)) => {
@@ -556,6 +580,14 @@ pub fn sm_open_session<P: PamHandler>(
     _opts: &ModuleOptions,
     req_opt: RequestOptions,
 ) -> PamResultCode {
+    let info = match pamh.service_info() {
+        Ok(info) => info,
+        Err(e) => {
+            error!(err = ?e, "get_pam_info");
+            return e;
+        }
+    };
+
     let account_id = match pamh.account_id() {
         Ok(acc) => acc,
         Err(err) => return err,
@@ -563,7 +595,7 @@ pub fn sm_open_session<P: PamHandler>(
 
     match req_opt.connect_to_daemon() {
         Source::Daemon(daemon_client) => {
-            let req = ClientRequest::PamAccountBeginSession(account_id);
+            let req = ClientRequest::PamAccountBeginSession { account_id, info };
 
             match daemon_client.call_and_wait(req, None) {
                 Ok(ClientResponse::Ok) => {
@@ -594,6 +626,18 @@ pub fn sm_chauthtok<P: PamHandler>(_pamh: &P, _opts: &ModuleOptions) -> PamResul
     PamResultCode::PAM_IGNORE
 }
 
-pub fn sm_setcred<P: PamHandler>(_pamh: &P, _opts: &ModuleOptions) -> PamResultCode {
+pub fn sm_setcred<P: PamHandler>(pamh: &P, _opts: &ModuleOptions) -> PamResultCode {
+    // We can set values here into the users session.
+    if let Err(err) = pamh.set_env("KANIDM_TEST_VAR=test") {
+        error!(?err, "set_env");
+    };
+
+    match pamh.envlist() {
+        Ok(envlist) => debug!(?envlist),
+        Err(err) => {
+            error!(?err, "get_envlist");
+        }
+    };
+
     PamResultCode::PAM_SUCCESS
 }

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -487,6 +487,7 @@ pub fn acct_mgmt<P: PamHandler>(
 ) -> PamResultCode {
     let info = pamh.service_info().inspect_err(|e| {
             error!(err = ?e, "get_pam_info");
+        }
     })?;
 
     /*

--- a/unix_integration/pam_sparkle_common/src/core.rs
+++ b/unix_integration/pam_sparkle_common/src/core.rs
@@ -487,7 +487,6 @@ pub fn acct_mgmt<P: PamHandler>(
 ) -> PamResultCode {
     let info = pamh.service_info().inspect_err(|e| {
             error!(err = ?e, "get_pam_info");
-        }
     })?;
 
     /*

--- a/unix_integration/pam_sparkle_common/src/pam/mod.rs
+++ b/unix_integration/pam_sparkle_common/src/pam/mod.rs
@@ -106,7 +106,7 @@ impl PamHooks for PamSparkle {
 
         install_subscriber(opts.debug);
 
-        debug!(?args, ?opts, "acct_mgmt");
+        debug!(?args, ?opts, "sm_authenticate");
 
         #[allow(clippy::disallowed_methods)]
         // Allowed as this is the source of time for the operation.

--- a/unix_integration/pam_sparkle_common/src/pam/module.rs
+++ b/unix_integration/pam_sparkle_common/src/pam/module.rs
@@ -66,6 +66,7 @@ extern "C" {
 
     fn pam_getenvlist(pamh: *const PamHandle) -> *mut *mut c_char;
 
+    #[allow(dead_code)]
     fn pam_putenv(pamh: *const PamHandle, value: *const c_char) -> PamResultCode;
 }
 
@@ -301,6 +302,7 @@ impl PamHandle {
         Ok(work_array)
     }
 
+    #[allow(dead_code)]
     fn putenv(&self, value: &str) -> PamResult<()> {
         let c_value = CString::new(value).map_err(|_| PamResultCode::PAM_CONV_ERR)?;
 

--- a/unix_integration/pam_sparkle_common/src/pam/module.rs
+++ b/unix_integration/pam_sparkle_common/src/pam/module.rs
@@ -1,19 +1,16 @@
 //! Functions for use in pam modules.
 
-use std::ffi::{CStr, CString};
-use std::{mem, ptr};
-
-use libc::c_char;
-
+use crate::core::PamHandler;
 use crate::pam::constants::{
     PamFlag, PamItemType, PamResultCode, PAM_PROMPT_ECHO_OFF, PAM_TEXT_INFO,
 };
 use crate::pam::conv::PamConv;
 use crate::pam::items::{PamAuthTok, PamRHost, PamService, PamTty};
-
-use crate::core::PamHandler;
+use libc::{c_char, c_void};
 use sparkle_unix_common::unix_proto::DeviceAuthorizationResponse;
 use sparkle_unix_common::unix_proto::PamServiceInfo;
+use std::ffi::{CStr, CString};
+use std::{mem, ptr};
 
 /// Opaque type, used as a pointer when making pam API calls.
 ///
@@ -66,6 +63,10 @@ extern "C" {
         user: &mut *const c_char,
         prompt: *const c_char,
     ) -> PamResultCode;
+
+    fn pam_getenvlist(pamh: *const PamHandle) -> *mut *mut c_char;
+
+    fn pam_putenv(pamh: *const PamHandle, value: *const c_char) -> PamResultCode;
 }
 
 /// # Safety
@@ -268,6 +269,49 @@ impl PamHandle {
     fn get_conv(&self) -> PamResult<&PamConv> {
         self.get_item::<PamConv>()
     }
+
+    fn get_envlist(&self) -> PamResult<Vec<String>> {
+        let array_ptr = unsafe { pam_getenvlist(self) };
+
+        if array_ptr.is_null() {
+            return Err(PamResultCode::PAM_CONV_ERR);
+        }
+
+        let mut work_array = Vec::new();
+
+        unsafe {
+            let mut offset = 0;
+            let mut str_ptr = *array_ptr;
+
+            while !str_ptr.is_null() {
+                let c_str = CStr::from_ptr(str_ptr);
+
+                let rust_str = c_str.to_string_lossy();
+                work_array.push(rust_str.to_string());
+
+                libc::free(str_ptr as *mut c_void);
+
+                offset += 1;
+                str_ptr = *(array_ptr.add(offset));
+            }
+
+            libc::free(array_ptr as *mut c_void);
+        }
+
+        Ok(work_array)
+    }
+
+    fn putenv(&self, value: &str) -> PamResult<()> {
+        let c_value = CString::new(value).map_err(|_| PamResultCode::PAM_CONV_ERR)?;
+
+        let res = unsafe { pam_putenv(self, c_value.as_ptr()) };
+
+        if PamResultCode::PAM_SUCCESS == res {
+            Ok(())
+        } else {
+            Err(res)
+        }
+    }
 }
 
 impl PamHandler for PamHandle {
@@ -277,6 +321,14 @@ impl PamHandler for PamHandle {
 
     fn service_info(&self) -> PamResult<PamServiceInfo> {
         self.get_pam_info()
+    }
+
+    fn envlist(&self) -> PamResult<Vec<String>> {
+        self.get_envlist()
+    }
+
+    fn set_env(&self, value: &str) -> PamResult<()> {
+        self.putenv(value)
     }
 
     fn authtok(&self) -> PamResult<Option<String>> {

--- a/unix_integration/pam_sparkle_common/src/tests.rs
+++ b/unix_integration/pam_sparkle_common/src/tests.rs
@@ -106,6 +106,14 @@ impl PamHandler for TestHandler {
         }
     }
 
+    fn envlist(&self) -> PamResult<Vec<String>> {
+        Ok(Vec::default())
+    }
+
+    fn set_env(&self, _value: &str) -> PamResult<()> {
+        Ok(())
+    }
+
     fn authtok(&self) -> PamResult<Option<String>> {
         let mut q = self.response_queue.lock().unwrap();
         match q.pop_front() {
@@ -323,7 +331,10 @@ fn pam_fallback_acct_mgmt_default() {
     let mod_opts = ModuleOptions::default();
     let test_time = OffsetDateTime::UNIX_EPOCH;
 
-    let pamh = TestHandler::from(vec![Event::Account("tobias")]);
+    let pamh = TestHandler::from(vec![
+        Event::ServiceInfo(PamServiceInfo::default()),
+        Event::Account("tobias"),
+    ]);
 
     assert_eq!(
         core::acct_mgmt(&pamh, &mod_opts, req_opt, test_time),
@@ -338,7 +349,10 @@ fn pam_fallback_acct_mgmt_root() {
     let mod_opts = ModuleOptions::default();
     let test_time = OffsetDateTime::UNIX_EPOCH;
 
-    let pamh = TestHandler::from(vec![Event::Account("root")]);
+    let pamh = TestHandler::from(vec![
+        Event::ServiceInfo(PamServiceInfo::default()),
+        Event::Account("root"),
+    ]);
 
     assert_eq!(
         core::acct_mgmt(&pamh, &mod_opts, req_opt, test_time),
@@ -353,7 +367,10 @@ fn pam_fallback_acct_mgmt_deny_unknown() {
     let mod_opts = ModuleOptions::default();
     let test_time = OffsetDateTime::UNIX_EPOCH;
 
-    let pamh = TestHandler::from(vec![Event::Account("nonexist")]);
+    let pamh = TestHandler::from(vec![
+        Event::ServiceInfo(PamServiceInfo::default()),
+        Event::Account("nonexist"),
+    ]);
 
     assert_eq!(
         core::acct_mgmt(&pamh, &mod_opts, req_opt, test_time),
@@ -371,7 +388,10 @@ fn pam_fallback_acct_mgmt_ignore_unknown() {
     };
     let test_time = OffsetDateTime::UNIX_EPOCH;
 
-    let pamh = TestHandler::from(vec![Event::Account("nonexist")]);
+    let pamh = TestHandler::from(vec![
+        Event::ServiceInfo(PamServiceInfo::default()),
+        Event::Account("nonexist"),
+    ]);
 
     assert_eq!(
         core::acct_mgmt(&pamh, &mod_opts, req_opt, test_time),
@@ -387,7 +407,10 @@ fn pam_fallback_acct_mgmt_expired() {
     let mod_opts = ModuleOptions::default();
     let test_time = OffsetDateTime::UNIX_EPOCH + time::Duration::days(16);
 
-    let pamh = TestHandler::from(vec![Event::Account("tobias")]);
+    let pamh = TestHandler::from(vec![
+        Event::ServiceInfo(PamServiceInfo::default()),
+        Event::Account("tobias"),
+    ]);
 
     assert_eq!(
         core::acct_mgmt(&pamh, &mod_opts, req_opt, test_time),
@@ -400,7 +423,10 @@ fn pam_fallback_sm_open_session() {
     let req_opt = RequestOptions::fallback_fixture();
     let mod_opts = ModuleOptions::default();
 
-    let pamh = TestHandler::from(vec![Event::Account("tobias")]);
+    let pamh = TestHandler::from(vec![
+        Event::ServiceInfo(PamServiceInfo::default()),
+        Event::Account("tobias"),
+    ]);
 
     assert_eq!(
         core::sm_open_session(&pamh, &mod_opts, req_opt),

--- a/unix_integration/resolver_common/src/cli/resolver.rs
+++ b/unix_integration/resolver_common/src/cli/resolver.rs
@@ -325,16 +325,22 @@ async fn handle_client(
                     }
 
                 }
-                ClientRequest::PamAccountAllowed(account_id) => cachelayer
-                    .pam_account_allowed(account_id.as_str())
+                ClientRequest::PamAccountAllowed {
+                    account_id,
+                    info
+                } => cachelayer
+                    .pam_account_allowed(account_id.as_str(), &info)
                     .await
                     .map(ClientResponse::PamStatus)
                     .unwrap_or(ClientResponse::Error(
                         OperationError::KU005ErrorCheckingAccount,
                     )),
-                ClientRequest::PamAccountBeginSession(account_id) => {
+                ClientRequest::PamAccountBeginSession {
+                    account_id,
+                    info
+                } => {
                     match cachelayer
-                        .pam_account_beginsession(account_id.as_str())
+                        .pam_account_beginsession(account_id.as_str(), &info)
                         .await
                     {
                         Ok(Some(info)) => {

--- a/unix_integration/resolver_common/src/cli/tool.rs
+++ b/unix_integration/resolver_common/src/cli/tool.rs
@@ -79,13 +79,15 @@ pub async fn main<F: SparkleFlavour>(flavour: F) -> ExitCode {
 
             info!("Sending request for user {}", &account_id);
 
+            let pam_info = PamServiceInfo {
+                service: "kanidm-unix".to_string(),
+                tty: None,
+                rhost: None,
+            };
+
             let mut req = ClientRequest::PamAuthenticateInit {
                 account_id: account_id.clone(),
-                info: PamServiceInfo {
-                    service: "kanidm-unix".to_string(),
-                    tty: None,
-                    rhost: None,
-                },
+                info: pam_info.clone(),
             };
             loop {
                 match daemon_client.call(req, None).await {
@@ -160,7 +162,10 @@ pub async fn main<F: SparkleFlavour>(flavour: F) -> ExitCode {
                 }
             }
 
-            let sereq = ClientRequest::PamAccountAllowed(account_id);
+            let sereq = ClientRequest::PamAccountAllowed {
+                account_id,
+                info: pam_info,
+            };
 
             match daemon_client.call(sereq, None).await {
                 Ok(r) => match r {

--- a/unix_integration/resolver_common/src/resolver.rs
+++ b/unix_integration/resolver_common/src/resolver.rs
@@ -961,7 +961,11 @@ impl Resolver {
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub async fn pam_account_allowed(&self, account_id: &str) -> Result<Option<bool>, ()> {
+    pub async fn pam_account_allowed(
+        &self,
+        account_id: &str,
+        pam_info: &PamServiceInfo,
+    ) -> Result<Option<bool>, ()> {
         let current_time = SystemTime::now();
         let id = Id::Name(account_id.to_string());
 
@@ -1438,6 +1442,7 @@ impl Resolver {
     pub async fn pam_account_beginsession(
         &self,
         account_id: &str,
+        pam_info: &PamServiceInfo,
     ) -> Result<Option<HomeDirectoryInfo>, ()> {
         let current_time = SystemTime::now();
         let id = Id::Name(account_id.to_string());

--- a/unix_integration/resolver_common/tests/cache_layer_test.rs
+++ b/unix_integration/resolver_common/tests/cache_layer_test.rs
@@ -20,6 +20,7 @@ use sparkle_unix_common::constants::{
 };
 use sparkle_unix_common::unix_config::{GroupMap, KanidmConfig};
 use sparkle_unix_common::unix_passwd::{CryptPw, EtcGroup, EtcShadow, EtcUser};
+use sparkle_unix_common::unix_proto::PamServiceInfo;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
@@ -610,9 +611,11 @@ async fn test_cache_account_pam_allowed() {
     let (cachelayer, async_refresh_rx, adminclient) = setup_test(fixture(test_fixture)).await;
     cachelayer.mark_next_check_now(SystemTime::now()).await;
 
+    let pam_info = PamServiceInfo::default();
+
     // Should fail
     let a1 = cachelayer
-        .pam_account_allowed("testaccount1")
+        .pam_account_allowed("testaccount1", &pam_info)
         .await
         .expect("failed to authenticate");
     assert_eq!(a1, Some(false));
@@ -631,7 +634,7 @@ async fn test_cache_account_pam_allowed() {
 
     // Should pass
     let a2 = cachelayer
-        .pam_account_allowed("testaccount1")
+        .pam_account_allowed("testaccount1", &pam_info)
         .await
         .expect("failed to authenticate");
     assert_eq!(a2, Some(true));
@@ -646,8 +649,10 @@ async fn test_cache_account_pam_nonexist() {
     let (cachelayer, async_refresh_rx, _adminclient) = setup_test(fixture(test_fixture)).await;
     cachelayer.mark_next_check_now(SystemTime::now()).await;
 
+    let pam_info = PamServiceInfo::default();
+
     let a1 = cachelayer
-        .pam_account_allowed("NO_SUCH_ACCOUNT")
+        .pam_account_allowed("NO_SUCH_ACCOUNT", &pam_info)
         .await
         .expect("failed to authenticate");
     assert!(a1.is_none());
@@ -661,7 +666,7 @@ async fn test_cache_account_pam_nonexist() {
     cachelayer.mark_offline().await;
 
     let a1 = cachelayer
-        .pam_account_allowed("NO_SUCH_ACCOUNT")
+        .pam_account_allowed("NO_SUCH_ACCOUNT", &pam_info)
         .await
         .expect("failed to authenticate");
     assert!(a1.is_none());
@@ -682,6 +687,8 @@ async fn test_cache_account_expiry() {
     let (cachelayer, async_refresh_rx, adminclient) = setup_test(fixture(test_fixture)).await;
     cachelayer.mark_next_check_now(SystemTime::now()).await;
     assert!(cachelayer.test_connection().await);
+
+    let pam_info = PamServiceInfo::default();
 
     // We need one good auth first to prime the cache with a hash.
     let a1 = cachelayer
@@ -717,7 +724,7 @@ async fn test_cache_account_expiry() {
 
     // Pam account allowed should be denied.
     let a3 = cachelayer
-        .pam_account_allowed("testaccount1")
+        .pam_account_allowed("testaccount1", &pam_info)
         .await
         .expect("failed to authenticate");
     assert_eq!(a3, Some(false));
@@ -742,7 +749,7 @@ async fn test_cache_account_expiry() {
 
     // Pam account allowed should be denied.
     let a5 = cachelayer
-        .pam_account_allowed("testaccount1")
+        .pam_account_allowed("testaccount1", &pam_info)
         .await
         .expect("failed to authenticate");
     assert_eq!(a5, Some(false));
@@ -987,6 +994,8 @@ async fn test_cache_authenticate_system_account() {
 
     let yescrypted_username = "yescrypted_account".to_string();
 
+    let pam_info = PamServiceInfo::default();
+
     // Important! This is what sets up that testaccount1 won't be resolved
     // because it's in the "local" user set.
     cachelayer
@@ -1143,32 +1152,32 @@ async fn test_cache_authenticate_system_account() {
     // due to how posix auth works, session and authorisation are simpler, and should
     // always just return "true".
     let a1 = cachelayer
-        .pam_account_allowed("testaccount1")
+        .pam_account_allowed("testaccount1", &pam_info)
         .await
         .expect("failed to authorise");
     assert_eq!(a1, Some(true));
 
     let a1 = cachelayer
-        .pam_account_allowed("testaccount2")
+        .pam_account_allowed("testaccount2", &pam_info)
         .await
         .expect("failed to authorise");
     assert_eq!(a1, Some(true));
 
     let a1 = cachelayer
-        .pam_account_allowed(&yescrypted_username)
+        .pam_account_allowed(&yescrypted_username, &pam_info)
         .await
         .expect("failed to authorise");
     assert_eq!(a1, Some(true));
 
     // Should we make home dirs?
     let a1 = cachelayer
-        .pam_account_beginsession("testaccount1")
+        .pam_account_beginsession("testaccount1", &pam_info)
         .await
         .expect("failed to begin session");
     assert_eq!(a1, None);
 
     let a1 = cachelayer
-        .pam_account_beginsession("testaccount2")
+        .pam_account_beginsession("testaccount2", &pam_info)
         .await
         .expect("failed to begin session");
     assert_eq!(a1, None);


### PR DESCRIPTION
# Change summary

- This adds support for pam service info to be accessible in more paths as well as an exploration of how environment variables interact with pam allowing us to propagate session information through pam calls. 

Relates #4360 

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
