### PR TITLE
LDAP session ID and application password cleanup

### DIFF
--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1540,13 +1540,13 @@ impl QueryServerReadV1 {
     #[instrument(
         level = "info",
         skip_all,
-        fields(uuid = ?request_id)
+        fields(uuid = ?eventid)
     )]
     /// Retrieve a public jwk
     pub async fn handle_public_jwk_get(
         &self,
         key_id: String,
-        request_id: Uuid,
+        eventid: Uuid,
     ) -> Result<Jwk, OperationError> {
         let mut idms_prox_read = self.idms.proxy_read().await?;
 

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1540,13 +1540,13 @@ impl QueryServerReadV1 {
     #[instrument(
         level = "info",
         skip_all,
-        fields(uuid = ?eventid)
+        fields(uuid = ?request_id)
     )]
     /// Retrieve a public jwk
     pub async fn handle_public_jwk_get(
         &self,
         key_id: String,
-        eventid: Uuid,
+        request_id: Uuid,
     ) -> Result<Jwk, OperationError> {
         let mut idms_prox_read = self.idms.proxy_read().await?;
 
@@ -1556,11 +1556,11 @@ impl QueryServerReadV1 {
     #[instrument(
         level = "info",
         skip_all,
-        fields(uuid = ?eventid)
+        fields(uuid = ?message_id)
     )]
     pub async fn handle_ldaprequest(
         &self,
-        eventid: Uuid,
+        message_id: Uuid,
         protomsg: LdapMsg,
         uat: Option<LdapBoundToken>,
         ip_addr: IpAddr,
@@ -1568,18 +1568,18 @@ impl QueryServerReadV1 {
         let res = match ServerOps::try_from(protomsg) {
             Ok(server_op) => self
                 .ldap
-                .do_op(&self.idms, server_op, uat, ip_addr, eventid)
+                .do_op(&self.idms, server_op, uat, ip_addr, message_id)
                 .await
                 .unwrap_or_else(|e| {
                     error!("do_op failed -> {:?}", e);
                     LdapResponseState::Disconnect(DisconnectionNotice::gen_response(
                         LdapResultCode::Other,
-                        format!("Internal Server Error {:?}", &eventid).as_str(),
+                        format!("Internal Server Error {:?}", &message_id).as_str(),
                     ))
                 }),
             Err(_) => LdapResponseState::Disconnect(DisconnectionNotice::gen_response(
                 LdapResultCode::ProtocolError,
-                format!("Invalid Request {:?}", &eventid).as_str(),
+                format!("Invalid Request {:?}", &message_id).as_str(),
             )),
         };
         Some(res)

--- a/server/core/src/actors/v1_read.rs
+++ b/server/core/src/actors/v1_read.rs
@@ -1556,11 +1556,11 @@ impl QueryServerReadV1 {
     #[instrument(
         level = "info",
         skip_all,
-        fields(uuid = ?message_id)
+        fields(uuid = ?request_id)
     )]
     pub async fn handle_ldaprequest(
         &self,
-        message_id: Uuid,
+        request_id: Uuid,
         protomsg: LdapMsg,
         uat: Option<LdapBoundToken>,
         ip_addr: IpAddr,
@@ -1568,18 +1568,18 @@ impl QueryServerReadV1 {
         let res = match ServerOps::try_from(protomsg) {
             Ok(server_op) => self
                 .ldap
-                .do_op(&self.idms, server_op, uat, ip_addr, message_id)
+                .do_op(&self.idms, server_op, uat, ip_addr, request_id)
                 .await
                 .unwrap_or_else(|e| {
                     error!("do_op failed -> {:?}", e);
                     LdapResponseState::Disconnect(DisconnectionNotice::gen_response(
                         LdapResultCode::Other,
-                        format!("Internal Server Error {:?}", &message_id).as_str(),
+                        "Internal Server Error",
                     ))
                 }),
             Err(_) => LdapResponseState::Disconnect(DisconnectionNotice::gen_response(
                 LdapResultCode::ProtocolError,
-                format!("Invalid Request {:?}", &message_id).as_str(),
+                "Invalid Request",
             )),
         };
         Some(res)

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -22,17 +22,10 @@ use tokio_util::codec::{FramedRead, FramedWrite};
 const LDAP_CLIENT_IO_TIMEOUT: Duration = Duration::from_secs(300);
 const LDAP_CLIENT_CONN_TIMEOUT: Duration = Duration::from_secs(30);
 
-struct LdapSession {
+/// Lifetime of the LDAP client connection, including the authentication token if authenticated.
+#[derive(Default)]
+struct LdapClientConnection {
     uat: Option<LdapBoundToken>,
-}
-
-impl LdapSession {
-    fn new() -> Self {
-        LdapSession {
-            // We start un-authenticated
-            uat: None,
-        }
-    }
 }
 
 #[instrument(name = "ldap-request", skip(client_address, qe_r_ref))]
@@ -43,7 +36,7 @@ async fn client_process_msg(
     qe_r_ref: &'static QueryServerReadV1,
     logging_pipeline: LoggerType,
 ) -> Option<LdapResponseState> {
-    let eventid = match logging_pipeline {
+    let message_id = match logging_pipeline {
         LoggerType::TracingForest => sketching::tracing_forest::id(),
         LoggerType::OpenTelemetry => {
             // try to the current span ID and fail back to generating a Uuid
@@ -59,7 +52,7 @@ async fn client_process_msg(
         "LDAP client"
     );
     qe_r_ref
-        .handle_ldaprequest(eventid, protomsg, uat, client_address.ip())
+        .handle_ldaprequest(message_id, protomsg, uat, client_address.ip())
         .await
 }
 
@@ -76,8 +69,7 @@ async fn client_process<STREAM>(
     let mut r = FramedRead::new(r, LdapCodec::default());
     let mut w = FramedWrite::new(w, LdapCodec::default());
 
-    // This is a connected client session. we need to associate some state to the session
-    let mut session = LdapSession::new();
+    let mut session = LdapClientConnection::default();
     // Now that we have the session we begin an event loop to process input OR we return.
     loop {
         let protomsg = match timeout(LDAP_CLIENT_IO_TIMEOUT, r.next()).await {
@@ -97,12 +89,17 @@ async fn client_process<STREAM>(
         };
 
         // Start the event
-        let uat = session.uat.clone();
-        let caddr = client_address;
-
         debug!(?client_address, ?connection_address);
 
-        match client_process_msg(uat, caddr, protomsg, qe_r_ref, logging_pipeline).await {
+        match client_process_msg(
+            session.uat.clone(),
+            client_address,
+            protomsg,
+            qe_r_ref,
+            logging_pipeline,
+        )
+        .await
+        {
             // I'd really have liked to have put this near the [LdapResponseState::Bind] but due
             // to the handing of `audit` it isn't possible due to borrows, etc.
             Some(LdapResponseState::Unbind) => break,

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -24,7 +24,7 @@ const LDAP_CLIENT_CONN_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Lifetime of the LDAP client connection, including the authentication token if authenticated.
 #[derive(Default)]
-struct LdapClientConnection {
+struct LdapSession {
     uat: Option<LdapBoundToken>,
 }
 
@@ -70,7 +70,7 @@ async fn client_process<STREAM>(
     let mut r = FramedRead::new(r, LdapCodec::default());
     let mut w = FramedWrite::new(w, LdapCodec::default());
 
-    let mut session = LdapClientConnection::default();
+    let mut session = LdapSession::default();
     // Now that we have the session we begin an event loop to process input OR we return.
     loop {
         let protomsg = match timeout(LDAP_CLIENT_IO_TIMEOUT, r.next()).await {

--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -36,7 +36,8 @@ async fn client_process_msg(
     qe_r_ref: &'static QueryServerReadV1,
     logging_pipeline: LoggerType,
 ) -> Option<LdapResponseState> {
-    let message_id = match logging_pipeline {
+    // The ID of the message/request
+    let request_id = match logging_pipeline {
         LoggerType::TracingForest => sketching::tracing_forest::id(),
         LoggerType::OpenTelemetry => {
             // try to the current span ID and fail back to generating a Uuid
@@ -52,7 +53,7 @@ async fn client_process_msg(
         "LDAP client"
     );
     qe_r_ref
-        .handle_ldaprequest(message_id, protomsg, uat, client_address.ip())
+        .handle_ldaprequest(request_id, protomsg, uat, client_address.ip())
         .await
 }
 

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -827,6 +827,7 @@ impl Account {
 
     pub(crate) fn verify_application_password(
         &self,
+        session_id: Uuid,
         application: &Application,
         cleartext: &str,
     ) -> Result<Option<LdapBoundToken>, OperationError> {
@@ -838,25 +839,32 @@ impl Account {
                 })?;
 
                 if password_verified {
-                    let session_id = uuid::Uuid::new_v4();
                     security_info!(
-                        "Starting session {} for {} {}",
+                        "Starting session {} for {} ({}) with application {}:{}",
                         session_id,
-                        self.spn,
-                        self.uuid
+                        self.spn(),
+                        self.uuid.hyphenated(),
+                        application.name,
+                        application.uuid.hyphenated(),
                     );
 
                     return Ok(Some(LdapBoundToken {
                         spn: self.spn.clone(),
                         session_id,
-                        effective_session: LdapSession::ApplicationPasswordBind(
-                            application.uuid,
-                            self.uuid,
-                        ),
+                        effective_session: LdapSession::ApplicationPasswordBind {
+                            application_id: application.uuid,
+                            user_id: self.uuid,
+                        },
                     }));
                 }
             }
         }
+
+        security_info!(
+            "Account {} ({}) does not have a configured application password.",
+            self.spn(),
+            self.uuid.hyphenated()
+        );
         Ok(None)
     }
 

--- a/server/lib/src/idm/account.rs
+++ b/server/lib/src/idm/account.rs
@@ -827,7 +827,6 @@ impl Account {
 
     pub(crate) fn verify_application_password(
         &self,
-        session_id: Uuid,
         application: &Application,
         cleartext: &str,
     ) -> Result<Option<LdapBoundToken>, OperationError> {
@@ -839,6 +838,8 @@ impl Account {
                 })?;
 
                 if password_verified {
+                    // New authenticated session has started, they get a new session ID
+                    let session_id = Uuid::new_v4();
                     security_info!(
                         "Starting session {} for {} ({}) with application {}:{}",
                         session_id,

--- a/server/lib/src/idm/application.rs
+++ b/server/lib/src/idm/application.rs
@@ -1,4 +1,4 @@
-use super::ldap::{LdapBoundToken, LdapSession};
+use super::ldap::LdapBoundToken;
 use crate::credential::apppwd::ApplicationPassword;
 use crate::idm::account::Account;
 use crate::idm::event::LdapApplicationAuthEvent;
@@ -165,7 +165,7 @@ impl IdmServerAuthTransaction<'_> {
             .applications
             .inner
             .set
-            .get(&lae.application)
+            .get(&lae.application.to_string())
             .ok_or_else(|| {
                 info!("Application {:?} not found", lae.application);
                 OperationError::NoMatchingEntries
@@ -185,29 +185,7 @@ impl IdmServerAuthTransaction<'_> {
             return Ok(None);
         }
 
-        match account.verify_application_password(application, lae.cleartext.as_str())? {
-            Some(_) => {
-                let session_id = Uuid::new_v4();
-                security_info!(
-                    "Starting session {} for {} {} with application {}:{:?}",
-                    session_id,
-                    account.spn(),
-                    account.uuid,
-                    application.name,
-                    application.uuid,
-                );
-
-                Ok(Some(LdapBoundToken {
-                    spn: account.spn().into(),
-                    session_id,
-                    effective_session: LdapSession::UnixBind(account.uuid),
-                }))
-            }
-            None => {
-                security_info!("Account does not have a configured application password.");
-                Ok(None)
-            }
-        }
+        account.verify_application_password(lae.eventid, application, &lae.cleartext)
     }
 }
 

--- a/server/lib/src/idm/application.rs
+++ b/server/lib/src/idm/application.rs
@@ -165,7 +165,7 @@ impl IdmServerAuthTransaction<'_> {
             .applications
             .inner
             .set
-            .get(&lae.application.to_string())
+            .get(&lae.application)
             .ok_or_else(|| {
                 info!("Application {:?} not found", lae.application);
                 OperationError::NoMatchingEntries
@@ -185,7 +185,7 @@ impl IdmServerAuthTransaction<'_> {
             return Ok(None);
         }
 
-        account.verify_application_password(lae.eventid, application, &lae.cleartext)
+        account.verify_application_password(application, &lae.cleartext)
     }
 }
 

--- a/server/lib/src/idm/event.rs
+++ b/server/lib/src/idm/event.rs
@@ -254,18 +254,20 @@ impl LdapTokenAuthEvent {
 }
 
 pub struct LdapApplicationAuthEvent {
+    pub eventid: Uuid,
     pub application: String,
     pub target: Uuid,
     pub cleartext: String,
 }
 
 impl LdapApplicationAuthEvent {
-    pub fn new(app_name: &str, usr_uuid: Uuid, cleartext: String) -> Result<Self, OperationError> {
-        Ok(LdapApplicationAuthEvent {
-            application: app_name.to_string(),
-            target: usr_uuid,
-            cleartext,
-        })
+    pub fn new(eventid: Uuid, application: &str, target: Uuid, cleartext: &str) -> Self {
+        LdapApplicationAuthEvent {
+            eventid,
+            application: application.to_string(),
+            target,
+            cleartext: cleartext.to_string(),
+        }
     }
 }
 

--- a/server/lib/src/idm/event.rs
+++ b/server/lib/src/idm/event.rs
@@ -227,30 +227,13 @@ impl CredentialStatusEvent {
 
 pub struct LdapAuthEvent {
     // pub ident: Identity,
+    pub eventid: Uuid,
     pub target: Uuid,
     pub cleartext: String,
 }
 
-impl LdapAuthEvent {
-    pub fn from_parts(target: Uuid, cleartext: String) -> Result<Self, OperationError> {
-        // let e = Event::from_ro_uat(audit, qs, uat)?;
-
-        Ok(LdapAuthEvent {
-            // event: e,
-            target,
-            cleartext,
-        })
-    }
-}
-
 pub struct LdapTokenAuthEvent {
     pub token: JwsCompact,
-}
-
-impl LdapTokenAuthEvent {
-    pub fn from_parts(token: JwsCompact) -> Result<Self, OperationError> {
-        Ok(LdapTokenAuthEvent { token })
-    }
 }
 
 pub struct LdapApplicationAuthEvent {

--- a/server/lib/src/idm/event.rs
+++ b/server/lib/src/idm/event.rs
@@ -226,8 +226,6 @@ impl CredentialStatusEvent {
 }
 
 pub struct LdapAuthEvent {
-    // pub ident: Identity,
-    pub eventid: Uuid,
     pub target: Uuid,
     pub cleartext: String,
 }
@@ -237,16 +235,14 @@ pub struct LdapTokenAuthEvent {
 }
 
 pub struct LdapApplicationAuthEvent {
-    pub eventid: Uuid,
     pub application: String,
     pub target: Uuid,
     pub cleartext: String,
 }
 
 impl LdapApplicationAuthEvent {
-    pub fn new(eventid: Uuid, application: &str, target: Uuid, cleartext: &str) -> Self {
+    pub fn new(application: &str, target: Uuid, cleartext: &str) -> Self {
         LdapApplicationAuthEvent {
-            eventid,
             application: application.to_string(),
             target,
             cleartext: cleartext.to_string(),

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -39,7 +39,8 @@ pub enum LdapSession {
     UnixBind(Uuid),
     UserAuthToken(UserAuthToken),
     ApiToken(ApiToken),
-    ApplicationPasswordBind(Uuid, Uuid),
+    // Application working on behalf of a user
+    ApplicationPasswordBind { application_id: Uuid, user_id: Uuid },
 }
 
 #[derive(Debug, Clone)]
@@ -52,7 +53,7 @@ pub struct LdapBoundToken {
     // * A valid unix pw bind
     // * A valid ApiToken
     // In a way, this is a stepping stone to an "ident" but allows us to check
-    // the session is still "valid" depending on it's origin.
+    // the session is still "valid" depending on its origin.
     pub effective_session: LdapSession,
 }
 
@@ -381,7 +382,7 @@ impl LdapServer {
             //
             // ! Remember, searchEvent wraps to ignore hidden for us.
             let ident = idm_read
-                .validate_ldap_session(&uat.effective_session, source, ct)
+                .validate_ldap_session(uat, source, ct)
                 .map_err(|e| {
                     admin_error!("Invalid identity: {:?}", e);
                     e
@@ -439,6 +440,7 @@ impl LdapServer {
         idms: &IdmServer,
         dn: &str,
         pw: &str,
+        eventid: Uuid,
     ) -> Result<Option<LdapBoundToken>, OperationError> {
         security_info!(
             "Attempt LDAP Bind for {}",
@@ -464,8 +466,7 @@ impl LdapServer {
                 idm_auth.token_auth_ldap(&lae, ct).await?
             }
             LdapBindTarget::Application(ref app_name, usr_uuid) => {
-                let lae =
-                    LdapApplicationAuthEvent::new(app_name.as_str(), usr_uuid, pw.to_string())?;
+                let lae = LdapApplicationAuthEvent::new(eventid, app_name, usr_uuid, pw);
                 idm_auth.application_auth_ldap(&lae, ct).await?
             }
         };
@@ -540,7 +541,7 @@ impl LdapServer {
 
         // Build the event, with the permissions from effective_session
         let ident = idm_read
-            .validate_ldap_session(&uat.effective_session, source, ct)
+            .validate_ldap_session(uat, source, ct)
             .map_err(|e| {
                 admin_error!("Invalid identity: {:?}", e);
                 e
@@ -618,7 +619,7 @@ impl LdapServer {
 
         match server_op {
             ServerOps::SimpleBind(sbr) => self
-                .do_bind(idms, sbr.dn.as_str(), sbr.pw.as_str())
+                .do_bind(idms, sbr.dn.as_str(), sbr.pw.as_str(), eventid)
                 .await
                 .map(|r| match r {
                     Some(lbt) => LdapResponseState::Bind(lbt, sbr.gen_success()),
@@ -640,7 +641,7 @@ impl LdapServer {
                 None => {
                     // Search can occur without a bind, so bind first.
                     // This is per section 4 of RFC 4513 (https://www.rfc-editor.org/rfc/rfc4513#section-4).
-                    let lbt = match self.do_bind(idms, "", "").await {
+                    let lbt = match self.do_bind(idms, "", "", eventid).await {
                         Ok(Some(lbt)) => lbt,
                         Ok(None) => {
                             return Ok(LdapResponseState::Respond(
@@ -678,7 +679,7 @@ impl LdapServer {
                 None => {
                     // Compare can occur without a bind, so bind first.
                     // This is per section 4 of RFC 4513 (https://www.rfc-editor.org/rfc/rfc4513#section-4).
-                    let lbt = match self.do_bind(idms, "", "").await {
+                    let lbt = match self.do_bind(idms, "", "", eventid).await {
                         Ok(Some(lbt)) => lbt,
                         Ok(None) => {
                             return Ok(LdapResponseState::Respond(
@@ -903,13 +904,13 @@ mod tests {
         // default UNIX_PW bind (default is set to true)
         // Hence allows all unix binds
         let admin_t = ldaps
-            .do_bind(idms, "admin", TEST_PASSWORD)
+            .do_bind(idms, "admin", TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "admin@example.com", TEST_PASSWORD)
+            .do_bind(idms, "admin@example.com", TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
@@ -927,15 +928,26 @@ mod tests {
             .modify(&disallow_unix_pw_flag)
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
         );
         assert!(
-            ldaps.do_bind(idms, "", "test").await.unwrap_err() == OperationError::NotAuthenticated
+            ldaps
+                .do_bind(idms, "", "test", Uuid::new_v4())
+                .await
+                .unwrap_err()
+                == OperationError::NotAuthenticated
         );
-        let admin_t = ldaps.do_bind(idms, "admin", TEST_PASSWORD).await.unwrap();
+        let admin_t = ldaps
+            .do_bind(idms, "admin", TEST_PASSWORD, Uuid::new_v4())
+            .await
+            .unwrap();
         assert!(admin_t.is_none());
 
         // Setting UNIX_PW_BIND flag to true :
@@ -949,25 +961,30 @@ mod tests {
 
         // Now test the admin and various DN's
         let admin_t = ldaps
-            .do_bind(idms, "admin", TEST_PASSWORD)
+            .do_bind(idms, "admin", TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "admin@example.com", TEST_PASSWORD)
+            .do_bind(idms, "admin@example.com", TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, STR_UUID_ADMIN, TEST_PASSWORD)
+            .do_bind(idms, STR_UUID_ADMIN, TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "name=admin,dc=example,dc=com", TEST_PASSWORD)
+            .do_bind(
+                idms,
+                "name=admin,dc=example,dc=com",
+                TEST_PASSWORD,
+                Uuid::new_v4(),
+            )
             .await
             .unwrap()
             .unwrap();
@@ -977,6 +994,7 @@ mod tests {
                 idms,
                 "spn=admin@example.com,dc=example,dc=com",
                 TEST_PASSWORD,
+                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -987,6 +1005,7 @@ mod tests {
                 idms,
                 format!("uuid={STR_UUID_ADMIN},dc=example,dc=com").as_str(),
                 TEST_PASSWORD,
+                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -994,13 +1013,13 @@ mod tests {
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
 
         let admin_t = ldaps
-            .do_bind(idms, "name=admin", TEST_PASSWORD)
+            .do_bind(idms, "name=admin", TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "spn=admin@example.com", TEST_PASSWORD)
+            .do_bind(idms, "spn=admin@example.com", TEST_PASSWORD, Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
@@ -1010,6 +1029,7 @@ mod tests {
                 idms,
                 format!("uuid={STR_UUID_ADMIN}").as_str(),
                 TEST_PASSWORD,
+                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -1017,13 +1037,23 @@ mod tests {
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
 
         let admin_t = ldaps
-            .do_bind(idms, "admin,dc=example,dc=com", TEST_PASSWORD)
+            .do_bind(
+                idms,
+                "admin,dc=example,dc=com",
+                TEST_PASSWORD,
+                Uuid::new_v4(),
+            )
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "admin@example.com,dc=example,dc=com", TEST_PASSWORD)
+            .do_bind(
+                idms,
+                "admin@example.com,dc=example,dc=com",
+                TEST_PASSWORD,
+                Uuid::new_v4(),
+            )
             .await
             .unwrap()
             .unwrap();
@@ -1033,6 +1063,7 @@ mod tests {
                 idms,
                 format!("{STR_UUID_ADMIN},dc=example,dc=com").as_str(),
                 TEST_PASSWORD,
+                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -1041,7 +1072,7 @@ mod tests {
 
         // Bad password, check last to prevent softlocking of the admin account.
         assert!(ldaps
-            .do_bind(idms, "admin", "test")
+            .do_bind(idms, "admin", "test", Uuid::new_v4())
             .await
             .unwrap()
             .is_none());
@@ -1051,7 +1082,8 @@ mod tests {
             .do_bind(
                 idms,
                 "spn=admin@example.com,dc=clownshoes,dc=example,dc=com",
-                TEST_PASSWORD
+                TEST_PASSWORD,
+                Uuid::new_v4()
             )
             .await
             .is_err());
@@ -1059,20 +1091,24 @@ mod tests {
             .do_bind(
                 idms,
                 "spn=claire@example.com,dc=example,dc=com",
-                TEST_PASSWORD
+                TEST_PASSWORD,
+                Uuid::new_v4()
             )
             .await
             .is_err());
         assert!(ldaps
-            .do_bind(idms, ",dc=example,dc=com", TEST_PASSWORD)
+            .do_bind(idms, ",dc=example,dc=com", TEST_PASSWORD, Uuid::new_v4())
             .await
             .is_err());
         assert!(ldaps
-            .do_bind(idms, "dc=example,dc=com", TEST_PASSWORD)
+            .do_bind(idms, "dc=example,dc=com", TEST_PASSWORD, Uuid::new_v4())
             .await
             .is_err());
 
-        assert!(ldaps.do_bind(idms, "claire", "test").await.is_err());
+        assert!(ldaps
+            .do_bind(idms, "claire", "test", Uuid::new_v4())
+            .await
+            .is_err());
     }
 
     #[idm_test]
@@ -1147,7 +1183,11 @@ mod tests {
         }
 
         // Setup the anonymous login
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -1222,7 +1262,11 @@ mod tests {
         }
 
         // Setup the anonymous login
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -1325,7 +1369,12 @@ mod tests {
 
         // No session, user not member of linked group
         let res = ldaps
-            .do_bind(idms, "spn=testperson1,app=testapp1,dc=example,dc=com", "")
+            .do_bind(
+                idms,
+                "spn=testperson1,app=testapp1,dc=example,dc=com",
+                "",
+                Uuid::new_v4(),
+            )
             .await;
         assert!(res.is_ok());
         assert!(res.unwrap().is_none());
@@ -1342,7 +1391,12 @@ mod tests {
 
         // No session, user does not have app password for testapp1
         let res = ldaps
-            .do_bind(idms, "spn=testperson1,app=testapp1,dc=example,dc=com", "")
+            .do_bind(
+                idms,
+                "spn=testperson1,app=testapp1,dc=example,dc=com",
+                "",
+                Uuid::new_v4(),
+            )
             .await;
         assert!(res.is_ok());
         assert!(res.unwrap().is_none());
@@ -1392,6 +1446,7 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 pass1.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1403,6 +1458,7 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 pass2.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1414,6 +1470,7 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 pass3.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1425,6 +1482,7 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 "FOO",
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1543,6 +1601,7 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app1_name},dc=example,dc=com").as_str(),
                 pass_app1.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1554,6 +1613,7 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app2_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1576,6 +1636,7 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app2_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1587,6 +1648,7 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app1_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1608,6 +1670,7 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app2_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_err());
@@ -1716,6 +1779,7 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app1_name},dc=example,dc=com").as_str(),
                 pass_app1.as_str(),
+                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1731,8 +1795,7 @@ mod tests {
         let time_high = Duration::from_secs(TEST_AFTER_EXPIRY);
 
         let mut idms_auth = idms.auth().await.unwrap();
-        let lae = LdapApplicationAuthEvent::new(app1_name, usr_uuid, pass_app1)
-            .expect("Failed to build auth event");
+        let lae = LdapApplicationAuthEvent::new(Uuid::new_v4(), app1_name, usr_uuid, &pass_app1);
 
         let r1 = idms_auth
             .application_auth_ldap(&lae, time_low)
@@ -1829,7 +1892,11 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2064,7 +2131,11 @@ mod tests {
         // we don't have purpose so this isn't tested.
 
         // Bind with anonymous, search and show mail attr isn't accessible.
-        let anon_lbt = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_lbt = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_lbt.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2097,7 +2168,7 @@ mod tests {
 
         // Bind using the token as a DN
         let sa_lbt = ldaps
-            .do_bind(idms, "dn=token", &apitoken.to_string())
+            .do_bind(idms, "dn=token", &apitoken.to_string(), Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
@@ -2108,7 +2179,7 @@ mod tests {
 
         // Bind using the token as a pw
         let sa_lbt = ldaps
-            .do_bind(idms, "", &apitoken.to_string())
+            .do_bind(idms, "", &apitoken.to_string(), Uuid::new_v4())
             .await
             .unwrap()
             .unwrap();
@@ -2239,7 +2310,11 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2319,7 +2394,11 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2386,7 +2465,11 @@ mod tests {
     async fn test_ldap_rootdse_basedn_change(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
         let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2442,7 +2525,11 @@ mod tests {
         // Now re-test
         let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2517,7 +2604,11 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2635,7 +2726,11 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2802,7 +2897,11 @@ mod tests {
         }
 
         // Setup the anonymous login
-        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
+        let anon_t = ldaps
+            .do_bind(idms, "", "", Uuid::new_v4())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2847,7 +2946,7 @@ mod tests {
 
         // Setup the anonymous login
         let anon_t = ldaps
-            .do_bind(idms, "", "")
+            .do_bind(idms, "", "", Uuid::new_v4())
             .await
             .expect("failed to connect to ldap")
             .expect("Failed to get token");

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -453,17 +453,22 @@ impl LdapServer {
 
         let result = match target {
             LdapBindTarget::Account(uuid) => {
-                let lae = LdapAuthEvent::from_parts(uuid, pw.to_string())?;
+                let lae = LdapAuthEvent {
+                    eventid,
+                    target: uuid,
+                    cleartext: pw.to_string(),
+                };
                 idm_auth.auth_ldap(&lae, ct).await?
             }
             LdapBindTarget::ApiToken => {
-                let jwsc = JwsCompact::from_str(pw).map_err(|err| {
+                let token = JwsCompact::from_str(pw).map_err(|err| {
                     error!(?err, "Invalid JwsCompact supplied as authentication token.");
                     OperationError::NotAuthenticated
                 })?;
 
-                let lae = LdapTokenAuthEvent::from_parts(jwsc)?;
-                idm_auth.token_auth_ldap(&lae, ct).await?
+                idm_auth
+                    .token_auth_ldap(&LdapTokenAuthEvent { token }, ct)
+                    .await?
             }
             LdapBindTarget::Application(ref app_name, usr_uuid) => {
                 let lae = LdapApplicationAuthEvent::new(eventid, app_name, usr_uuid, pw);

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -440,7 +440,6 @@ impl LdapServer {
         idms: &IdmServer,
         dn: &str,
         pw: &str,
-        eventid: Uuid,
     ) -> Result<Option<LdapBoundToken>, OperationError> {
         security_info!(
             "Attempt LDAP Bind for {}",
@@ -454,7 +453,6 @@ impl LdapServer {
         let result = match target {
             LdapBindTarget::Account(uuid) => {
                 let lae = LdapAuthEvent {
-                    eventid,
                     target: uuid,
                     cleartext: pw.to_string(),
                 };
@@ -471,7 +469,7 @@ impl LdapServer {
                     .await?
             }
             LdapBindTarget::Application(ref app_name, usr_uuid) => {
-                let lae = LdapApplicationAuthEvent::new(eventid, app_name, usr_uuid, pw);
+                let lae = LdapApplicationAuthEvent::new(app_name, usr_uuid, pw);
                 idm_auth.application_auth_ldap(&lae, ct).await?
             }
         };
@@ -624,7 +622,7 @@ impl LdapServer {
 
         match server_op {
             ServerOps::SimpleBind(sbr) => self
-                .do_bind(idms, sbr.dn.as_str(), sbr.pw.as_str(), eventid)
+                .do_bind(idms, sbr.dn.as_str(), sbr.pw.as_str())
                 .await
                 .map(|r| match r {
                     Some(lbt) => LdapResponseState::Bind(lbt, sbr.gen_success()),
@@ -646,7 +644,7 @@ impl LdapServer {
                 None => {
                     // Search can occur without a bind, so bind first.
                     // This is per section 4 of RFC 4513 (https://www.rfc-editor.org/rfc/rfc4513#section-4).
-                    let lbt = match self.do_bind(idms, "", "", eventid).await {
+                    let lbt = match self.do_bind(idms, "", "").await {
                         Ok(Some(lbt)) => lbt,
                         Ok(None) => {
                             return Ok(LdapResponseState::Respond(
@@ -684,7 +682,7 @@ impl LdapServer {
                 None => {
                     // Compare can occur without a bind, so bind first.
                     // This is per section 4 of RFC 4513 (https://www.rfc-editor.org/rfc/rfc4513#section-4).
-                    let lbt = match self.do_bind(idms, "", "", eventid).await {
+                    let lbt = match self.do_bind(idms, "", "").await {
                         Ok(Some(lbt)) => lbt,
                         Ok(None) => {
                             return Ok(LdapResponseState::Respond(
@@ -909,13 +907,13 @@ mod tests {
         // default UNIX_PW bind (default is set to true)
         // Hence allows all unix binds
         let admin_t = ldaps
-            .do_bind(idms, "admin", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "admin", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "admin@example.com", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "admin@example.com", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
@@ -933,26 +931,15 @@ mod tests {
             .modify(&disallow_unix_pw_flag)
             .is_ok());
         assert!(idms_prox_write.commit().is_ok());
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
         );
         assert!(
-            ldaps
-                .do_bind(idms, "", "test", Uuid::new_v4())
-                .await
-                .unwrap_err()
-                == OperationError::NotAuthenticated
+            ldaps.do_bind(idms, "", "test").await.unwrap_err() == OperationError::NotAuthenticated
         );
-        let admin_t = ldaps
-            .do_bind(idms, "admin", TEST_PASSWORD, Uuid::new_v4())
-            .await
-            .unwrap();
+        let admin_t = ldaps.do_bind(idms, "admin", TEST_PASSWORD).await.unwrap();
         assert!(admin_t.is_none());
 
         // Setting UNIX_PW_BIND flag to true :
@@ -966,30 +953,25 @@ mod tests {
 
         // Now test the admin and various DN's
         let admin_t = ldaps
-            .do_bind(idms, "admin", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "admin", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "admin@example.com", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "admin@example.com", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, STR_UUID_ADMIN, TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, STR_UUID_ADMIN, TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(
-                idms,
-                "name=admin,dc=example,dc=com",
-                TEST_PASSWORD,
-                Uuid::new_v4(),
-            )
+            .do_bind(idms, "name=admin,dc=example,dc=com", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
@@ -999,7 +981,6 @@ mod tests {
                 idms,
                 "spn=admin@example.com,dc=example,dc=com",
                 TEST_PASSWORD,
-                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -1010,7 +991,6 @@ mod tests {
                 idms,
                 format!("uuid={STR_UUID_ADMIN},dc=example,dc=com").as_str(),
                 TEST_PASSWORD,
-                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -1018,13 +998,13 @@ mod tests {
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
 
         let admin_t = ldaps
-            .do_bind(idms, "name=admin", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "name=admin", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(idms, "spn=admin@example.com", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "spn=admin@example.com", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
@@ -1034,7 +1014,6 @@ mod tests {
                 idms,
                 format!("uuid={STR_UUID_ADMIN}").as_str(),
                 TEST_PASSWORD,
-                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -1042,23 +1021,13 @@ mod tests {
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
 
         let admin_t = ldaps
-            .do_bind(
-                idms,
-                "admin,dc=example,dc=com",
-                TEST_PASSWORD,
-                Uuid::new_v4(),
-            )
+            .do_bind(idms, "admin,dc=example,dc=com", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(admin_t.effective_session, LdapSession::UnixBind(UUID_ADMIN));
         let admin_t = ldaps
-            .do_bind(
-                idms,
-                "admin@example.com,dc=example,dc=com",
-                TEST_PASSWORD,
-                Uuid::new_v4(),
-            )
+            .do_bind(idms, "admin@example.com,dc=example,dc=com", TEST_PASSWORD)
             .await
             .unwrap()
             .unwrap();
@@ -1068,7 +1037,6 @@ mod tests {
                 idms,
                 format!("{STR_UUID_ADMIN},dc=example,dc=com").as_str(),
                 TEST_PASSWORD,
-                Uuid::new_v4(),
             )
             .await
             .unwrap()
@@ -1077,7 +1045,7 @@ mod tests {
 
         // Bad password, check last to prevent softlocking of the admin account.
         assert!(ldaps
-            .do_bind(idms, "admin", "test", Uuid::new_v4())
+            .do_bind(idms, "admin", "test")
             .await
             .unwrap()
             .is_none());
@@ -1087,8 +1055,7 @@ mod tests {
             .do_bind(
                 idms,
                 "spn=admin@example.com,dc=clownshoes,dc=example,dc=com",
-                TEST_PASSWORD,
-                Uuid::new_v4()
+                TEST_PASSWORD
             )
             .await
             .is_err());
@@ -1096,24 +1063,20 @@ mod tests {
             .do_bind(
                 idms,
                 "spn=claire@example.com,dc=example,dc=com",
-                TEST_PASSWORD,
-                Uuid::new_v4()
+                TEST_PASSWORD
             )
             .await
             .is_err());
         assert!(ldaps
-            .do_bind(idms, ",dc=example,dc=com", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, ",dc=example,dc=com", TEST_PASSWORD)
             .await
             .is_err());
         assert!(ldaps
-            .do_bind(idms, "dc=example,dc=com", TEST_PASSWORD, Uuid::new_v4())
+            .do_bind(idms, "dc=example,dc=com", TEST_PASSWORD)
             .await
             .is_err());
 
-        assert!(ldaps
-            .do_bind(idms, "claire", "test", Uuid::new_v4())
-            .await
-            .is_err());
+        assert!(ldaps.do_bind(idms, "claire", "test").await.is_err());
     }
 
     #[idm_test]
@@ -1188,11 +1151,7 @@ mod tests {
         }
 
         // Setup the anonymous login
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -1267,11 +1226,7 @@ mod tests {
         }
 
         // Setup the anonymous login
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -1374,12 +1329,7 @@ mod tests {
 
         // No session, user not member of linked group
         let res = ldaps
-            .do_bind(
-                idms,
-                "spn=testperson1,app=testapp1,dc=example,dc=com",
-                "",
-                Uuid::new_v4(),
-            )
+            .do_bind(idms, "spn=testperson1,app=testapp1,dc=example,dc=com", "")
             .await;
         assert!(res.is_ok());
         assert!(res.unwrap().is_none());
@@ -1396,12 +1346,7 @@ mod tests {
 
         // No session, user does not have app password for testapp1
         let res = ldaps
-            .do_bind(
-                idms,
-                "spn=testperson1,app=testapp1,dc=example,dc=com",
-                "",
-                Uuid::new_v4(),
-            )
+            .do_bind(idms, "spn=testperson1,app=testapp1,dc=example,dc=com", "")
             .await;
         assert!(res.is_ok());
         assert!(res.unwrap().is_none());
@@ -1451,7 +1396,6 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 pass1.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1463,7 +1407,6 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 pass2.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1475,7 +1418,6 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 pass3.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1487,7 +1429,6 @@ mod tests {
                 idms,
                 "spn=testperson1,app=testapp1,dc=example,dc=com",
                 "FOO",
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1606,7 +1547,6 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app1_name},dc=example,dc=com").as_str(),
                 pass_app1.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1618,7 +1558,6 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app2_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1641,7 +1580,6 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app2_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1653,7 +1591,6 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app1_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1675,7 +1612,6 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app2_name},dc=example,dc=com").as_str(),
                 pass_app2.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_err());
@@ -1784,7 +1720,6 @@ mod tests {
                 idms,
                 format!("spn={usr_name},app={app1_name},dc=example,dc=com").as_str(),
                 pass_app1.as_str(),
-                Uuid::new_v4(),
             )
             .await;
         assert!(res.is_ok());
@@ -1800,7 +1735,7 @@ mod tests {
         let time_high = Duration::from_secs(TEST_AFTER_EXPIRY);
 
         let mut idms_auth = idms.auth().await.unwrap();
-        let lae = LdapApplicationAuthEvent::new(Uuid::new_v4(), app1_name, usr_uuid, &pass_app1);
+        let lae = LdapApplicationAuthEvent::new(app1_name, usr_uuid, &pass_app1);
 
         let r1 = idms_auth
             .application_auth_ldap(&lae, time_low)
@@ -1897,11 +1832,7 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2136,11 +2067,7 @@ mod tests {
         // we don't have purpose so this isn't tested.
 
         // Bind with anonymous, search and show mail attr isn't accessible.
-        let anon_lbt = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_lbt = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_lbt.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2173,7 +2100,7 @@ mod tests {
 
         // Bind using the token as a DN
         let sa_lbt = ldaps
-            .do_bind(idms, "dn=token", &apitoken.to_string(), Uuid::new_v4())
+            .do_bind(idms, "dn=token", &apitoken.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -2184,7 +2111,7 @@ mod tests {
 
         // Bind using the token as a pw
         let sa_lbt = ldaps
-            .do_bind(idms, "", &apitoken.to_string(), Uuid::new_v4())
+            .do_bind(idms, "", &apitoken.to_string())
             .await
             .unwrap()
             .unwrap();
@@ -2315,11 +2242,7 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2399,11 +2322,7 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2470,11 +2389,7 @@ mod tests {
     async fn test_ldap_rootdse_basedn_change(idms: &IdmServer, _idms_delayed: &IdmServerDelayed) {
         let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2530,11 +2445,7 @@ mod tests {
         // Now re-test
         let ldaps = LdapServer::new(idms).await.expect("failed to start ldap");
 
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2609,11 +2520,7 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2731,11 +2638,7 @@ mod tests {
         }
 
         // Setup the anonymous login.
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2902,11 +2805,7 @@ mod tests {
         }
 
         // Setup the anonymous login
-        let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
-            .await
-            .unwrap()
-            .unwrap();
+        let anon_t = ldaps.do_bind(idms, "", "").await.unwrap().unwrap();
         assert_eq!(
             anon_t.effective_session,
             LdapSession::UnixBind(UUID_ANONYMOUS)
@@ -2951,7 +2850,7 @@ mod tests {
 
         // Setup the anonymous login
         let anon_t = ldaps
-            .do_bind(idms, "", "", Uuid::new_v4())
+            .do_bind(idms, "", "")
             .await
             .expect("failed to connect to ldap")
             .expect("Failed to get token");

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1079,9 +1079,8 @@ pub trait IdmServerTransaction<'a> {
                 let entry = self
                     .get_qs_txn()
                     .internal_search_uuid(apit.account_id)
-                    .map_err(|e| {
+                    .inspect_err(|e| {
                         admin_error!("Failed to validate ldap session -> {:?}", e);
-                        e
                     })?;
 
                 self.process_apit_to_identity(&apit, source, entry, ct)

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -997,13 +997,14 @@ pub trait IdmServerTransaction<'a> {
 
     fn process_ldap_uuid_to_identity(
         &mut self,
-        uuid: &Uuid,
+        uuid: Uuid,
         ct: Duration,
         source: Source,
+        session_id: Uuid,
     ) -> Result<Identity, OperationError> {
         let entry = self
             .get_qs_txn()
-            .internal_search_uuid(*uuid)
+            .internal_search_uuid(uuid)
             .map_err(|err| {
                 error!(?err, ?uuid, "Failed to search user by uuid");
                 err
@@ -1018,7 +1019,7 @@ pub trait IdmServerTransaction<'a> {
         }
 
         // Good to go
-        let anon_entry = if *uuid == UUID_ANONYMOUS {
+        let anon_entry = if uuid == UUID_ANONYMOUS {
             // We already have it.
             entry
         } else {
@@ -1035,7 +1036,6 @@ pub trait IdmServerTransaction<'a> {
         };
 
         let mut limits = Limits::default();
-        let session_id = Uuid::new_v4();
 
         // Update limits from account policy
         if let Some(max_results) = account_policy.limit_search_max_results() {
@@ -1063,15 +1063,18 @@ pub trait IdmServerTransaction<'a> {
     #[instrument(level = "debug", skip_all)]
     fn validate_ldap_session(
         &mut self,
-        session: &LdapSession,
+        ldap_bound: &LdapBoundToken,
         source: Source,
         ct: Duration,
     ) -> Result<Identity, OperationError> {
-        match session {
-            LdapSession::UnixBind(uuid) | LdapSession::ApplicationPasswordBind(_, uuid) => {
-                self.process_ldap_uuid_to_identity(uuid, ct, source)
+        match ldap_bound.effective_session.clone() {
+            LdapSession::UnixBind(user_id)
+            | LdapSession::ApplicationPasswordBind { user_id, .. } => {
+                self.process_ldap_uuid_to_identity(user_id, ct, source, ldap_bound.session_id)
             }
-            LdapSession::UserAuthToken(uat) => self.process_uat_to_identity(uat, ct, source),
+            LdapSession::UserAuthToken(uat_inner) => {
+                self.process_uat_to_identity(&uat_inner, ct, source)
+            }
             LdapSession::ApiToken(apit) => {
                 let entry = self
                     .get_qs_txn()
@@ -1081,7 +1084,7 @@ pub trait IdmServerTransaction<'a> {
                         e
                     })?;
 
-                self.process_apit_to_identity(apit, source, entry, ct)
+                self.process_apit_to_identity(&apit, source, entry, ct)
             }
         }
     }

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1586,16 +1586,17 @@ impl IdmServerAuthTransaction<'_> {
                 return Ok(None);
             }
 
+            let session_id = Uuid::new_v4();
             security_info!(
                 "Starting session {} for {} {}",
-                lae.eventid,
+                session_id,
                 account.spn(),
                 account.uuid
             );
 
             // Account must be anon, so we can gen the uat.
             Ok(Some(LdapBoundToken {
-                session_id: lae.eventid,
+                session_id,
                 spn: account.spn().into(),
                 effective_session: LdapSession::UnixBind(UUID_ANONYMOUS),
             }))
@@ -1605,26 +1606,26 @@ impl IdmServerAuthTransaction<'_> {
                 return Ok(None);
             }
 
-            let auth = self
+            if let Some(account) = self
                 .auth_with_unix_pass(lae.target, &lae.cleartext, ct)
-                .await?;
+                .await?
+            {
+                // New session id for this ldap bind, which is not the same as the session id of the uat.
+                let session_id = Uuid::new_v4();
+                security_info!(
+                    "Starting session {} for {} {}",
+                    session_id,
+                    account.spn(),
+                    account.uuid
+                );
 
-            match auth {
-                Some(account) => {
-                    security_info!(
-                        "Starting session {} for {} {}",
-                        lae.eventid,
-                        account.spn(),
-                        account.uuid
-                    );
-
-                    Ok(Some(LdapBoundToken {
-                        spn: account.spn().into(),
-                        session_id: lae.eventid,
-                        effective_session: LdapSession::UnixBind(account.uuid),
-                    }))
-                }
-                None => Ok(None),
+                Ok(Some(LdapBoundToken {
+                    spn: account.spn().into(),
+                    session_id,
+                    effective_session: LdapSession::UnixBind(account.uuid),
+                }))
+            } else {
+                Ok(None)
             }
         }
     }
@@ -4401,7 +4402,6 @@ mod tests {
             .unwrap()
             .auth_ldap(
                 &LdapAuthEvent {
-                    eventid: Uuid::new_v4(),
                     target: target_uuid,
                     cleartext: if has_posix_password {
                         "kampai".to_string()

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1073,7 +1073,7 @@ pub trait IdmServerTransaction<'a> {
                 self.process_ldap_uuid_to_identity(*user_id, ct, source, ldap_bound.session_id)
             }
             LdapSession::UserAuthToken(uat_inner) => {
-                self.process_uat_to_identity(&uat_inner, ct, source)
+                self.process_uat_to_identity(uat_inner, ct, source)
             }
             LdapSession::ApiToken(apit) => {
                 let entry = self
@@ -1083,7 +1083,7 @@ pub trait IdmServerTransaction<'a> {
                         admin_error!("Failed to validate ldap session -> {:?}", e);
                     })?;
 
-                self.process_apit_to_identity(&apit, source, entry, ct)
+                self.process_apit_to_identity(apit, source, entry, ct)
             }
         }
     }

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1067,10 +1067,10 @@ pub trait IdmServerTransaction<'a> {
         source: Source,
         ct: Duration,
     ) -> Result<Identity, OperationError> {
-        match ldap_bound.effective_session.clone() {
+        match &ldap_bound.effective_session {
             LdapSession::UnixBind(user_id)
             | LdapSession::ApplicationPasswordBind { user_id, .. } => {
-                self.process_ldap_uuid_to_identity(user_id, ct, source, ldap_bound.session_id)
+                self.process_ldap_uuid_to_identity(*user_id, ct, source, ldap_bound.session_id)
             }
             LdapSession::UserAuthToken(uat_inner) => {
                 self.process_uat_to_identity(&uat_inner, ct, source)

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -1586,17 +1586,16 @@ impl IdmServerAuthTransaction<'_> {
                 return Ok(None);
             }
 
-            let session_id = Uuid::new_v4();
             security_info!(
                 "Starting session {} for {} {}",
-                session_id,
+                lae.eventid,
                 account.spn(),
                 account.uuid
             );
 
             // Account must be anon, so we can gen the uat.
             Ok(Some(LdapBoundToken {
-                session_id,
+                session_id: lae.eventid,
                 spn: account.spn().into(),
                 effective_session: LdapSession::UnixBind(UUID_ANONYMOUS),
             }))
@@ -1612,17 +1611,16 @@ impl IdmServerAuthTransaction<'_> {
 
             match auth {
                 Some(account) => {
-                    let session_id = Uuid::new_v4();
                     security_info!(
                         "Starting session {} for {} {}",
-                        session_id,
+                        lae.eventid,
                         account.spn(),
                         account.uuid
                     );
 
                     Ok(Some(LdapBoundToken {
                         spn: account.spn().into(),
-                        session_id,
+                        session_id: lae.eventid,
                         effective_session: LdapSession::UnixBind(account.uuid),
                     }))
                 }
@@ -4375,7 +4373,7 @@ mod tests {
                     Value::Cred(
                         "primary".to_string(),
                         Credential::new_password_only(&p, "banana", OffsetDateTime::UNIX_EPOCH)
-                            .unwrap()
+                            .expect("Failed to create credential")
                     )
                 )
             );
@@ -4386,7 +4384,7 @@ mod tests {
                     Value::Cred(
                         "unix".to_string(),
                         Credential::new_password_only(&p, "kampai", OffsetDateTime::UNIX_EPOCH)
-                            .unwrap(),
+                            .expect("Failed to create credential"),
                     ),
                 );
             }
@@ -4403,6 +4401,7 @@ mod tests {
             .unwrap()
             .auth_ldap(
                 &LdapAuthEvent {
+                    eventid: Uuid::new_v4(),
                     target: target_uuid,
                     cleartext: if has_posix_password {
                         "kampai".to_string()


### PR DESCRIPTION
tl;dr found some weirdness, wasn't clear how things worked so this is really just a developer UX refactor

Changes:

- Refactored LdapSession::ApplicationPasswordBind to a struct variant with named fields for clarity.
- application_auth_ldap was previously resolving down to a LdapSession::UnixBind instead of an LdapSession::ApplicationPasswordBind - the resulting policy decisions are the same, because the system really only acts on the user's uuid but now it's not using the wrong struct just 'cause.
- "eventid" is now request_id for the lifetime to denote it's an individual request which matches the function names a little clearer

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
