### PR TITLE
FreeBSD enable ctap2 on cli tools

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -67,7 +67,7 @@ webauthn-authenticator-rs = { workspace = true, default-features = false }
 workspace = true
 features = ["win10"]
 
-[target."cfg(any(target_os = \"linux\",target_os = \"macos\"))".dependencies.webauthn-authenticator-rs]
+[target."cfg(any(target_os = \"linux\", target_os = \"macos\", target_os = \"freebsd\"))".dependencies.webauthn-authenticator-rs]
 workspace = true
 features = ["mozilla"]
 


### PR DESCRIPTION
# Change summary

- Enable webauthn support in the CLI for freebsd

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
