### PR TITLE
Support SOCKS proxies via reqwest "socks" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,7 @@ reqwest = { version = "0.13.4", default-features = false, features = [
     "multipart",
     "rustls",
     "query",
+    "socks",
 ] }
 rusqlite = { version = "0.40.1", features = ["array", "bundled"] }
 rustls = { version = "0.23.37", default-features = false, features = [


### PR DESCRIPTION
Enable reqwest's socks feature to allow using the kanidm CLI with a server only reachable through a socks proxy by setting the environment variable HTTPS_PROXY as documented at
https://docs.rs/reqwest/latest/reqwest/#proxies

For example `HTTPS_PROXY=socks5h://127.0.0.1:1080 kanidm` causes kanidm to use the socks5 proxy at local port 1080 for both https traffic and dns lookup.

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
