### PR TITLE
ldap-sync: Add usage example of mail and ssh person_attr opts

### DIFF
--- a/examples/kanidm-ldap-sync
+++ b/examples/kanidm-ldap-sync
@@ -61,6 +61,8 @@ ldap_filter = "(|(objectclass=person)(objectclass=posixgroup))"
 # person_attr_gidnumber = "uidnumber"
 # person_attr_login_shell = "loginshell"
 # person_attr_password = "userpassword"
+# person_attr_mail = "mail"
+# person_attr_ssh_public_key = "sshpublickey"
 
 # If the password value requires a prefix for Kanidm to import it, this can be optionally
 # provided here.


### PR DESCRIPTION
# Change summary

- ldap-sync: Add usage example of mail and ssh person_attr opts

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
