### PR TITLE
Security: medium - ldap bind state reset on failure

### DIFF
--- a/server/core/src/ldaps.rs
+++ b/server/core/src/ldaps.rs
@@ -118,6 +118,15 @@ async fn client_process<STREAM>(
                     break;
                 }
             }
+            Some(LdapResponseState::BindFailed(uat, rmsg)) => {
+                // RFC 4513 Section 4 - if a bind fails, move to
+                // the anonymous bind state. This is provided in the returned
+                // uat here.
+                session.uat = Some(uat);
+                if w.send(rmsg).await.is_err() {
+                    break;
+                }
+            }
             Some(LdapResponseState::Respond(rmsg)) => {
                 if w.send(rmsg).await.is_err() {
                     break;

--- a/server/lib/src/idm/ldap.rs
+++ b/server/lib/src/idm/ldap.rs
@@ -27,6 +27,7 @@ pub enum LdapResponseState {
     Unbind,
     Disconnect(LdapMsg),
     Bind(LdapBoundToken, LdapMsg),
+    BindFailed(LdapBoundToken, LdapMsg),
     Respond(LdapMsg),
     MultiPartResponse(Vec<LdapMsg>),
     BindMultiPartResponse(LdapBoundToken, Vec<LdapMsg>),
@@ -617,17 +618,32 @@ impl LdapServer {
         let source = Source::Ldaps(ip_addr);
 
         match server_op {
-            ServerOps::SimpleBind(sbr) => self
-                .do_bind(idms, sbr.dn.as_str(), sbr.pw.as_str())
-                .await
-                .map(|r| match r {
-                    Some(lbt) => LdapResponseState::Bind(lbt, sbr.gen_success()),
-                    None => LdapResponseState::Respond(sbr.gen_invalid_cred()),
-                })
-                .or_else(|e| {
-                    let (rc, msg) = operationerr_to_ldapresultcode(e);
-                    Ok(LdapResponseState::Respond(sbr.gen_error(rc, msg)))
-                }),
+            ServerOps::SimpleBind(sbr) => {
+                let result = self.do_bind(idms, sbr.dn.as_str(), sbr.pw.as_str()).await;
+
+                let err = match result {
+                    Ok(Some(lbt)) => return Ok(LdapResponseState::Bind(lbt, sbr.gen_success())),
+                    Ok(None) => {
+                        // On a failed bind, move to anonymous.
+                        // Important that if anonymous is locked/expired this will FAIL which is
+                        // what we want!
+                        match self.do_bind(idms, "", "").await {
+                            Ok(Some(lbt)) => {
+                                return Ok(LdapResponseState::BindFailed(
+                                    lbt,
+                                    sbr.gen_invalid_cred(),
+                                ))
+                            }
+                            _ => OperationError::InvalidRequestState,
+                        }
+                    }
+                    Err(err) => err,
+                };
+
+                let (rc, msg) = operationerr_to_ldapresultcode(err);
+                // Unable to proceed, we are in an invalid state now. Disconnect the client.
+                Ok(LdapResponseState::Disconnect(sbr.gen_error(rc, msg)))
+            }
             ServerOps::Search(sr) => match uat {
                 Some(u) => self
                     .do_search(idms, &sr, &u, source)

--- a/server/testkit/src/lib.rs
+++ b/server/testkit/src/lib.rs
@@ -202,6 +202,43 @@ pub async fn setup_account_passkey(rsclient: &KanidmClient, account_name: &str) 
     wa
 }
 
+pub async fn login_account_passkey(
+    rsclient: &KanidmClient,
+    account_name: &str,
+    soft_passkey: &mut SoftPasskey,
+) {
+    rsclient.logout().await.expect("Failed to logout");
+
+    let res = rsclient
+        .auth_passkey_begin(account_name)
+        .await
+        .expect("Failed to start passkey auth");
+
+    let pkc = soft_passkey
+        .do_authentication(rsclient.get_origin().clone(), res)
+        .map(Box::new)
+        .expect("Failed to authentication with soft passkey");
+
+    let res = rsclient.auth_passkey_complete(pkc).await;
+    assert!(res.is_ok());
+}
+
+pub async fn reauth_account_passkey(rsclient: &KanidmClient, soft_passkey: &mut SoftPasskey) {
+    // We need RW privs, elevate now.
+    let res = rsclient
+        .reauth_passkey_begin()
+        .await
+        .expect("Failed to start passkey reauth");
+
+    let pkc = soft_passkey
+        .do_authentication(rsclient.get_origin().clone(), res)
+        .map(Box::new)
+        .expect("Failed to authentication with soft passkey");
+
+    let res = rsclient.reauth_passkey_complete(pkc).await;
+    assert!(res.is_ok());
+}
+
 /// creates a user (username: `id`) and puts them into a group, creating it if need be.
 pub async fn create_user(rsclient: &KanidmClient, id: &str, group_name: &str) {
     #[allow(clippy::expect_used)]

--- a/server/testkit/tests/testkit/ldap_basic.rs
+++ b/server/testkit/tests/testkit/ldap_basic.rs
@@ -3,11 +3,11 @@ use kanidm_proto::scim_v1::{
     ScimApplicationPasswordCreate,
 };
 use kanidmd_testkit::{
-    setup_account_passkey, AsyncTestEnvironment, IDM_ADMIN_TEST_PASSWORD, IDM_ADMIN_TEST_USER,
+    login_account_passkey, reauth_account_passkey, setup_account_passkey, AsyncTestEnvironment,
+    IDM_ADMIN_TEST_PASSWORD, IDM_ADMIN_TEST_USER, NOT_ADMIN_TEST_PASSWORD,
 };
 use ldap3_client::LdapClientBuilder;
 use tracing::debug;
-use webauthn_authenticator_rs::WebauthnAuthenticator;
 
 const TEST_PERSON: &str = "user_mcuserton";
 const TEST_GROUP: &str = "group_mcgroupington";
@@ -23,6 +23,77 @@ async fn test_ldap_basic_unix_bind(test_env: &AsyncTestEnvironment) {
         .bind("".to_string(), "".to_string())
         .await
         .unwrap();
+
+    let whoami = ldap_client.whoami().await.unwrap();
+
+    assert_eq!(whoami, Some("u: anonymous@localhost".to_string()));
+}
+
+#[kanidmd_testkit::test(ldap = true)]
+async fn test_ldap_failed_bind_anonymous(test_env: &AsyncTestEnvironment) {
+    let idm_admin_rsclient = test_env.rsclient.new_session().unwrap();
+
+    // Create a person
+
+    idm_admin_rsclient
+        .auth_simple_password(IDM_ADMIN_TEST_USER, IDM_ADMIN_TEST_PASSWORD)
+        .await
+        .expect("Failed to login as admin");
+
+    idm_admin_rsclient
+        .idm_person_account_create(TEST_PERSON, TEST_PERSON)
+        .await
+        .expect("Failed to create the user");
+
+    idm_admin_rsclient
+        .idm_person_account_unix_extend(TEST_PERSON, None, None)
+        .await
+        .expect("Failed to setup posix attrs.");
+
+    let mut soft_passkey = setup_account_passkey(&idm_admin_rsclient, TEST_PERSON).await;
+
+    // Login as the person
+    let person_rsclient = test_env.rsclient.new_session().unwrap();
+
+    login_account_passkey(&person_rsclient, TEST_PERSON, &mut soft_passkey).await;
+
+    reauth_account_passkey(&person_rsclient, &mut soft_passkey).await;
+
+    person_rsclient
+        .idm_person_account_unix_cred_put(TEST_PERSON, NOT_ADMIN_TEST_PASSWORD)
+        .await
+        .expect("Failed to set unix password");
+
+    let ldap_url = test_env.ldap_url.as_ref().unwrap();
+
+    let mut ldap_client = LdapClientBuilder::new(ldap_url).build().await.unwrap();
+
+    // Bind as anonymous
+    ldap_client
+        .bind("".to_string(), "".to_string())
+        .await
+        .unwrap();
+
+    let whoami = ldap_client.whoami().await.unwrap();
+
+    assert_eq!(whoami, Some("u: anonymous@localhost".to_string()));
+
+    // Now rebind correctly as the user
+    ldap_client
+        .bind(TEST_PERSON.to_string(), NOT_ADMIN_TEST_PASSWORD.to_string())
+        .await
+        .unwrap();
+
+    let whoami = ldap_client.whoami().await.unwrap();
+
+    assert_eq!(whoami, Some("u: user_mcuserton@localhost".to_string()));
+
+    // On a failed bind, should revert to anonymous
+    ldap_client
+        .bind(TEST_PERSON.to_string(), TEST_PERSON.to_string())
+        .await
+        //We expect this to fail
+        .expect_err("Bind must FAIL");
 
     let whoami = ldap_client.whoami().await.unwrap();
 
@@ -103,34 +174,9 @@ async fn test_ldap_application_password_basic(test_env: &AsyncTestEnvironment) {
     // Login as the person
     let person_rsclient = test_env.rsclient.new_session().unwrap();
 
-    let _ = person_rsclient.logout().await;
+    login_account_passkey(&person_rsclient, TEST_PERSON, &mut soft_passkey).await;
 
-    let res = person_rsclient
-        .auth_passkey_begin(TEST_PERSON)
-        .await
-        .expect("Failed to start passkey auth");
-
-    let pkc = soft_passkey
-        .do_authentication(person_rsclient.get_origin().clone(), res)
-        .map(Box::new)
-        .expect("Failed to authentication with soft passkey");
-
-    let res = person_rsclient.auth_passkey_complete(pkc).await;
-    assert!(res.is_ok());
-
-    // We need RW privs, elevate now.
-    let res = person_rsclient
-        .reauth_passkey_begin()
-        .await
-        .expect("Failed to start passkey reauth");
-
-    let pkc = soft_passkey
-        .do_authentication(person_rsclient.get_origin().clone(), res)
-        .map(Box::new)
-        .expect("Failed to authentication with soft passkey");
-
-    let res = person_rsclient.reauth_passkey_complete(pkc).await;
-    assert!(res.is_ok());
+    reauth_account_passkey(&person_rsclient, &mut soft_passkey).await;
 
     // List the applications we can see
     let applications = person_rsclient


### PR DESCRIPTION
A subtle default of rfc4513 is that on a failed bind the state should move to anonymous. Previously we left the former bind state in place on a failed bind.

We now move to anonymous on failure, and if anonymous is disabled then we disconnect the connection.

Fixes #GHSA-6pw6-3f73-6v9q

Checklist

- [x] This PR contains no AI generated content (code, docs, etc)
- [ ] book chapter included (if relevant)
- [ ] design document included (if relevant)
