### PR TITLE
Container build cleanup part uno

### DIFF
--- a/.github/workflows/docker_build_kanidm_tools.yml
+++ b/.github/workflows/docker_build_kanidm_tools.yml
@@ -1,0 +1,21 @@
+---
+name: Container - Kanidm Tools
+
+"on":
+  pull_request:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  container_build:
+    name: Build kanidm-tools container
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable_container_build.yml
+    with:
+      container_name: kanidm-tools
+      docker_file: tools/Dockerfile

--- a/.github/workflows/reusable_container_build.yml
+++ b/.github/workflows/reusable_container_build.yml
@@ -1,0 +1,91 @@
+---
+name: Reusable Container Build
+
+"on":
+  workflow_call:
+    inputs:
+      docker_file:
+        description: Project-relative path to the Dockerfile
+        required: true
+        type: string
+      container_name:
+        description: Name of the container image
+        required: true
+        type: string
+
+jobs:
+  set_tag_values:
+    name: Set image tag values
+    runs-on: ubuntu-latest
+    outputs:
+      owner_lc: ${{ steps.tags.outputs.owner_lc }}
+      ref_name: ${{ steps.tags.outputs.ref_name }}
+    steps:
+      - id: tags
+        name: Normalise tag values
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "owner_lc=${OWNER,,}" >> "${GITHUB_OUTPUT}"
+          ref_name="${REF_NAME,,}"
+          echo "ref_name=${ref_name%%/*}" >> "${GITHUB_OUTPUT}"
+
+  container_build:
+    name: Build ${{ inputs.container_name }} Docker image
+    runs-on: ubuntu-latest
+    needs: set_tag_values
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+      - name: Build ${{ inputs.container_name }}
+        uses: docker/build-push-action@v7
+        with:
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/${{ inputs.container_name }}:devel
+            ghcr.io/${{ needs.set_tag_values.outputs.owner_lc }}/${{ inputs.container_name }}:${{ needs.set_tag_values.outputs.ref_name }}
+          file: ${{ inputs.docker_file }}
+          context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          outputs: type=oci,dest=/tmp/container-image.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.container_name }}-docker
+          path: /tmp/container-image.tar
+
+  container_push:
+    name: Push ${{ inputs.container_name }} Docker image
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' || github.ref == 'refs/heads/master'
+    needs: [container_build, set_tag_values]
+    permissions:
+      packages: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.container_name }}-docker
+          path: /tmp
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@v2
+      - name: Push image to GHCR
+        env:
+          CONTAINER_NAME: ${{ inputs.container_name }}
+          GHCR_OWNER: ${{ needs.set_tag_values.outputs.owner_lc }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USERNAME: ${{ github.actor }}
+        run: |
+          echo "${GHCR_PASSWORD}" | \
+            oras login -u "${GHCR_USERNAME}" --password-stdin ghcr.io
+          oras copy --from-oci-layout "/tmp/container-image.tar:devel" \
+            "ghcr.io/${GHCR_OWNER}/${CONTAINER_NAME}:devel"

--- a/.github/workflows/reusable_container_build.yml
+++ b/.github/workflows/reusable_container_build.yml
@@ -56,6 +56,8 @@ jobs:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha,scope=${{ inputs.container_name }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.container_name }}
           outputs: type=oci,dest=/tmp/container-image.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -18,18 +18,18 @@ ENV RUSTFLAGS="-Clinker=clang"
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
-    sccache \
-    cargo \
-    cargo-auditable \
-    clang \
-    gcc \
-    make \
-    automake \
-    autoconf \
-    pam-devel \
-    libudev-devel \
-    sqlite3-devel \
-    rsync
+        sccache \
+        cargo \
+        cargo-auditable \
+        clang \
+        gcc \
+        make \
+        automake \
+        autoconf \
+        pam-devel \
+        libudev-devel \
+        sqlite3-devel \
+        rsync
 
 
 FROM build_base AS fido_mds_builder
@@ -44,11 +44,11 @@ RUN \
     export RUSTC_WRAPPER=/usr/bin/sccache; \
     export CC="/usr/bin/clang"; \
     cargo auditable install \
-    --git https://github.com/kanidm/webauthn-rs.git \
-    --rev 2ac5ff0e20f323cd904856a38a15899adf13fa5b \
-    --root /out \
-    --target-dir=/target \
-    fido-mds-tool
+        --git https://github.com/kanidm/webauthn-rs.git \
+        --rev 2ac5ff0e20f323cd904856a38a15899adf13fa5b \
+        --root /out \
+        --target-dir=/target \
+        fido-mds-tool
 
 FROM build_base AS builder
 
@@ -65,21 +65,21 @@ RUN \
     export SCCACHE_DIR=/sccache; \
     export CC="/usr/bin/clang"; \
     cargo auditable build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release && \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release && \
     cargo auditable build --locked -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release && \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release && \
     cargo auditable build --locked -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release && \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release && \
     cargo auditable build --locked -p kanidm-mail-sender ${KANIDM_BUILD_OPTIONS} \
-    --target-dir="/usr/src/kanidm/target/" \
-    --features="${KANIDM_FEATURES}" \
-    --release && \
+        --target-dir="/usr/src/kanidm/target/" \
+        --features="${KANIDM_FEATURES}" \
+        --release && \
     sccache -s
 
 # == Construct the tools container
@@ -90,14 +90,15 @@ ENV RUST_BACKTRACE=1
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
-    timezone \
-    openssl-3
+        timezone \
+        openssl-3
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ldap-sync /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-mail-sender /sbin/
 COPY --from=fido_mds_builder /out/bin/fido-mds-tool /sbin/
+
 RUN chmod +x /sbin/kanidm
 RUN chmod +x /sbin/kanidm-ipa-sync
 RUN chmod +x /sbin/kanidm-ldap-sync
@@ -108,3 +109,4 @@ RUN mkdir /etc/kanidm && \
     touch /etc/kanidm/config
 
 CMD [ "/sbin/kanidm", "-h" ]
+

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -54,12 +54,12 @@ COPY . /usr/src/kanidm
 
 WORKDIR /usr/src/kanidm/
 
-# export RUSTC_WRAPPER=/usr/bin/sccache; \
 # build the CLI
 RUN \
     --mount=type=cache,id=cargo,target=/cargo \
     --mount=type=cache,id=sccache,target=/sccache \
     export CARGO_HOME=/cargo; \
+    export RUSTC_WRAPPER="$(which sccache)"; \
     export SCCACHE_DIR=/sccache; \
     export CC="/usr/bin/clang"; \
     cargo auditable build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE} AS repos
 ADD ../scripts/zypper_fixing.sh /zypper_fixing.sh
 RUN --mount=type=cache,id=zypp,target=/var/cache/zypp /zypper_fixing.sh
 
-FROM repos AS builder
+FROM repos AS build_base
 ARG KANIDM_FEATURES
 ARG KANIDM_BUILD_PROFILE
 ARG KANIDM_BUILD_OPTIONS=""
@@ -18,18 +18,37 @@ ENV RUSTFLAGS="-Clinker=clang"
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y --no-recommends \
-        sccache \
-        cargo \
-        cargo-auditable \
-        clang \
-        gcc \
-        make \
-        automake \
-        autoconf \
-        pam-devel \
-        libudev-devel \
-        sqlite3-devel \
-        rsync
+    sccache \
+    cargo \
+    cargo-auditable \
+    clang \
+    gcc \
+    make \
+    automake \
+    autoconf \
+    pam-devel \
+    libudev-devel \
+    sqlite3-devel \
+    rsync
+
+FROM build_base AS fido_mds_builder
+
+RUN \
+    --mount=type=cache,id=fido-cargo,target=/cargo \
+    --mount=type=cache,id=fido-sccache,target=/sccache \
+    --mount=type=cache,id=fido-target,target=/target \
+    export CARGO_HOME=/cargo; \
+    export SCCACHE_DIR=/sccache; \
+    export RUSTC_WRAPPER=/usr/bin/sccache; \
+    export CC="/usr/bin/clang"; \
+    cargo auditable install \
+    --git https://github.com/kanidm/webauthn-rs.git \
+    --rev 2ac5ff0e20f323cd904856a38a15899adf13fa5b \
+    --root /out \
+    --target-dir=/target \
+    fido-mds-tool
+
+FROM build_base AS builder
 
 COPY . /usr/src/kanidm
 
@@ -44,26 +63,21 @@ RUN \
     export RUSTC_WRAPPER=/usr/bin/sccache; \
     export CC="/usr/bin/clang"; \
     cargo auditable build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
-        --target-dir="/usr/src/kanidm/target/" \
-        --features="${KANIDM_FEATURES}" \
-        --release && \
+    --target-dir="/usr/src/kanidm/target/" \
+    --features="${KANIDM_FEATURES}" \
+    --release && \
     cargo auditable build --locked -p kanidm-ipa-sync ${KANIDM_BUILD_OPTIONS} \
-        --target-dir="/usr/src/kanidm/target/" \
-        --features="${KANIDM_FEATURES}" \
-        --release && \
+    --target-dir="/usr/src/kanidm/target/" \
+    --features="${KANIDM_FEATURES}" \
+    --release && \
     cargo auditable build --locked -p kanidm-ldap-sync ${KANIDM_BUILD_OPTIONS} \
-        --target-dir="/usr/src/kanidm/target/" \
-        --features="${KANIDM_FEATURES}" \
-        --release && \
+    --target-dir="/usr/src/kanidm/target/" \
+    --features="${KANIDM_FEATURES}" \
+    --release && \
     cargo auditable build --locked -p kanidm-mail-sender ${KANIDM_BUILD_OPTIONS} \
-        --target-dir="/usr/src/kanidm/target/" \
-        --features="${KANIDM_FEATURES}" \
-        --release && \
-    cargo auditable install \
-        --git https://github.com/kanidm/webauthn-rs.git \
-        --rev 8d17715ae596173aac0577846b3cd3982616d50f \
-        --force fido-mds-tool \
-        --target-dir="/usr/src/kanidm/target/" && \
+    --target-dir="/usr/src/kanidm/target/" \
+    --features="${KANIDM_FEATURES}" \
+    --release && \
     sccache -s
 
 # == Construct the tools container
@@ -74,14 +88,14 @@ ENV RUST_BACKTRACE=1
 RUN \
     --mount=type=cache,id=zypp,target=/var/cache/zypp \
     zypper install -y \
-        timezone \
-        openssl-3
+    timezone \
+    openssl-3
 
 COPY --from=builder /usr/src/kanidm/target/release/kanidm /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ipa-sync /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-ldap-sync /sbin/
 COPY --from=builder /usr/src/kanidm/target/release/kanidm-mail-sender /sbin/
-COPY --from=builder /usr/src/kanidm/target/release/fido-mds-tool /sbin/
+COPY --from=fido_mds_builder /out/bin/fido-mds-tool /sbin/
 RUN chmod +x /sbin/kanidm
 RUN chmod +x /sbin/kanidm-ipa-sync
 RUN chmod +x /sbin/kanidm-ldap-sync

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -54,13 +54,13 @@ COPY . /usr/src/kanidm
 
 WORKDIR /usr/src/kanidm/
 
+# export RUSTC_WRAPPER=/usr/bin/sccache; \
 # build the CLI
 RUN \
     --mount=type=cache,id=cargo,target=/cargo \
     --mount=type=cache,id=sccache,target=/sccache \
     export CARGO_HOME=/cargo; \
     export SCCACHE_DIR=/sccache; \
-    export RUSTC_WRAPPER=/usr/bin/sccache; \
     export CC="/usr/bin/clang"; \
     cargo auditable build --locked -p kanidm_tools ${KANIDM_BUILD_OPTIONS} \
     --target-dir="/usr/src/kanidm/target/" \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -31,7 +31,9 @@ RUN \
     sqlite3-devel \
     rsync
 
+
 FROM build_base AS fido_mds_builder
+# doing this separately means the docker cache doesn't get polluted by the install of a thing being pulled from another repo, reducing build time on multiple runs
 
 RUN \
     --mount=type=cache,id=fido-cargo,target=/cargo \


### PR DESCRIPTION
# Change summary

- start building the tools container automagically so one doesn't have to remember to keep publishing dev builds on dockerhub
- create a reusable container build workflow that we can use to drop all the repeat code in the other container build workflows
- moves the fido-mds tool install into its own builder step so it stops polluting the build cache in general

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
