### PR TITLE
Fix documented command syntax for credential reset token

### DIFF
--- a/book/src/accounts/authentication_and_credentials.md
+++ b/book/src/accounts/authentication_and_credentials.md
@@ -51,9 +51,9 @@ These processes are very similar. You can send a credential reset link to a user
 own credentials. To generate this link or qrcode:
 
 ```bash
-kanidm person credential create-reset-token <account_id> [<time to live in seconds>]
+kanidm person credential create-reset-token <account_id> [--ttl <time to live in seconds>]
 kanidm person credential create-reset-token demo_user --name idm_admin
-kanidm person credential create-reset-token demo_user 86400 --name idm_admin
+kanidm person credential create-reset-token demo_user --ttl 86400 --name idm_admin
 # The person can use one of the following to allow the credential reset
 #
 # Scan this QR Code:


### PR DESCRIPTION
# Change summary

--ttl is missing in example

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
