### PR TITLE
Resolve renew-cert timeout issue

### DIFF
--- a/server/core/src/repl/mod.rs
+++ b/server/core/src/repl/mod.rs
@@ -960,7 +960,12 @@ async fn repl_acceptor(
             Some(TlsAcceptor::from(Arc::new(tls_server_config)))
         };
 
-        loop {
+        // IMPORTANT: We have to drop the retry timeout else the renew
+        // cert times out. This is a HACK until I swap in the new actors
+        // framework.
+        retry_timeout = Duration::from_secs(1);
+
+        'event_inner: loop {
             // This is great to diagnose when spans are entered or present and they capture
             // things incorrectly.
             // eprintln!("🔥 C ---> {:?}", tracing::Span::current());
@@ -970,7 +975,7 @@ async fn repl_acceptor(
                 Ok(action) = rx.recv() => {
                     match action {
                         CoreAction::Shutdown => break 'event,
-                        CoreAction::Reload => {}
+                        CoreAction::Reload => continue 'event,
                     }
                 }
                 Some(ctrl_msg) = ctrl_rx.recv() => {
@@ -984,6 +989,7 @@ async fn repl_acceptor(
                             } else {
                                 trace!("Sent server certificate via control channel");
                             }
+                            continue 'event_inner
                         }
                         ReplCtrl::RenewCertificate {
                             respond
@@ -1044,6 +1050,7 @@ async fn repl_acceptor(
                             } else {
                                 trace!("Sent refresh comms channel to requester");
                             }
+                            continue 'event_inner
                         }
                     }
                 }
@@ -1076,6 +1083,7 @@ async fn repl_acceptor(
                             error!("replication acceptor error, continuing -> {:?}", e);
                         }
                     }
+                    continue 'event_inner
                 }
             } // end select
               // Continue to poll/loop


### PR DESCRIPTION
# Change summary

- We initially added in a retry-timeout into the replication task handler  to attempt to resolve a problem with misconfiguration of replication causing an infinite speed loop. However, this introduced a new problem as all great fixes do. When we would request a certificate renewal we didn't reset the sleep-timeout which then lead to the renew taking *60 seconds* to sleep before the reload proceeded. This timeout caused the admin socket to timeout and disconnect. 

Fixes #4507

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
