### PR TITLE
Better guard for WebAuthn buttons

### DIFF
--- a/server/core/static/pkhtml.js
+++ b/server/core/static/pkhtml.js
@@ -43,22 +43,18 @@ function passkey_login() {
         });
 }
 
-try {
-    const myButton = document.getElementById("start-passkey-button");
-    myButton.addEventListener("click", () => {
+const passkeyButton = document.getElementById("start-passkey-button");
+if (passkeyButton) {
+    passkeyButton.addEventListener("click", () => {
         passkey_login();
     });
-} catch (error) {
-    console.error(`Failed to add button event listener for passkey authentication: ${error}`);
 }
 
-try {
-    const myButton = document.getElementById("start-seckey-button");
-    myButton.addEventListener("click", () => {
+const seckeyButton = document.getElementById("start-seckey-button");
+if (seckeyButton) {
+    seckeyButton.addEventListener("click", () => {
         passkey_login();
     });
-} catch (error) {
-    console.error(`Failed to add button event listener for security key authentication: ${error}`);
 }
 
 try {


### PR DESCRIPTION
# Change summary

i was getting

```
Failed to add button event listener for security key authentication: TypeError: null is not an object (evaluating 'myButton.addEventListener')
```

on pkhtml.js:61 `/ui/login/mech_choose` in my 1.11.0 deployment

it seems to me that the try catch block is not needed because neither `document.getElementById` nor `addEventListener` will throw anything and the console.error will be invoked on either passkey button or secret key button as the element won't appear at the same time

since they won't appear at the same time, `myButton` would be null at least once causing the error to be logged

tested this patch in my deployment

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
