### PR TITLE
Fix incorrect logic in bindmount processing

### DIFF
--- a/unix_integration/resolver_common/src/cli/tasks.rs
+++ b/unix_integration/resolver_common/src/cli/tasks.rs
@@ -265,11 +265,11 @@ fn home_alias_update_bind_mount(alias_path: &Path, hd_mount_path: &Path) -> Resu
         .map_err(|e| format!("While updating home directory bind mount, could not get mount info: {e}"))?;
 
     // Remove conflicting mount if it exists:
-    let mismatching_mount = current_mounts.iter().find(|m| {
+    let mut mismatching_mounts = current_mounts.iter().filter(|m| {
         m.mount_point == alias_path && m.mount_source.as_ref().map(Path::new) != Some(hd_mount_path)
     });
 
-    if let Some(m) = mismatching_mount {
+    for mismatching_mount in mismatching_mounts {
         nix::mount::umount(&m.mount_point).map_err(|e| {
             format!(
                 "Unable to remove conflicting mount at {:?}: {e}",
@@ -280,7 +280,7 @@ fn home_alias_update_bind_mount(alias_path: &Path, hd_mount_path: &Path) -> Resu
 
     // If mount point exists and is already correctly mounted, we are done
     if current_mounts.iter().any(|m| {
-        m.mount_point == alias_path && m.mount_source.as_ref().map(Path::new) != Some(hd_mount_path)
+        m.mount_point == alias_path && m.mount_source.as_ref().map(Path::new) == Some(hd_mount_path)
     }) {
         return Ok(());
     }

--- a/unix_integration/resolver_common/src/cli/tasks.rs
+++ b/unix_integration/resolver_common/src/cli/tasks.rs
@@ -265,7 +265,7 @@ fn home_alias_update_bind_mount(alias_path: &Path, hd_mount_path: &Path) -> Resu
         .map_err(|e| format!("While updating home directory bind mount, could not get mount info: {e}"))?;
 
     // Remove conflicting mount if it exists:
-    let mut mismatching_mounts = current_mounts.iter().filter(|m| {
+    let mismatching_mounts = current_mounts.iter().filter(|m| {
         m.mount_point == alias_path && m.mount_source.as_ref().map(Path::new) != Some(hd_mount_path)
     });
 

--- a/unix_integration/resolver_common/src/cli/tasks.rs
+++ b/unix_integration/resolver_common/src/cli/tasks.rs
@@ -270,10 +270,10 @@ fn home_alias_update_bind_mount(alias_path: &Path, hd_mount_path: &Path) -> Resu
     });
 
     for mismatching_mount in mismatching_mounts {
-        nix::mount::umount(&m.mount_point).map_err(|e| {
+        nix::mount::umount(&mismatching_mount.mount_point).map_err(|e| {
             format!(
                 "Unable to remove conflicting mount at {:?}: {e}",
-                &m.mount_point
+                &mismatching_mount.mount_point
             )
         })?;
     }


### PR DESCRIPTION
The logic in bindmounting did not correctly handle when the mount already existed, which may lead to the home dir not being mounted.

# Change summary

Fixes #4432

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
