### PR TITLE
Add example & description of max_ber_size opt for ldap-sync

### DIFF
--- a/examples/kanidm-ldap-sync
+++ b/examples/kanidm-ldap-sync
@@ -80,6 +80,11 @@ ldap_filter = "(|(objectclass=person)(objectclass=posixgroup))"
 # group_attr_member = "member"
 # group_attr_gidnumber = "gidnumber"
 
+# LDAP client max ber (message) size.
+# If one of your LDAP fields is large, your client can maybe throw "lber request too large".
+# With this options you can increse the size.
+# Size is in kilobytes ! (Kanidm ldap3 client default ber size is 32768)
+# max_ber_size = 1024000
 
 # The sync tool can alter or exclude entries. These are mapped by their syncuuid
 # The syncuuid is derived from nsUniqueId in 389-ds. It is the entryUUID for OpenLDAP


### PR DESCRIPTION
In my personal use of Kanidm I have throw "lber request too large" error, this PR is the result of my recherche and source code reading.

# Change summary

- Document the max_ber_size opt usage in kanidm-ldap-sync config

Fixes #

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)

### About IA
The first time I made a description with my word but by using a LLM, as I see you want 0 LLM code even in doc, I rewrite full description only with my keyboard and my brain. I hope my version do not contain english error (this is not my natural language) but I do my best.

In case of curiosity this was the first description (with process -> Word of my brain -> LLM -> Reformat of me again and then we are done).
```
# If an LDAP attribute contains a large value, such as a JPEG photo,
# the client may fail with "lber request too large" error.
# This option allows you to configure the maximum ber size that the client can handle.
# Size is in kilobytes ! (Kanidm ldap3 client default ber size is 32768)
```