### PR TITLE
Resolve new database index creation issue

### DIFF
--- a/server/core/src/lib.rs
+++ b/server/core/src/lib.rs
@@ -480,7 +480,6 @@ pub async fn restore_server_core(config: &Configuration, dst_path: &Path) {
 }
 
 pub async fn reindex_server_core(config: &Configuration) {
-    info!("Start Index Phase 1 ...");
     // First, we provide the in-memory schema so that core attrs are indexed correctly.
     let schema = match Schema::new() {
         Ok(s) => s,
@@ -504,6 +503,7 @@ pub async fn reindex_server_core(config: &Configuration) {
 }
 
 async fn reindex_inner(be: Backend, schema: Schema, config: &Configuration) {
+    info!("Start Index Phase 1 ...");
     // Reindex only the core schema attributes to bootstrap the process.
     let mut be_wr_txn = match be.write() {
         Ok(txn) => txn,
@@ -525,7 +525,7 @@ async fn reindex_inner(be: Backend, schema: Schema, config: &Configuration) {
     }
     info!("Index Phase 1 Success!");
 
-    info!("Attempting to init query server ...");
+    debug!("Attempting to init query server ...");
 
     let (qs, _idms, _idms_delayed, _idms_audit) = match setup_qs_idms(be, schema, config).await {
         Ok(t) => t,
@@ -534,7 +534,7 @@ async fn reindex_inner(be: Backend, schema: Schema, config: &Configuration) {
             return;
         }
     };
-    info!("Init Query Server Success!");
+    debug!("Init Query Server Success!");
 
     info!("Start Index Phase 2 ...");
 

--- a/server/lib/src/server/migrations.rs
+++ b/server/lib/src/server/migrations.rs
@@ -20,11 +20,6 @@ impl QueryServer {
         // databases during upgrades.
         let mut write_txn = self.write(ts).await?;
 
-        // Check our database version - attempt to do an initial indexing
-        // based on the in memory configuration. This ONLY triggers ONCE on
-        // the very first run of the instance when the DB in newely created.
-        write_txn.upgrade_reindex(SYSTEM_INDEX_VERSION)?;
-
         // Because we init the schema here, and commit, this reloads meaning
         // that the on-disk index meta has been loaded, so our subsequent
         // migrations will be correctly indexed.
@@ -35,6 +30,15 @@ impl QueryServer {
         // mem schema that defines how schema is structured, and this is all
         // marked "system", then we won't have an issue here.
         if domain_target_level < DOMAIN_LEVEL_1_11 {
+            // Check our database version - attempt to do an initial indexing
+            // based on the in memory configuration. This ONLY triggers ONCE on
+            // the very first run of the instance when the DB in newely created.
+            //
+            // NOTE: After DL_1_11 this is no longer needed since all the schema
+            // is in memory, and we don't need these initial indexes in order
+            // to speed up index loading.
+            write_txn.upgrade_reindex(SYSTEM_INDEX_VERSION)?;
+
             // We don't create these in the DB after 1_11
             write_txn
                 .initialise_schema_core()
@@ -739,6 +743,10 @@ impl QueryServerWriteTransaction<'_> {
     }
 
     pub(crate) fn migrate_schema_1_11(&mut self) -> Result<(), OperationError> {
+        // Flag that the schema changes - this is important because now that the
+        // schema is in memory only, the on-disk triggers won't fire now.
+        self.force_schema_reload();
+
         self.schema.extend_in_memory(
             migration_data::dl15::phase_1_schema_attrs(),
             migration_data::dl15::phase_2_schema_classes(),
@@ -837,6 +845,10 @@ impl QueryServerWriteTransaction<'_> {
     }
 
     pub(crate) fn migrate_schema_1_12(&mut self) -> Result<(), OperationError> {
+        // Flag that the schema changes - this is important because now that the
+        // schema is in memory only, the on-disk triggers won't fire now.
+        self.force_schema_reload();
+
         self.schema.extend_in_memory(
             migration_data::dl_1_12::phase_1_schema_attrs(),
             migration_data::dl_1_12::phase_2_schema_classes(),

--- a/server/lib/src/server/mod.rs
+++ b/server/lib/src/server/mod.rs
@@ -2253,70 +2253,86 @@ impl<'a> QueryServerWriteTransaction<'a> {
 
     #[instrument(level = "debug", skip_all)]
     pub(crate) fn reload_schema(&mut self) -> Result<(), OperationError> {
-        if self.get_domain_version() < DOMAIN_LEVEL_1_11 {
-            // supply entries to the writable schema to reload from.
-            // find all attributes.
-            let filt = filter!(f_eq(Attribute::Class, EntryClass::AttributeType.into()));
-            let res = self.internal_search(filt).map_err(|e| {
-                error!("reload schema internal search failed {:?}", e);
-                e
-            })?;
-            // load them.
-            let attributetypes: Result<Vec<_>, _> =
-                res.iter().map(|e| SchemaAttribute::try_from(e)).collect();
+        match self.get_domain_version() {
+            /*
+            0 => {
+                // server is being brought up, so the schema was already set by a caller.
+            }
+            */
+            level if level < DOMAIN_LEVEL_1_11 => {
+                // supply entries to the writable schema to reload from.
+                // find all attributes.
+                let filt = filter!(f_eq(Attribute::Class, EntryClass::AttributeType.into()));
+                let res = self.internal_search(filt).map_err(|e| {
+                    error!("reload schema internal search failed {:?}", e);
+                    e
+                })?;
+                // load them.
+                let attributetypes: Result<Vec<_>, _> =
+                    res.iter().map(|e| SchemaAttribute::try_from(e)).collect();
 
-            let attributetypes = attributetypes.map_err(|e| {
-                error!("reload schema attributetypes {:?}", e);
-                e
-            })?;
-
-            self.schema
-                .update_attributes(attributetypes.into_iter())
-                .map_err(|e| {
-                    error!("reload schema update attributetypes {:?}", e);
+                let attributetypes = attributetypes.map_err(|e| {
+                    error!("reload schema attributetypes {:?}", e);
                     e
                 })?;
 
-            // find all classes
-            let filt = filter!(f_eq(Attribute::Class, EntryClass::ClassType.into()));
-            let res = self.internal_search(filt).map_err(|e| {
-                error!("reload schema internal search failed {:?}", e);
-                e
-            })?;
-            // load them.
-            let classtypes: Result<Vec<_>, _> =
-                res.iter().map(|e| SchemaClass::try_from(e)).collect();
-            let classtypes = classtypes.map_err(|e| {
-                error!("reload schema classtypes {:?}", e);
-                e
-            })?;
+                // IMPORTANT: If attribute types is empty, it's because we are in "in memory schema"
+                // mode only. This is a horrid hack but it's needed for backwards compat for now.
+                //
+                // The reason it's needed is that at this phase in bootstrap, domain_version is 0
+                // but the on-disk schema mode relies on that to trigger a read from the DB. We can't
+                // gate on version == 0 because that breaks the older versions. But if we DONT do
+                // anything then this call will nuke the in memory schema that we just setup causing
+                // the server to fail.
+                if attributetypes.is_empty() {
+                    debug!("DB attributes are empty - we are probably in DL_1_11 memory only schema mode.");
+                } else {
+                    self.schema
+                        .update_attributes(attributetypes.into_iter())
+                        .map_err(|e| {
+                            error!("reload schema update attributetypes {:?}", e);
+                            e
+                        })?;
 
-            self.schema
-                .update_classes(classtypes.into_iter())
-                .map_err(|e| {
-                    error!("reload schema update classtypes {:?}", e);
-                    e
-                })?;
+                    // find all classes
+                    let filt = filter!(f_eq(Attribute::Class, EntryClass::ClassType.into()));
+                    let res = self.internal_search(filt).map_err(|e| {
+                        error!("reload schema internal search failed {:?}", e);
+                        e
+                    })?;
+                    // load them.
+                    let classtypes: Result<Vec<_>, _> =
+                        res.iter().map(|e| SchemaClass::try_from(e)).collect();
+                    let classtypes = classtypes.map_err(|e| {
+                        error!("reload schema classtypes {:?}", e);
+                        e
+                    })?;
 
-            // validate.
-            let valid_r = self.schema.validate();
+                    self.schema
+                        .update_classes(classtypes.into_iter())
+                        .map_err(|e| {
+                            error!("reload schema update classtypes {:?}", e);
+                            e
+                        })?;
 
-            // Translate the result.
-            if !valid_r.is_empty() {
-                // Log the failures
-                error!("Schema reload failed -> {:?}", valid_r);
-                return Err(OperationError::ConsistencyError(
-                    valid_r.into_iter().filter_map(|v| v.err()).collect(),
-                ));
-            };
-        } else {
-            match self.get_domain_version() {
-                DOMAIN_LEVEL_1_11 => self.migrate_schema_1_11()?,
-                DOMAIN_LEVEL_1_12 => self.migrate_schema_1_12()?,
-                _ => {
-                    debug_assert!(false, "domain level was not configured in reload_schema");
-                    return Err(OperationError::MG0001InvalidReMigrationLevel);
+                    // validate.
+                    let valid_r = self.schema.validate();
+
+                    // Translate the result.
+                    if !valid_r.is_empty() {
+                        // Log the failures
+                        error!("Schema reload failed -> {:?}", valid_r);
+                        return Err(OperationError::ConsistencyError(
+                            valid_r.into_iter().filter_map(|v| v.err()).collect(),
+                        ));
+                    };
                 }
+            }
+            DOMAIN_LEVEL_1_11 => self.migrate_schema_1_11()?,
+            DOMAIN_LEVEL_1_12 => self.migrate_schema_1_12()?,
+            _ => {
+                debug_assert!(false, "domain level was not configured in reload_schema");
+                return Err(OperationError::MG0001InvalidReMigrationLevel);
             }
         }
 


### PR DESCRIPTION
Due to the move from on-disk to in-memory schema this caused an issue in server migrations where the index metadata was not reloaded correctly at the right stage in server bootstrap. This led to only a subset of core attributes being indexed.

This correctly flags that the reload needs to occur, and also handles the edge cases with older versions and their bring up that still relies on the on-disk path.

Fixes #4534

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
