### PR TITLE
Limit password max length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,6 +3826,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "unicode-segmentation",
  "url",
  "utoipa",
  "uuid",
@@ -7321,6 +7322,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ tracing = { version = "^0.1.44", features = [
 ] }
 tracing-subscriber = { version = "^0.3.23", features = ["env-filter"] }
 tracing-forest = { version = "^0.3.1", features = ["defer"] }
+unicode-segmentation = "1.13.3"
 url = "^2.5.8"
 urlencoding = "2.1.3"
 utoipa = { version = "5.5.0", features = ["url", "uuid"] }

--- a/libs/crypto/src/lib.rs
+++ b/libs/crypto/src/lib.rs
@@ -38,7 +38,7 @@ pub use sha2;
 
 // Per https://pages.nist.gov/800-63-4/sp800-63b.html max length should be 64. This is
 // measured in GRAPHEMES, not bytes.
-pub const PW_MAX_LENGTH_NIST: u32 = 64;
+pub const PW_MAX_LENGTH_NIST: u32 = 128;
 
 // Single factor passwords have a greater minimum length requirement per nist.
 pub const PW_SFA_MIN_LENGTH_NIST: u32 = 15;

--- a/libs/crypto/src/lib.rs
+++ b/libs/crypto/src/lib.rs
@@ -36,7 +36,8 @@ mod crypt_md5;
 
 pub use sha2;
 
-// Per https://pages.nist.gov/800-63-4/sp800-63b.html max length should be 64.
+// Per https://pages.nist.gov/800-63-4/sp800-63b.html max length should be 64. This is
+// measured in GRAPHEMES, not bytes.
 pub const PW_MAX_LENGTH_NIST: u32 = 64;
 
 // Single factor passwords have a greater minimum length requirement per nist.
@@ -46,8 +47,8 @@ pub const PW_SFA_MIN_LENGTH_NIST: u32 = 15;
 pub const PW_MFA_MIN_LENGTH: u32 = 10;
 
 // Since we added a max length constraint later, we should continue to allow long
-// passwords to be validated.
-pub const PW_MAX_LENGTH_CHECK: usize = PW_MAX_LENGTH_NIST as usize * 2;
+// passwords to be validated. NOTE this is BYTES not GRAPHEMES.
+pub const PW_MAX_LENGTH_CHECK: usize = PW_MAX_LENGTH_NIST as usize * 4;
 
 // NIST 800-63.b salt should be 112 bits -> 14  8u8.
 const PBKDF2_SALT_LEN: usize = 24;

--- a/libs/crypto/src/lib.rs
+++ b/libs/crypto/src/lib.rs
@@ -36,6 +36,19 @@ mod crypt_md5;
 
 pub use sha2;
 
+// Per https://pages.nist.gov/800-63-4/sp800-63b.html max length should be 64.
+pub const PW_MAX_LENGTH_NIST: u32 = 64;
+
+// Single factor passwords have a greater minimum length requirement per nist.
+pub const PW_SFA_MIN_LENGTH_NIST: u32 = 15;
+// When used with MFA, the MIN length can be relaxed. Per NIST 8 is acceptable, but we
+// have used 10 for this value.
+pub const PW_MFA_MIN_LENGTH: u32 = 10;
+
+// Since we added a max length constraint later, we should continue to allow long
+// passwords to be validated.
+pub const PW_MAX_LENGTH_CHECK: usize = PW_MAX_LENGTH_NIST as usize * 2;
+
 // NIST 800-63.b salt should be 112 bits -> 14  8u8.
 const PBKDF2_SALT_LEN: usize = 24;
 
@@ -920,6 +933,11 @@ impl Password {
         cleartext: &str,
         hsm: Option<(&mut dyn TpmHmacS256, &HmacS256Key)>,
     ) -> Result<bool, CryptoError> {
+        if cleartext.len() > PW_MAX_LENGTH_CHECK {
+            error!("Cleartext input exceeds safe KDF length {PW_MAX_LENGTH_CHECK}, refusing to proceed.");
+            return Ok(false);
+        }
+
         match (&self.material, hsm) {
             (
                 Kdf::TPM_ARGON2ID {

--- a/proto/src/internal/credupdate.rs
+++ b/proto/src/internal/credupdate.rs
@@ -336,6 +336,7 @@ pub enum PasswordFeedback {
     CommonNamesAndSurnamesAreEasyToGuess,
     // Custom
     TooShort(u32),
+    TooLong(u32),
     BadListed,
     DontReusePasswords,
 }
@@ -423,6 +424,10 @@ impl fmt::Display for PasswordFeedback {
             PasswordFeedback::TooShort(minlength) => write!(
                 f,
                 "Password was too short, needs to be at least {minlength} characters long."
+            ),
+            PasswordFeedback::TooLong(maxlength) => write!(
+                f,
+                "Password was too long, must not be greater than {maxlength} characters long."
             ),
             PasswordFeedback::UseAFewWordsAvoidCommonPhrases => {
                 write!(f, "Use a few words and avoid common phrases.")

--- a/server/lib/Cargo.toml
+++ b/server/lib/Cargo.toml
@@ -65,6 +65,7 @@ tokio = { workspace = true, features = ["net", "sync", "time", "rt"] }
 nonempty = { workspace = true, features = ["serialize"] }
 
 tracing = { workspace = true, features = ["attributes"] }
+unicode-segmentation = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 utoipa = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/server/lib/src/constants/mod.rs
+++ b/server/lib/src/constants/mod.rs
@@ -172,7 +172,6 @@ pub const RECYCLEBIN_MAX_AGE: u64 = 7 * 86400;
 pub const AUTH_SESSION_TIMEOUT: u64 = 300;
 // 5 minute mfa reg window
 pub const MFAREG_SESSION_TIMEOUT: u64 = 300;
-pub const PW_MIN_LENGTH: u32 = 10;
 
 // Maximum - Sessions have no upper bound.
 pub const MAXIMUM_AUTH_SESSION_EXPIRY: u32 = u32::MAX;

--- a/server/lib/src/idm/accountpolicy.rs
+++ b/server/lib/src/idm/accountpolicy.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::value::CredentialType;
+use kanidm_lib_crypto::{PW_MAX_LENGTH_NIST, PW_MFA_MIN_LENGTH, PW_SFA_MIN_LENGTH_NIST};
 use webauthn_rs::prelude::AttestationCaList;
 
 #[derive(Clone)]
@@ -34,7 +35,7 @@ impl From<&EntrySealedCommitted> for Option<AccountPolicy> {
 
         let pw_min_length = val
             .get_ava_single_uint32(Attribute::AuthPasswordMinimumLength)
-            .unwrap_or(PW_MIN_LENGTH);
+            .unwrap_or(PW_MFA_MIN_LENGTH);
 
         let credential_policy = val
             .get_ava_single_credential_type(Attribute::CredentialTypeMinimum)
@@ -74,6 +75,7 @@ pub(crate) struct ResolvedAccountPolicy {
     privilege_expiry: u32,
     authsession_expiry: u32,
     pw_min_length: u32,
+    pw_max_length: u32,
     credential_policy: CredentialType,
     webauthn_att_ca_list: Option<AttestationCaList>,
     limit_search_max_filter_test: Option<u64>,
@@ -87,7 +89,8 @@ impl ResolvedAccountPolicy {
         ResolvedAccountPolicy {
             privilege_expiry: DEFAULT_AUTH_PRIVILEGE_EXPIRY,
             authsession_expiry: DEFAULT_AUTH_SESSION_EXPIRY,
-            pw_min_length: PW_MIN_LENGTH,
+            pw_min_length: PW_MFA_MIN_LENGTH,
+            pw_max_length: PW_MAX_LENGTH_NIST,
             credential_policy: CredentialType::Any,
             webauthn_att_ca_list: None,
             limit_search_max_filter_test: Some(DEFAULT_LIMIT_SEARCH_MAX_FILTER_TEST),
@@ -104,7 +107,8 @@ impl ResolvedAccountPolicy {
         let mut accumulate = ResolvedAccountPolicy {
             privilege_expiry: MAXIMUM_AUTH_PRIVILEGE_EXPIRY,
             authsession_expiry: MAXIMUM_AUTH_SESSION_EXPIRY,
-            pw_min_length: PW_MIN_LENGTH,
+            pw_min_length: PW_MFA_MIN_LENGTH,
+            pw_max_length: PW_MAX_LENGTH_NIST,
             credential_policy: CredentialType::Any,
             webauthn_att_ca_list: None,
             limit_search_max_filter_test: None,
@@ -170,6 +174,14 @@ impl ResolvedAccountPolicy {
             }
         });
 
+        // Per NIST, if a password can be used as a single factor authenticator,
+        // then we need to set the minimum length to a greater value.
+        if accumulate.credential_policy < CredentialType::Mfa
+            && accumulate.pw_min_length < PW_SFA_MIN_LENGTH_NIST
+        {
+            accumulate.pw_min_length = PW_SFA_MIN_LENGTH_NIST;
+        }
+
         accumulate
     }
 
@@ -183,6 +195,10 @@ impl ResolvedAccountPolicy {
 
     pub(crate) fn pw_min_length(&self) -> u32 {
         self.pw_min_length
+    }
+
+    pub(crate) fn pw_max_length(&self) -> u32 {
+        self.pw_max_length
     }
 
     pub(crate) fn credential_policy(&self) -> CredentialType {

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -1879,9 +1879,17 @@ impl IdmServerCredUpdateTransaction<'_> {
         let pw_min_length = resolved_account_policy.pw_min_length();
         let pw_max_length = resolved_account_policy.pw_max_length();
 
-        if cleartext.len() < pw_min_length as usize {
+        let pw_graphemes = (0..cleartext.len()).fold(0, |acc, idx| {
+            if cleartext.is_char_boundary(idx) {
+                acc + 1
+            } else {
+                acc
+            }
+        });
+
+        if pw_graphemes < pw_min_length as usize {
             return Err(PasswordQuality::TooShort(pw_min_length));
-        } else if cleartext.len() > pw_max_length as usize {
+        } else if pw_graphemes > pw_max_length as usize {
             return Err(PasswordQuality::TooLong(pw_max_length));
         };
 

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -42,6 +42,7 @@ const MAXIMUM_INTENT_TTL: Duration = Duration::from_secs(86400);
 #[derive(Debug)]
 pub enum PasswordQuality {
     TooShort(u32),
+    TooLong(u32),
     BadListed,
     DontReusePasswords,
     Feedback(Vec<PasswordFeedback>),
@@ -1876,9 +1877,13 @@ impl IdmServerCredUpdateTransaction<'_> {
 
         // is the password at least 10 char?
         let pw_min_length = resolved_account_policy.pw_min_length();
+        let pw_max_length = resolved_account_policy.pw_max_length();
+
         if cleartext.len() < pw_min_length as usize {
             return Err(PasswordQuality::TooShort(pw_min_length));
-        }
+        } else if cleartext.len() > pw_max_length as usize {
+            return Err(PasswordQuality::TooLong(pw_max_length));
+        };
 
         if let Some(some_radius_secret) = radius_secret {
             if cleartext.contains(some_radius_secret) {
@@ -2055,6 +2060,9 @@ impl IdmServerCredUpdateTransaction<'_> {
             PasswordQuality::TooShort(sz) => {
                 OperationError::PasswordQuality(vec![PasswordFeedback::TooShort(sz)])
             }
+            PasswordQuality::TooLong(sz) => {
+                OperationError::PasswordQuality(vec![PasswordFeedback::TooLong(sz)])
+            }
             PasswordQuality::BadListed => {
                 OperationError::PasswordQuality(vec![PasswordFeedback::BadListed])
             }
@@ -2097,6 +2105,9 @@ impl IdmServerCredUpdateTransaction<'_> {
         .map_err(|e| match e {
             PasswordQuality::TooShort(sz) => {
                 OperationError::PasswordQuality(vec![PasswordFeedback::TooShort(sz)])
+            }
+            PasswordQuality::TooLong(sz) => {
+                OperationError::PasswordQuality(vec![PasswordFeedback::TooLong(sz)])
             }
             PasswordQuality::BadListed => {
                 OperationError::PasswordQuality(vec![PasswordFeedback::BadListed])
@@ -2713,6 +2724,9 @@ impl IdmServerCredUpdateTransaction<'_> {
             PasswordQuality::TooShort(sz) => {
                 OperationError::PasswordQuality(vec![PasswordFeedback::TooShort(sz)])
             }
+            PasswordQuality::TooLong(sz) => {
+                OperationError::PasswordQuality(vec![PasswordFeedback::TooLong(sz)])
+            }
             PasswordQuality::BadListed => {
                 OperationError::PasswordQuality(vec![PasswordFeedback::BadListed])
             }
@@ -2865,10 +2879,11 @@ mod tests {
     };
     use crate::idm::server::{IdmServer, IdmServerCredUpdateTransaction, IdmServerDelayed};
     use crate::prelude::*;
-    use crate::utils::password_from_random_len;
+    use crate::utils::{password_from_random_len, readable_password_from_random};
     use crate::value::CredentialType;
     use crate::valueset::ValueSetEmailAddress;
     use compact_jwt::JwsCompact;
+    use kanidm_lib_crypto::{PW_MAX_LENGTH_NIST, PW_SFA_MIN_LENGTH_NIST};
     use kanidm_proto::internal::{CUExtPortal, CredentialDetailType, PasswordFeedback};
     use kanidm_proto::v1::OutboundMessage;
     use kanidm_proto::v1::{AuthAllowed, AuthIssueSession, AuthMech, UnixUserToken};
@@ -2884,8 +2899,6 @@ mod tests {
     const TEST_CURRENT_TIME: u64 = 6000;
     const TESTPERSON_UUID: Uuid = uuid!("cf231fea-1a8f-4410-a520-fd9b1a379c86");
     const TESTPERSON_NAME: &str = "testperson";
-
-    const TESTPERSON_PASSWORD: &str = "SSBndWVzcyB5b3UgZGlzY292ZXJlZCB0aGUgc2VjcmV0";
 
     const SSHKEY_VALID_1: &str = "sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBENubZikrb8hu+HeVRdZ0pp/VAk2qv4JDbuJhvD0yNdWDL2e3cBbERiDeNPkWx58Q4rVnxkbV1fa8E2waRtT91wAAAAEc3NoOg== testuser@fidokey";
     const SSHKEY_VALID_2: &str = "sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBIbkSsdGCRoW6v0nO/3vNYPhG20YhWU0wQPY7x52EOb4dmYhC4IJfzVDpEPg313BxWRKQglb5RQ1PPkou7JFyCUAAAAEc3NoOg== testuser@fidokey";
@@ -3711,7 +3724,7 @@ mod tests {
         idms: &IdmServer,
         idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -3731,7 +3744,7 @@ mod tests {
         // Test initially creating a credential.
         //   - pw first
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         assert!(c_status.can_commit);
@@ -3740,7 +3753,7 @@ mod tests {
         commit_session(idms, ct, cust).await;
 
         // Check it works!
-        assert!(check_testperson_password(idms, idms_delayed, test_pw, ct)
+        assert!(check_testperson_password(idms, idms_delayed, &test_pw, ct)
             .await
             .is_some());
 
@@ -3811,18 +3824,28 @@ mod tests {
             .unwrap_err();
         trace!(?err);
         assert!(
-            matches!(err, OperationError::PasswordQuality(details) if details == vec!(PasswordFeedback::TooShort(PW_MIN_LENGTH),))
+            matches!(err, OperationError::PasswordQuality(details) if details == vec!(PasswordFeedback::TooShort(PW_SFA_MIN_LENGTH_NIST),))
+        );
+
+        let random_pw = password_from_random_len(PW_MAX_LENGTH_NIST + 1);
+        let err = cutxn
+            .credential_primary_set_password(&cust, ct, &random_pw)
+            .unwrap_err();
+        trace!(?err);
+        assert!(
+            matches!(err, OperationError::PasswordQuality(details) if details == vec!(PasswordFeedback::TooLong(PW_MAX_LENGTH_NIST),))
         );
 
         let err = cutxn
-            .credential_primary_set_password(&cust, ct, "password1234")
+            .credential_primary_set_password(&cust, ct, "password 12345678")
             .unwrap_err();
         trace!(?err);
         assert!(
             matches!(err, OperationError::PasswordQuality(details) if details
             == vec!(
+                PasswordFeedback::UseAFewWordsAvoidCommonPhrases,
                 PasswordFeedback::AddAnotherWordOrTwo,
-                PasswordFeedback::ThisIsACommonPassword,
+                PasswordFeedback::NoNeedForSymbolsDigitsOrUppercaseLetters
             ))
         );
 
@@ -3835,7 +3858,7 @@ mod tests {
         );
 
         let err = cutxn
-            .credential_primary_set_password(&cust, ct, "testperson2023")
+            .credential_primary_set_password(&cust, ct, "testperson 2023")
             .unwrap_err();
         trace!(?err);
         assert!(
@@ -3849,7 +3872,7 @@ mod tests {
             .credential_primary_set_password(
                 &cust,
                 ct,
-                "demo_badlist_shohfie3aeci2oobur0aru9uushah6EiPi2woh4hohngoighaiRuepieN3ongoo1",
+                "demo_badlist_shohfie3aeci2oobur0aru9uushah6EiPi2woh4hohngoighaiR",
             )
             .unwrap_err();
         trace!(?err);
@@ -3874,7 +3897,7 @@ mod tests {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         // Set the account policy min pw length
-        let test_pw_min_length = PW_MIN_LENGTH * 2;
+        let test_pw_min_length = PW_SFA_MIN_LENGTH_NIST * 2;
 
         let mut idms_prox_write = idms.proxy_write(ct).await.unwrap();
 
@@ -3947,7 +3970,7 @@ mod tests {
         idms: &IdmServer,
         idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -3955,7 +3978,7 @@ mod tests {
 
         // Setup the PW
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Since it's pw only.
@@ -4069,7 +4092,7 @@ mod tests {
 
         // Check it works!
         assert!(
-            check_testperson_password_totp(idms, idms_delayed, test_pw, &totp_token, ct)
+            check_testperson_password_totp(idms, idms_delayed, &test_pw, &totp_token, ct)
                 .await
                 .is_some()
         );
@@ -4093,7 +4116,7 @@ mod tests {
         commit_session(idms, ct, cust).await;
 
         // Check it works with totp removed.
-        assert!(check_testperson_password(idms, idms_delayed, test_pw, ct)
+        assert!(check_testperson_password(idms, idms_delayed, &test_pw, ct)
             .await
             .is_some());
     }
@@ -4104,7 +4127,7 @@ mod tests {
         idms: &IdmServer,
         idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -4112,7 +4135,7 @@ mod tests {
 
         // Setup the PW
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Since it's pw only.
@@ -4166,7 +4189,7 @@ mod tests {
 
         // Check it works!
         assert!(
-            check_testperson_password_totp(idms, idms_delayed, test_pw, &totp_token, ct)
+            check_testperson_password_totp(idms, idms_delayed, &test_pw, &totp_token, ct)
                 .await
                 .is_some()
         );
@@ -4178,7 +4201,7 @@ mod tests {
         idms: &IdmServer,
         idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -4186,7 +4209,7 @@ mod tests {
 
         // Setup the PW
         let _c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Backup codes are refused to be added because we don't have mfa yet.
@@ -4249,7 +4272,7 @@ mod tests {
         assert!(check_testperson_password_backup_code(
             idms,
             idms_delayed,
-            test_pw,
+            &test_pw,
             backup_code,
             ct
         )
@@ -4315,7 +4338,7 @@ mod tests {
         idms: &IdmServer,
         idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -4323,7 +4346,7 @@ mod tests {
 
         // Setup the PW
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Since it's pw only.
@@ -4352,7 +4375,7 @@ mod tests {
         commit_session(idms, ct, cust).await;
 
         // It's pw only, since we canceled TOTP
-        assert!(check_testperson_password(idms, idms_delayed, test_pw, ct)
+        assert!(check_testperson_password(idms, idms_delayed, &test_pw, ct)
             .await
             .is_some());
     }
@@ -4409,7 +4432,7 @@ mod tests {
         idms_delayed: &mut IdmServerDelayed,
     ) {
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
 
         let (cust, _) = setup_test_session(idms, ct).await;
         let cutxn = idms.cred_update_transaction().await.unwrap();
@@ -4457,7 +4480,7 @@ mod tests {
 
         // For now, set a password to allow saving.
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Could proceed now!
@@ -4662,7 +4685,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let mut idms_prox_write = idms.proxy_write(ct).await.unwrap();
@@ -4697,7 +4720,7 @@ mod tests {
         // Test initially creating a credential.
         //   - pw first
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         assert!(!c_status.can_commit);
@@ -4784,7 +4807,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let mut idms_prox_write = idms.proxy_write(ct).await.unwrap();
@@ -4820,7 +4843,7 @@ mod tests {
         ));
 
         let err = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .unwrap_err();
         assert!(matches!(err, OperationError::AccessDenied));
 
@@ -5388,7 +5411,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -5412,7 +5435,7 @@ mod tests {
         assert!(!c_status.can_commit);
         // User needs at least one credential else they can't save.
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
         assert!(c_status.can_commit);
         assert!(!c_status
@@ -5422,7 +5445,7 @@ mod tests {
         // Test initially creating a credential.
         //   - pw first
         let c_status = cutxn
-            .credential_unix_set_password(&cust, ct, test_pw)
+            .credential_unix_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the unix cred password");
 
         assert!(c_status.can_commit);
@@ -5431,7 +5454,7 @@ mod tests {
         commit_session(idms, ct, cust).await;
 
         // Check it works!
-        assert!(check_testperson_unix_password(idms, test_pw, ct)
+        assert!(check_testperson_unix_password(idms, &test_pw, ct)
             .await
             .is_some());
 
@@ -5455,14 +5478,14 @@ mod tests {
         commit_session(idms, ct, cust).await;
 
         // Must fail now!
-        assert!(check_testperson_unix_password(idms, test_pw, ct)
+        assert!(check_testperson_unix_password(idms, &test_pw, ct)
             .await
             .is_none());
     }
 
     #[idm_test]
     async fn credential_update_sshkeys(idms: &IdmServer, _idms_delayed: &mut IdmServerDelayed) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let sshkey_valid_1 =
             SshPublicKey::from_string(SSHKEY_VALID_1).expect("Invalid SSHKEY_VALID_1");
         let sshkey_valid_2 =
@@ -5485,7 +5508,7 @@ mod tests {
         assert!(!c_status.can_commit);
         // User needs at least one credential else they can't save.
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Ready to proceed with ssh keys
@@ -5555,7 +5578,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
-        let test_pw = "fo3EitierohF9AelaNgiem0Ei6vup4equo1Oogeevaetehah8Tobeengae3Ci0ooh0uki";
+        let test_pw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -5580,7 +5603,7 @@ mod tests {
 
         // Test initially creating a credential.
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, test_pw)
+            .credential_primary_set_password(&cust, ct, &test_pw)
             .expect("Failed to update the primary cred password");
 
         // Could proceed now!
@@ -5615,6 +5638,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
+        let testpw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session(idms, ct).await;
@@ -5625,7 +5649,7 @@ mod tests {
         // Primary Cred with No fallback => EPOCH
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_primary_set_password(&cust, ct, &testpw)
             .expect("Failed to update the primary cred password");
         assert!(c_status.can_commit);
         drop(cutxn);
@@ -5640,7 +5664,7 @@ mod tests {
         let (cust, _) = renew_test_session(idms, ct).await;
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let c_status = cutxn
-            .credential_unix_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_unix_set_password(&cust, ct, &testpw)
             .expect("Failed to set unix password");
         assert!(c_status.can_commit);
         drop(cutxn);
@@ -5675,16 +5699,17 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
+        let testpw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         // Set up both credentials.
         let (cust, _) = setup_test_session(idms, ct).await;
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let _ = cutxn
-            .credential_primary_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_primary_set_password(&cust, ct, &testpw)
             .expect("Failed to set primary password");
         let _ = cutxn
-            .credential_unix_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_unix_set_password(&cust, ct, &testpw)
             .expect("Failed to set unix password");
         drop(cutxn);
         commit_session(idms, ct, cust).await;
@@ -5719,6 +5744,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
+        let testpw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
 
         let (cust, _) = setup_test_session_no_posix(idms, ct).await;
@@ -5729,7 +5755,7 @@ mod tests {
         // No POSIX still causes default to EPOCH
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let c_status = cutxn
-            .credential_primary_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_primary_set_password(&cust, ct, &testpw)
             .expect("Failed to set primary password");
         assert!(c_status.can_commit);
         drop(cutxn);
@@ -5758,7 +5784,7 @@ mod tests {
         let (cust, _) = renew_test_session(idms, ct).await;
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let _ = cutxn
-            .credential_primary_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_primary_set_password(&cust, ct, &testpw)
             .expect("Failed to set primary password");
         drop(cutxn);
         commit_session(idms, ct, cust).await;
@@ -5802,15 +5828,16 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
+        let testpw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
         let (cust, _) = setup_test_session(idms, ct).await;
 
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let _ = cutxn
-            .credential_primary_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_primary_set_password(&cust, ct, &testpw)
             .expect("Failed to set primary password");
         let _ = cutxn
-            .credential_unix_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_unix_set_password(&cust, ct, &testpw)
             .expect("Failed to set unix password");
         drop(cutxn);
         commit_session(idms, ct, cust).await;
@@ -5840,6 +5867,7 @@ mod tests {
         idms: &IdmServer,
         _idms_delayed: &mut IdmServerDelayed,
     ) {
+        let testpw = readable_password_from_random();
         let ct = Duration::from_secs(TEST_CURRENT_TIME);
         let ct2 = Duration::from_secs(TEST_CURRENT_TIME + 50);
 
@@ -5864,11 +5892,11 @@ mod tests {
 
         let cutxn = idms.cred_update_transaction().await.unwrap();
         let _ = cutxn
-            .credential_primary_set_password(&cust, ct, TESTPERSON_PASSWORD)
+            .credential_primary_set_password(&cust, ct, &testpw)
             .expect("Failed to set primary password");
 
         let _ = cutxn
-            .credential_unix_set_password(&cust, ct2, TESTPERSON_PASSWORD)
+            .credential_unix_set_password(&cust, ct2, &testpw)
             .expect("Failed to set unix password");
 
         let c_status = cutxn

--- a/server/lib/src/idm/credupdatesession.rs
+++ b/server/lib/src/idm/credupdatesession.rs
@@ -5,7 +5,9 @@ use crate::idm::account::Account;
 use crate::idm::server::{IdmServerCredUpdateTransaction, IdmServerProxyWriteTransaction};
 use crate::prelude::*;
 use crate::server::access::Access;
-use crate::utils::{backup_code_from_random, readable_password_from_random, uuid_from_duration};
+use crate::utils::{
+    backup_code_from_random, readable_password_from_random, utf8_len, uuid_from_duration,
+};
 use crate::value::{CredUpdateSessionPerms, CredentialType, IntentTokenState, LABEL_RE};
 use compact_jwt::compact::JweCompact;
 use compact_jwt::jwe::JweBuilder;
@@ -1879,13 +1881,7 @@ impl IdmServerCredUpdateTransaction<'_> {
         let pw_min_length = resolved_account_policy.pw_min_length();
         let pw_max_length = resolved_account_policy.pw_max_length();
 
-        let pw_graphemes = (0..cleartext.len()).fold(0, |acc, idx| {
-            if cleartext.is_char_boundary(idx) {
-                acc + 1
-            } else {
-                acc
-            }
-        });
+        let pw_graphemes = utf8_len(cleartext);
 
         if pw_graphemes < pw_min_length as usize {
             return Err(PasswordQuality::TooShort(pw_min_length));

--- a/server/lib/src/idm/server.rs
+++ b/server/lib/src/idm/server.rs
@@ -35,7 +35,7 @@ use compact_jwt::{Jwk, JwsCompact};
 use concread::bptree::{BptreeMap, BptreeMapReadTxn, BptreeMapWriteTxn};
 use concread::cowcell::CowCellReadTxn;
 use concread::hashmap::{HashMap, HashMapReadTxn, HashMapWriteTxn};
-use kanidm_lib_crypto::CryptoPolicy;
+use kanidm_lib_crypto::{CryptoPolicy, PW_MAX_LENGTH_NIST, PW_SFA_MIN_LENGTH_NIST};
 use kanidm_proto::internal::{
     ApiToken, CredentialStatus, PasswordFeedback, RadiusAuthToken, ScimSyncToken, UatPurpose,
     UserAuthToken,
@@ -1805,14 +1805,15 @@ impl IdmServerProxyWriteTransaction<'_> {
     ) -> Result<(), OperationError> {
         // password strength and badlisting is always global, rather than per-pw-policy.
         // pw-policy as check on the account is about requirements for mfa for example.
-        //
-
-        // is the password at least 10 char?
-        if cleartext.len() < PW_MIN_LENGTH as usize {
+        if cleartext.len() < PW_SFA_MIN_LENGTH_NIST as usize {
             return Err(OperationError::PasswordQuality(vec![
-                PasswordFeedback::TooShort(PW_MIN_LENGTH),
+                PasswordFeedback::TooShort(PW_SFA_MIN_LENGTH_NIST),
             ]));
-        }
+        } else if cleartext.len() > PW_MAX_LENGTH_NIST as usize {
+            return Err(OperationError::PasswordQuality(vec![
+                PasswordFeedback::TooLong(PW_MAX_LENGTH_NIST),
+            ]));
+        };
 
         // does the password pass zxcvbn?
 

--- a/server/lib/src/migration_data/dl15/system_config.rs
+++ b/server/lib/src/migration_data/dl15/system_config.rs
@@ -79,7 +79,7 @@ pub fn e_system_config_v1() -> EntryInitNew {
     ]);
     for pw in [
         "bad@no3IBTyqHu$list",
-        "demo_badlist_shohfie3aeci2oobur0aru9uushah6EiPi2woh4hohngoighaiRuepieN3ongoo1",
+        "demo_badlist_shohfie3aeci2oobur0aru9uushah6EiPi2woh4hohngoighaiR",
         "100preteamare",
         "14defebrero",
         "1life1love",

--- a/server/lib/src/utils.rs
+++ b/server/lib/src/utils.rs
@@ -5,6 +5,7 @@ use hashbrown::HashSet;
 use rand::distr::{Distribution, Uniform};
 use rand::{rng, Rng, RngExt};
 use std::ops::Range;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug)]
 pub struct DistinctAlpha;
@@ -109,18 +110,17 @@ impl<'a> GraphemeClusterIter<'a> {
         let char_bounds = if value.len() < window {
             Vec::with_capacity(0)
         } else {
-            let mut char_bounds = Vec::with_capacity(value.len());
-            for idx in 0..value.len() {
-                if value.is_char_boundary(idx) {
-                    char_bounds.push(idx);
-                }
-            }
-            char_bounds.push(value.len());
-            char_bounds
+            value
+                .grapheme_indices(true)
+                .map(|(idx, _grapheme)| idx)
+                .chain(std::iter::once(value.len()))
+                .collect::<Vec<_>>()
         };
 
         let window_max = char_bounds.len().saturating_sub(window);
         let range = 0..window_max;
+
+        eprintln!("{:?} {}", char_bounds, window_max);
 
         GraphemeClusterIter {
             value,
@@ -151,7 +151,7 @@ impl<'a> Iterator for GraphemeClusterIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let clusters = self.char_bounds.len().saturating_sub(1);
+        let clusters = self.char_bounds.len().saturating_sub(self.window);
         (clusters, Some(clusters))
     }
 }
@@ -162,12 +162,16 @@ pub(crate) fn trigraph_iter(value: &str) -> impl Iterator<Item = &str> {
         .chain(GraphemeClusterIter::new(value, 1))
 }
 
+pub(crate) fn utf8_len(value: &str) -> usize {
+    value.graphemes(true).count()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
     use std::time::Duration;
 
-    use crate::utils::{uuid_from_duration, uuid_to_gid_u32, GraphemeClusterIter};
+    use crate::utils::{utf8_len, uuid_from_duration, uuid_to_gid_u32, GraphemeClusterIter};
 
     #[test]
     fn test_utils_uuid_from_duration() {
@@ -203,30 +207,32 @@ mod tests {
     fn test_utils_grapheme_cluster_iter() {
         let d = "❤️🧡💛💚💙💜";
 
-        let gc_expect = vec!["❤", "\u{fe0f}", "🧡", "💛", "💚", "💙", "💜"];
-        let gc: Vec<_> = GraphemeClusterIter::new(d, 1).collect();
+        let gc_expect = vec!["❤\u{fe0f}", "🧡", "💛", "💚", "💙", "💜"];
+        let gc_iter = GraphemeClusterIter::new(d, 1);
+        assert_eq!(gc_iter.size_hint().0, 6);
+        let gc: Vec<_> = gc_iter.collect();
         assert_eq!(gc, gc_expect);
 
-        let gc_expect = vec!["❤\u{fe0f}", "\u{fe0f}🧡", "🧡💛", "💛💚", "💚💙", "💙💜"];
-        let gc: Vec<_> = GraphemeClusterIter::new(d, 2).collect();
+        let gc_expect = vec!["❤\u{fe0f}🧡", "🧡💛", "💛💚", "💚💙", "💙💜"];
+        let gc_iter = GraphemeClusterIter::new(d, 2);
+        assert_eq!(gc_iter.size_hint().0, 5);
+        let gc: Vec<_> = gc_iter.collect();
         assert_eq!(gc, gc_expect);
 
-        let gc_expect = vec!["❤\u{fe0f}🧡", "\u{fe0f}🧡💛", "🧡💛💚", "💛💚💙", "💚💙💜"];
-        let gc: Vec<_> = GraphemeClusterIter::new(d, 3).collect();
+        let gc_expect = vec!["❤\u{fe0f}🧡💛", "🧡💛💚", "💛💚💙", "💚💙💜"];
+        let gc_iter = GraphemeClusterIter::new(d, 3);
+        assert_eq!(gc_iter.size_hint().0, 4);
+        let gc: Vec<_> = gc_iter.collect();
         assert_eq!(gc, gc_expect);
+    }
 
-        let d = "🤷🏿‍♂️";
-
-        let gc_expect = vec!["🤷", "🏿", "\u{200d}", "♂", "\u{fe0f}"];
-        let gc: Vec<_> = GraphemeClusterIter::new(d, 1).collect();
-        assert_eq!(gc, gc_expect);
-
-        let gc_expect = vec!["🤷🏿", "🏿\u{200d}", "\u{200d}♂", "♂\u{fe0f}"];
-        let gc: Vec<_> = GraphemeClusterIter::new(d, 2).collect();
-        assert_eq!(gc, gc_expect);
-
-        let gc_expect = vec!["🤷🏿\u{200d}", "🏿\u{200d}♂", "\u{200d}♂\u{fe0f}"];
-        let gc: Vec<_> = GraphemeClusterIter::new(d, 3).collect();
-        assert_eq!(gc, gc_expect);
+    #[test]
+    fn test_utils_grapheme_len() {
+        assert_eq!(utf8_len(""), 0);
+        assert_eq!(utf8_len("a"), 1);
+        assert_eq!(utf8_len("ab"), 2);
+        assert_eq!(utf8_len("abcdef"), 6);
+        assert_eq!(utf8_len("🤷"), 1);
+        assert_eq!(utf8_len("🤷🏿"), 1);
     }
 }


### PR DESCRIPTION
This checks new passwords that they are not in excess of 64 bytes. As some users may have created passwords in the past that are longer than this, existing passwords up to 128 bytes can continue to be validated.

Fixes #4414

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
