### PR TITLE
Return correct OAuth2 HTTP Code on invalid token responses

### DIFF
--- a/server/core/src/https/errors.rs
+++ b/server/core/src/https/errors.rs
@@ -50,28 +50,25 @@ impl WebError {
 impl IntoResponse for WebError {
     fn into_response(self) -> Response {
         match self {
-            WebError::OAuth2(error) => {
-                if let Oauth2Error::AuthenticationRequired = error {
-                    (
-                        StatusCode::UNAUTHORIZED,
-                        [
-                            (WWW_AUTHENTICATE, "Bearer"),
-                            (ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
-                        ],
-                    )
-                        .into_response()
-                } else {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        [(ACCESS_CONTROL_ALLOW_ORIGIN, "*")],
-                        Json(ErrorResponse {
-                            error: error.to_string(),
-                            ..Default::default()
-                        }),
-                    )
-                        .into_response()
-                }
-            }
+            WebError::OAuth2(Oauth2Error::AuthenticationRequired)
+            | WebError::OAuth2(Oauth2Error::InvalidToken) => (
+                StatusCode::UNAUTHORIZED,
+                [
+                    (WWW_AUTHENTICATE, "Bearer"),
+                    (ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+                ],
+            )
+                .into_response(),
+            WebError::OAuth2(error) => (
+                StatusCode::BAD_REQUEST,
+                [(ACCESS_CONTROL_ALLOW_ORIGIN, "*")],
+                Json(ErrorResponse {
+                    error: error.to_string(),
+                    ..Default::default()
+                }),
+            )
+                .into_response(),
+
             WebError::InternalServerError(inner) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, inner).into_response()
             }


### PR DESCRIPTION
# Change summary

- Return 401 on invalid token responses per RFC6750

Fixes #4495

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
