### PR TITLE
Add minor version tag to container images

### DIFF
--- a/.github/workflows/docker_build_kanidm.yml
+++ b/.github/workflows/docker_build_kanidm.yml
@@ -26,9 +26,15 @@ jobs:
           echo "REF_NAME=$(echo ${REF_NAME,,} | awk -F/ '{print $1}')" >> "${GITHUB_OUTPUT}"
         env:
           REF_NAME: '${{ github.ref_name }}'
+      - id: step3
+        run: |
+          echo "MINOR_VERSION=$(echo "${REF_NAME}" | cut -d. -f1,2)" >> "${GITHUB_OUTPUT}"
+        env:
+          REF_NAME: '${{ steps.step2.outputs.REF_NAME }}'
     outputs:
       owner_lc: ${{ steps.step1.outputs.OWNER_LC }}
       ref_name: ${{ steps.step2.outputs.REF_NAME }}
+      minor_version: ${{ steps.step3.outputs.MINOR_VERSION }}
   kanidm_build:
     name: Build kanidm Docker image
     runs-on: ubuntu-latest
@@ -48,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           platforms: "linux/amd64"
-          tags: ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:devel,ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:${{ needs.set_tag_values.outputs.ref_name}}
+          tags: ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:devel,ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:${{ needs.set_tag_values.outputs.ref_name}},ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:${{ needs.set_tag_values.outputs.minor_version}}
 
           build-args: |
             "KANIDM_FEATURES="

--- a/.github/workflows/docker_build_kanidmd.yml
+++ b/.github/workflows/docker_build_kanidmd.yml
@@ -26,9 +26,15 @@ jobs:
           echo "REF_NAME=$(echo ${REF_NAME,,} | awk -F/ '{print $1}')" >> "${GITHUB_OUTPUT}"
         env:
           REF_NAME: '${{ github.ref_name }}'
+      - id: step3
+        run: |
+          echo "MINOR_VERSION=$(echo "${REF_NAME}" | cut -d. -f1,2)" >> "${GITHUB_OUTPUT}"
+        env:
+          REF_NAME: '${{ steps.step2.outputs.REF_NAME }}'
     outputs:
       owner_lc: ${{ steps.step1.outputs.OWNER_LC }}
       ref_name: ${{ steps.step2.outputs.REF_NAME }}
+      minor_version: ${{ steps.step3.outputs.MINOR_VERSION }}
 
   kanidmd_build:
     name: Build kanidmd Docker image
@@ -48,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           platforms: "linux/amd64"
-          tags: ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidmd:devel,ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidmd:${{ needs.set_tag_values.outputs.ref_name}}
+          tags: ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidmd:devel,ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidmd:${{ needs.set_tag_values.outputs.ref_name}},ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:${{ needs.set_tag_values.outputs.minor_version}}
           # build-args: |
           #  "KANIDM_BUILD_OPTIONS=-j1"
           file: server/Dockerfile

--- a/.github/workflows/docker_build_radiusd.yml
+++ b/.github/workflows/docker_build_radiusd.yml
@@ -26,9 +26,15 @@ jobs:
           echo "REF_NAME=$(echo ${REF_NAME,,} | awk -F/ '{print $1}')" >> "${GITHUB_OUTPUT}"
         env:
           REF_NAME: '${{ github.ref_name }}'
+      - id: step3
+        run: |
+          echo "MINOR_VERSION=$(echo "${REF_NAME}" | cut -d. -f1,2)" >> "${GITHUB_OUTPUT}"
+        env:
+          REF_NAME: '${{ steps.step2.outputs.REF_NAME }}'
     outputs:
       owner_lc: ${{ steps.step1.outputs.OWNER_LC }}
       ref_name: ${{ steps.step2.outputs.REF_NAME }}
+      minor_version: ${{ steps.step3.outputs.MINOR_VERSION }}
 
   radius_build:
     name: Build radius Docker image
@@ -50,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           platforms: linux/arm64,linux/amd64
-          tags: ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/radius:devel,ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/radius:${{ needs.set_tag_values.outputs.ref_name}}
+          tags: ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/radius:devel,ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/radius:${{ needs.set_tag_values.outputs.ref_name}},ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/kanidm:${{ needs.set_tag_values.outputs.minor_version}}
           file: rlm_python/Dockerfile
           context: .
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Change summary

- Add minor version tag to docker builds, for automatic updates within minor versions

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

## Background

With podman-auto-update, the newest tagged container gets pulled. With the full semver string, it would not pull newly patched versions. By tagging images additionally with [major].[minor] such updates can be done automatically. As those patch updates should not require any intervention from the admin, I see no problem in handling those in that way. Many other projects handle tags the same way e.g. traefik, mariadb...